### PR TITLE
/usr/sbin/filemnt: revert 'abort if file extension is not recognized'

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -95,10 +95,6 @@ on \$MNTDIMG_MNT_PT from \$MNTDIMG")"    #120220 121105 add gettext.
     4fs) Type='ext4'     ;;
     sfs) Type='squashfs' ;;
     iso) Type='iso'      ;;
-    *) 
-       pupdialog --background red --title "$(gettext 'ERROR')" --msgbox "$(eval_gettext "Unsupported file extension: $Ext")" 0 0
-       exit 1
-       ;;
   esac
 
   #v423 detect wrong squashfs version...


### PR DESCRIPTION
The file extension is actually the mount option,
so, when using filemnt, one must rename a file

ex:
mv diskimage.img diskimage.vfat
filemnt diskimage.vfat