### PR TITLE
Enhancement: btrfs support in pup_event & pmount

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/drive_all
+++ b/woof-code/rootfs-skeleton/usr/local/bin/drive_all
@@ -297,7 +297,7 @@ if [ "$FSTYPE" != "" ];then
 else
  #ONEDRVNAME is probably a drive name, ex sda...
  pPTN="/dev/${ONEDRVNAME}" #no space on end!
- DOPARTS="`probepart -m | grep "$pPTN" | cut -f 1,2 -d '|' | cut -f 3 -d '/' | grep -E 'minix|jfs|hfs|f2fs|ext2|ext3|ext4|udf|is09660|vfat|reiser|btrfs|ntfs|msdos|minix' | tr '\n' ' '`" #ex: sda1|ext3 sda2|vfat sda3|ext3  130216 added f2fs	# SFR: enabled minix, jfs & hfs
+ DOPARTS="`probepart -m | grep "$pPTN" | cut -f 1,2 -d '|' | cut -f 3 -d '/' | grep -E 'btrfs|ext2|ext3|ext4|f2fs|hfs|iso9660|jfs|minix|msdos|ntfs|reiser|udf|vfat|xfs' | tr '\n' ' '`" #ex: sda1|ext3 sda2|vfat sda3|ext3  130216 added f2fs	# SFR: enabled jfs & hfs
 fi
 
 #if it is a mountable partition then mount and open with rox. If already mntd then open in rox...

--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_change
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_change
@@ -139,7 +139,7 @@ do
    fi
   fi
  done
- PROBEPART="`echo -n "$xPROBEPART" | tr ' ' '\n' | grep -E 'minix|jfs|hfs|ext2|ext3|ext4|f2fs|ntfs|msdos|vfat|reiser|iso9660|udf|audiocd|xfs'`" #130610 screen out unwanted filesystems.	# SFR: enabled minix, jfs & hfs
+ PROBEPART="`echo -n "$xPROBEPART" | tr ' ' '\n' | grep -E 'audiocd|btrfs|ext2|ext3|ext4|f2fs|hfs|iso9660|jfs|minix|msdos|ntfs|reiser|udf|vfat|xfs'`" #130610 screen out unwanted filesystems.	# SFR: enabled btrfs, minix, jfs & hfs
  
  #also find PROBEDISK, extract code from /sbin/probedisk...
  PROBEDISK=''

--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -457,7 +457,7 @@ TABLIST="`echo -n "$DISKINFO" | cut -f 2 -d '|' | uniq | tr '\n' '|' | sed -e 's
 CURRENTTAB=''
 
 #v408 v410 moved up...  130216 added f2fs...
-VALIDPARTS="`echo "$PARTSINFO" | grep -E 'jfs|hfs|f2fs|vfat|msdos|ntfs|minix|ext2|ext3|ext4|reiser|xfs|iso9660|udf'`" #130128
+VALIDPARTS="`echo "$PARTSINFO" | grep -E 'btrfs|ext2|ext3|ext4|f2fs|hfs|iso9660|jfs|minix|msdos|ntfs|reiser|udf|vfat|xfs'`" #130128
 
 #get actual top tab...
 TOPACTUAL="`echo "$TABLIST" | cut -f 1 -d '|'`"


### PR DESCRIPTION
Added 'btrfs' to pmount and drive_all (frontend_change has it already).
Corrected error in drive_all (was 'is09660').
Alphabetically reordered.

Note: in my previous commit I added 'minix' to drive_all, but didn't notice that it was already there. Corrected.

Greetings!
