### PR TITLE
snapmerge: 2 fixes

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -78,7 +78,7 @@ fi
 
 echo "Merging $SNAP onto $BASE..."
 
-SFSPoints=$( grep -o "/initrd/pup_ro[1-9]" /proc/mounts |sort -u ) #110206 Dougal: get a list of the sfs mountpoints
+SFSPoints=$( grep -o -E "/initrd/pup_ro[0-9]+" /proc/mounts |sort -t o -k2 -nu ) #110206 Dougal: get a list of the sfs mountpoints	SFR: increase amount of mountpoints (sfs_load can load >=10)
 
 #Handle Whiteouts...
 find . -mount \( -regex '.*/\.wh\.[^/]*' -type f \) | sed -e 's/\.\///;s/\.wh\.//' |
@@ -113,7 +113,7 @@ do
  #110206 Dougal: speedup and refine the search...
  for P in $SFSPoints
  do
-   if [ -e "$P/$N" ] ; then
+   if [ -e "$P/$N" ] || [ -L "$P/$N" ] ; then	# SFR: broken symlinks also deserve to be processed ( '-e' won't detect them, needs to be also '-L')
      [ ! -d "${BASE}/${DN}" ] && mkdir -p "${BASE}/${DN}"
      touch "${BASE}/${DN}/.wh.${BN}"
      break


### PR DESCRIPTION
1. Increased amount of SFSPoints, because sfs_load can handle >= pup_ro10
2. In case of deleting a broken symlink (which originally resides in one of loaded SFS-es), a corresponding .wh file wasn't created in pup_ro1.

Greetings!
