### PR TITLE
/etc/rc.d/rc.shutdown : Move code that prints

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -97,13 +97,6 @@ which rfkill &>/dev/null && rfkill unblock all #110919 jemimah has this in flupp
 
 ORIGPUPMODE=$PUPMODE #v2.22
 
-#echo "`eval_gettext \"\\\${DISTRO_NAME} is now shutting down...\"`" > /dev/console
-#echo "${DISTRO_NAME} is now shutting down..." > /dev/console
-echo "${DISTRO_NAME} $(gettext 'is now shutting down...')" > /dev/console #120130
-
-#echo $(gettext "Executing /etc/rc.d/rc.shutdown...")
-echo "Executing /etc/rc.d/rc.shutdown..."
-
 #puppy.sfs is in a subdirectory, default to saving in it...
 PUPSFSFILE="`echo "$PUPSFS" | cut -f 3 -d ','`"
 PSUBDIR="`dirname "$PUPSFSFILE"`"
@@ -145,6 +138,13 @@ killzombies() {
   kill $ONEZOMBIE
  done
 }
+
+#echo "`eval_gettext \"\\\${DISTRO_NAME} is now shutting down...\"`" > /dev/console
+#echo "${DISTRO_NAME} is now shutting down..." > /dev/console
+echo "${DISTRO_NAME} $(gettext 'is now shutting down...')" > /dev/console #120130
+
+#echo $(gettext "Executing /etc/rc.d/rc.shutdown...")
+echo "Executing /etc/rc.d/rc.shutdown..."
 
 #100315 improper shutdown check. see /etc/rc.d/rc.sysinit, /init in initramfs, and /sbin/init...
 if [ -f /fsckme.flg ];then


### PR DESCRIPTION
is now shutting down... out of the VARIABLES generation block
below the last "known" function of the head of the script.
