### PR TITLE
ROX-Trash: fixed old bug with restoring to a non-existent dir

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/apps/Trash/template/temp-AppRun
+++ b/woof-code/rootfs-skeleton/usr/local/apps/Trash/template/temp-AppRun
@@ -3,6 +3,7 @@
 #130214 internationalized. 
 #130215 BK: tidy up. replace puppy-trash-restore.wav with puppy-trash.wav
 #130310 BK 130310 change "burp" sound to "goodbye" and "hello" --no, avoid english, use 2barks.
+#130712 SFR: Proper handling when restoring an item to a non-existent directory
 
 export TEXTDOMAIN=trash
 export OUTPUT_CHARSET=UTF-8
@@ -85,12 +86,31 @@ function RemoveItem
  fi
  # Delete this file and directory.
  rm -fr "$APPDIR"
- PlaySoundTrashIt
+ #PlaySoundTrashIt
 }
 
 function RestoreItem
 {
 
+ # Check if destination path is in /mnt and warn a user
+ restore_path="`dirname "PATH"`"
+ restore_name="`basename "PATH"`"
+ if [ "`echo "PATH" | grep '^/mnt/'`" ]; then
+   pupdialog --title "$(gettext 'Caution')" --yes-label "$(gettext 'Restore')" --no-label "$(gettext 'Cancel')" --yesno "$restore_name $(gettext 'will be restored to: ')$restore_path
+$(gettext 'Make sure that the appropriate device is mounted!')"
+   [ $? -ne 0 ] && exit   
+ fi
+ 
+ # If dest dir doesn't exist, ask to create one
+ if [ ! -d "$restore_path" ]; then
+   pupdialog --title "$(gettext 'Confirm Action')" --yes-label "$(gettext 'Create')" --no-label "$(gettext 'Cancel')" --yesno "$(gettext 'Destination directory: ')$restore_path
+$(gettext 'does not exist! Create it?')"
+   if [ $? -eq 0 ]; then
+     mkdir -p "$restore_path"
+   else
+     exit
+   fi
+ fi
  # Remove existing item.
  rm -fr "PATH"
  # Restore the item.


### PR DESCRIPTION
Old bug with ROX-Trash, see: http://www.murga-linux.com/puppy/viewtopic.php?p=713099#713099
Well, the perfect solution would be to rewrite the whole app in a way Disciple suggests there, but still I don't have a concept how to do it decently and Disciple himself also keeps silent since then, unfortunately...

Anyway, this solution is at least better than current state, where user, restoring an item, simply loses it, if destination dir doesn't exist.

Also, commented out 'PlaySoundTrashIt' in 'RemoveItem' func to avoid playing 2barks.wav twice.

Greetings!
