### PR TITLE
pmount: fixed automounting drives in PUPMODE=13

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -556,7 +556,7 @@ do
 	</menuitem>"
 	if [ "$ONEFS" != "iso9660" ];then
 		#check if patrition is mounted at boot
-		[ "`grep "^mount" /etc/rc.d/rc.local | grep -F $DEVNAME | grep -F '#pmount'`" ] && MENU_BOOTMOUNT=true
+		[ "`grep "^mkdir -p /mnt/${DEVNAME}; mount" /etc/rc.d/rc.local | grep -F '#pmount'`" ] && MENU_BOOTMOUNT=true
 		#---
 		ACTION_MENU="$ACTION_MENU
 		<menuitemseparator></menuitemseparator>
@@ -576,7 +576,7 @@ do
 		 ${INVISBUT}
 		 <action>cp -f /etc/rc.d/rc.local /tmp/pmount_tmp</action>
 		 <action>if false grep -v '${DEVNAME} #pmount' /tmp/pmount_tmp > /etc/rc.d/rc.local</action>
-		 <action>if true echo 'mount -t $ONEFS $ONEDEV /mnt/$DEVNAME #pmount' >> /etc/rc.d/rc.local</action>
+		 <action>if true echo 'mkdir -p /mnt/${DEVNAME}; mount -t $ONEFS $ONEDEV /mnt/$DEVNAME #pmount' >> /etc/rc.d/rc.local</action>
 		</menuitem>"
 	fi
 	BUTTON="


### PR DESCRIPTION
_pmount_ adds line(s) like:
`mount -t ext4 /dev/sda2 /mnt/sda2 #pmount`
to /etc/rc.d/rc.local, however in PUPMODE=13, where snapmerge excludes the whole /mnt dir from being merged onto pup_ro1, appropriate subdirs (sdaX, sdbX, etc.) don't exist when system starts up.
Simple 'mkdir -p' did the job.

Nice feature, btw. Just discovered it right now - I was using a separate app for this before. So many years and still surprises! :)

Greetings!
