### PR TITLE
Raspbian changes2

### DIFF
--- a/woof-code/rootfs-skeleton/etc/X11/xorg.conf-auto-armsystem
+++ b/woof-code/rootfs-skeleton/etc/X11/xorg.conf-auto-armsystem
@@ -1,0 +1,156 @@
+#barry Kauler 2011
+#pre-constructed xorg.conf, for use by /usr/sbin/xorgwizard-automatic
+#110627 working on mageia1 build, this needs fixing.
+#111029 Terryphi reported 1cm screen displacement, changed vert freq range from 56-76 to 59-76.
+#120329 more placemarkers for xorgwizard-automatic script.
+#121013 change depth from 16 to 24. note, some arm boards need 16.
+
+# **********************************************************************
+# Module section -- this  section  is used to specify
+# which dynamically loadable modules to load.
+# **********************************************************************
+#
+Section "Module"
+#	Load "synaptics" #loadsynaptics
+
+# This loads the DBE extension module.
+
+    Load        "dbe"  	# Double buffer extension
+
+# This loads the miscellaneous extensions module, and disables
+# initialisation of the XFree86-DGA extension within that module.
+    SubSection  "extmod"
+      Option    "omit xfree86-dga"   # don't initialise the DGA extension
+    EndSubSection
+
+# This loads the font modules
+#    Load        "type1"
+#    Load        "freetype"
+
+# This loads xtrap extension, used by xrandr
+#    Load       "xtrap"
+
+# This loads the GLX module (if present). xorg 7.4/5, need explicit disable to disable... change "Disable" to "Load" if reqd...
+#    Disable       "glx" #LOADGLX
+
+# This loads dri module (if present). 7.4 loads it by default, have to disable... change "Disable" to "Load" if reqd...
+#    Disable       "dri" #LOADDRI
+
+EndSection
+
+# **********************************************************************
+# Files section.  This allows default font paths to be set
+# **********************************************************************
+
+Section "Files"
+
+# Multiple FontPath entries are allowed (which are concatenated together),
+# as well as specifying multiple comma-separated entries in one FontPath
+# command (or a combination of both methods)
+
+    #FontPath   "/usr/share/fonts/X11/misc/"
+    #FontPath   "/usr/share/fonts/liberation/"
+    FontPath   "/usr/share/X11/fonts/misc/"
+    FontPath   "/usr/share/X11/fonts/Type1/"
+    FontPath   "/usr/share/X11/fonts/TTF/"
+
+EndSection
+
+# **********************************************************************
+# Server flags section.
+# **********************************************************************
+
+Section "ServerFlags"
+
+# Uncomment this to disable the <Crtl><Alt><Fn> VT switch sequence
+# (where n is 1 through 12).  This allows clients to receive these key
+# events.
+
+#    Option "DontVTSwitch"
+
+# Enables mode switching with xrandr
+# There is a report that this can cause Xorg not to work on some
+# video hardware, so default is commented-out...
+# but i want to use it in xorgwizard so leave on...
+
+    Option "RandR" "on"
+
+# With this, Xorg won't talk to HAL to add evdev devices and you'll be back
+# with the old Xorg behavior (pre-7.4)...
+
+    Option "AutoAddDevices" "false"
+
+# For no-Hal, kirk also suggests this...
+
+#    Option "AllowMouseOpenFail" "true"
+
+# Xorg 7.4, Ubuntu Jaunty, CTRL-ALT-BACKSPACE is disabled by default...
+
+    Option "DontZap" "false"
+
+EndSection
+
+
+Section "ServerLayout"
+#	InputDevice "Synaptics Mouse" "AlwaysCore" #serverlayoutsynaptics
+	Identifier     "X.org Configured"
+	Screen      0  "Screen0" 0 0
+	InputDevice    "Mouse0" "CorePointer"
+	InputDevice    "Keyboard0" "CoreKeyboard"
+EndSection
+
+Section "InputDevice"
+	Identifier  "Keyboard0"
+	Driver      "kbd"
+	Option      "XkbRules" "xorg"
+	Option      "XkbModel" "pc102" #xkbmodel0
+	Option      "XkbLayout" "us" #xkeymap0
+	#Option      "XkbVariant" "" #xkbvariant0
+EndSection
+
+Section "InputDevice"
+	Identifier  "Mouse0"
+	Driver      "mouse"
+	Option	    "Protocol" "IMPS/2" #mouse0protocol
+	Option	    "Device" "/dev/mouse"
+	#Option      "Emulate3Buttons"
+	#Option      "Emulate3Timeout" "50"
+	Option      "ZAxisMapping" "4 5" #scrollwheel
+EndSection
+
+Section "Monitor"
+	Identifier   "Monitor0"
+	VendorName   "Monitor Vendor"
+	ModelName    "Monitor Model"
+	HorizSync    35-81
+	VertRefresh  59-76
+	#UseModes     "Modes0" #monitor0usemodes
+#	Option      "PreferredMode" "1024x768" #monitor0prefmode
+	EndSection
+	
+Section "Modes"
+	Identifier "Modes0"
+	#modes0modeline0
+EndSection
+
+#110627 remove...
+##server can find BusID automatically, comment out...
+#Section "Device"
+#	Identifier  "Card0"
+#	Driver      "vesa" #card0driver
+#	VendorName  "Unknown Vendor"
+#	BoardName   "Unknown Board"
+##	BusID       "PCI:0:2:0" #card0busid
+#EndSection
+
+Section "Screen"
+	Identifier "Screen0"
+#	Device     "Card0"
+	Monitor    "Monitor0"
+#	DefaultDepth 24   # Xorg from Raspbian won't start if uncommented.
+	#Option         "metamodes" "1280x800_60 +0+0" #METAMODES_0
+	Subsection "Display"
+		Depth       24
+#		Modes       "1024x768" #screen0modes
+	EndSubsection
+EndSection

--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard-automatic
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard-automatic
@@ -17,7 +17,7 @@
 #120517
 if [ "`which ddcprobe`" = "" ];then
  #running on an arm board...
- cp -f /etc/X11/xorg.conf-auto-pc /etc/X11/xorg.conf
+ cp -f /etc/X11/xorg.conf-auto-armsystem /etc/X11/xorg.conf
  echo "#PuppyHardwareProfile=armsystem" >> /etc/X11/xorg.conf
  #create a copy of xorg.conf with the profile in the filename...
  cp -af /etc/X11/xorg.conf /etc/X11/xorg.conf.armsystem


### PR DESCRIPTION
This was the only change that wasn't to a template or DISTRO_PKGS_SPECS-raspbian-wheezy

The only change in xorg.conf-auto-armsystem is
#      DefaultDepth 24   # Xorg from Raspbian won't start if uncommented.
but making it to xorg.conf-auto-pc would affect all builds.
