### PR TITLE
/usr/sbin/filemnt: added more file extensions

### DIFF
--- a/woof-code/rootfs-skeleton/etc/group
+++ b/woof-code/rootfs-skeleton/etc/group
@@ -27,3 +27,4 @@ cdrom::107:root,spot,fido
 tape::108:root
 tty::109:root,spot,fido
 plugdev::110:root,spot,fido
+mlocate:x:1001:

--- a/woof-code/rootfs-skeleton/etc/passwd
+++ b/woof-code/rootfs-skeleton/etc/passwd
@@ -10,3 +10,4 @@ uucp:x:10:10:uucp:/var/spool/uucp:/bin/sh
 sshd:x:33:33:sshd:/:
 webuser:x:1002:504:Linux User,,,:/root/Web-Server:/bin/sh
 fido:x:1001:500:Linux User,,,:/root:/bin/sh
+man:x:65534:65534::/tmp:

--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -90,11 +90,13 @@ on \$MNTDIMG_MNT_PT from \$MNTDIMG")"    #120220 121105 add gettext.
   Ext=${imgFile##*.} #get file extension   ## Ext=`echo "$imgFile" |sed 's/^.*\.//'`
   Ext=${Ext,,}       #convert to lowercase ## Ext=`echo $Ext | tr [:upper:] [:lower:]`
   case $Ext in
-    2fs) Type='ext2'     ;;
-    3fs) Type='ext3'     ;;
-    4fs) Type='ext4'     ;;
-    sfs) Type='squashfs' ;;
-    iso) Type='iso'      ;;
+    2fs|ext2) Type='ext2'     ;;
+    3fs|ext3) Type='ext3'     ;;
+    4fs|ext4) Type='ext4'     ;;
+    sfs)      Type='squashfs' ;;
+    iso|udf)  Type='iso'      ;;
+    fat|vfat) Type='fat'      ;; #20150503 
+    ntfs)     Type='ntfs'     ;; #20150503
     *) 
        pupdialog --background red --title "$(gettext 'ERROR')" --msgbox "$(eval_gettext "Unsupported file extension: $Ext")" 0 0
        exit 1
@@ -185,6 +187,16 @@ Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
         if [ $Err -ne 0 ] ; then
           mount -t iso9660 -o loop "$imgFile" "$MntPt"
 		  Err=$?
+        fi
+        ;;
+      fat)
+        mount -t vfat -o loop "$imgFile" "$MntPt"
+        Err=$?
+        if [ $Err -ne 0 ] ; then
+          #The file system ms-dos (FAT-16) must be installed in the 
+          #Kernel in filesystems section (kernel/fs/ms-dos).
+          mount -t msdos -o loop "$imgFile" "$MntPt"
+          Err=$?
         fi
         ;;
       *)


### PR DESCRIPTION
I added more file extensions. There is a file with custom PUPPY mimetypes:
/usr/share/mime/packages/puppy.xml

I don't see it in woof-CE, that file needs to be updated with new mimetypes.

Also need to place more files in:
/root/Choices/MIME-types

And there is the free dekstop MIME types, we should also add the latest version to woof-CE, paving the way for a new Puppy.
/usr/share/mime/packages/freedesktop.org.xml
