### PR TITLE
eventmanager: added partitions labels and placement options

### DIFF
--- a/woof-code/rootfs-skeleton/etc/eventmanager
+++ b/woof-code/rootfs-skeleton/etc/eventmanager
@@ -17,6 +17,9 @@ ICONDESK="true"
 #read by pup_event_frontend_d. only effecive if ICONDESK=true. show individual partitions as icons...
 ICONPARTITIONS="true"
 
+#read by pup_event_frontend_d. only effecive if ICONPARTITIONS=true. show partitions labels...
+LABELPARTITIONS="false"
+
 #read by pup_event_frontend_d and /root/.pup_event/drive_*
 #true if want an automatic 'handler' to run if a drive plugged in...
 HOTPLUGNOISY="false"
@@ -38,7 +41,6 @@ POWERTIMEOUT=0
 AUTOUNMOUNT="false"
 
 #091208 adjust drive icons placement, read by /sbin/pup_event_frontend_d
-#TODO: GUI in /usr/sbin/eventmanager
 #gap between icons and edge of screen (>0 if need to leave space for a tray)...
 ICON_PLACE_EDGE_GAP=64
 #indent from edge before icons start...

--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
@@ -206,6 +206,13 @@ add_pinboard_func() { #needs ONEDRVNAME, DRV_CATEGORY, FSTYPE
  free_coord
  #120503 the label "mmcblk0p1" (SD memory cards via mmc interface) is too long...
  cutONEDRVNAME="`echo -n "${ONEDRVNAME}" | sed -e 's%cblk%%'`"
+ #140101 SFR: partitions labels
+ if [ "$ICONPARTITIONS" = "true" ] && [ "$LABELPARTITIONS" = "true" ]; then
+   realLABEL=`blkid "/dev/${cutONEDRVNAME}" | grep -o "LABEL=.*" | cut -f2 -d '"'`
+   [ "$realLABEL" = "" ] && realLABEL=" "
+   [ "${#realLABEL}" -gt 8 ] && realLABEL="${realLABEL:0:7}..."
+   cutONEDRVNAME="${cutONEDRVNAME}`echo -e "\n$realLABEL"`"
+ fi
  echo "<?xml version=\"1.0\"?>
 <env:Envelope xmlns:env=\"http://www.w3.org/2001/12/soap-envelope\">
  <env:Body xmlns=\"http://rox.sourceforge.net/SOAP/ROX-Filer\">

--- a/woof-code/rootfs-skeleton/usr/sbin/eventmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/eventmanager
@@ -12,6 +12,7 @@
 #120201 BK: internationalized.
 #130212 /var/local/pup_event_icon_change_flag path changed from /tmp (see /sbin/clean_desk_icons)
 #131123 zigbert: gui (gtkdialog) improvements.
+#140101 SFR: added 'partitions labels' + 'placement' options
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
 
@@ -32,11 +33,17 @@ KERNVER="`uname -r`"
 [ "$HOTPLUGNOISY" != "true" -a "$HOTPLUGNOISY" != "false" ] && HOTPLUGNOISY="false"
 [ "$AUTOTARGET" != "true" -a "$AUTOTARGET" != "false" ] && AUTOTARGET="true"
 [ "$ICONPARTITIONS" != "true" -a "$ICONPARTITIONS" != "false" ] && ICONPARTITIONS="true"
+[ "$LABELPARTITIONS" != "true" -a "$LABELPARTITIONS" != "false" ] && LABELPARTITIONS="false"
 [ "$HOTPLUGON" != "true" -a "$HOTPLUGON" != "false" ] && HOTPLUGON="true"
 [ "$BACKENDON" != "true" -a "$BACKENDON" != "false" ] && BACKENDON="true"
 [ "$FD0ICON" != "true" -a "$FD0ICON" != "false" ] && FD0ICON="true"
 [ ! $POWERTIMEOUT ] && POWERTIMEOUT=0 #w007 0=never.
 [ ! $AUTOUNMOUNT ] && AUTOUNMOUNT="false" #v424
+
+[ "$ICON_PLACE_ORIENTATION" != "bottom" -a "$ICON_PLACE_ORIENTATION" != "top" -a "$ICON_PLACE_ORIENTATION" != "right" -a "$ICON_PLACE_ORIENTATION" != "left" ] && ICON_PLACE_ORIENTATION="bottom"
+[ ! "$ICON_PLACE_EDGE_GAP" ] && ICON_PLACE_EDGE_GAP=64
+[ ! "$ICON_PLACE_START_GAP" ] && ICON_PLACE_START_GAP=32
+[ ! "$ICON_PLACE_SPACING" ] && ICON_PLACE_SPACING=64
 
 #w007 as have a optional cutdown gui, make sure these are all preset...
 NEWICONDESK="$ICONDESK"
@@ -44,11 +51,23 @@ NEWRAMSAVEINTERVAL=$RAMSAVEINTERVAL
 NEWHOTPLUGNOISY="$HOTPLUGNOISY"
 NEWAUTOTARGET="$AUTOTARGET"
 NEWICONPARTITIONS="$ICONPARTITIONS"
+NEWLABELPARTITIONS="$LABELPARTITIONS"
 NEWHOTPLUGON="$HOTPLUGON"
 NEWBACKENDON="$BACKENDON"
 NEWFD0ICON="$FD0ICON"
 NEWPOWERTIMEOUT=$POWERTIMEOUT
 NEWAUTOUNMOUNT="$AUTOUNMOUNT"
+
+case "$ICON_PLACE_ORIENTATION" in
+  bottom)	ICON_PLACE_ORIENTATION="$(gettext "Bottom")" ;;
+  top)		ICON_PLACE_ORIENTATION="$(gettext "Top")" ;;
+  right)	ICON_PLACE_ORIENTATION="$(gettext "Right")" ;;
+  left)		ICON_PLACE_ORIENTATION="$(gettext "Left")" ;;
+esac
+NEWICON_PLACE_ORIENTATION="$ICON_PLACE_ORIENTATION"
+NEWICON_PLACE_EDGE_GAP="$ICON_PLACE_EDGE_GAP"
+NEWICON_PLACE_START_GAP="$ICON_PLACE_START_GAP"
+NEWICON_PLACE_SPACING="$ICON_PLACE_SPACING"
 
 [ "$SHOWMODE" = "desktop" ] && PAGE_NR=2 || PAGE_NR=0
 
@@ -102,35 +121,95 @@ export Puppy_Event_Manager='
       </vbox>
     </frame>
 
-
     <notebook tab-pos="2" labels="'$(gettext 'Show Icons')'|'$(gettext 'Icon Handler')'|'$(gettext 'Floppy drive')'|'$(gettext 'Power')'">
       <frame '$(gettext 'Drive icons on desktop')'>
         <vbox space-expand="true" space-fill="true">
           '"`/usr/lib/gtkdialog/xml_info scale desktop_icons.svg 60 "$(gettext "When this box is ticked, there will be an icon for each drive. If you plugin a USB pen drive for example, an icon will appear. Unplug and it will disappear. If you don't want these drive icons on the desktop, untick this box (but there will still remain just one icon that will launch Pmount when clicked on). The individual drive icons are purely a convenience and Puppy works fine without them.")"`"'
           <vbox space-expand="false" space-fill="false">
             <text height-request="20"><label>""</label></text>
-            <checkbox>
-              <label>'$(gettext 'Show desktop icons for each DRIVE')'</label>
-              <default>'${ICONDESK}'</default>
-              <variable>NEWICONDESK</variable>
-              <action>if true enable:NEWICONPARTITIONS</action>
-              <action>if false disable:NEWICONPARTITIONS</action>
-            </checkbox>
-            <checkbox>
-              <label>'$(gettext 'Show desktop icons for each PARTITION')'</label>
-              <default>'${ICONPARTITIONS}'</default>
-              <variable>NEWICONPARTITIONS</variable>
-            </checkbox>
-            <checkbox>
-              <label>'$(gettext 'Refresh / Realign existing icons')'</label>
-              <default>false</default>
-              <variable>NEWICONWIPE</variable>
-            </checkbox>
+            
+            <hbox>
+              <vbox homogeneous="true">
+                <checkbox>
+                  <label>'$(gettext 'Show desktop icons for each DRIVE')'</label>
+                  <default>'${ICONDESK}'</default>
+                  <variable>NEWICONDESK</variable>
+                  <action>if true enable:NEWICONPARTITIONS</action>
+                  <action>if true enable:NEWICON_PLACE_ORIENTATION</action>
+                  <action>if true enable:NEWICON_PLACE_EDGE_GAP</action>
+                  <action>if true enable:NEWICON_PLACE_START_GAP</action>
+                  <action>if true enable:NEWICON_PLACE_SPACING</action>
+                  <action>if false disable:NEWICONPARTITIONS</action>
+                  <action>if false disable:NEWICON_PLACE_ORIENTATION</action>
+                  <action>if false disable:NEWICON_PLACE_EDGE_GAP</action>
+                  <action>if false disable:NEWICON_PLACE_START_GAP</action>
+                  <action>if false disable:NEWICON_PLACE_SPACING</action>
+                  <action condition="sensitive_is_true(NEWICONPARTITIONS)">enable:NEWLABELPARTITIONS</action>
+			      <action condition="sensitive_is_false(NEWICONPARTITIONS)">disable:NEWLABELPARTITIONS</action>
+                  <action condition="active_is_false(NEWICONPARTITIONS)">disable:NEWLABELPARTITIONS</action>
+                </checkbox>
+                <checkbox>
+                  <label>'$(gettext 'Show desktop icons for each PARTITION')'</label>
+                  <default>'${ICONPARTITIONS}'</default>
+                  <variable>NEWICONPARTITIONS</variable>
+                  <action>if true enable:NEWLABELPARTITIONS</action>
+                  <action>if false disable:NEWLABELPARTITIONS</action>
+                </checkbox>
+                <checkbox>
+                  <label>'$(gettext 'Show labels for each PARTITION')'</label>
+                  <default>'${LABELPARTITIONS}'</default>
+                  <variable>NEWLABELPARTITIONS</variable>
+                </checkbox>
+                <checkbox>
+                  <label>'$(gettext 'Refresh / Realign existing icons')'</label>
+                  <default>false</default>
+                  <variable>NEWICONWIPE</variable>
+                </checkbox>
+              </vbox>
+            
+              <vseparator></vseparator>
+              <text space-fill="true" space-expand="true"><label>""</label></text>
+            
+              <vbox>
+                <hbox>
+                  <text xalign="0"><label>'$(gettext 'Placement: ')'</label></text>
+                  <text space-fill="true" space-expand="true"><label>""</label></text>
+                  <comboboxtext>
+                    <default>'${ICON_PLACE_ORIENTATION}'</default>
+                    <variable>NEWICON_PLACE_ORIENTATION</variable>
+                    <item>'$(gettext 'Top')'</item>
+                    <item>'$(gettext 'Bottom')'</item>
+                    <item>'$(gettext 'Left')'</item>
+                    <item>'$(gettext 'Right')'</item>
+                  </comboboxtext>
+                </hbox>
+                <hbox>
+                  <text xalign="0"><label>'$(gettext 'Start gap: ')'</label></text>
+                  <text space-fill="true" space-expand="true"><label>""</label></text>
+                  <spinbutton range-min="32" range-max="1024" range-step="1" range-value="'${ICON_PLACE_START_GAP}'">
+                    <variable>NEWICON_PLACE_START_GAP</variable>
+                  </spinbutton>
+                </hbox>
+                <hbox>
+                  <text xalign="0"><label>'$(gettext 'Edge gap: ')'</label></text>
+                  <text space-fill="true" space-expand="true"><label>""</label></text>
+                  <spinbutton range-min="32" range-max="1024" range-step="1" range-value="'${ICON_PLACE_EDGE_GAP}'">
+                    <variable>NEWICON_PLACE_EDGE_GAP</variable>
+                  </spinbutton>
+                </hbox>
+                <hbox>
+                  <text xalign="0"><label>'$(gettext 'Spacing: ')'</label></text>
+                  <text space-fill="true" space-expand="true"><label>""</label></text>
+                  <spinbutton range-min="48" range-max="256" range-step="1" range-value="'${ICON_PLACE_SPACING}'">
+                    <variable>NEWICON_PLACE_SPACING</variable>
+                  </spinbutton>
+                </hbox>
+              </vbox>     
+            </hbox>
             <text height-request="5"><label>""</label></text>
           </vbox>
         </vbox>
       </frame>
-
 
       <frame '$(gettext "Drive 'handler'")'>
         <vbox space-expand="true" space-fill="true">
@@ -211,6 +290,12 @@ export Puppy_Event_Manager='
 <action signal="show" condition="command_is_true([[ '${BACKENDON}' != true ]] && echo true)">disable:NEWHOTPLUGON</action>
 <action signal="show" condition="command_is_true([[ '${BACKENDON}' != true ]] && echo true)">disable:NEWAUTOUNMOUNT</action>
 <action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWICONPARTITIONS</action>
+<action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWLABELPARTITIONS</action>
+<action signal="show" condition="command_is_true([[ '${ICONPARTITIONS}' != true ]] && echo true)">disable:NEWLABELPARTITIONS</action>
+<action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWICON_PLACE_ORIENTATION</action>
+<action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWICON_PLACE_EDGE_GAP</action>
+<action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWICON_PLACE_START_GAP</action>
+<action signal="show" condition="command_is_true([[ '${ICONDESK}' != true ]] && echo true)">disable:NEWICON_PLACE_SPACING</action>
 </window>'
 
 . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
@@ -247,15 +332,25 @@ NEWPOWERTIMEOUT=`echo -n "$NEWPOWERTIMEOUT" | sed -e 's/[^0-9]//g'`
 if [ "$NEWHOTPLUGON" = "false" ];then
  NEWICONDESK="false"
  NEWICONPARTITIONS="false"
+ NEWLABELPARTITIONS="false"
  NEWHOTPLUGNOISY="false"
  NEWAUTOTARGET="false"
  NEWAUTOUNMOUNT="false" #v424
 fi
 
 #v403 /sbin/clean_desk_icons can read this, then wipe all current icons... 120213 path changed from /tmp (see /sbin/clean_desk_icons)...
+[ "$LABELPARTITIONS" != "$NEWLABELPARTITIONS" ] && echo "LABELPARTITIONS" > /var/local/pup_event_icon_change_flag
 [ "$ICONPARTITIONS" != "$NEWICONPARTITIONS" ] && echo "ICONPARTITIONS" > /var/local/pup_event_icon_change_flag
 [ "$ICONDESK" != "$NEWICONDESK" ] && echo "ICONDESK" > /var/local/pup_event_icon_change_flag
 [ "$NEWICONWIPE" = "true" ] && echo "ICONWIPE" > /var/local/pup_event_icon_change_flag #v411
+
+case "$NEWICON_PLACE_ORIENTATION" in
+  "$(gettext "Bottom")")	NEWICON_PLACE_ORIENTATION="bottom" ;;
+  "$(gettext "Top")")		NEWICON_PLACE_ORIENTATION="top" ;;
+  "$(gettext "Left")")		NEWICON_PLACE_ORIENTATION="left" ;;
+  "$(gettext "Right")")		NEWICON_PLACE_ORIENTATION="right" ;;
+  *)						NEWICON_PLACE_ORIENTATION="bottom" ;;	#precaution
+esac
 
 CONFIG="`cat /etc/eventmanager`"
 
@@ -271,6 +366,9 @@ CONFIG="`echo "$CONFIG" | sed -e "$idPATTERN"`"
 
 ipPATTERN="s/^ICONPARTITIONS=.*/ICONPARTITIONS=${NEWICONPARTITIONS}/"
 CONFIG="`echo "$CONFIG" | sed -e "$ipPATTERN"`"
+
+lpPATTERN="s/^LABELPARTITIONS=.*/LABELPARTITIONS=${NEWLABELPARTITIONS}/"
+CONFIG="`echo "$CONFIG" | sed -e "$lpPATTERN"`"
 
 hnPATTERN="s/^HOTPLUGNOISY=.*/HOTPLUGNOISY=${NEWHOTPLUGNOISY}/"
 CONFIG="`echo "$CONFIG" | sed -e "$hnPATTERN"`"
@@ -289,6 +387,18 @@ CONFIG="`echo "$CONFIG" | sed -e "$fiPATTERN"`"
 
 auPATTERN="s/^AUTOUNMOUNT=.*/AUTOUNMOUNT=${NEWAUTOUNMOUNT}/" #v424
 CONFIG="`echo "$CONFIG" | sed -e "$auPATTERN"`"
+
+poPATTERN="s/^ICON_PLACE_ORIENTATION=.*/ICON_PLACE_ORIENTATION=${NEWICON_PLACE_ORIENTATION}/"
+CONFIG="`echo "$CONFIG" | sed -e "$poPATTERN"`"
+
+egPATTERN="s/^ICON_PLACE_EDGE_GAP=.*/ICON_PLACE_EDGE_GAP=${NEWICON_PLACE_EDGE_GAP}/"
+CONFIG="`echo "$CONFIG" | sed -e "$egPATTERN"`"
+
+sgPATTERN="s/^ICON_PLACE_START_GAP=.*/ICON_PLACE_START_GAP=${NEWICON_PLACE_START_GAP}/"
+CONFIG="`echo "$CONFIG" | sed -e "$sgPATTERN"`"
+
+psPATTERN="s/^ICON_PLACE_SPACING=.*/ICON_PLACE_SPACING=${NEWICON_PLACE_SPACING}/"
+CONFIG="`echo "$CONFIG" | sed -e "$psPATTERN"`"
 
 echo "$CONFIG" > /etc/eventmanager
 


### PR DESCRIPTION
Initially I wanted to implement the labels only, but the second row (where labels are) may appear partially beneath JWM's panel, so users most likely will need to "fine-tune" icons' positions in such case, therefore I've implemented it as well.

Here's a screenie: http://oi39.tinypic.com/2wrp5kk.jpg
- by default labels are disabled in /etc/eventmanager (LABELPARTITIONS="false")
- labels longer than 8 chars are being truncated to 7 chars + ...
- minimal value for 'start/edge gap' is 32, because ROX (even if "Keep icons within screen limits" is unchecked) refuses to place an icon beyond left/upper edge, even partially

Greetings!
