### PR TITLE
/usr/sbin/bootmanager: Speedup yeslist_func by using

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/bootmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/bootmanager
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/ash
 #BK 2007, original idea from sunburnt
 #Lesser GPL licence v2 (/usr/share/doc/legal). 2007 www.puppylinux.com
 #written for Puppy 2.16.
@@ -57,6 +57,7 @@ export OUTPUT_CHARSET=UTF-8
 CLPARAM1="$1"
 CLPARAM2="$2"
 
+MY_SELF="$0"
 CURRDIR="`pwd`"
 . /etc/rc.d/PUPSTATE
 . /etc/DISTRO_SPECS
@@ -147,7 +148,7 @@ extrasfs_func() {
  #  UNMOUNTME="/mnt/$PDEV1"
  # fi
  #fi
- 	
+
  #cd $EXTRASFSMNTPT
  #v409 lobster gets some non-sfs files in ALLSFSLIST ...i have no idea how, but
  #need an extra grep filter here... w007 new name woof-007.sfs ... w478 fix for 'pup2' prefix... 100809 bug fix...
@@ -155,7 +156,7 @@ extrasfs_func() {
  #cd $CURRDIR
  sync
  [ "$UNMOUNTME" != "" ] && umount $UNMOUNTME
- 
+
  #eliminate other versions from list...
  BASEFIXEDSFSLIST=""; ITEMCNT=0
  rm -f /tmp/bootmanager_wrong_sfs_version 2>/dev/null #v423
@@ -216,7 +217,7 @@ extrasfs_func() {
  do
   DLGLIST="$DLGLIST $ONESFS $ONESFS on"
  done
- 
+
  #v423 let user know wrong sfs's...
  if [ -e /tmp/bootmanager_wrong_sfs_version ];then
   pupmessage -bg '#FFC0C0' "`eval_gettext \"NOTICE: The following SFS files located in directory \\\${MSGz}
@@ -228,7 +229,7 @@ are the wrong version for the current Linux kernel:\"`
 The kernel requires \\\${SFSSTR}, SFS files.
 Note, there is an SFS-version-converter in the Utility menu.\"`" &
  fi
- 
+
  if [ "$DLGLIST" = "" ];then
   [ "$CLPARAM2" = "quiet" ] && return 1
   pupmessage -center -bg '#FFC0C0' "`eval_gettext \"Sorry, there are no SFS files in directory \\\$MSGz
@@ -241,7 +242,7 @@ You will need to download and place one there first.\"`"
 #v424 remove checkbox...
 # EXECME="Xdialog --wmclass \"module16\" --backtitle \"Choose which SFS files are to be loaded at bootup.\n(top entry will be on top Unionfs layer)\" --title \"BootManager: SFS files\" --left --stdout --separator \" \" --check \"Ignore above user selection, load all with '_${DISTRO_VERSION}.sfs' in filename\" $EXTRASFSAUTO --help \"
  #EXECME="Xdialog --wmclass \"module16\" --backtitle \"Choose which SFS files are to be loaded at bootup.\n(top entry will be on top Unionfs layer)\" --title \"BootManager: SFS files\" --left --stdout --separator \" \" --help \"Extra SFS files are available for your Puppy: see announcements on the Forum.\n\nDownload to '$MSGz', choose what you want using the BootManager,\nthen reboot Puppy.\n\nNote1: \nBootManager is in the 'System' menu.\nNote2: \nWhen naming an SFS file, do not name it with '_nnn.sfs' where the nnn is\n3 numeric digits, as Puppy will interpret this as a Puppy-version number, \nand will refuse to load it if it is not '_${DISTRO_VERSION}.sfs'.\nNote3: \nIn fact, if '_nnn.sfs' is not '_${DISTRO_VERSION}.sfs' then it will not even\nbe listed -- please note this!\" --buildlist \"Note1: No more than 6 SFS files in right-pane!\n${MSGx}\" 0 0 8 $DLGLIST >/tmp/bmrettags.txt"
- #111113 revert to Xdialog... 
+ #111113 revert to Xdialog...
  EXECME="Xdialog --wmclass \"module16\" --backtitle \"$(gettext 'Choose which SFS files are to be loaded at bootup.\n(top entry will be on top Unionfs layer)')\" --title \"$(gettext 'BootManager: SFS files')\" --left --stdout --separator \" \" --help \"`eval_gettext \"Please click the 'install' icon on the desktop for information about SFS files.\nYou will find an introduction, plus links to SFS files that can be downloaded.\n\nNote, the BootManager performs some filtering of the available SFS files,\nscreening out some that might have incorrect version number -- files of the\nformat '*_nnn.sfs' should be '*_\\\${DISTRO_VERSION}.sfs' to pass the filter.\"`\" --buildlist \"$(gettext 'Note1: No more than 6 SFS files in right-pane!')\n${MSGx}\" 0 0 8 $DLGLIST >/tmp/bmrettags.txt"
 # #111011 change over to pupdialog...
 # EXECME="pupdialog --helpwindow \"/tmp/bootmanager_help_sfs\" --backtitle \"Choose which SFS files are to be loaded at bootup\" --title \"BootManager: SFS files\" --stdout --ok-label \"OKAY\" --cancel-label \"Cancel\" --checklist \"Note1: No more than 6 SFS files may be selected\n${MSGx}\" 0 0 0 $DLGLIST >/tmp/bmrettags.txt"
@@ -265,7 +266,7 @@ You will need to download and place one there first.\"`"
  eval ${EXECME}
  RETVAL=$?
  [ ! $RETVAL -eq 0 ] && return 1
- 
+
  #111113 revert...
  RETTAGS="`cat /tmp/bmrettags.txt`"
 # #111011 actually, now want the description fields... grep -w option not good enough...
@@ -275,7 +276,7 @@ You will need to download and place one there first.\"`"
 #  echo "$BMRETTAGS" > /tmp/bmrettags.txt #converted tags to reg. expressions.
 #  RETTAGS="`grep -f /tmp/bmrettags.txt /tmp/bootmanager_sfs_dlglist | cut -f 2 -d ' ' | tr '\n' ' '`"
 # fi
- 
+
  #v424 remove...
  #if [ "`echo "$RETTAGS" | grep 'unchecked'`" = "" ];then
  # #auto mode, remove EXTRASFSLIST entry from BOOTCONFIG...
@@ -292,7 +293,7 @@ You will need to download and place one there first.\"`"
  grep -v 'EXTRASFSLIST' /etc/rc.d/BOOTCONFIG > /tmp/BOOTCONFIG
  cat /tmp/BOOTCONFIG > /etc/rc.d/BOOTCONFIG
  echo "EXTRASFSLIST='${RETTAGS}'" >> /etc/rc.d/BOOTCONFIG
- 
+
  #120527 shinobar's sfs-load on-the-fly pet has this, sync it...
  if [ -f /etc/rc.d/BOOTCONFIG.save ];then
   bPTN="s%^EXTRASFSLIST=.*%EXTRASFSLIST='${RETTAGS}'%"
@@ -333,10 +334,13 @@ Note, you need to reboot for any change to take effect.')\" 0 0 8 $MODLIST >/tmp
 yeslist_func() {
  #choose extra modules to load at bootup.
 # yaf-splash -font "8x16" -outline 0 -margin 4 -bg orange -text "Please wait, processing..." &
- yaf-splash -close never -bg orange -text "$(gettext 'Please wait, processing...')" &
+ file `which yaf-splash` | grep -q ELF || PARAMS='-close never'
+ yaf-splash $PARAMS -bg orange -text "$(gettext 'Please wait, processing...')" &
  X1PID=$!
  . /etc/rc.d/MODULESCONFIG
  MODLIST=""
+
+old_slow_off_list(){
  #note, lsmod will show all modules with '-' as '_'...
  LOADEDMODULES=" `lsmod | grep -v '^Module' | cut -f 1 -d ' ' | tr '\n' ' '`"
  #v403 handles both .ko and .ko.gz modules...
@@ -350,8 +354,18 @@ yeslist_func() {
   MODPATTERN=' '"$NAMEONLY"'[ :]'
   #leave off left pane if already on right pane...
   [ "`echo "$ADDLIST" | grep "$MODPATTERN"`" != "" ] && continue
-  MODLIST="$MODLIST $NAMEONLY $NAMEONLY off"  
- done
+  MODLIST="$MODLIST $NAMEONLY $NAMEONLY off"
+  done
+} #old_slow_off_list
+
+  LOADEDMODULES=`cut -f1 -d' ' /proc/modules`
+  ALLMODULES=`cut -f 1 -d ':' /lib/modules/$KERNVER/modules.dep | grep -o '[a-zA-Z0-9_-]*\.ko' | tr '\-' '_' | sed 's%\.k.*$%%' | sort`
+  ALLMODULES=`echo "$ALLMODULES" | /bin/grep -vw "$LOADEDMODULES"`
+  ADDLIST_MOD_ONLY=`echo "$ADDLIST" | tr ' ' '\n' | sed 's%:.*%%;/^$/d'`
+  ALLMODULES=`echo "$ALLMODULES" | /bin/grep -vw "$ADDLIST_MOD_ONLY"`
+  ALLMODULES=`echo "$ALLMODULES" | sed 's%\(.*\)%& & off%'`
+  MODLIST=`echo "$ALLMODULES" | tr '\n' ' '`
+  #echo "$MODLIST" >&2
  for ONEMOD in $ADDLIST
  do
   NAMEONLY="$ONEMOD"
@@ -366,13 +380,16 @@ yeslist_func() {
   [ "`echo "$LOADEDMODULES" | grep "$MODPATTERN"`" != "" ] && continue
   MODLIST="$MODLIST $ONEMOD \"$xONEMOD\" on"
  done
- kill $X1PID
+ #echo >&2
+ #echo "$MODLIST" >&2
+ [ "$MODLIST" ] || : ##TODO something
+ kill $X1PID 2>/dev/null
  EXECME="Xdialog --wmclass \"module16\" --title \"$(gettext 'BootManager: Module add-list manager')\" --left --stdout --separator \" \" --buildlist \"$(gettext 'On the left pane is the complete list of modules available to be\nused by Puppy (and not currently loaded).\nOn the right pane are modules that you have explicitly chosen to\nbe loaded at bootup (not auto-loaded by default).\nIf you want to force a module to load, move it to the right pane,\nclick OK button, then reboot Puppy.\nNote, if you want to find out further information about any module,\nrun PupScan (look in the System menu)')\" 0 0 8 $MODLIST >/tmp/yesrettags.txt"
  eval $EXECME
  RETVAL=$?
  [ ! $RETVAL -eq 0 ] && return 1
  cat /tmp/yesrettags.txt | tr ' ' '\n' | tr ':' ' ' > /tmp/modules_addlist_edit #v411
- Xdialog --backtitle "$(gettext "If you wish, add any required parameters to these modules\nExample: mmc_block major=179\nIf you don't know what this means, just click 'OK' button")"  --wmclass "module16" --title "$(gettext 'BootManager: Edit module addlist')" --left --stdout --no-cancel --editbox /tmp/modules_addlist_edit 0 0 > /tmp/modules_addlist_edit_out
+ Xdialog --backtitle "$(gettext "If you wish, add any required parameters to these modules\nExample: mmc_block major=179\nIf you don't know what this means, just click 'OK' button")"  --wmclass "module16" --title "$(gettext 'BootManager: Edit module addlist')" --left --stdout --no-cancel --editbox /tmp/modules_addlist_edit 0 0 > /tmp/modules_addlist_edit_out  #'geany
  [ $? -ne 0 ] && return 1
  ADDLIST="`cat /tmp/modules_addlist_edit_out`"
  ADDLIST=' '"`echo "$ADDLIST" | tr ' ' ':' | tr '\n' ' ' | tr -s ' '`"
@@ -435,7 +452,7 @@ sysdaemons_func() { #100125
  [ "`grep '^BACKENDON' /etc/eventmanager | grep 'true'`" != "" ] && OSDDEFAULT='true'
  OSDBOXES="${OSDBOXES} <checkbox><label>udev (`gettext \"Hardware hotplug detection -- see 'Help'\"`)</label><default>${OSDDEFAULT}</default><variable>OSDCHK_${osdcnt}_</variable></checkbox>"
  echo "OSDCHK_${osdcnt}_||udev" >> /tmp/bootmanager_osd
- 
+
  export BootManager_Services='
 <window title="'$(gettext 'BootManager - System services')'" icon-name="gtk-execute" default-height="400">
 <vbox space-expand="true" space-fill="true">
@@ -460,7 +477,7 @@ sysdaemons_func() { #100125
 </vbox>
 </window>'
 
- RETSTRING="`gtkdialog -p BootManager_Services`" 
+ RETSTRING="`gtkdialog -p BootManager_Services`"
  [ "`echo "$RETSTRING" | grep 'EXIT' | grep 'OK'`" = "" ] && return
  while [ $osdcnt -gt 0 ];do
   OSDVAR="OSDCHK_${osdcnt}_"
@@ -490,68 +507,67 @@ You will need to untick the 'hotplug module/firmware loading' checkbox...\"`"
   fi
   osdcnt=`expr $osdcnt - 1`
  done
- 
+
 } #end sysdaemons_func
 
 if [ "$CLPARAM1" = "extrasfs" ];then
  extrasfs_func
  exit
-fi
 
-if [ "$CLPARAM1" = "blacklist" ];then
+elif [ "$CLPARAM1" = "blacklist" ];then
  blacklist_func
  exit
-fi
 
-if [ "$CLPARAM1" = "yeslist" ];then
+elif [ "$CLPARAM1" = "yeslist" ];then
  yeslist_func
  exit
-fi
 
-if [ "$CLPARAM1" = "preflist" ];then
+elif [ "$CLPARAM1" = "preflist" ];then
  preflist_func
  exit
-fi
 
-if [ "$CLPARAM1" = "sysdaemons" ];then #100125
+elif [ "$CLPARAM1" = "sysdaemons" ];then #100125
  sysdaemons_func
  exit
 fi
 
 #120626 only offer to load sfs files if have layered f.s., mention sfs_load...
 if [ -d /initrd ];then #PUPMODE=2, full hd install, will not have this.
-	if [ "`cat /root/.packages/woof-installed-packages /root/.packages/user-installed-packages | grep '^sfs_load'`" != "" ];then
-		SFSLOAD_XML="$(gettext "ALTERNATIVE: Shinobar's SFS_Load application will enable you to install SFS files on-the-fly, that is, load and unload them without having to reboot -- see the 'Setup' menu.")"
-	fi
-	SFSFRAME_XML='
-	<frame '$(gettext 'Load SFS files')'>
-	  <vbox space-expand="true" space-fill="true">
-		'"`/usr/lib/gtkdialog/xml_info scale package_sfs.svg 60 "$(gettext "Puppy has a file named") ${DISTRO_PUPPYSFS} $(gettext "that is always loaded. However, extra SFS files can be loaded at bootup, for example 'kde.sfs' to provide KDE applications, and 'devx.sfs' to provide everything for compiling C/C++ source. These can be thought of as 'combo packs' of many packages in one file.")" " " "${SFSLOAD_XML}"`"'
-		<vbox space-expand="false" space-fill="false">
-		  <text height-request="20"><label>""</label></text>
-		  <hbox>
-			<text><label>'$(gettext 'Choose which extra SFS files to load at bootup')'</label></text>
-			<button>
+    if [ "`cat /root/.packages/woof-installed-packages /root/.packages/user-installed-packages | grep '^sfs_load'`" != "" ];then
+        SFSLOAD_XML="$(gettext "ALTERNATIVE: Shinobar's SFS_Load application will enable you to install SFS files on-the-fly, that is, load and unload them without having to reboot -- see the 'Setup' menu.")"
+    #'geany
+    fi
+    SFSFRAME_XML='
+    <frame '$(gettext 'Load SFS files')'>
+      <vbox space-expand="true" space-fill="true">
+        '"`/usr/lib/gtkdialog/xml_info scale package_sfs.svg 60 "$(gettext "Puppy has a file named") ${DISTRO_PUPPYSFS} $(gettext "that is always loaded. However, extra SFS files can be loaded at bootup, for example 'kde.sfs' to provide KDE applications, and 'devx.sfs' to provide everything for compiling C/C++ source. These can be thought of as 'combo packs' of many packages in one file.")" " " "${SFSLOAD_XML}"`"'
+        <vbox space-expand="false" space-fill="false">
+          <text height-request="20"><label>""</label></text>
+          <hbox>
+            <text><label>'$(gettext 'Choose which extra SFS files to load at bootup')'</label></text>
+            <button>
               '"`/usr/lib/gtkdialog/xml_button-icon package_sfs.svg big`"'
-			  <action>bootmanager extrasfs</action>
-			</button>
-		  </hbox>
-		  <text height-request="5"><label>""</label></text>
-		</vbox>
-	  </vbox>
-	</frame>'
+              <action>'"$MY_SELF"' extrasfs &</action>
+            </button>
+          </hbox>
+          <text height-request="5"><label>""</label></text>
+        </vbox>
+      </vbox>
+    </frame>'
 else
-	if [ "`cat /root/.packages/woof-installed-packages /root/.packages/user-installed-packages  | grep '^sfs_load'`" != "" ];then
-		SFSLOAD_XML="$(gettext "Shinobar's SFS_Load application will enable you to install SFS files -- see the 'Setup' menu.")"
-	else
-		SFSLOAD_XML="$(gettext "TECHNICAL: Clicking on an SFS file will open it, and it's contents can then be copied to /. It is recommended to use the '-a -f --remove-destination' parameters for the 'cp' command.")"
-	fi
-	SFSFRAME_XML='
-	<frame '$(gettext 'Load SFS files')'>
-	  <vbox space-expand="true" space-fill="true">
-		'"`/usr/lib/gtkdialog/xml_info scale package_sfs.svg 60 "$(gettext "NOTICE: As this is a full installation of Puppy without an initrd, SFS files cannot be loaded/unloaded at bootup. However, they can be permanently installed.")" " " "${SFSLOAD_XML}"`"'	
-	  </vbox>
-	</frame>'
+    if [ "`cat /root/.packages/woof-installed-packages /root/.packages/user-installed-packages  | grep '^sfs_load'`" != "" ];then
+        SFSLOAD_XML="$(gettext "Shinobar's SFS_Load application will enable you to install SFS files -- see the 'Setup' menu.")"
+    #'geany
+    else
+        SFSLOAD_XML="$(gettext "TECHNICAL: Clicking on an SFS file will open it, and it's contents can then be copied to /. It is recommended to use the '-a -f --remove-destination' parameters for the 'cp' command.")"
+    #'geany
+    fi
+    SFSFRAME_XML='
+    <frame '$(gettext 'Load SFS files')'>
+      <vbox space-expand="true" space-fill="true">
+        '"`/usr/lib/gtkdialog/xml_info scale package_sfs.svg 60 "$(gettext "NOTICE: As this is a full installation of Puppy without an initrd, SFS files cannot be loaded/unloaded at bootup. However, they can be permanently installed.")" " " "${SFSLOAD_XML}"`"'
+      </vbox>
+    </frame>'
 fi
 
 #######################################################
@@ -572,21 +588,21 @@ export BootManager='
             <text><label>'$(gettext "'Blacklist' module")'</label></text>
             <button>
               '"`/usr/lib/gtkdialog/xml_button-icon module_no.svg big`"'
-              <action>bootmanager blacklist</action>
+              <action>'"$MY_SELF"' blacklist &</action>
             </button>
           </hbox>
           <hbox>
             <text><label>'$(gettext 'Add new module')'</label></text>
             <button>
               '"`/usr/lib/gtkdialog/xml_button-icon module_yes.svg big`"'
-              <action>bootmanager yeslist</action>
+              <action>'"$MY_SELF"' yeslist &</action>
             </button>
           </hbox>
           <hbox>
             <text><label>'$(gettext 'Give preference to one module over another')'</label></text>
             <button>
               '"`/usr/lib/gtkdialog/xml_button-icon module.svg big`"'
-              <action>bootmanager preflist</action>
+              <action>'"$MY_SELF"' preflist &</action>
             </button>
           </hbox>
           <text height-request="5"><label>""</label></text>
@@ -603,7 +619,7 @@ export BootManager='
             <text><label>'$(gettext 'Choose which system services to run at startup')'</label></text>
             <button>
               '"`/usr/lib/gtkdialog/xml_button-icon startup_services.svg big`"'
-              <action>bootmanager sysdaemons</action>
+              <action>'"$MY_SELF"' sysdaemons &</action>
             </button>
           </hbox>
           <text height-request="5"><label>""</label></text>
@@ -611,7 +627,7 @@ export BootManager='
       </vbox>
     </frame>
   </notebook>
- 
+
   <hbox height-request="30" space-expand="false" space-fill="false">
     <button>'"`/usr/lib/gtkdialog/xml_button-icon quit`"'<label>'$(gettext 'Quit')'</label></button>
   </hbox>


### PR DESCRIPTION
ash instead of sh and bypassing the slow for loop on the myriads of modules.

Minor thingis :
     Use elif instead of many if .
     Use MY_SELF instead of action bootmanager to be able to run several versions that are renamed.
     Several geany formatting fixes.
     Make yaf-splash compatible with the binary version of Puppy-4.
