### PR TITLE
Gui cleanup in Puppy Event Manager

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/eventmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/eventmanager
@@ -10,7 +10,8 @@
 #v424 automatic unmounting (see pup_event_frontend_d).
 #110505 support sudo for non-root user.
 #120201 BK: internationalized.
-#120213 /var/local/pup_event_icon_change_flag path changed from /tmp (see /sbin/clean_desk_icons)
+#130212 /var/local/pup_event_icon_change_flag path changed from /tmp (see /sbin/clean_desk_icons)
+#131123 zigbert: gui (gtkdialog) improvements.
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
 
@@ -49,240 +50,179 @@ NEWFD0ICON="$FD0ICON"
 NEWPOWERTIMEOUT=$POWERTIMEOUT
 NEWAUTOUNMOUNT="$AUTOUNMOUNT"
 
-if [ "$SHOWMODE" = "desktop" ];then
- #cutdown, only show choices for settng the desktop icons...
- export MAIN_DIALOG="
-<window title=\"$(gettext 'Event Manager: Desktop drive icons')\" icon-name=\"gtk-execute\">
-<vbox>
+infobox (){
+	#generate xml-code used many times in gui
+	echo '
+	<hbox scrollable="true" shadow-type="3" vscrollbar-policy="2" hscrollbar-policy="2" space-expand="true" space-fill="true">
+	  <vbox space-expand="false" space-fill="false">
+		<text height-request="5"><label>""</label></text>
+		<hbox>
+		  <vbox><pixmap><input file stock="gtk-info"></input></pixmap></vbox>
+		  <vbox>
+		    <hbox space-expand="true" space-fill="true">
+		      <text use-markup="true" space-expand="false" space-fill="false"><label>"'$1'"</label></text>
+		      <text space-expand="true" space-fill="true"><label>""</label></text>
+		    </hbox>'
+		    [ "$2" ] && echo '<text><label>""</label></text><hbox space-expand="true" space-fill="true"><text use-markup="true" space-expand="false" space-fill="false"><label>"'$2'"</label></text><text space-expand="true" space-fill="true"><label>""</label></text></hbox>'
+		    [ "$3" ] && echo '<hbox space-expand="true" space-fill="true"><text use-markup="true" space-expand="false" space-fill="false"><label>"'$3'"</label></text><text space-expand="true" space-fill="true"><label>""</label></text></hbox>'
+		    echo '
+		  </vbox>
+		</hbox>
+	  </vbox>
+	  <text space-expand="true" space-fill="true"><label>""</label></text>
+	</hbox>'
+}
 
-  <text use-markup=\"true\">
-  <label>\"<b>$(gettext 'Restart X for changes to take effect')</b>\"</label></text>
+[ "$SHOWMODE" = "desktop" ] && PAGE_NR=2 || PAGE_NR=0
 
-<notebook labels=\"$(gettext 'Desktop Icons')|$(gettext 'Icon Handler')|$(gettext 'Legacy')\">
+export Puppy_Event_Manager='
+<window title="'$(gettext 'Puppy Event Manager')'" icon-name="gtk-execute" default_height="400" default_width="480">
+<vbox space-expand="true" space-fill="true">
+  <notebook tab-pos="2" page="'$PAGE_NR'" labels="'$(gettext 'Activate')'|'$(gettext 'Save Session')'|'$(gettext 'Desktop Icons')'|'$(gettext 'Power')'">
+    <frame '$(gettext 'Activate Puppy Event Manager')'>
+      '"`infobox "$(gettext "The 'pup_event' Puppy Event Manager runs in the background and handles hotplugging of drives, including the desktop drive icons. This also includes automatic module and firmware loading if new hardware is detected. However, turn it all off, and Puppy will revert to the same behaviour as versions prior to 4.x, in which there is no hotplug support. This reduces resource usage, so try unticking these on very old slow PCs. Pmount can still be run manually to mount and unmount partitions.")"`"'
+      <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+      <checkbox>
+        <label>'$(gettext 'Activate Puppy Event Manager')'</label>
+        <default>'${BACKENDON}'</default>
+        <variable>NEWBACKENDON</variable>
+        <action>if true enable:NEWHOTPLUGON</action>
+        <action>if true enable:NEWAUTOUNMOUNT</action>
+        <action>if false disable:NEWHOTPLUGON</action>
+        <action>if false disable:NEWAUTOUNMOUNT</action>
+      </checkbox>
+      <checkbox>
+        <label>'$(gettext 'Activate desktop hotplug support')'</label>
+        <default>'${HOTPLUGON}'</default>
+        <variable>NEWHOTPLUGON</variable>
+      </checkbox>
+      <checkbox tooltip-text="'$(gettext 'WARNING: auto unmounting is highly experimental')'">
+        <label>'$(gettext 'Activate auto unmounting of partitions (-EXPERIMENTAL-)')'</label>
+        <default>'${AUTOUNMOUNT}'</default>
+        <variable>NEWAUTOUNMOUNT</variable>
+      </checkbox>
+      <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+    </frame>
 
- <frame $(gettext 'Drive icons on desktop')>
- <vbox>
-  <text><label>$(gettext "When this box is ticked, there will be an icon for each drive. If you plugin a USB pen drive for example, an icon will appear. Unplug and it will disappear. If you don't want these drive icons on the desktop, untick this box (but there will still remain just one icon that will launch Pmount when clicked on). The individual drive icons are purely a convenience and Puppy works fine without them.")</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for drive icons on desktop')</label>
-   <default>${ICONDESK}</default>
-   <variable>NEWICONDESK</variable>
-  </checkbox>
 
-  <hbox>
-  <text><label>\"  \"</label></text>
-  <vbox>
-  <text><label>$(gettext 'If the above is ticked, then you can choose to have an icon for each partition, rather than one icon for the entire drive:')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for an icon for each partition')</label>
-   <default>${ICONPARTITIONS}</default>
-   <variable>NEWICONPARTITIONS</variable>
-  </checkbox>
-  </vbox>
+    <frame '$(gettext 'Periodic save from RAM')'>
+      <vbox space-expand="true" space-fill="true">
+        '"`infobox "$(gettext "Puppy runs in a particular 'state' that we call the PUPMODE. This depends on the type of installation and the type of hardware. Currently, PUPMODE=")${PUPMODE}. $(gettext "If it is an odd number, for example 13, then Puppy is doing everything in RAM and saving the current session to a drive periodically -- this is done in the case of Flash memory to make it last longer. When Puppy runs in an odd PUPMODE, there will be a 'save' icon on the desktop, also a save occurs at shutdown. You can also specify a periodic save here")" "<b>$(gettext 'Note!')</b> $(gettext 'PUPMODE=77 (multisession DVD) excluded, only manual save with desktop icon and at shutdown.')" "<b>$(gettext 'Note!')</b> $(gettext 'PUPMODE=5 there are no saves, above value ignored.')"`"'
+        <vbox space-expand="false" space-fill="false">
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+          <hbox>
+            <text space-expand="true" space-fill="true"><label>""</label></text>
+            <text space-expand="false" space-fill="false"><label>"'$(gettext 'Save interval (0=never):')'  "</label></text>
+            <entry max_length="4" width-request="40" space-expand="false" space-fill="false">
+              <default>'${RAMSAVEINTERVAL}'</default>
+              <variable>NEWRAMSAVEINTERVAL</variable>
+            </entry>
+            <text><label>"'$(gettext 'minutes')' "</label></text>
+          </hbox>
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+        </vbox>
+      </vbox>
+    </frame>
+
+
+    <notebook tab-pos="2" labels="'$(gettext 'Show Icons')'|'$(gettext 'Icon Handler')'|'$(gettext 'Legacy')'|'$(gettext 'Power')'">
+      <frame '$(gettext 'Drive icons on desktop')'>
+        <vbox space-expand="true" space-fill="true">
+          '"`infobox "$(gettext "When this box is ticked, there will be an icon for each drive. If you plugin a USB pen drive for example, an icon will appear. Unplug and it will disappear. If you don't want these drive icons on the desktop, untick this box (but there will still remain just one icon that will launch Pmount when clicked on). The individual drive icons are purely a convenience and Puppy works fine without them.")"`"'
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+          <checkbox>
+            <label>'$(gettext 'Show desktop icons for each DRIVE')'</label>
+            <default>'${ICONDESK}'</default>
+            <variable>NEWICONDESK</variable>
+            <action>if true enable:NEWICONPARTITIONS</action>
+            <action>if false disable:NEWICONPARTITIONS</action>
+          </checkbox>
+          <checkbox space-expand="false" space-fill="false">
+            <label>'$(gettext 'Show desktop icons for each PARTITION')'</label>
+            <default>'${ICONPARTITIONS}'</default>
+            <variable>NEWICONPARTITIONS</variable>
+          </checkbox>
+          <checkbox space-expand="false" space-fill="false">
+            <label>'$(gettext 'Refresh / Realign existing icons')'</label>
+            <default>false</default>
+            <variable>NEWICONWIPE</variable>
+          </checkbox>
+          <text height-request="20" space-expand="false" space-fill="false"><label>""</label></text>
+        </vbox>
+      </frame>
+
+
+      <frame '$(gettext "Drive 'handler'")'>
+        <vbox space-expand="true" space-fill="true">
+          '"`infobox "$(gettext "The 'handler' decides what to do when you click on a desktop drive icon. Normally, this just starts Pmount if you click on a drive icon. For partitions, it mounts and shows content in a file browser. This behavior can be extended...")"`"'
+          <checkbox space-expand="false" space-fill="false">
+            <label>'$(gettext 'Auto-play video-DVD and audio-CD')'</label>
+            <default>'${AUTOTARGET}'</default>
+            <variable>NEWAUTOTARGET</variable>
+          </checkbox>
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+        </vbox>
+        <vbox space-expand="true" space-fill="true">
+          '"`infobox "$(gettext "Normally you have to click on a drive icon to run the 'handler', but this checkbox makes the 'handler' run as soon as a media is plugged in. For example, plug in a DVD and it will immediately either get mounted, or if the above checkbox is ticked the media player will run.")"`"'
+          <checkbox space-expand="false" space-fill="false">
+            <label>'$(gettext "Auto-launch 'handler' when media plugged in")'</label>
+            <default>'${HOTPLUGNOISY}'</default>
+            <variable>NEWHOTPLUGNOISY</variable>
+          </checkbox>
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+        </vbox>
+      </frame>
+
+
+      <frame Legacy>
+        <vbox space-expand="true" space-fill="true">
+          '"`infobox "$(gettext 'Linux does not support hotplug detection of when a legacy floppy diskette is inserted or removed. Periodic probing requires starting the drive motor, which is very slow -- and do you want the motor to startup every 4 seconds? Therefore, if your PC has a floppy drive, tick this box to have a permanent icon on desktop (regardless whether a diskette is actually inserted, or even a floppy drive!).')"`"'
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+          <checkbox>
+            <label>'$(gettext 'Add floppy drive icon on desktop')'</label>
+            <default>'${FD0ICON}'</default>
+            <variable>NEWFD0ICON</variable>
+          </checkbox>
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+        </vbox>
+      </frame>
+    </notebook>
+
+
+    <frame '$(gettext 'Power')'>
+      <vbox space-expand="true" space-fill="true">
+        '"`infobox "$(gettext 'Puppy is able to power-off your computer after a period of mouse inactivity. This will occur if the mouse cursor has not been moved for the designated interval.')"`"'
+        <vbox space-expand="false" space-fill="false">
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+          <hbox>
+            <text space-expand="true" space-fill="true"><label>""</label></text>
+            <text space-expand="false" space-fill="false"><label>"'$(gettext 'Inactivity interval (0=never):')'  "</label></text>
+            <entry max_length="4" width-request="40" space-expand="false" space-fill="false">
+              <default>'${POWERTIMEOUT}'</default>
+              <variable>NEWPOWERTIMEOUT</variable>
+            </entry>
+            <text><label>"'$(gettext 'minutes')' "</label></text>
+          </hbox>
+          <vbox space-expand="false" space-fill="false"><text height-request="20"><label>""</label></text></vbox>
+        </vbox>
+      </vbox>
+    </frame>
+  </notebook>
+
+
+  <hbox space-expand="false" space-fill="false">
+    <text use-markup="true" space-expand="false" space-fill="false"><label>" <b>'$(gettext 'Restart X for changes to take effect')'</b>"</label></text>
+    <text space-expand="true" space-fill="true"><label>""</label></text>
+    <button ok></button>
+    <button cancel></button>
   </hbox>
-
-  <checkbox>
-   <label>$(gettext 'Tick box to erase then redraw and realign existing icons')</label>
-   <default>false</default>
-   <variable>NEWICONWIPE</variable>
-  </checkbox>
-
- </vbox>
- </frame>
-
- <frame $(gettext "Drive 'handler'")>
- 
- <vbox>
-  <text><label>$(gettext "The 'handler' decides what to do when you click on a desktop drive icon. Normally, this just starts Pmount if you click on a drive icon, or mounts it and starts ROX-Filer if a partition icon, but this behavior can be extended by these checkboxes.")</label></text>
-  
-  <text><label>$(gettext 'This checkbox extends the default behavior, and will launch a more appropriate application. Currently, it adds detection of a video DVD or audio CD and launches the media player:')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for auto-detection of target application')</label>
-   <default>${AUTOTARGET}</default>
-   <variable>NEWAUTOTARGET</variable>
-  </checkbox>
- </vbox>
-  
- <vbox>
-  <text><label>$(gettext "Normally you have to click on a drive icon to run the 'handler', but this checkbox makes the 'handler' run as soon as a media is plugged in. For example, plug in a DVD and it will immediately either get mounted, or if the above checkbox is ticked the media player will run:")</label></text>
-  <checkbox>
-   <label>$(gettext "Tick box for auto-launch 'handler' when media plugged in")</label>
-   <default>${HOTPLUGNOISY}</default>
-   <variable>NEWHOTPLUGNOISY</variable>
-  </checkbox>
- </vbox>
-
- </frame>
- 
- <frame Legacy>
-  <text><label>$(gettext 'Linux does not support hotplug detection of when a legacy floppy diskette is inserted or removed. Periodic probing requires starting the drive motor, which is very slow -- and do you want the motor to startup every 4 seconds? Therefore, if your PC has a floppy drive, tick this box to have a permanent icon on desktop (regardless whether a diskette is actually inserted, or even a floppy drive!).')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for floppy drive icon on desktop')</label>
-   <default>${FD0ICON}</default>
-   <variable>NEWFD0ICON</variable>
-  </checkbox>
- </frame>
- 
- </notebook>
-
- <hbox>
-   <button>
-    <label>$(gettext 'Show full Event Manager')</label>
-    <action type=\"exit\">fullem</action>
-   </button>
-   <button ok></button>
-   <button cancel></button>
- </hbox>
 </vbox>
-</window>
-"
-else #'geanyfix.
- export MAIN_DIALOG="
-<window title=\"$(gettext 'Puppy Event Manager')\" icon-name=\"gtk-execute\">
-<vbox>
+<action signal="show" condition="command_is_true([[ '${BACKENDON}' != true ]] && echo true)">disable:NEWHOTPLUGON</action>
+<action signal="show" condition="command_is_true([[ '${BACKENDON}' != true ]] && echo true)">disable:NEWAUTOUNMOUNT</action>
+<action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWICONPARTITIONS</action>
+</window>'
 
-  <text use-markup=\"true\">
-  <label>\"<b>$(gettext 'Restart X for changes to take effect')</b>\"</label></text>
-
-<notebook labels=\"$(gettext 'Activate')|$(gettext 'Save Session')|$(gettext 'Desktop Icons')|$(gettext 'Icon Handler')|$(gettext 'Legacy')|$(gettext 'Power')\">
-
- <frame $(gettext 'Activate Puppy Event Manager')>
-  <text><label>$(gettext "The 'pup_event' Puppy Event Manager runs in the background and handles hotplugging of drives, including the desktop drive icons. This also includes automatic module and firmware loading if new hardware is detected. However, turn it all off, and Puppy will revert to the same behaviour as versions prior to 4.x, in which there is no hotplug support. This reduces resource usage, so try unticking these on very old slow PCs. Pmount can still be run manually to mount and unmount partitions.")</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for hotplug module/firmware loading')</label>
-   <default>${BACKENDON}</default>
-   <variable>NEWBACKENDON</variable>
-  </checkbox>
-
-  <hbox>
-  <text><label>\"  \"</label></text>
-  <vbox>
-  <text><label>$(gettext 'If the above is ticked, then can also turn on these:')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for desktop hotplug support')</label>
-   <default>${HOTPLUGON}</default>
-   <variable>NEWHOTPLUGON</variable>
-  </checkbox>
-  <checkbox>
-   <label>$(gettext 'Tick box for auto unmounting of partitions')</label>
-   <default>${AUTOUNMOUNT}</default>
-   <variable>NEWAUTOUNMOUNT</variable>
-  </checkbox>
-  <text><label>$(gettext '(WARNING: auto unmounting is highly experimental)')</label></text>
-  </vbox>
-  </hbox>
-
-
- </frame>
-
- <frame $(gettext 'Periodic save from RAM')>
- <vbox>
-  <text><label>$(gettext "Puppy runs in a particular 'state' that we call the PUPMODE. This depends on the type of installation and the type of hardware. Currently, PUPMODE=")${PUPMODE}. $(gettext "If it is an odd number, for example 13, then Puppy is doing everything in RAM and saving the current session to a drive periodically -- this is done in the case of Flash memory to make it last longer. When Puppy runs in an odd PUPMODE, there will be a 'save' icon on the desktop, also a save occurs at shutdown. You can also specify a periodic save here:")</label></text>
-  <hbox>
-   <text><label>$(gettext 'Save interval (0=never):')</label></text>
-   <entry max_length=\"4\">
-    <default>${RAMSAVEINTERVAL}</default>
-    <variable>NEWRAMSAVEINTERVAL</variable>
-   </entry>
-   <text><label>$(gettext 'minutes')</label></text>
-   <text><label>\"       \"</label></text>
-  </hbox>
-  <text><label>$(gettext 'NOTE1: PUPMODE=77 (multisession DVD) excluded, only manual save with desktop icon and at shutdown.')</label></text>
-  <text><label>$(gettext 'NOTE2: PUPMODE=5 there are no saves, above value ignored.')</label></text>
- </vbox>
- </frame>
- 
- <frame $(gettext 'Drive icons on desktop')>
- <vbox>
-  <text><label>$(gettext "When this box is ticked, there will be an icon for each drive. If you plugin a USB pen drive for example, an icon will appear. Unplug and it will disappear. If you don't want these drive icons on the desktop, untick this box (but there will still remain just one icon that will launch Pmount when clicked on). The individual drive icons are purely a convenience and Puppy works fine without them.")</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for drive icons on desktop')</label>
-   <default>${ICONDESK}</default>
-   <variable>NEWICONDESK</variable>
-  </checkbox>
-
-  <hbox>
-  <text><label>\"  \"</label></text>
-  <vbox>
-  <text><label>$(gettext 'If the above is ticked, then you can choose to have an icon for each partition, rather than one icon for the entire drive:')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for an icon for each partition')</label>
-   <default>${ICONPARTITIONS}</default>
-   <variable>NEWICONPARTITIONS</variable>
-  </checkbox>
-  </vbox>
-  </hbox>
-
-  <checkbox>
-   <label>$(gettext 'Tick box to erase then redraw and realign existing icons')</label>
-   <default>false</default>
-   <variable>NEWICONWIPE</variable>
-  </checkbox>
-
- </vbox>
- </frame>
-
-
- <frame $(gettext "Drive 'handler'")>
- 
- <vbox>
-  <text><label>$(gettext "The 'handler' decides what to do when you click on a desktop drive icon. Normally, this just starts Pmount if you click on a drive icon, or mounts it and starts ROX-Filer if a partition icon, but this behavior can be extended by these checkboxes.")</label></text>
-  
-  <text><label>$(gettext 'This checkbox extends the default behavior, and will launch a more appropriate application. Currently, it adds detection of a video DVD or audio CD and launches the media player:')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for auto-detection of target application')</label>
-   <default>${AUTOTARGET}</default>
-   <variable>NEWAUTOTARGET</variable>
-  </checkbox>
- </vbox>
-  
- <vbox>
-  <text><label>$(gettext "Normally you have to click on a drive icon to run the 'handler', but this checkbox makes the 'handler' run as soon as a media is plugged in. For example, plug in a DVD and it will immediately either get mounted, or if the above checkbox is ticked the media player will run:")</label></text>
-  <checkbox>
-   <label>$(gettext "Tick box for auto-launch 'handler' when media plugged in")</label>
-   <default>${HOTPLUGNOISY}</default>
-   <variable>NEWHOTPLUGNOISY</variable>
-  </checkbox>
- </vbox>
-
- </frame>
- 
- <frame $(gettext 'Legacy')>
-  <text><label>$(gettext 'Linux does not support hotplug detection of when a legacy floppy diskette is inserted or removed. Periodic probing requires starting the drive motor, which is very slow -- and do you want the motor to startup every 4 seconds? Therefore, if your PC has a floppy drive, tick this box to have a permanent icon on desktop (regardless whether a diskette is actually inserted, or even a floppy drive!).')</label></text>
-  <checkbox>
-   <label>$(gettext 'Tick box for floppy drive icon on desktop')</label>
-   <default>${FD0ICON}</default>
-   <variable>NEWFD0ICON</variable>
-  </checkbox>
- </frame>
-
- <frame $(gettext 'Power')>
- <vbox>
-  <text><label>$(gettext 'Puppy is able to power-off your computer after a period of mouse inactivity. This will occur if the mouse cursor has not been moved for the designated interval:')</label></text>
-  <hbox>
-   <text><label>$(gettext 'Inactivity interval (0=never):')</label></text>
-   <entry max_length=\"4\">
-    <default>${POWERTIMEOUT}</default>
-    <variable>NEWPOWERTIMEOUT</variable>
-   </entry>
-   <text><label>$(gettext 'minutes')</label></text>
-   <text><label>\"       \"</label></text>
-  </hbox>
- </vbox>
- </frame>
- 
- </notebook>
-
- <hbox>
-   <button ok></button>
-   <button cancel></button>
- </hbox>
-</vbox>
-</window>
-" #'geany fix
-fi
-
-RETSTRING="`gtkdialog3 --program=MAIN_DIALOG --center`"
+RETSTRING="`gtkdialog -p Puppy_Event_Manager`"
 [ $? -ne 0 ] && exit
 
 eval "$RETSTRING"


### PR DESCRIPTION
This is a test of giving Puppy a general facelift.
Is it too dangerous, or are you willing to let me swipe through the guis.

Please check the diff, and validate.
Could we settle on some guidelines?
- Only touch gtkdialog code
- Take advantages of the recent gtkdialog features
- Allow scaling of window
- Clean up gui
- Make gui code more human readable
- Change gtkdialog3/4 to gtkdialog
- Touch-friendly interface
- All text should be set by gettext
