### PR TITLE
fixmenus: to not display commented categories

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/fixmenus
+++ b/woof-code/rootfs-skeleton/usr/sbin/fixmenus
@@ -46,7 +46,7 @@ do
  cat $ONESRC |
  while read ONELINE
  do
-  EXECMENU="`echo -n "$ONELINE" | grep -o 'PUPPYMENU.*' | cut -f 2-5 -d ' '`"
+  EXECMENU="`echo -n "$ONELINE" | grep -o '^PUPPYMENU.*' | cut -f 2-5 -d ' '`"
   if echo "$ONELINE" | grep -q "MENHEIGHT" ;then #131213 designed to be backward compatible
    [ "$MENHEIGHT" ] && echo $ONELINE | sed "s%MENHEIGHT%$MENHEIGHT%" >> $ONEDEST \
    || echo $ONELINE | sed "s%MENHEIGHT%24%" >> $ONEDEST


### PR DESCRIPTION
A fix to not display in main menu, categories commented in /etc/xdg/templates/_root_.jwmrc
See http://woof-ce.26403.n7.nabble.com/fixmenus-categories-displayed-in-main-menu-td743.html