### PR TITLE
Woof code changes

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -327,6 +327,9 @@ fi
 cd $CURDIR
 sync
 
+#output dir for iso and img files
+mkdir -p ../woof-output
+
 #common dir to download pet pkgs to...
 mkdir -p ../local-repositories/${TARGETARCH}/packages-pet
 [ ! -e ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/packages-pet ] && ln -s ../local-repositories/${TARGETARCH}/packages-pet ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/packages-pet #111203 check exist.
@@ -351,6 +354,11 @@ if [ -f ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/D
 
  mkdir -p ../local-repositories/${TARGETARCH}/packages-${BINARIES}
  [ ! -e ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/packages-${BINARIES} ] && ln -s ../local-repositories/${TARGETARCH}/packages-${BINARIES} ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/packages-${BINARIES} #111203 check exist.
+
+ if [ "$DISTRO_TARGETARCH" = "arm" ]; then
+  mkdir -p ../local-repositories/${TARGETARCH}/sd-skeleton-images
+  [ ! -e ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/sd-skeleton-images ] && ln -s ../local-repositories/${TARGETARCH}/sd-skeleton-images ../woof-out_${HOSTARCH}_${TARGETARCH}_${COMPATDISTRO}_${COMPATVERSION}/sd-skeleton-images
+ fi
 fi
 
 #record target architecture in DISTRO_SPECS (will end up in /etc/ in Puppy build)...

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -280,9 +280,7 @@ echo "Do you want to create a live-CD .iso file, which is the normal choice for 
 PC-compatible target, or is your target an SD-card for an ARM-based board?
 In the latter case, you would already have downloaded an SD-card skeleton image
 file into folder 'sd-skeleton-images' (done by script '1download') -- if there
-is no image file in that folder, you cannot choose the SD-card option.
-The latter choice will also require an SD card to write to, and you must have
-it available now."
+is no image file in that folder, you cannot choose the SD-card option."
 echo "WARNING: for the SD-card option, you must have enough free space in the
 current directory ${WKGDIR}/sandbox3
 to expand the SD image file, typically 4GB."
@@ -3116,7 +3114,18 @@ fi
 
 rm -rf rootfs-complete/tmp/* #121123 some above chroot operations may have left something behind in here.
 
-
+BUILD_SFS='yes'
+if [ "$SDFLAG" != "" ]; then
+ echo
+ echo "Since you are building a SD card image, it is not necessary"
+ echo "to build the main sfs file.  Press ENTER only to skip,"
+ echo "any other character then ENTER to build it anyway."
+ read buildanyway
+ if [ "$buildanyway" = '' ]; then
+  BUILD_SFS='no'
+ fi
+fi
+if [ "$BUILD_SFS" = 'yes' ]; then
 ###########
 #build the rootfs-complete sfs...
 echo
@@ -3128,6 +3137,7 @@ sync
 echo -n "$IDSTRING" >> build/${PUPPYSFS} #100911 16-byte id-string appended to file.
 sync
 ###########
+fi # if BUILD_SFS
 
 #if separate 'zdrv' exists, copy that into live-cd also...
 if [ -f ${ZDRVSFS} ];then #100911
@@ -3156,7 +3166,7 @@ fi
 
 #build live-cd .iso file...
 echo "Now building ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso"
-rm -f ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso 2>/dev/null
+rm -f ../../woof-output/${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso 2>/dev/null
 if [ -f rootfs-complete/usr/lib/syslinux/isolinux.bin ];then
  cp -a rootfs-complete/usr/lib/syslinux/isolinux.bin build/
 else
@@ -3269,12 +3279,15 @@ sync
 
 
 if [ "$SDFLAG" = "" ];then #120506
- $MKISOFS -D -R -o ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table ./build/
+ $MKISOFS -D -R -o ../../woof-output/${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso -b isolinux.bin -c boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table ./build/
  sync
  # 131227 iguleder: made the generated ISO image hybrid, so it can be written to flash drives using dd
  isohybrid="$(which isohybrid)"
- [ -n "$isohybrid" ] && $isohybrid ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso
+ [ -n "$isohybrid" ] && $isohybrid ../../woof-output/${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso
+ CUR_DIR="$PWD"
+ cd ../../woof-output
  md5sum ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso > ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso.md5.txt
+ cd "$CUR_DIR"
  echo
  echo "Would you like to burn it to a CD? "
  echo -n "ENTER only for yes, or any printable char then ENTER not to: "
@@ -3297,7 +3310,7 @@ if [ "$SDFLAG" = "" ];then #120506
   echo -n "Then hit ENTER key: "
   read yayburn
 # $CDRECORD $BURNMULTI -data -eject -v speed=4 padsize=300k dev=ATAPI:$CDR ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso
-  $CDRECORD $BURNMULTI -data -eject -v speed=4 padsize=300k dev=$CDR ${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso
+  $CDRECORD $BURNMULTI -data -eject -v speed=4 padsize=300k dev=$CDR ../../woof-output/${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${SCSIFLAG}.iso
   sync
   eject $CDR
   echo "...done"
@@ -3324,70 +3337,35 @@ else #120506 sd image
   read sdcorrect
   [ "$sdcorrect" = "" ] && break
  done
+ SDBASE="`basename ../sd-skeleton-images/${SDIMAGE} .xz`"
  echo
- echo "Please insert the SD card. Make sure that it is the same size or bigger than
-indicated on the filename of the skeleton image file that you chose."
- echo -n "Press ENTER after it is inserted: "
- read waitinsert
- sleep 2
- while [ 1 ];do
-  CNT=1
-  echo -n "" > /tmp/3builddistro-probedisk
-  probedisk | 
-  while read ONEPROBE
-  do
-   echo "${CNT} ${ONEPROBE}" >> /tmp/3builddistro-probedisk
-   CNT=`expr $CNT + 1`
-  done
-  echo
-  echo "Type number which is your SD card:"
-  cat /tmp/3builddistro-probedisk
-  read sdnumber
-  SDDEVICE="`cat /tmp/3builddistro-probedisk | head -n $sdnumber | tail -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '|'`"
-  echo -n "You chose ${SDDEVICE} Press ENTER if correct: "
-  read sdcorrect
-  [ "$sdcorrect" = "" ] && break
- done
- echo
- echo "Sanity check: ../sd-skeleton-images/${SDIMAGE}
-is to be written to ${SDDEVICE}."
- echo -n "Press ENTER to continue: "
- read yepgo
+ echo "Please type the name that you want to give the SD image file, or press ENTER"
+ SDBASEBASE="`basename $SDBASE .img | sed -e 's%-201[0-9]*%-%' -e 's%-skeleton%-%' | cut -f 1,2,3 -d '-'`"
+ PUPIMG="${SDBASEBASE}-${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}.img"
+ echo -n "only for the default [${PUPIMG}]: "
+ read PUPIMG1
+ [ "$PUPIMG1" != "" ] && PUPIMG="`basename $PUPIMG1 .img`.img"
+ echo "...chosen $PUPIMG"
  echo
  
  #need to know uncompressed size of image...
  echo "Uncompressing image, please wait..."
- cp -f ../sd-skeleton-images/${SDIMAGE} ./${SDIMAGE}
- sync
- SDBASE="`basename $SDIMAGE .xz`"
- [ -f ./${SDBASE} ] && rm -f ./${SDBASE}
- unxz ${SDIMAGE}
+ [ -f ../../woof-output/${PUPIMG} ] && rm -f ../../woof-output/${PUPIMG}
+ unxz --stdout ../sd-skeleton-images/${SDIMAGE} > ../../woof-output/${PUPIMG}
  if [ $? -ne 0 ];then
-  [ -f ./$SDIMAGE ] && rm -f ./$SDIMAGE
-  [ -f ./$SDBASE ] && rm -f ./$SDBASE
+  [ -f ../../woof-output/${PUPIMG} ] && rm -f ../../woof-output/${PUPIMG}
   echo "Uncompress fail. Aborting."
   exit 1
  fi
  sync
 
- IMGBYTES=`stat --format=%s $SDBASE`
- SDCARDINFO="`disktype ${SDDEVICE}`"
- #120506b check that sd card big enough...
- SDCARDBYTES=`echo "$SDCARDINFO" | grep '^Block device' | cut -f 2 -d '(' | cut -f 1 -d ' '` #ex: 4023386112
- if [ $IMGBYTES -gt $SDCARDBYTES ];then
-  echo
-  echo "Sorry, the image file is ${IMGBYTES}bytes, however the
-SD card is only ${SDCARDBYTES}bytes. Cannot continue."
-  exit 1
- fi
-
  #120703 allow 2nd partition to be ext2, ext3 or ext4...
- SDIMGINFO="`disktype ${SDBASE}`"
+ SDIMGINFO="`disktype ../../woof-output/${PUPIMG}`"
  SDFS2="`echo "$SDIMGINFO" | grep -o 'Ext[0-9] file system' | cut -f 1 -d ' ' | tr '[A-Z]' '[a-z]'`"
  case $SDFS2 in
   ext2|ext3|ext4) SDFS2="ext4" ;; #120706 hack for now. disktype misreports ext4 without journal as ext2.
   *)
-   echo -n "wrong f.s. ${SDFS2} in ${SDBASE}, aborting. Press ENTER: "
+   echo -n "wrong f.s. ${SDFS2} in ${SDIMAGE}, aborting. Press ENTER: "
    read exitme
    exit
   ;;
@@ -3410,9 +3388,9 @@ SD card is only ${SDCARDBYTES}bytes. Cannot continue."
  echo "Copying Linux kernel to SD image file..."
  mkdir -p /mnt/sdimagep1
  mkdir -p /mnt/sdimagep2
- mount-FULL -t vfat -o loop,offset=${P1STARTBYTES} ${SDBASE} /mnt/sdimagep1
+ mount-FULL -t vfat -o loop,offset=${P1STARTBYTES} ../../woof-output/${PUPIMG} /mnt/sdimagep1
  if [ $? -ne 0 ];then
-  echo "Sorry, mounting vfat partition 1 (at offset ${P1STARTBYTES}) of ${SDBASE} failed. Aborting script."
+  echo "Sorry, mounting vfat partition 1 (at offset ${P1STARTBYTES}) of ${PUPIMG} failed. Aborting script."
   exit 1
  fi
  #120613 restore correct kernel image name...
@@ -3428,46 +3406,125 @@ SD card is only ${SDCARDBYTES}bytes. Cannot continue."
  
  echo
  echo "Copying Puppy filesystem to SD image file, please wait..."
- mount-FULL -t ${SDFS2} -o loop,offset=${P2STARTBYTES} ${SDBASE} /mnt/sdimagep2
+ mount-FULL -t ${SDFS2} -o loop,offset=${P2STARTBYTES} ../../woof-output/${PUPIMG} /mnt/sdimagep2
  if [ $? -ne 0 ];then
-  echo "Sorry, mounting ${SDFS2} partition 2 (at offset ${P2STARTBYTES}) of ${SDBASE} failed. Aborting script."
+  echo "Sorry, mounting ${SDFS2} partition 2 (at offset ${P2STARTBYTES}) of ${PUPIMG} failed. Aborting script."
   exit 1
  fi
  cp -a rootfs-complete/* /mnt/sdimagep2/
  sync
  #120704 add to /etc/fstab...
- echo "/dev/${SDDEVICE}2     /     ${SDFS2}     defaults,noatime   0 1" >> /mnt/sdimagep2/etc/fstab #120707 change relatime to noatime.
+# echo "/dev/${SDDEVICE}2     /     ${SDFS2}     defaults,noatime   0 1" >> /mnt/sdimagep2/etc/fstab #120707 change relatime to noatime.
+ #not sure if the root partition is referred to as /dev/root or /dev/mmcblk0p2 on the raspi
+ echo "/dev/mmcblk0p2     /     ${SDFS2}     defaults,noatime   0 1" >> /mnt/sdimagep2/etc/fstab
  sync
  echo "...done"
  busybox umount /mnt/sdimagep2 2>/dev/null
  
- echo
- echo "Writing image file ${SDBASE} to SD card ${SDDEVICE}..."
- dd if=${SDBASE} of=${SDDEVICE} bs=4M #120704 added bs=4M
- if [ $? -ne 0 ];then
-  echo "Sorry, operation failure. Aborting script."
-  exit 1
- fi
- sync
+ IMGBYTES=`stat --format=%s ../../woof-output/$PUPIMG`
  
- echo
- echo "Please type the name that you want to give the SD image file, or press ENTER"
- SDBASEBASE="`basename $SDBASE .img | sed -e 's%-201[0-9]*%-%' -e 's%-skeleton%-%' | cut -f 1,2,3 -d '-'`"
- PUPIMG="${SDBASEBASE}-${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}.img"
- echo -n "only for the default [${PUPIMG}]: "
- read PUPIMG1
- [ "$PUPIMG1" != "" ] && PUPIMG="$PUPIMG1"
- echo "...chosen $PUPIMG"
  echo
  IMGK=`expr $IMGBYTES \/ 1024`
  echo "The image file is ${IMGK}KB, so needs to be compressed for distribution."
+
+ echo "If you only want to write to SD card choose 'none' which is the fastest."
+ echo "You can also compress the image file yourself later."
+ echo "Choose compression type:
+1 xz   (smallest, slowest)
+2 gz   (larger, faster)
+3 none (huge, instant)"
+ read compresstype
+ case $compresstype in
+  1) COMPRESS='xz' ;;
+  2) COMPRESS='gz' ;;
+  *) COMPRESS='none' ;;
+ esac
+ echo "...you chose $COMPRESS"
+
+ if [ "$COMPRESS" != 'none' ]; then
  echo "Compressing, please wait..."
- [ -f ./${PUPIMG}.xz ] && rm -f ./${PUPIMG}.xz
- xz --stdout ${SDBASE} > ${PUPIMG}.xz
+ [ -f ../../woof-output/${PUPIMG}.${COMPRESS} ] && rm -f ../../woof-output/${PUPIMG}.${COMPRESS}
+ if [ "$COMPRESS" = 'xz' ]; then
+ xz --stdout ../../woof-output/${PUPIMG} > ../../woof-output/${PUPIMG}.xz
+ elif [ "$COMPRESS" = 'gz' ]; then
+ gzip --stdout ../../woof-output/${PUPIMG} > ../../woof-output/${PUPIMG}.gz
+ fi
  sync
- rm -f ./${SDBASE}
- echo "...${PUPIMG}.xz created."
- 
+ echo "...${PUPIMG}.${COMPRESS} created."
+ COMPRIMGBYTES=`stat --format=%s ../../woof-output/${PUPIMG}.${COMPRESS}`
+ echo
+ echo "The image is now ${PUPIMG}.${COMPRESS} and is ${COMPRIMGBYTES}bytes."
+ COMPRIMGK=`expr $COMPRIMGBYTES \/ 1024`
+ echo "(${COMPRIMGK}KB)"
+ echo "Image file may be distributed to others!"
+ echo
+ fi # if COMPRESS
+
+ echo
+ echo "Would you like to write it to a SD card?  ENTER only for no,"
+ echo -n "or any printable char then ENTER to write image to SD card: "
+ read writeSD
+ if [ "$writeSD" = "" ];then
+  WRITE_SD="no"
+ else
+  WRITE_SD="yes"
+ fi
+
+ if [ "$WRITE_SD" = "yes" ];then
+
+  echo
+  echo "Please insert the SD card. Make sure that it is the same size or bigger than
+ indicated on the filename of the skeleton image file that you chose."
+  echo -n "Press ENTER after it is inserted: "
+  read waitinsert
+  sleep 2
+  while [ 1 ];do
+   CNT=1
+   echo -n "" > /tmp/3builddistro-probedisk
+   probedisk |
+   while read ONEPROBE
+   do
+    echo "${CNT} ${ONEPROBE}" >> /tmp/3builddistro-probedisk
+    CNT=`expr $CNT + 1`
+   done
+   echo
+   echo "Type number which is your SD card:"
+   cat /tmp/3builddistro-probedisk
+   read sdnumber
+   SDDEVICE="`cat /tmp/3builddistro-probedisk | head -n $sdnumber | tail -n 1 | cut -f 2 -d ' ' | cut -f 1 -d '|'`"
+   echo -n "You chose ${SDDEVICE} Press ENTER if correct: "
+   read sdcorrect
+   [ "$sdcorrect" = "" ] && break
+  done
+  echo
+  echo "Sanity check: ${PUPIMG}
+ is to be written to ${SDDEVICE}."
+  echo -n "Press ENTER to continue: "
+  read yepgo
+
+  SDCARDINFO="`disktype ${SDDEVICE}`"
+  #120506b check that sd card big enough...
+  SDCARDBYTES=`echo "$SDCARDINFO" | grep '^Block device' | cut -f 2 -d '(' | cut -f 1 -d ' '` #ex: 4023386112
+  if [ $IMGBYTES -gt $SDCARDBYTES ];then
+   echo
+   echo "Sorry, the image file is ${IMGBYTES}bytes, however the
+SD card is only ${SDCARDBYTES}bytes. Cannot continue."
+   exit 1
+  fi
+
+  echo
+  echo "Writing image file ${PUPIMG} to SD card ${SDDEVICE}..."
+  dd if=../../woof-output/${PUPIMG} of=${SDDEVICE} bs=4M #120704 added bs=4M
+  if [ $? -ne 0 ];then
+   echo "Sorry, operation failure. Aborting script."
+   exit 1
+  fi
+  sync
+ fi # if WRITE_SD
+
+ if [ "$COMPRESS" != 'none' ]; then
+ rm -f ../../woof-output/${PUPIMG}
+ fi
  
 #130530 this is old code...
 # echo "Writing skeleton image to ${SDDEVICE}, please wait very patiently..."
@@ -3570,17 +3627,11 @@ SD card is only ${SDCARDBYTES}bytes. Cannot continue."
 # sync
 
 
+ if [ "$WRITE_SD" = "yes" ];then
  #update desktop drive icons. note, this is also done in /usr/sbin/bootflash, puppyinstaller, gparted_shell...
  #/tmp/pup_event_frontend_block_request is used in /sbin/pup_event_frontend_d to refresh drv...
  THEDRIVE="`echo -n "$SDDEVICE" | cut -f 3 -d '/'`"
  echo "$THEDRIVE" > /tmp/pup_event_frontend_block_request
- COMPRIMGBYTES=`stat --format=%s ${PUPIMG}.xz`
- echo
- echo "The image is now ${PUPIMG}.xz and is ${COMPRIMGBYTES}bytes."
- COMPRIMGK=`expr $COMPRIMGBYTES \/ 1024`
- echo "(${COMPRIMGK}KB)"
- echo "Image file may be distributed to others!"
- echo
 
  #120510...
  echo "If the SD card currently plugged in is bigger than the image, for example
@@ -3601,6 +3652,7 @@ ${SDFS2} partition to fill the remaining space -- this is for your own use."
    echo "$THEDRIVE" > /tmp/pup_event_frontend_block_request
   fi
  fi
+ fi # if WRITE_SD
 
 fi
 
@@ -3619,7 +3671,7 @@ echo "Building ${DEVXSFS}..."
 echo " building sandbox3/devx ..."
 rm -f /tmp/3builddistro_removed_alt_dev #101013
 ALLGENNAMESD="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | cut -f 2 -d '|' | sed -e 's%$%_DEV%'`"
-rm -f sandbox3/${DEVXSFS} 2>/dev/null #100911
+rm -f ../woof-output/${DEVXSFS} 2>/dev/null #100911
 for ONEDEV in `ls -1 packages-${DISTRO_FILE_PREFIX} | grep '_DEV$' | tr '\n' ' '`
 do
 
@@ -3817,14 +3869,15 @@ rm -f sandbox3/devx/etc/profile.d/*.csh
 # rm -rf sandbox3/devx/usr/bin/multiarch-i386-linux
 #fi
 
-echo "Now creating sandbox3/${DEVXSFS} ..."
-./support/${MKSQUASHFS} sandbox3/devx sandbox3/${DEVXSFS} ${COMPCHOICE} #100911 110713
+echo "Now creating ${DEVXSFS} ..."
+./support/${MKSQUASHFS} sandbox3/devx ../woof-output/${DEVXSFS} ${COMPCHOICE} #100911 110713
 sync
-chmod 644 sandbox3/${DEVXSFS}
-cd sandbox3
+chmod 644 ../woof-output/${DEVXSFS}
+CUR_DIR="$PWD"
+cd ../woof-output
 echo -n "$IDSTRING" >> ${DEVXSFS} #100911 16-byte id-string appended to file.
 md5sum ${DEVXSFS} > ${DEVXSFS}.md5.txt #100911
-cd ..
+cd "$CUR_DIR"
 sync
 echo "...done"
 


### PR DESCRIPTION
Most of these changes only apply to SD image builds, except 'Add a ../woof-output directory'.

I do my builds in a 4GB loopback mounted ext2 image file on a FAT partition, and it is impossible to expand a 4GB SD card image inside of a 4GB ext2 image file.  By unpacking  the SD image into ../woof-output, and making woof-output a symlink to a directory on the FAT partition I can build inside the ext2 image file without hard-coding the path to the SD image file into 3builddistro.
I haven't tested the Raspbian build without these changes, but I kept them separate because I don't think they are necessary if building on a linux partition with plenty of room.
