### PR TITLE
snapmergepuppy: fix for .wh files in pup_rw

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -65,7 +65,16 @@ else
  BASE="/initrd/pup_ro1"
 fi
 
+[ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ] || { echo "Wrong PUPMODE ($PUPMODE)!"; exit 1; }	# SFR: precaution
 mountpoint -q "$BASE" || { echo "$BASE is not mounted!"; exit 1; }	# SFR: precaution
+
+# SFR: fix for .wh files not being created (in some cases) in pup_rw
+if [ "`lsmod | grep "^aufs" `" != "" ]; then
+  # Remount aufs with best evaluation mode.
+  busybox mount -t aufs -o remount,udba=notify unionfs /
+  # There's more than one 'exit' in the code, so let's use 'trap' to remount aufs back to defaults
+  trap 'busybox mount -t aufs -o remount,udba=reval unionfs /' EXIT
+fi
 
 echo "Merging $SNAP onto $BASE..."
 


### PR DESCRIPTION
Fix for .wh files not being created (in some cases) in pup_rw, described here:
http://woof-ce.26403.n7.nabble.com/Fixing-snapmerge-td240.html#a363

Greetings!
