### PR TITLE
/etc/rc.d/rc.shutdown : Use grep /proc/mounts instead of

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -405,7 +405,7 @@ case $PUPMODE in
   ;;
  32) #first shutdown, save back to PDEV1. v3.97: xPDEV
   echo "$(eval_gettext "Saving session to \${xPDEV}...")" >/dev/console #121104
-  DEV1MNT="`mount | grep "/dev/$xPDEV" | tr -s " " | cut -f 3 -d " "`"
+  DEV1MNT=`grep "/dev/${xPDEV} " /proc/mounts | cut -f 2 -d " "`
   if [ "$DEV1MNT" = "" ];then
    mkdir -p /mnt/$xPDEV
    mount -t $xDEVFS /dev/$xPDEV /mnt/$xPDEV
@@ -502,7 +502,7 @@ case $PUPMODE in
    if [ "$SAVEPART" != "$PDEV1" ];then
     SAVEMARK="`echo -n "$SAVEPART" | rev | sed -e 's%[a-z].*%%' | rev`" #ex: sdc2 becomes 2.
     aPATTERN="/dev/$PDEV1 "
-    aMNTPT="`mount | grep "$aPATTERN" | cut -f 3 -d ' '`"
+    aMNTPT=`grep "$aPATTERN" /proc/mounts | cut -f 2 -d ' '`
     mkdir -p /mnt/$PDEV1
     if [ "$aMNTPT" = "" ];then
      mount -t $DEV1FS /dev/$PDEV1 /mnt/$PDEV1
@@ -635,13 +635,13 @@ fi
 #v2.16rc try this too... SAVE_LAYER defined in /etc/rc.d/PUPSTATE...
 if [ "$SAVE_LAYER" ];then
  sync
- SAVEDEV="`mount | grep "/initrd${SAVE_LAYER}" | cut -f 1 -d ' '`"
- SAVEFS="`mount | grep "/initrd${SAVE_LAYER}" | cut -f 5 -d ' '`"
+ SAVEDEV=`grep "/initrd${SAVE_LAYER}" /proc/mounts | cut -f 1 -d ' '`
+ SAVEFS=`grep "/initrd${SAVE_LAYER}" /proc/mounts | cut -f 3 -d ' '`
  #100615 Patriot: suggested this code to enable save-layer to remount ro...
- uniFS=$(awk '/unionfs/ {print $3}' /proc/mounts) #ex: aufs
+ uniFS=$(awk '/unionfs/ {print $3}' /proc/mounts) #gets fstype, ex: aufs
  if [ "$uniFS" == "aufs" -a "$SAVE_LAYER" == "/pup_rw" ]; then
   #i think only work if prepended dir is a separate f.s...
-  if [ "`mount | grep '^tmpfs on /tmp '`" != "" ];then #created in initrd.
+  if [ "`mount | grep '^tmpfs on /tmp '`" != "" ];then #created by /init in initrd.gz
    mkdir -p /tmp/unrootfs
    busybox mount -o remount,prepend:/tmp/unrootfs,xino=/tmp/unrootfs/xino -t $uniFS / /
    sync


### PR DESCRIPTION
mount | grep .
Less commands and likely better space support in mountpoints,
since /proc/mounts escapes space as\040 .
