### PR TITLE
/etc/rc.d/rc.shutdown : Reworked the ugly STRAYPARTandMNT

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -130,12 +130,12 @@ export CDRECORD MKISOFS
 killzombies() {
  #ZOMBIES="`ps -H -A | grep '<defunct>' | sed -e 's/  /|/g' | grep -v '|||' | cut -f 1 -d ' ' | tr '\n' ' '`"
  #ZOMBIES="`ps -H -A | grep '<defunct>' | sed 's/^[[:blank:]]*//g' | grep -v '|||' | cut -f 1 -d ' ' | tr '\n' ' '`" #120103 karl godt: because i was getting a bunch of "killall no such process must be either pid or name" on the screen by the killzombies function.
- ZOMBIES="`ps -H -A | grep '<defunct>' | sed 's/^[[:blank:]]*//g' | cut -f 1 -d ' ' | sort -gr | tr '\n' ' '`" #120129 karl godt: improved, see http://www.murga-linux.com/puppy/viewtopic.php?t=73122
+ ZOMBIES="`/bin/ps -H -A | grep '<defunct>' | sed 's/^[[:blank:]]*//g' | cut -f 1 -d ' ' | sort -gr | tr '\n' ' '`" #120129 karl godt: improved, see http://www.murga-linux.com/puppy/viewtopic.php?t=73122
  for ONEZOMBIE in $ZOMBIES
  do
   #echo "`eval_gettext \"Killing parentless zombie process \\\${ONEZOMBIE}\"`"
   echo "Killing parentless zombie process $ONEZOMBIE"
-  kill $ONEZOMBIE
+  /bin/ps --no-header -p $ONEZOMBIE && kill $ONEZOMBIE
  done
 }
 
@@ -558,7 +558,7 @@ case $PUPMODE in
   ;;
 esac
 
-
+retired_unmount_partitions(){
 #120129 karl godt: need to rearrange order, refer http://murga-linux.com/puppy/viewtopic.php?t=71767&start=405 ...
 MNTDPARTS="`mount`"
 MNTDPARTS="`echo $MNTDPARTS |rev|sed 's# )#\n)#g' |rev`" #reverses order of lines.
@@ -586,6 +586,30 @@ do
  sync
  umount -r $ONESTRAYMNT #120103 karl godt.
 done
+}
+# Karl Godt: 2013-12-14 reworked the whole unmount block
+MOUNTED=`tac /proc/mounts | grep -vE '/dev/root | rootfs | / | usbfs | aufs | unionfs | tmpfs ' | cut -f2 -d' '`
+STRAY_MOUNTPOINTS=`echo "$MOUNTED" | grep -vE '/proc|/sys|/initrd|/dev/pts'`
+#echo
+#echo $(gettext "Unmounting stray filesystems:")
+[ "$STRAY_MOUNTPOINTS" ] && echo "Unmounting stray filesystems:" >/dev/console
+
+for MOUNT_POINT in $STRAY_MOUNTPOINTS;
+do
+ MOUNT_POINT=`busybox echo -e "$MOUNT_POINT"` # formats escaped chars like \040 to literal like ' ' (space)
+ #echo "`eval_gettext \"Unmounting \\\${MOUNT_POINT}...\"`"
+ echo "Unmounting '$MOUNT_POINT' ..."               >/dev/console
+ FLAGCIFS=`echo -n "${MOUNT_POINT}" | grep '^//'`
+ if [ ! "$FLAGCIFS" ]; then
+  xFUSER=`fuser -m "$MOUNT_POINT" 2>/dev/null`
+  [ "$xFUSER" ] && fuser -k -m "$MOUNT_POINT"
+ fi
+  killzombies #v3.99
+ sync
+ umount -r "$MOUNT_POINT" #120103 karl godt.
+done
+
+
 
 swapoff -a #works only if swaps are in mtab or ftab
 #v2.13 menno suggests this improvement...


### PR DESCRIPTION
part by wrapping the old one into unused function retired_unmount_partitions
and wrote new with some code parts of the old code reused.
Since it calls the killzombies function, made it test for killable PID
by using /bin/ps --no-header -p ONEZOMBIE since it seems that fuser pid
fragments are around, but unkillable. Further use /bin/ps instead of
just ps if busybox is compiled to lookup internal applets first.
