### PR TITLE
quicksetup: fixed a few strings not being displayed

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -1328,7 +1328,7 @@ if [ "$SET_KEYBOARD" ];then
  NEW_KMAP="`echo -n "$COMBO_KEYBOARD" | cut -f 1 -d ' ' | cut -f 1 -d "$TABCHAR"`"
  FONTMAP=""; CODEPAGE=""
  if [ "$DEF_KMAP" != "$NEW_KMAP" ];then
-  FLAG_CHANGED="${FLAG_CHANGED}${TT_kb2}:yes|" #111020 no need to restart X.
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard Layout'):yes|" #111020 no need to restart X.
   case $NEW_KMAP in #note, same code in /etc/rc.d/rc.country, init, and input-wizard.
    de*|be*|br*|dk*|es*|fi*|fr*|it*|no*|se*|sv*|pt*)
     modprobe nls_cp850
@@ -1347,7 +1347,7 @@ if [ "$SET_KEYBOARD" ];then
   #120224 fontmap will be handled in locale code below.
  fi
  if [ "$DEFAULT_NUMLOCK" != "$CHECK_NUMLOCK" ];then
-  FLAG_CHANGED="${FLAG_CHANGED}${T_num}:yes|"
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard numlock'):yes|"
   STATUS_NUMLOCK=off
   [ "$CHECK_NUMLOCK" = "true" ] && STATUS_NUMLOCK=on
   echo -e "#!/bin/sh\nnumlockx ${STATUS_NUMLOCK}" > /root/Startup/numlockx
@@ -1366,7 +1366,7 @@ if [ "$SET_LOCALE" ];then
  [ "$PARAM2" = "quiet" ] && CURRLANG=en_US #so as to force below code block to run...
 
  if [ "$LANGCHOICE" != "" -a "${LANGCHOICE}${UTF8}" != "$CURRLANG" ];then
-  FLAG_CHANGED="${FLAG_CHANGED}${TT_mainlanguage}:restart|"
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Main Language'):restart|"
   # creates locale files in /usr/lib/locale...
   OLDLANGLINE="LANG=$CURRLANG"
   NEWLANGLINE="LANG=${LANGCHOICE}"
@@ -1573,7 +1573,7 @@ if [ "$SET_TIMEZONE" ];then
  [ "$CHECK_UTC" = "true" ] && NEW_HWCLOCKTIME="utc"
  [ ! -e /etc/localtime ] && DEF_TIMEZONE="" #111027 precaution.
  if [ "$DEF_TIMEZONE" != "$ZONERETVAL" -o "$HWCLOCKTIME" != "$NEW_HWCLOCKTIME" ];then
-  FLAG_CHANGED="${FLAG_CHANGED}${TT_tz2}:yes|"
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Time Zone'):yes|"
   [ "`echo "$ZONERETVAL" | grep 'GMT'`" != "" ] && ZONERETVAL="Etc/$ZONERETVAL"
   #111103 these are also in Etc dir...
   [ "$ZONERETVAL" = "Greenwich" ] && ZONERETVAL="Etc/$ZONERETVAL"
@@ -1602,7 +1602,7 @@ if [ "$SET_XRES" ];then
  NEW_XYRES="$(echo -n "$COMBO_XYRES" | tr '\t' ' ' | cut -f 1 -d ' ')" #130202
  NEW_VFREQ="$(echo -n "$COMBO_XYRES" | tr '\t' ' ' | tr -s ' ' | cut -f 2 -d ' ' | cut -f 1 -d '*')" #130202
  if [ "$DEF_XYRES$DEF_VFREQ" != "$NEW_XYRES$NEW_VFREQ" ];then
-  FLAG_CHANGED="${FLAG_CHANGED}${TT_xy1}:yes|"
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Xrandr Screen Resolution'):yes|"
   T_yesno="`gettext 'Change resolution to:'`"
   M_yesno1="`gettext 'Click the OK button to change the resolution.'`"
   M_yesno2="`gettext 'If the new resolution does not work, wait 60 seconds, or hit the CTRL-ALT-BACKSPACE key combination to kill X.'`"
@@ -1680,12 +1680,12 @@ fi #end SET_XRES
 if [ "$SET_XWIZARD" ];then
 
  if [ "$CHECK_XUPGRADE" = "true" ];then
-  #FLAG_CHANGED="${FLAG_CHANGED}${TT_xup2}:yes|" #"Video Upgrade Wizard"
+  #FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Video Upgrade Wizard'):yes|" #"Video Upgrade Wizard"
   /usr/sbin/video_upgrade_wizard
  fi
 
  if [ "$CHECK_XORGWIZARD" = "true" ];then
-  FLAG_CHANGED="${FLAG_CHANGED}${TT_xorg2}:restart|" #"Xorg Video Wizard"
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Xorg Video Wizard'):restart|" #"Xorg Video Wizard"
   sed -i -e "s%^DISTRO_XORG_AUTO.*%DISTRO_XORG_AUTO='no'%" /etc/DISTRO_SPECS #/usr/bin/xwin reads this when X starts.
   mv -f /etc/X11/xorg.conf /etc/X11/xorg.conf.prev 2>/dev/null #/usr/bin/xwin will then run xorgwizard.
   echo "ICONWIPE" > /var/local/pup_event_icon_change_flag #120226 .xinitrc -> clean_desk_icons will read this, and redraw drive icons. ...actually, redundant, as xorgwizard does this.


### PR DESCRIPTION
Reported by Rodin.s here:
http://www.murga-linux.com/puppy/viewtopic.php?p=748489#748489

I just replaced variables (that, due to recent changes, are no longer defined in the code) with actual gettext strings, in the same manner as it is done later in the code (see further occurences of FLAG_CHANGED= ).

Greetings!
