### PR TITLE
Update fontmanager: use xml_button-icon

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/fontmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/fontmanager
@@ -111,7 +111,7 @@ S='
               <action>rox -d /usr/share/fonts/default/TTF</action>
             </button>'
             S=$S'<button>
-	          <input file>/usr/share/pixmaps/puppy/font_add.svg</input>
+	          '"`/usr/lib/gtkdialog/xml_button-icon font_add.svg`"'
 	          <label>'$(gettext 'Install font(s)')'</label>
 	          <action>install</action>
 	          <action>clear:FONT</action>


### PR DESCRIPTION
Mick discovered that the default scaling of the svg icons is not compatible with how jwm scales icons in the menu.

Now all icons is set static to 100x100
To fix scaling of buttons, I have pointed the button height-setting to /usr/lib/gtkdialog xml_button-icon

Now, let's see if this solution is bullet proof
