### PR TITLE
frontend_func: fix to enable gettext in 'snapmergepuppy'

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
@@ -441,7 +441,7 @@ savepuppy_func() { #called every 4 seconds.
   LANG=$OLDLANG yaf-splash -bg orange -placement top -close never -text "$(gettext "Saving RAM to 'pup_save' file...")" & #130116 set LANG.
   YAFPID=$!
   sync
-  nice -n 19 /usr/sbin/snapmergepuppy
+  LANG=$OLDLANG nice -n 19 /usr/sbin/snapmergepuppy
   kill $YAFPID
  fi
 }


### PR DESCRIPTION
Additional commit, related to: https://github.com/puppylinux-woof-CE/woof-CE/pull/325
Hmm, gettext works fine only when running 'snapmergepuppy' alone, from terminal, but not via "Save" icon.
It's also necessary to add 'LANG=$OLDLANG' in frontend_func, before calling snapmergepuppy, just like it is with yaf-splash a couple of lines earlier.

Greetings!
