### PR TITLE
Testing

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -166,7 +166,7 @@ find . -mount \
 	   -not -type d \
 	   -regextype posix-extended \
 	   -not \( -regex '.*/\.wh\.[^\]*' -type f \) \
-	   -not \( -regex '^./mnt.*|^./initrd.*|^./proc.*|^./sys.*|^./tmp.*|^./pup_.*|^./zdrv_.*|^./root/tmp.*|.*_zdrv_.*|^./dev/\..*|^./dev/fd.*|^./dev/pts.*|^./dev/snd.*|^./dev/shm.*|^./\.wh\..*|^./var/run.*|^./root/ftpd.*|^./var/tmp.*|.*\.XLOADED$' \) \
+	   -not \( -regex '^./mnt.*|^./initrd.*|^./proc.*|^./sys.*|^./tmp.*|^./pup_.*|^./zdrv_.*|^./root/tmp.*|.*_zdrv_.*|^./dev/\..*|^./dev/fd.*|^./dev/pts.*|^./dev/snd.*|^./dev/shm.*|^./dev/tty.*|^./\.wh\..*|^./var/run.*|^./root/ftpd.*|^./var/tmp.*|.*\.XLOADED$' \) \
 	   -not \( -regex '.*\.thumbnails.*|.*\.part$|.*\.crdownload$' \) \
 	   -printf "%s %C@ %P\n" |
 while read -r NSIZE NCTIME N


### PR DESCRIPTION
Both commits are against 'snapmergepuppy'
Neither of these commits is required by TahrPup 6, so probably not required in woof-ce.
I have generated this pull-request, in case you want to use either or both of them anyway.
gyro 
