### PR TITLE
change syntax for 'Boot Manager' in System-menu 

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/applications/BootManager-configure-bootup.desktop
+++ b/woof-code/rootfs-skeleton/usr/share/applications/BootManager-configure-bootup.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=BootManager configure bootup
+Name=Boot Manager
 Icon=so.xpm
 Comment=BootManager configure bootup
 Exec=bootmanager


### PR DESCRIPTION
One small step in towards a clean menu.

It is maybe just me, but
'BootManager configure bootup'
is just too much.
'Boot Manager' tells it all.
