### PR TITLE
/usr/sbin/filemnt: the file extension is actually the mount type.

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -89,16 +89,13 @@ on \$MNTDIMG_MNT_PT from \$MNTDIMG")"    #120220 121105 add gettext.
 
   Ext=${imgFile##*.} #get file extension   ## Ext=`echo "$imgFile" |sed 's/^.*\.//'`
   Ext=${Ext,,}       #convert to lowercase ## Ext=`echo $Ext | tr [:upper:] [:lower:]`
-  case $Ext in
+  Type=${Ext}        #file extension is the mount type/filesystem
+  case $Ext in           #exceptions
     2fs) Type='ext2'     ;;
     3fs) Type='ext3'     ;;
     4fs) Type='ext4'     ;;
     sfs) Type='squashfs' ;;
     iso) Type='iso'      ;;
-    *) 
-       pupdialog --background red --title "$(gettext 'ERROR')" --msgbox "$(eval_gettext "Unsupported file extension: $Ext")" 0 0
-       exit 1
-       ;;
   esac
 
   #v423 detect wrong squashfs version...


### PR DESCRIPTION
The script behaves as usual, but it can also be used to mount
and unmount whatever is supported by the mount utility.

sh-4.3# mv freedos10.img freedos10.vfat
sh-4.3# filemnt ${PWD}/freedos10.vfat
  Mount: /mnt/home/freedos10.vfat
sh-4.3# filemnt ${PWD}/freedos10.vfat
  UnMount: /mnt/home/freedos10.vfat