### PR TITLE
wmexit, wmreboot, wmpoweroff, wmrestart: use busybox ps

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/restartwm
+++ b/woof-code/rootfs-skeleton/usr/bin/restartwm
@@ -13,13 +13,13 @@ echo -n "$NEXTWM" > /tmp/wmexitmode.txt
 #w478 testing 2.6.18.1 kernel, pup_event_frontend_d did not exit when it
 #detected /tmp/wmeximode.txt, but became 'defunct'...
 KCNT=0
-PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 #while [ "`pidof pup_event_frontend_d`" != "" ];do
 while [ "$PSPEFD" != "" ];do
  sleep 0.5
  KCNT=`expr $KCNT + 1`
  [ $KCNT -gt 60 ] && break #30 secs.
- PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+ PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 done
 sleep 0.2
 

--- a/woof-code/rootfs-skeleton/usr/bin/wmexit
+++ b/woof-code/rootfs-skeleton/usr/bin/wmexit
@@ -8,13 +8,13 @@ echo -n "exit" > /tmp/wmexitmode.txt
 #w478 testing 2.6.18.1 kernel, pup_event_frontend_d did not exit when it
 #detected /tmp/wmeximode.txt, but became 'defunct'...
 KCNT=0
-PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 #while [ "`pidof pup_event_frontend_d`" != "" ];do
 while [ "$PSPEFD" != "" ];do
  sleep 0.5
  KCNT=`expr $KCNT + 1`
  [ $KCNT -gt 60 ] && break #30 secs.
- PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+ PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 done
 sleep 0.2
 

--- a/woof-code/rootfs-skeleton/usr/bin/wmpoweroff
+++ b/woof-code/rootfs-skeleton/usr/bin/wmpoweroff
@@ -34,12 +34,12 @@ echo -n "poweroff" > /tmp/wmexitmode.txt
 #w478 testing 2.6.18.1 kernel, pup_event_frontend_d did not exit when it
 #detected /tmp/wmeximode.txt, but became 'defunct'...
 KCNT=0
-PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 while [ "$PSPEFD" != "" ];do
  sleep 0.5
  KCNT=`expr $KCNT + 1`
  [ $KCNT -gt 60 ] && break #30 secs.
- PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+ PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 done
 sleep 0.2
 

--- a/woof-code/rootfs-skeleton/usr/bin/wmreboot
+++ b/woof-code/rootfs-skeleton/usr/bin/wmreboot
@@ -34,13 +34,13 @@ echo -n "reboot" > /tmp/wmexitmode.txt
 #w478 testing 2.6.18.1 kernel, pup_event_frontend_d did not exit when it
 #detected /tmp/wmeximode.txt, but became 'defunct'...
 KCNT=0
-PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 #while [ "`pidof pup_event_frontend_d`" != "" ];do
 while [ "$PSPEFD" != "" ];do
  sleep 0.5
  KCNT=`expr $KCNT + 1`
  [ $KCNT -gt 60 ] && break #30 secs.
- PSPEFD="`ps -C pup_event_frontend_d | grep 'pup_event_front' | grep -v 'defunct'`"
+ PSPEFD="$(busybox ps | grep 'pup_event_frontend_d' | grep -v -E 'defunct|grep')"
 done
 sleep 0.2
 


### PR DESCRIPTION
In late 2013, when I firt experimented with building a puplet, I didn't know that packages-templates modified every package. So when everything was done, I placed some packages without the template filtering.

Everything seemed to be ok, but when I tried to shutdown, nothing happened.

ps was a symlink to busybox, but 'ps -C' required ps-FULL. 'ps' was a script, a hack to handle the variety of scripts that were already written.

To prevent such an incident from happening again, better use 'busybox ps'.