### PR TITLE
Added a few more MIME-types for ROX

### DIFF
--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-7z-compressed
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-7z-compressed
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec pupzip "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-arj
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-arj
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec pupzip "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-lzma
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-lzma
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec pupzip "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-lzma-compressed-tar
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-lzma-compressed-tar
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec pupzip "$1"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-navi-animation
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/application_x-navi-animation
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_vnd.microsoft.icon
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_vnd.microsoft.icon
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_vnd.wap.wbmp
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_vnd.wap.wbmp
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-pcx
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-pcx
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-portable-pixmap
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-portable-pixmap
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-tga
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-tga
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"

--- a/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-win-bitmap
+++ b/woof-code/rootfs-skeleton/root/Choices/MIME-types/image_x-win-bitmap
@@ -1,0 +1,2 @@
+#! /bin/sh
+exec defaultimageviewer "$@"


### PR DESCRIPTION
Added missing MIME-types (.7z/.arj/.lzma/.tar.lzma) also for ROX, for consistency.
It's related to: https://github.com/puppylinux-woof-CE/woof-CE/commit/20fe251233d3e11050973c1f0a0b793c4c1fda5e

Also, added a few more ROX MIME-types for image formats: .ani/.cur/.ico/.ppm/.pcx/.tga

BTW: default action for .bmp|.tif/.svg is defaultpaint/defaultdraw.
Aren't they supposed to be opened in defaultimageviewer also?
It's especially important in case of SVGs, because as we know, Inklite doesn't handle some more complex images too well (or even at all (!) - try: http://upload.wikimedia.org/wikipedia/commons/8/88/Edit-cut.svg).
I wanted to change them too, but all those four files (image_bmp, image_svg, image_svg+xml, image_tiff) originally reside in rox_filer.pet package, so I guess even if I'd add them here in Woof, they would be overwritten by files from that package during building, am I right..?

Anyway, Viewnior handles all of the above formats correctly.

Greetings!
