### PR TITLE
/usr/sbin/filemnt: comment out code to detect wrong squashfs version

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -23,27 +23,27 @@ export TEXTDOMAIN=filemnt
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
-#v423...
-KERNELVER="`uname -r`"
-if vercmp $KERNELVER ge 3.0;then #111016
- SFSSTR='squashfs, version 4'
- SFSMAJOR=4
-else
- KERNELSUBVER=`echo -n "$KERNELVER" | cut -f 3 -d '.' | cut -f 1 -d '-' | cut -f 1 -d '_'` #100831
- KERNELSUBSUBVER=`echo -n "$KERNELVER" | cut -f 4 -d '.' | cut -f 1 -d '-'`
- SFSSTR='squashfs, version 3'
- SFSMAJOR=3
- if [ $KERNELSUBVER -eq 27 ];then
-  if [ $KERNELSUBSUBVER -gt 46 ];then #100606
-   SFSSTR='squashfs, version 4'
-   SFSMAJOR=4
-  fi
- fi
- if [ $KERNELSUBVER -gt 28 ];then
-  SFSSTR='squashfs, version 4'
-  SFSMAJOR=4
- fi
-fi
+##v423...
+#KERNELVER="`uname -r`"
+#if vercmp $KERNELVER ge 3.0;then #111016
+# SFSSTR='squashfs, version 4'
+# SFSMAJOR=4
+#else
+# KERNELSUBVER=`echo -n "$KERNELVER" | cut -f 3 -d '.' | cut -f 1 -d '-' | cut -f 1 -d '_'` #100831
+# KERNELSUBSUBVER=`echo -n "$KERNELVER" | cut -f 4 -d '.' | cut -f 1 -d '-'`
+# SFSSTR='squashfs, version 3'
+# SFSMAJOR=3
+# if [ $KERNELSUBVER -eq 27 ];then
+#  if [ $KERNELSUBSUBVER -gt 46 ];then #100606
+#   SFSSTR='squashfs, version 4'
+#   SFSMAJOR=4
+#  fi
+# fi
+# if [ $KERNELSUBVER -gt 28 ];then
+#  SFSSTR='squashfs, version 4'
+#  SFSMAJOR=4
+# fi
+#fi
 
 imgFile="$1"
 if [ ! -f "$imgFile" ];then echo "No regular file: $imgFile";exit 1;fi #120220
@@ -98,22 +98,23 @@ on \$MNTDIMG_MNT_PT from \$MNTDIMG")"    #120220 121105 add gettext.
     iso) Type='iso'      ;;
   esac
 
-  #v423 detect wrong squashfs version...
   if [ "$Type" = "squashfs" ];then
-   if [ "`disktype "${imgFile}" | grep "$SFSSTR"`" = "" ];then
-    if [ $SFSMAJOR -eq 4 ];then #100606
-     pupmessage -center -bg '#FFC0C0' "`gettext \"NOTICE: This is an older version 3.x squashfs file, not usable.
-All Linux kernels 2.6.29 or later require version 4.x squashfs files
-(note, some 2.6.27.47+ kernels have Squashfs4 backported to them).
-Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
-    else
-     pupmessage -center -bg '#FFC0C0' "`gettext \"NOTICE: This is a newer version 4.x squashfs file, not usable.
-All Linux kernels 2.6.28 or earlier require version 3.x squashfs files
-(note, an exception is some 2.6.27.47+ kernels that have Squashfs4 backported).
-Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
-    fi
-    exit
-   fi
+
+#  #v423 detect wrong squashfs version...  
+#   if [ "`disktype "${imgFile}" | grep "$SFSSTR"`" = "" ];then
+#    if [ $SFSMAJOR -eq 4 ];then #100606
+#     pupmessage -center -bg '#FFC0C0' "`gettext \"NOTICE: This is an older version 3.x squashfs file, not usable.
+#All Linux kernels 2.6.29 or later require version 4.x squashfs files
+#(note, some 2.6.27.47+ kernels have Squashfs4 backported to them).
+#Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
+#    else
+#     pupmessage -center -bg '#FFC0C0' "`gettext \"NOTICE: This is a newer version 4.x squashfs file, not usable.
+#All Linux kernels 2.6.28 or earlier require version 3.x squashfs files
+#(note, an exception is some 2.6.27.47+ kernels that have Squashfs4 backported).
+#Note, there is an SFS-version-converter in the Utility menu, run that first.\"`"
+#    fi
+#    exit
+#   fi
 
    #120525 take into account shinobar's load-on-the-fly pet...
    if [ "`which sfs_load`" != "" ];then


### PR DESCRIPTION
squashfs v3 is long dead. I have never come across an sfs file with squashfs v3
(I use Puppy since 2012)

That code could be reused when there is a new major release of squashfs (v5)

http://squashfs.sourceforge.net/