### PR TITLE
Enhancement: support for minix, jfs & hfs in pup_event & pmount

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/drive_all
+++ b/woof-code/rootfs-skeleton/usr/local/bin/drive_all
@@ -297,7 +297,7 @@ if [ "$FSTYPE" != "" ];then
 else
  #ONEDRVNAME is probably a drive name, ex sda...
  pPTN="/dev/${ONEDRVNAME}" #no space on end!
- DOPARTS="`probepart -m | grep "$pPTN" | cut -f 1,2 -d '|' | cut -f 3 -d '/' | grep -E 'f2fs|ext2|ext3|ext4|udf|is09660|vfat|reiser|btrfs|ntfs|msdos|minix' | tr '\n' ' '`" #ex: sda1|ext3 sda2|vfat sda3|ext3  130216 added f2fs
+ DOPARTS="`probepart -m | grep "$pPTN" | cut -f 1,2 -d '|' | cut -f 3 -d '/' | grep -E 'minix|jfs|hfs|f2fs|ext2|ext3|ext4|udf|is09660|vfat|reiser|btrfs|ntfs|msdos|minix' | tr '\n' ' '`" #ex: sda1|ext3 sda2|vfat sda3|ext3  130216 added f2fs	# SFR: enabled minix, jfs & hfs
 fi
 
 #if it is a mountable partition then mount and open with rox. If already mntd then open in rox...

--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_change
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_change
@@ -139,7 +139,7 @@ do
    fi
   fi
  done
- PROBEPART="`echo -n "$xPROBEPART" | tr ' ' '\n' | grep -E 'ext2|ext3|ext4|f2fs|ntfs|msdos|vfat|reiser|iso9660|udf|audiocd|xfs'`" #130610 screen out unwanted filesystems.
+ PROBEPART="`echo -n "$xPROBEPART" | tr ' ' '\n' | grep -E 'minix|jfs|hfs|ext2|ext3|ext4|f2fs|ntfs|msdos|vfat|reiser|iso9660|udf|audiocd|xfs'`" #130610 screen out unwanted filesystems.	# SFR: enabled minix, jfs & hfs
  
  #also find PROBEDISK, extract code from /sbin/probedisk...
  PROBEDISK=''

--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -457,7 +457,7 @@ TABLIST="`echo -n "$DISKINFO" | cut -f 2 -d '|' | uniq | tr '\n' '|' | sed -e 's
 CURRENTTAB=''
 
 #v408 v410 moved up...  130216 added f2fs...
-VALIDPARTS="`echo "$PARTSINFO" | grep -E 'f2fs|vfat|msdos|ntfs|minix|ext2|ext3|ext4|reiser|xfs|iso9660|udf'`" #130128
+VALIDPARTS="`echo "$PARTSINFO" | grep -E 'jfs|hfs|f2fs|vfat|msdos|ntfs|minix|ext2|ext3|ext4|reiser|xfs|iso9660|udf'`" #130128
 
 #get actual top tab...
 TOPACTUAL="`echo "$TABLIST" | cut -f 1 -d '|'`"


### PR DESCRIPTION
It seems to me that kernels in Puppy tend to support minix, jfs and hfs filesystems (I checked in Wary, Precise, Slacko, Lupu), so why shouldn't we enable support for them also in pup_event (for ROX-Desktop drive Icons) and Pmount (minix is already in the latter)..?

Greetings!
