### PR TITLE
Cleanup and fix a missed bit in the save-folder code in "init"

### DIFF
--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -1195,7 +1195,12 @@ if [ "$CREATEPUPSAVE2FS" != "" ];then
       echo "Backing off, not using save-file, booting in RAM only, PUPMODE=5..." >/dev/console
       echo -en "\\033[0;39m" >/dev/console
       sync
-      umount $CREATEPUPSAVE2FS #unmount the save-file.
+      if [ -L $CREATEPUPSAVE2FS ]; then
+       rm -f $CREATEPUPSAVE2FS #get rid of save-folder
+       mkdir $CREATEPUPSAVE2FS
+      else
+       umount $CREATEPUPSAVE2FS #unmount the save-file.
+      fi
       PUPMODE=5
       CREATETMPFS="";CREATEPDEV1="";CREATEPUPXXXSFS="";CREATEPUPSAVE2FS="";CREATEFOLDERS=""
       CREATETMPFS="/pup_rw";CREATEPUPXXXSFS="/pup_ro2"

--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -1087,7 +1087,7 @@ if [ "$CREATEPUPSAVE2FS" != "" ];then
      ;;
    esac
   fi
-  if [ -d /mnt/dev_save$PUPSAVEFILE ]; then
+  if [ -d /mnt/dev_save${PUPSAVEFILE} ]; then
    # Check partition if user calls for savefile check
    if [ "$PFSCK" = "yes" -a "$pdev1" = "" ]; then
     umount /mnt/dev_save

--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -1195,7 +1195,7 @@ if [ "$CREATEPUPSAVE2FS" != "" ];then
       echo "Backing off, not using save-file, booting in RAM only, PUPMODE=5..." >/dev/console
       echo -en "\\033[0;39m" >/dev/console
       sync
-      if [ -L $CREATEPUPSAVE2FS ]; then
+      if [ -L "$CREATEPUPSAVE2FS" ]; then
        rm -f $CREATEPUPSAVE2FS #get rid of save-folder
        mkdir $CREATEPUPSAVE2FS
       else


### PR DESCRIPTION
The cleanup commit simply changes the code to consistently use {} around variable names.
The fix commit relates to code that backs-out of updating a save-file/folder to do pupmode=5. This code was missed in all previous save-folder patches. 