### PR TITLE
/usr/sbin/askpass: small improvements

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/askpass
+++ b/woof-code/rootfs-skeleton/usr/sbin/askpass
@@ -24,19 +24,20 @@ if [ $DISPLAY ];then
   <vbox>
   <frame>
     ${INSERTMSG}
-    <entry visible_char=\"x\" visibility=\"false\"  width_chars=\"25\">
+    <entry visible_char=\"x\" visibility=\"false\" width_chars=\"25\" activates_default=\"true\">
       <variable>ADMINPASSWORD</variable>
     </entry>
 
     <hbox>
-     <button ok></button>
+     <button use-stock=\"true\" label=\"gtk-ok\" can-default=\"true\" has-default=\"true\"></button>
     </hbox>
   </frame>
   </vbox>
 </window>
 "
- RETVAL="`gtkdialog3 --program=ASKDIALOG 2>/dev/null`"
- eval "$RETVAL"
+ RETVAL="`gtkdialog --program=ASKDIALOG 2>/dev/null | grep '^ADMINPASSWORD='`"
+ #eval "$RETVAL"
+ ADMINPASSWORD="`echo "$RETVAL" | cut -f2- -d '"' | rev | cut -f2- -d '"' | rev`"
 else
  echo >/dev/console
  echo -n "$(gettext 'Type admin password required to run this app:') " >/dev/console


### PR DESCRIPTION
Ok, something small & simple for starters, to warm up and test the whole thing...
Three changes:
1. Now it's enough to press ENTER after typing a password, instead of TAB+ENTER or using mouse.
2. 'gtkdialog3' replaced with 'gtkdialog' (following Zigbert's guidelines)
3. Maybe it's not worth the effort, but on the other hand "if anything can go wrong, it will" sooner or later...
'eval' chokes itself if password contains quotation mark. I'm not especially proud of the way I fixed this, but at least it works now. Anyone knows better way..?

Greetings!
