### PR TITLE
Create ptheme_gtk

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-skeleton/usr/sbin/ptheme_gtk
@@ -1,0 +1,147 @@
+#!/bin/sh
+#ptheme_gtk - change gtk-theme
+#Copyright - GPL 2010,2014
+#Sigmund Berglund, Michael Amadio
+
+set -a 
+TMP="`grep 'gtkrc"' $HOME/.gtkrc-2.0 | awk -F '/gtk-2.0' '{print $1}' | cut -d'"' -f2-`"
+ACTIVE_THEME="`basename $TMP`"
+echo -n > /tmp/ptheme_gtkfont
+
+#functions
+set_theme (){
+	exec switch2 -f "$FONT" "/usr/share/themes/$THEME"
+
+	#make Qt4 apps theme match gtk2...
+	#see also /etc/profile.d/pup_gtk and /root/.config/Trolltech.conf
+	THEREBEFORE="$(grep '^gtk-theme-name' /root/.gtkrc-2.0)"
+	if [ "$THEREBEFORE" = "" ]; then
+		echo "gtk-theme-name=\"${THEME}\"" >> /root/.gtkrc-2.0
+		#gtk3 theme support thunor http://murga-linux.com/puppy/viewtopic.php?p=695722#695722
+		pathGTK3THEME="`find /usr/share/themes/${THEME} -type d -name gtk-3.0`"
+		if [ "$pathGTK3THEME" ]; then #XDG_CONFIG_HOME=/root/.config
+			#130404 link to actual theme...
+			ln -snf "$pathGTK3THEME" ${XDG_CONFIG_HOME}/gtk-3.0
+		fi
+	fi
+}
+
+set_font (){
+	Xdialog --fontsel 0 0 0 2> /tmp/ptheme_gtkfont
+}
+
+#parameters
+while [ $# != 0 ]; do
+	I=1
+	while [ $I -le `echo $# | wc -c` ]; do 
+		case $1 in
+			-t) export THEME="$2"; shift;;
+			-f) export FONT="$2"; shift;;
+			-h|--help)
+echo 'Usage: ptheme_gtk [OPTIONS]
+
+Options
+  -f FONT     Set font for theme
+  -t THEME    Set theme without open gui 
+  -h          Show this help message'; exit;;
+		esac
+		shift
+		I=$[$I+1]
+	done
+done
+if [ "$THEME" ]; then
+	set_theme
+	exit
+fi
+
+#build list
+ls -1A /usr/share/themes > /tmp/ptheme_gtkthemes
+while read I; do ITEMS="$ITEMS<item>$I</item>"; done < /tmp/ptheme_gtkthemes
+
+pThemeGTK='
+<window title="GTK '$(gettext 'theme switcher')'" icon-name="gtk-preferences">
+<vbox space-expand="true" space-fill="true">
+  '"`/usr/lib/gtkdialog/xml_info fixed "puppy_theme.svg" 60 "$(gettext 'A GTK-theme defines how widgets in programs shows up. This is buttons, lists, fields, and so on. Please apply a theme from the list.')"`"' 
+  <frame '$(gettext 'Preview')'>
+    <menubar>
+      <menu>
+        <menuitem><label>'$(gettext 'Simple item')'</label></menuitem>
+        <menuitem><label>'$(gettext 'Simple item')'</label></menuitem>
+        <separator></separator>
+        <menuitem icon="gtk-convert"><label>'$(gettext 'With image')'</label></menuitem>
+        <menuitem icon="gtk-convert"><label>'$(gettext 'With image')'</label></menuitem>
+        <label>'$(gettext 'Menu')'</label>
+      </menu>
+    </menubar>
+    <hbox>
+      <checkbox><default>true</default><label>'$(gettext 'Check')' 1</label></checkbox>
+      <checkbox><label>'$(gettext 'Check')' 2</label></checkbox>
+      <text><label>"  "</label></text>
+      <radiobutton><label>'$(gettext 'Radio')' 1</label></radiobutton>
+      <radiobutton><label>'$(gettext 'Radio')' 2</label></radiobutton>
+      <radiobutton><label>'$(gettext 'Radio')' 3</label></radiobutton>
+    </hbox>
+    <hbox>
+      <button><label>Button</label><input file stock="gtk-execute"></input></button>
+      <text><label>"  "</label></text>
+      <checkbox draw_indicator="false"><default>true</default><label>" '$(gettext 'Toggle')' 1 "</label></checkbox>
+      <checkbox draw_indicator="false"><label>" '$(gettext 'Toggle')' 2 "</label></checkbox>
+      <text><label>"  "</label></text>
+      <button><label>'$(gettext 'Disabled')'</label><input file stock="gtk-close"></input><visible>disabled</visible></button>
+    </hbox>
+    <hbox>
+      <progressbar><input>echo 40; echo "(40%)"</input></progressbar>
+      <combobox>
+       <item>'$(gettext 'item')' A</item>
+       <item>'$(gettext 'item')' B</item>
+       <item>'$(gettext 'item')' C</item>
+      </combobox>
+    </hbox>
+  </frame>
+  <vbox space-expand="true" space-fill="true">
+    <frame '$(gettext 'Define Theme')'>  
+      <tree rules_hint="true" space-expand="true" space-fill="true">
+        <label>'$(gettext 'Themes')'</label>
+        <variable>THEME</variable>
+        <height>200</height><width>50</width>
+        '$ITEMS'
+        <action>set_theme</action>
+      </tree>
+      <hbox>
+        <button>
+          <label>'$(gettext 'Font')'</label>
+          <input file stock="gtk-bold"></input>
+          <action>set_font</action>
+          <action>refresh:FONT</action>
+        </button>
+        <entry editable="false">
+          <variable>FONT</variable>
+          <input>cat /tmp/ptheme_gtkfont</input>
+        </entry>
+        <button>
+          <label>'$(gettext 'Clear')'</label>
+          <input file stock="gtk-clear"></input>
+          <action>echo > /tmp/ptheme_gtkfont</action>
+          <action>refresh:FONT</action>
+        </button>
+      </hbox>
+    </frame>
+  </vbox>
+  <hbox space-expand="false" space-fill="false">
+    <button>
+      '"`/usr/lib/gtkdialog/xml_button-icon apply`"'
+     <label>'$(gettext 'Apply')'</label>
+     <action>set_theme</action>
+   </button>
+   <button>
+     '"`/usr/lib/gtkdialog/xml_button-icon quit`"'
+     <label>'$(gettext 'Quit')'</label>
+     <action>THEME='$ACTIVE_THEME'; set_theme</action>
+     <action>EXIT:cancel</action>
+   </button>
+   '"`/usr/lib/gtkdialog/xml_scalegrip`"'
+  </hbox>
+</vbox>
+</window>'
+. /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
+gtkdialog -p pThemeGTK 2> /dev/null


### PR DESCRIPTION
gtk2 theme switcher that works from cli
It includes the wrapper used in Slacko 5.7 (/usr/bin/gtk_chtheme_wrapper) to support QT and gtk3.
Depends on switch2 (Mick has compiled)
