### PR TITLE
init: fixed mounting of encrypted savefile

### DIFF
--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -556,11 +556,27 @@ resize_pupsave_func() { #131225
     sync
 }
 fsck_pupsave_func() {
-    e2fsck -y -f /mnt/dev_save$PUPSAVEFILE
-    resize2fs -pf /mnt/dev_save$PUPSAVEFILE #no size, will fill all of file.
+    e2fsck -y -f $1
+    resize2fs -pf $1 #no size, will fill all of file.
     sync
     check_status 0 #note, e2fsck gives an error even though it works. v2.21 maybe okay now.
     echo -n "...continuing with loading $PUPSAVEFILE..." > /dev/console
+}
+
+mnt_enc_pupsave_func() {
+	echo >/dev/console
+    echo "NOTICE: As you type your password nothing will be displayed on the screen."  >/dev/console
+    echo "This is a security measure. Just type it in then press ENTER key..." >/dev/console
+    echo -e "\\033[1;36m" >/dev/console #aqua-blue
+    echo -n "Password: " >/dev/console
+    echo -en "\\033[0;39m" >/dev/console
+    if [ "$CRYPTO" = "-e aes" ];then #v3.98
+     read -s MYPASS #< /dev/console v403
+     echo "$MYPASS" | losetup -p 0 -e aes /dev/loop1 /mnt/dev_save$PUPSAVEFILE
+    else
+     #losetup does not accept -p param for xor encryption... may not work...
+     losetup $CRYPTO /dev/loop1 /mnt/dev_save$PUPSAVEFILE
+    fi
 }
 
 #pmedia= usbflash|usbhd|usbcd|ataflash|atahd|atacd|atazip|scsihd|scsicd|cd
@@ -1061,49 +1077,17 @@ if [ "$CREATEPUPSAVE2FS" != "" ];then
       else
        resize_pupsave_func #131225
       fi # end pupsave increase, old code removed 131225
-      if [ "$CRYPTO" = "-e aes" ];then #v3.98
-       echo "NOTICE: As you type your password nothing will be displayed on the screen."  >/dev/console
-       echo "This is a security measure. Just type it in then press ENTER key..." >/dev/console
-       echo -e "\\033[1;36m" >/dev/console #aqua-blue
-       echo -n "Password: " >/dev/console
-       echo -en "\\033[0;39m" >/dev/console
-       read -s MYPASS #< /dev/console v403
-       echo "$MYPASS" | losetup -p 0 -e aes /dev/loop1 /mnt/dev_save$PUPSAVEFILE
-      else
-       echo -e "\\033[1;36m" >/dev/console #aqua-blue
-       echo -n "Password: " >/dev/console
-       echo -en "\\033[0;39m" >/dev/console
-       #losetup does not accept -p param for xor encryption... may not work...
-       losetup $CRYPTO /dev/loop1 /mnt/dev_save$PUPSAVEFILE
-      fi
-      fsck_pupsave_func #131225
+      mnt_enc_pupsave_func
+      fsck_pupsave_func /dev/loop1 #131225
      else
-      echo -e "\\033[1;36m" >/dev/console #aqua-blue
-      echo -n "Password: " >/dev/console
-      echo -en "\\033[0;39m" >/dev/console
-      if [ "$CRYPTO" = "-e aes" ];then #v3.98
-       read -s MYPASS #< /dev/console v403
-       echo "$MYPASS" | losetup -p 0 -e aes /dev/loop1 /mnt/dev_save$PUPSAVEFILE
-      else
-       #losetup does not accept -p param for xor encryption... may not work...
-       losetup $CRYPTO /dev/loop1 /mnt/dev_save$PUPSAVEFILE
-      fi
+      mnt_enc_pupsave_func
      fi #131225
     else
-     echo -e "\\033[1;36m" >/dev/console #aqua-blue
-     echo -n "Password: " >/dev/console
-     echo -en "\\033[0;39m" >/dev/console
-     if [ "$CRYPTO" = "-e aes" ];then #v3.98
-      read -s MYPASS #< /dev/console v403
-      echo "$MYPASS" | losetup -p 0 -e aes /dev/loop1 /mnt/dev_save$PUPSAVEFILE
-     else
-      #losetup does not accept -p param for xor encryption... may not work...
-      losetup $CRYPTO /dev/loop1 /mnt/dev_save$PUPSAVEFILE
-     fi
+      mnt_enc_pupsave_func
     fi
 
     echo "/dev/loop1 $CREATEPUPSAVE2FS ext2 defaults  1 1" >> /etc/fstab #v2.21
-    [ "$PFSCK" = "yes" ] && fsckme_func loop1 ext2 #100318 however, commented out as there was an old not that f.s. check on an encrypted pupsave is broken. #140106 SFR: re-enableed
+    [ "$PFSCK" = "yes" ] && fsckme_func loop1 ext2 #100318 however, commented out as there was an old not that f.s. check on an encrypted pupsave is broken. #140106 SFR: re-enabled
     mount -t ext2 -o noatime,rw /dev/loop1 $CREATEPUPSAVE2FS #only ext2 allowed.
     MNTSTAT=$?
     if [ "$MNTSTAT" = "0" ] ; then
@@ -1133,7 +1117,7 @@ if [ "$CREATEPUPSAVE2FS" != "" ];then
       rm -f /mnt/dev_save/pupsaveresizenew.txt
      else
       resize_pupsave_func #131225
-      fsck_pupsave_func #131225
+      fsck_pupsave_func /mnt/dev_save$PUPSAVEFILE #131225
      fi
     fi
    fi


### PR DESCRIPTION
Ok, I think I found it!
Perhaps it could be done in a bit more "economical" way, but I don't want to mess with init too much...

Tested and:
- mounting encrypted savefile - [OK]
- increasing the size of encrypted savefile - [OK]
- mounting encrypted savefile when 'pupsaveresizenew.txt' exists, but for another savefile - [OK]

however if someone would like to double-check, I'd be grateful.

Additionally, I re-enabled the ability to fsck encrypted savefile (if pfix=fsck).
Since when I have it enabled (about 4 months ago or maybe more?) it's only better!

Greetings!
