### PR TITLE
savefolder - extra fix for pupmode 3,7,13

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
@@ -362,7 +362,11 @@ free_func() { #called every 4 seconds.
 
 free_flash_func() { #PUPMODE 3,7,13. called every 4 seconds.
  WARNMSG=""
- SIZEFREEM=`df -m | grep ' /initrd/pup_ro1$' | tr -s ' ' | cut -f 4 -d ' '`
+ if [ -L /initrd/pup_ro1 ]; then
+  SIZEFREEM=`df -m | grep ' /initrd/mnt/dev_save$' | tr -s ' ' | cut -f 4 -d ' '`
+ else
+  SIZEFREEM=`df -m | grep ' /initrd/pup_ro1$' | tr -s ' ' | cut -f 4 -d ' '`
+ fi
  SIZETMPM=`df -m | grep ' /initrd/pup_rw$' | tr -s ' ' | cut -f 4 -d ' '`
  [ -s /tmp/pup_event_sizefreem ] && PREVSIZEFREEM=`cat /tmp/pup_event_sizefreem`
  [ -s /tmp/pup_event_sizetmpm ] && PREVSIZETMPM=`cat /tmp/pup_event_sizetmpm`


### PR DESCRIPTION
Original patch to "frontend_funcs" is incomplete, only pupmode 6,12.
This does it for pupmode 3,7,13.

gyro
