### PR TITLE
PPM: fixed non-functional mouse cursor after resizing columns

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/ui_Classic
+++ b/woof-code/rootfs-skeleton/usr/local/petget/ui_Classic
@@ -54,9 +54,9 @@ export MAIN_DIALOG="<window title=\"$(gettext 'Puppy Package Manager')\" icon-na
     <height>280</height><width>668</width>
     <variable>TREE1</variable>
     <input${APPICONXMLINSERT}>cat /tmp/petget/filterpkgs.results.post</input>
-    <action signal=\"button-release-event\">/usr/local/petget/installpreview.sh</action>
-    <action signal=\"button-release-event\">/usr/local/petget/finduserinstalledpkgs.sh</action>
-    <action signal=\"button-release-event\">refresh:TREE2</action>
+    <action>/usr/local/petget/installpreview.sh</action>
+    <action>/usr/local/petget/finduserinstalledpkgs.sh</action>
+    <action>refresh:TREE2</action>
   </tree>
   </vbox>
  </hbox>
@@ -125,9 +125,9 @@ export MAIN_DIALOG="<window title=\"$(gettext 'Puppy Package Manager')\" icon-na
     <height>100</height><width>480</width>
     <variable>TREE2</variable>
     <input${APPICONXMLINSERT}>cat /tmp/petget/installedpkgs.results.post</input>
-    <action signal=\"button-release-event\">/usr/local/petget/removepreview.sh</action>
-    <action signal=\"button-release-event\">/usr/local/petget/finduserinstalledpkgs.sh</action>
-    <action signal=\"button-release-event\">refresh:TREE2</action>
+    <action>/usr/local/petget/removepreview.sh</action>
+    <action>/usr/local/petget/finduserinstalledpkgs.sh</action>
+    <action>refresh:TREE2</action>
   </tree>
  </frame>
 </hbox>

--- a/woof-code/rootfs-skeleton/usr/local/petget/ui_Ziggy
+++ b/woof-code/rootfs-skeleton/usr/local/petget/ui_Ziggy
@@ -173,17 +173,17 @@ export MAIN_DIALOG="<window title=\"$(gettext 'Puppy Package Manager')\" icon-na
    <item stock=\"gtk-Fun\">$(gettext 'Fun')</item>
    ${ALLITEM}
    <width>140</width><height>${CATHEIGHT}</height>
-   <action signal=\"button-release-event\">/tmp/ppm-ui-ziggy-fix \$CATEGORY | xargs -I CATINSERT /usr/local/petget/filterpkgs.sh CATINSERT</action>
-   <action signal=\"button-release-event\">refresh:TREE1</action>
+   <action signal=\"changed\">/tmp/ppm-ui-ziggy-fix \$CATEGORY | xargs -I CATINSERT /usr/local/petget/filterpkgs.sh CATINSERT</action>
+   <action signal=\"changed\">refresh:TREE1</action>
   </tree>
 </vbox>
   <tree>
     <label>$(gettext 'Package|Description')</label>
     <variable>TREE1</variable>
     <input${APPICONXMLINSERT}>cat /tmp/petget/filterpkgs.results.post</input>
-    <action signal=\"button-release-event\">/usr/local/petget/installpreview.sh</action>
-    <action signal=\"button-release-event\">/usr/local/petget/finduserinstalledpkgs.sh</action>
-    <action signal=\"button-release-event\">refresh:TREE2</action>
+    <action>/usr/local/petget/installpreview.sh</action>
+    <action>/usr/local/petget/finduserinstalledpkgs.sh</action>
+    <action>refresh:TREE2</action>
   </tree>
 
 </hbox>
@@ -196,9 +196,9 @@ export INSTALLED_DIALOG='<window title="'$(gettext 'Uninstall Puppy Package')'" 
     <label>'$(gettext 'Installed Package|Description')'</label>
     <variable>TREE2</variable>
     <input'${APPICONXMLINSERT}'>cat /tmp/petget/installedpkgs.results.post</input>
-    <action signal="button-release-event">/usr/local/petget/removepreview.sh</action>
-    <action signal="button-release-event">/usr/local/petget/finduserinstalledpkgs.sh</action>
-    <action signal="button-release-event">refresh:TREE2</action>
+    <action>/usr/local/petget/removepreview.sh</action>
+    <action>/usr/local/petget/finduserinstalledpkgs.sh</action>
+    <action>refresh:TREE2</action>
   </tree>
   </vbox>
 </window>' 


### PR DESCRIPTION
Here's the report on the bug:
http://www.murga-linux.com/puppy/viewtopic.php?t=91038

Side effects of my modification are:
- it's necessary to double-click a package name in order to (un)install it, although for categories single-click is still valid
- it's possible to choose a package also using a keyboard (space/enter), not only a mouse

The 'single->double click' change might be considered as "radical", but I'm pretty sure that it won't be confusing for more than few seconds - if single-click doesn't work, the natural human reaction (developed by millenia of evolution) is to try double-click.

Greetings!
