### PR TITLE
Mavrothal woof ce testing

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -70,7 +70,7 @@ imgFileDEV_INODE="`stat -L -c "%d_%i" "$imgFile"`" || exit #120220
 
 if [ "$MNTEDLOOP" = "" ];then #130223 BK
  #not mounted on $MntPt.
- 
+
   #BK check if already mounted elsewhere...
   for ONELOOP in `mount | grep '^/dev/loop' | cut -f 1 -d ' ' | tr '\n' ' '`
   do
@@ -86,7 +86,7 @@ on \$MNTDIMG_MNT_PT from \$MNTDIMG")"    #120220 121105 add gettext.
      exit
     fi
   done
-   
+
   Ext=`echo "$imgFile" |sed 's/^.*\.//'`	# get file type from extention
   Ext="`echo $Ext | tr [:upper:] [:lower:]`" 	# SFR: extension to lowercase (If Bash >= 4 it could be just Ext=${Ext,,} )
   if [ "$Ext" = '2fs' ] ;then
@@ -100,7 +100,7 @@ on \$MNTDIMG_MNT_PT from \$MNTDIMG")"    #120220 121105 add gettext.
   elif [ "$Ext" = 'iso' ] ;then
    Type='iso9660'
   fi
-  
+
   #v423 detect wrong squashfs version...
   if [ "$Type" = "squashfs" ];then
    if [ "`disktype "${imgFile}" | grep "$SFSSTR"`" = "" ];then
@@ -117,7 +117,7 @@ Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
     fi
     exit
    fi
-   
+
    #120525 take into account shinobar's load-on-the-fly pet...
    if [ "`which sfs_load`" != "" ];then
     SFSMSG1a="$(eval_gettext "You can choose to mount the \${imgFileBASE} file to view it's contents (read-only), or you can install it.")" #'geany
@@ -127,12 +127,12 @@ Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
     [ $RETVAL -eq 1 ] && exec sfs_load "$1"
     [ $RETVAL -ne 0 ] && exit #120527
    fi
-   
+
   fi
-  
+
   echo -e "\n ### Mount: $imgFile\n"
   mkdir -p "$MntPt"
-  
+
   #111110 handle encrypted save-files...
   CRYPTO=""; Err=0
   DEVLOOP="`losetup-FULL -f`" #next free loop device.
@@ -171,10 +171,10 @@ Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
    mount -t $Type -o loop "$imgFile" "$MntPt"
    Err=$?
   fi
-  
+
   if [ $Err -eq 0 ] ;then
    #130223 BK: got a empty window, use -x option to rescan files...
-   rox -x "$MntPt" -d "$MntPt" # mount good, run rox filer 
+   rox -x "$MntPt" -d "$MntPt" # mount good, run rox filer
    /usr/lib/gtkdialog/box_splash -timeout 6 -bg green -text "`eval_gettext \"SUCCESS! Click \\\$imgFileBASE icon again to unmount it\"`" & #BK
   else
    rmdir "$MntPt" #121203


### PR DESCRIPTION
filemnt: 
Code cleanup for further things:

1)    Want to add .sqfs and .squashfs ( ubuntu ) extensions - and what was it with udf ?
1.1) Change the if tests for filesystems into case lines

2)    Want to ease the ugly kernelversion code

But currently on slacko64:
stat: cannot stat ‘/initrd/initrd/mnt/tmpfs/puppy_slacko64_5.8.8.sfs’: No such file or directory

needs something like test -e "$MNTDIMG_DEV_INODE" || continue

I remember truncated output of losetup, 
probably because long filenames were reduced to 32bit strings ??
