### PR TITLE
Created folder.png symlink

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/icons/folder.png
+++ b/woof-code/rootfs-skeleton/usr/share/icons/folder.png
@@ -1,0 +1,1 @@
+../../local/lib/X11/pixmaps/folder48.png


### PR DESCRIPTION
Without this, some apps (File-Roller) are using the same icon to illustrate both dirs and files, what is really confusing.
