### PR TITLE
Update wmstartups

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/wmstartups
+++ b/woof-code/rootfs-skeleton/usr/sbin/wmstartups
@@ -4,6 +4,11 @@
 # 01micko 131217, ui enhancements by zigbert
 
 # lists
+
+export TEXTDOMAIN=wmstartups
+export OUTPUT_CHARSET=UTF-8
+. gettext.sh 
+
 LIST1=`ls $XDG_CONFIG_HOME/autostart|grep \.desktop$`
 LIST2=`ls $XDG_CONFIG_HOME/autostart|grep \.bak$`
 export TMP1=/tmp/${RANDOM}1


### PR DESCRIPTION
export gettext missing (fixed)
<code>
export TEXTDOMAIN=wmstartups
export OUTPUT_CHARSET=UTF-8
. gettext.sh 
</code>
