### PR TITLE
improve readability of svg_bar text

### DIFF
--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/svg_bar
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/svg_bar
@@ -33,7 +33,7 @@ echo '<?xml version="1.1" encoding="UTF-8"?>
   <rect style="fill:url(#LG_02);" width="'$(($1-3))'" height="'$(($SVG_BAR_HEIGHT-3))'" x="1.5" y="1.5"/>
   <path style="fill:none;stroke:#ffffff;stroke-width:3" d="M 0,'$SVG_BAR_HEIGHT' '$1','$SVG_BAR_HEIGHT' M '$1',0 '$1','$SVG_BAR_HEIGHT'"/>
   <text
-	 style="fill:'$SVG_BAR_COLOR_TEXT';font-family:Mono;font-size:'$(($SVG_BAR_HEIGHT/2))';text-anchor:middle"
+	 style="fill:'$SVG_BAR_COLOR_TEXT';font-family:Mono:bold;font-size:'$(($SVG_BAR_HEIGHT/2))';text-anchor:middle"
 	 x="'$(($1/2))'" y="'$(($SVG_BAR_HEIGHT*17/24))'">
 	'$3'
   </text>


### PR DESCRIPTION
adding 'bold' to the text line greatly improves the readability of text in pmount and other apps using svg_bar