### PR TITLE
/usr/sbin/shutdownconfig : Write xPSUBDIR variable

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -86,14 +86,14 @@ DU_INITRD_PUP_RW=0
 #130525 introduced 130522. moved up.
 ORANGEGTKRC="style \"windowstuff\"
 {
-	bg[NORMAL]		= \"#FFDC32\"
-	fg[NORMAL]		= \"#000000\"
+    bg[NORMAL]      = \"#FFDC32\"
+    fg[NORMAL]      = \"#000000\"
 }
 class \"*\" style \"windowstuff\"
 "
 echo "$ORANGEGTKRC" > /tmp/orange_gtkrc${$}
 
-choosepartfunc() { 
+choosepartfunc() {
  #dialog to choose what partition to create ${DISTRO_FILE_PREFIX}save.2fs on...
  T_admin="$(gettext 'administrator')"
  T_fidomsg="`eval_gettext \"fido CURRENTLY EXPERIMENTAL STATUS, PLEASE CHOOSE \\\${T_admin}\"`"
@@ -110,7 +110,7 @@ ${FIDOMSG2}"
  ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fidotitle" --colors --yes-label "$T_admin" --no-label "fido" --yesno "$T_yesno" 0 0 >/dev/console
  SAVECHOICE=$?
  [ $SAVECHOICE -eq 1 ] && /usr/sbin/root2user
- 
+
  [ ! "$PMEDIA" ] && PCHOOSE="yes"
  [ "$PMEDIA" = "cd" ] && PCHOOSE="yes"
  [ "$PMEDIA" = "scsicd" ] && PCHOOSE="yes"
@@ -146,7 +146,7 @@ ${FIDOMSG2}"
   PUPSAVE="$PDEV1,$DEV1FS,$SAVEFILE"
   return 0
  fi
- 
+
  if [ "$expBOOTDRV" = "" ];then
   T_fidotitle="$(gettext 'First shutdown: get ready')"
   T_yesno1="$(eval_gettext "WARNING: If you want to create a save-file (\${DISTRO_FILE_PREFIX}save.2fs) in a NTFS partition (Windows XP), it is strongly recommended that you defragment the partition first.")
@@ -157,7 +157,7 @@ ${FIDOMSG2}"
   ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fidotitle" --colors --yes-label "$T_continue" --no-label "$T_abort" --yesno "$T_yesno" 0 0 >/dev/console
   [ ! $? -eq 0 ] && return 1 #abort.
  fi
- 
+
  #130216 add f2fs...
  PARTSLIST="`probepart -m 2> /dev/null | grep '^/dev/' | grep "$expBOOTDRV" | grep -E 'f2fs|ext2|ext3|ext4|reiserfs|msdos|vfat|minix|ntfs|btrfs' | cut -f 1-3 -d '|' | sed -e 's/msdos/vfat/g'`"
 
@@ -172,7 +172,7 @@ ${FIDOMSG2}"
    fi
   fi
  fi
- 
+
  #nothing to save to...
  if [ "$PARTSLIST" = "" ];then
   if [ $DISPLAY ];then
@@ -244,7 +244,7 @@ $(gettext "Instead, you should first run Microsoft Windows -- most often this pr
   fi
  done
  kill $ppPID
- 
+
  [ -s /tmp/shutdownconfig_deftag ] && DEFTAG="`cat /tmp/shutdownconfig_deftag`"
  [ -s /tmp/schoices.txt ] && SCHOICES="`cat /tmp/schoices.txt`"
  if [ "$SCHOICES" = "" ];then
@@ -258,7 +258,7 @@ $(gettext "Instead, you should first run Microsoft Windows -- most often this pr
   return 1
  fi
  xSCHOICES="`cat /tmp/schoices.txt | tr '\n' ' '`"
- 
+
  if [ `echo "$SCHOICES" | wc -l` -eq 1 ];then
   SAVEPART="`echo -n "$SCHOICES" | cut -f 1 -d ' '`" #no need for dlg.
  else
@@ -275,15 +275,15 @@ $(gettext 'Highlight desired choice, then click OK button...')"
   echo -n "$xSCHOICES"  >> /tmp/savedlg
   echo ' 2>/tmp/tag.txt' >> /tmp/savedlg
   chmod 755 /tmp/savedlg
- 
+
   #seems some people have problem, do not select anything...
   T_notchosentitle="$(gettext 'First shutdown: Not chosen')"
   T_tryagain="$(gettext 'Try again')"
   T_yesno="$(gettext '\Zb\Z1ERROR:\Zn\ZB you did not choose any partition.')
-  
+
 $(eval_gettext 'Choose \Zb${T_tryagain}\ZB button to try again...')
 $(eval_gettext 'Or, \Zb${T_abort}\ZB to shutdown without saving...')"
-  
+
   while [ 1 ];do
    /tmp/savedlg >/dev/console
    SAVEPART="`cat /tmp/tag.txt | head -n 1`" #head is in case of errs in output.
@@ -295,7 +295,7 @@ $(eval_gettext 'Or, \Zb${T_abort}\ZB to shutdown without saving...')"
    break
   done
  fi
- 
+
  SAVEFS="`echo "$SCHOICES" | grep "^${SAVEPART} " | tr -s " " | cut -f 2 -d ':' | cut -f 2 -d " "`"
  SAVEFILE="$PSUBDIR/${DISTRO_FILE_PREFIX}save.2fs"
  [ "$SAVEPART" = "fd0" ] && SAVEFILE="/${DISTRO_FILE_PREFIX}save.2fs"
@@ -328,7 +328,7 @@ choosesizefunc(){
   fi
   NUM=`expr $NUM + 1`
  done
- 
+
  T_sizetitle="$(gettext 'First shutdown: size save-file')"
  T_sitemenu="$(gettext 'Please choose the size you would like for the personal save file.')
 $(gettext 'Note, 512M is a good choice, or highest if that not available.')
@@ -351,7 +351,7 @@ pupsavefunc() {
   mount -t $SAVEFS /dev/$SAVEPART /mnt/$SAVEPART
   SMNTPT="/mnt/$SAVEPART"
  fi
- 
+
  #choose f.s. of save-file... 100410 for now, leave out ext4, doesn't work...
  #dialog --no-cancel --title "Choose filesystem of save-file" --menu "Previously, Puppy has only used 'ext2', now there is a choice. Regarding power-failure, note that Puppy will do a f.s. check at next boot so ext2 can recover, however journalled filesystems can recover even without a f.s. check. If in doubt, just press ENTER to choose 'ext2', otherwise TAB down then ENTER..." 0 0 0 ext2 "Maximum storage space, encrypted save-file must use ext2" ext3 "Journalled f.s., safest if power failure etc." ext4 "Journalled f.s., safest if power failure etc."  >/dev/console 2>/tmp/rc.shutdown_pupsave_fs
  T_fstitle="$(gettext 'First shutdown: choose filesystem')"
@@ -378,7 +378,7 @@ pupsavefunc() {
  SAVEFILE="`echo -n "$SAVEFILE" | sed -e "$sfPATTERN"`"
  PUPSAVE="$SAVEPART,$SAVEFS,$SAVEFILE"
  NAMEONLY="`basename $SAVEFILE`"
- 
+
  #customise the name of the ${DISTRO_FILE_PREFIX}save file...
  T_nametitle="$(gettext 'First shutdown: save-file name')"
  T_nameinput="$(eval_gettext "Would you like to customise the name of the '\${DISTRO_FILE_PREFIX}save.\${SFEXT}' file?")
@@ -393,7 +393,7 @@ $(gettext 'Type any characters you wish, then click OK button:')"
   SAVEFILE="$PSUBDIR/$NAMEONLY"
   PUPSAVE="$SAVEPART,$SAVEFS,$SAVEFILE"
  fi
- 
+
  CRYPTO=""
  T_cryptotitle="$(gettext 'First shutdown: encryption')"
  T_cryptono="$(gettext 'NORMAL (no encryp.)')"
@@ -442,13 +442,13 @@ entered at every bootup.')"
   PUPSAVE="$SAVEPART,$SAVEFS,$SAVEFILE"
  fi
  MNAMEONLY="`basename $SAVEFILE .${SFEXT}`"
- 
+
  #save with different name if clash...
  if [ -f $SMNTPT$SAVEFILE ]; then
   T_clashtitle="$(gettext 'First shutdown: name clash')"
   T_save="$(gettext 'SAVE')"
   T_yesno="$(eval_gettext "There already exists a '\${NAMEONLY}' file on the partition you chose.")
-  
+
 $(eval_gettext 'To create another one, with a slightly different name (such as ${MNAMEONLY}-1.${SFEXT}), select \Zb${T_save}\ZB button...')
 $(eval_gettext 'To quit without saving, select \Zb${T_no}\ZB button...')"
   ${DIALOGEXE} ${BACKGROUNDPINK} ${TITLEPARAM} "$T_clashtitle" --colors --yes-label "$T_save" --yesno "$T_yesno" 0 0 >/dev/console
@@ -461,7 +461,7 @@ $(eval_gettext 'To quit without saving, select \Zb${T_no}\ZB button...')"
   PUPSAVE="$SAVEPART,$SAVEFS,$SAVEFILE"
   NAMEONLY="`basename $SAVEFILE`"
  fi
- 
+
  #we should check to see that there is enough space on the partition...
  PARTFREE=`df | grep "$SMNTPT" | tr -s " " | head -n 1 | cut -f 4 -d " "`
  [ ! $PARTFREE ] && PARTFREE=0
@@ -476,7 +476,7 @@ $(eval_gettext 'To quit without saving, select \Zb${T_no}\ZB button...')"
 
  SAVEPATH="`dirname $SAVEFILE`"
  [ ! -d ${SMNTPT}${SAVEPATH} ] && mkdir -p ${SMNTPT}${SAVEPATH}
-  
+
  #final sanity check...
  AAAMB=`expr $SIZEPFILE \/ 1024`
  T_sanititle="$(gettext 'First shutdown: sanity check')"
@@ -500,9 +500,9 @@ If anything looks wrong, choose \Zb\\\${T_notsave}\ZB...\"`"
   [ $SANITYRET -eq 0 ] && break
   if [ $SANITYRET -eq 3 ];then #change folder.
    T_choosefoldertitle="$(gettext 'First shutdown: choose folder')"
-   T_inputbox="$(gettext 'Edit path. '/' means top-level of partition. 
-You are only allowed to save one-deep, for example: '/puppy300'. 
-If folder does not exist, it will be created. Spaces are not allowed. 
+   T_inputbox="$(gettext 'Edit path. '/' means top-level of partition.
+You are only allowed to save one-deep, for example: '/puppy300'.
+If folder does not exist, it will be created. Spaces are not allowed.
 If uncertain, just click OK button.')"
    NEWSAVEPATH="`${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_choosefoldertitle" --screen-center --stdout --no-cancel --inputbox "$T_inputbox" 0 0 "$SAVEPATH"`"
    [ "$NEWSAVEPATH" = "" ] && NEWSAVEPATH="$SAVEPATH"
@@ -524,7 +524,7 @@ If uncertain, just click OK button.')"
  [ ! -d ${SMNTPT}${SAVEPATH} ] && return 1 #some kind of error, abort.
 
  #JOPT=""
- [ "$SAVEPART" = "fd0" ] && SIZEPFILE=`expr $SIZEPFILE - 16` 
+ [ "$SAVEPART" = "fd0" ] && SIZEPFILE=`expr $SIZEPFILE - 16`
  [ "$SFEXT" = "3fs" ] && JOPT='-j'
  #echo "Creating $NAMEONLY in /dev/$SAVEPART, please wait awhile..." >/dev/console
  T_createtitle="$(gettext 'First shutdown: creating save-file')"
@@ -568,7 +568,7 @@ If uncertain, just click OK button.')"
   #'-p 0' means read password from stdin...
   #v2.17 crap, '-p 0' works for aes, not for xor encryption....
   if [ "$CRYPTO" = '-E 1' ];then #light xor encr.
-  
+
    T_note1="$(gettext 'Note, a bug in one of the Linux utility programs requires you to reenter')"
    T_note2="$(gettext 'the password in the case of light encryption...')"
 
@@ -627,10 +627,10 @@ case $xDEVFS in
   #do not allow save to entire partition if pup installed in a subdirectory...
   xPSUBDIR="`echo -n "$PUPSFS" | cut -f 3 -d ',' | sed -e 's%/[^/]*$%%'`" #ex: sda3,ext2,/pup220/puppy.sfs will return /pup220
   SAVECHOICE=1
- 
+
   if [ "$xPSUBDIR" = "" ];then
-   T_nosubdir="`eval_gettext \"You can now choose to save the personal session files to a file, named '\\\${DISTRO_FILE_PREFIX}save.2fs'. 
-Or, if \\\${xPDEV} partition is not being used by anything else (no other operating system) then you can choose to save the session files direct to the partition. 
+   T_nosubdir="`eval_gettext \"You can now choose to save the personal session files to a file, named '\\\${DISTRO_FILE_PREFIX}save.2fs'.
+Or, if \\\${xPDEV} partition is not being used by anything else (no other operating system) then you can choose to save the session files direct to the partition.
 Either way, your choice will be remembered at next bootup.
 
 Which to choose?
@@ -640,14 +640,14 @@ Which to choose?
    if [ $DISPLAY ];then
     T_display="`eval_gettext \"If in doubt, click \Zb\\\${T_savetofile}\ZB button.
 
-Select \Zb\\\${T_savetofile}\ZB to create a '\\\${DISTRO_FILE_PREFIX}save.2fs file', 
+Select \Zb\\\${T_savetofile}\ZB to create a '\\\${DISTRO_FILE_PREFIX}save.2fs file',
 select \Zb\\\${T_savetopart}\ZB to save direct to partition, or \Zb\\\${T_notsave}\ZB to shutdown without saving session...\"`"
     yesno="$T_nosubdir \n\n$T_display \n\n$T_orwait240"
     pupdialog --background '#FFFF80' --colors --title "$T_canceltitle" --backtitle "$T_title" --timeout 240 --countdown "$T_countdown" --extra-button --ok-label "$T_savetofile"  --extra-label "$T_savetopart" --cancel-label "$T_notsave" --yesno "$yesno" 0 0 >/dev/console
    else
     T_display="`eval_gettext \"If in doubt, just press ENTER to accept the default.
 
-Select \Zb\\\${T_savetofile}\ZB to create a '\\\${DISTRO_FILE_PREFIX}save.2fs file', 
+Select \Zb\\\${T_savetofile}\ZB to create a '\\\${DISTRO_FILE_PREFIX}save.2fs file',
 select \Zb\\\${T_savetopart}\\\${PDEV1}   \ZB (TAB then ENTER) to save direct to partition, or \Zb\\\${T_notsave}\ZB to shutdown without saving session...\"`"
     yesno="$T_nosubdir \n\n$T_display \n\n$T_orwait240"
     dialog --colors --title "$T_title" --timeout 240 --extra-button --ok-label "$T_savetofile"  --extra-label "$T_savetopart" --cancel-label "$T_notsave" --yesno "$yesno" 0 0 >/dev/console
@@ -656,7 +656,7 @@ select \Zb\\\${T_savetopart}\\\${PDEV1}   \ZB (TAB then ENTER) to save direct to
   else
    T_subdir="`eval_gettext \"You can now choose to save the personal session files to a file, named '\\\${DISTRO_FILE_PREFIX}save.2fs'. Your choice will be remembered at next bootup.
 
-NOTE: You cannot choose to save the session to the entire partition \\\${xPDEV}, as Puppy is installed into a sub-directory '\\\${xPSUBDIR}'. If Puppy had been installed at '/', not in a folder, then you would have the option of saving the session to the entire partition (assuming that the partition does not have any other distro installed in it) which has the advantage of all the free space in the partition available for your session files.\"`"   
+NOTE: You cannot choose to save the session to the entire partition \\\${xPDEV}, as Puppy is installed into a sub-directory '\\\${xPSUBDIR}'. If Puppy had been installed at '/', not in a folder, then you would have the option of saving the session to the entire partition (assuming that the partition does not have any other distro installed in it) which has the advantage of all the free space in the partition available for your session files.\"`"
    if [ $DISPLAY ];then
     T_display="`eval_gettext \"Click the \Zb\\\${T_savetofile}\ZB button to create a '\\\${DISTRO_FILE_PREFIX}save.2fs' file, or \Zb\\\${T_notsave}\ZB to shutdown without saving session...\"`"
     yesno="$T_subdir \n\n$T_display \n\n$T_orwait240"
@@ -732,8 +732,8 @@ if [ $PUPMODE -eq 128 ];then #will be saving session.
    NAMEONLY="`basename $SAVEFILE`"
    T_copytitle="$(gettext 'First shutdown: copy .sfs from CD')"
    T_copy="$(gettext 'COPY')"
-   yesno="`eval_gettext \"The CD has '\\\${DISTRO_PUPPYSFS}' and maybe other .sfs files on it. It will speed startup considerably if these are on the hard drive. 
-Also, for PCs with less than 256MB of RAM, \\\${DISTRO_NAME} does not copy the \\\${DISTRO_PUPPYSFS} file to RAM so the CD drive remains mounted, meaning that the drive cannot be used for other purposes. 
+   yesno="`eval_gettext \"The CD has '\\\${DISTRO_PUPPYSFS}' and maybe other .sfs files on it. It will speed startup considerably if these are on the hard drive.
+Also, for PCs with less than 256MB of RAM, \\\${DISTRO_NAME} does not copy the \\\${DISTRO_PUPPYSFS} file to RAM so the CD drive remains mounted, meaning that the drive cannot be used for other purposes.
 However, if you reply \Zb\\\${T_copy}\ZB here then it will be copied to the same drive as the '\\\${DISTRO_FILE_PREFIX}save' file and loaded from there at startup, thus freeing the CD drive for other uses.
 Even if you have heaps of RAM, it is still good to answer \Zb\\\${T_copy}\ZB to get the faster startup.
 
@@ -808,6 +808,7 @@ MYPASSWORD='${MYPASSWORD}'
 SFEXT='${SFEXT}'
 xPDEV='${xPDEV}'
 xDEVFS='${xDEVFS}'
+xPSUBDIR='${xPSUBDIR}'
 SMNTPT='${SMNTPT}'
 CRYPTO='${CRYPTO}'
 expBOOTDRV='${expBOOTDRV}'" > /tmp/shutdownconfig_results


### PR DESCRIPTION
to /tmp/shutdownconfig_results, since case PUPMODE in 128 uses it,
and xPSUBDIR is only generated in shutdownconfig script, and not in
/etc/rc.d/rc.shurtdown anymore. PSAVEMARK uses this - never used
PSAVEMARK but I remember pics attached to the murga-forum showing
PSAVEMARK file.

Likely lots of space cleanup, too.
