### PR TITLE
bring back puppy.css ...lost earlier this year

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/doc/forums.htm
+++ b/woof-code/rootfs-skeleton/usr/share/doc/forums.htm
@@ -5,6 +5,7 @@
 	<meta charset="utf-8">
 	<link href="./manual.css" rel="stylesheet" type="text/css">
 	<link href="./forums.css" rel="stylesheet" type="text/css">
+	<link href="./puppy.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
 	<div id="container">

--- a/woof-code/rootfs-skeleton/usr/share/doc/home.htm
+++ b/woof-code/rootfs-skeleton/usr/share/doc/home.htm
@@ -5,6 +5,7 @@
 	<meta charset="utf-8">
 	<link href="./manual.css" rel="stylesheet" type="text/css">
 	<link href="./home.css" rel="stylesheet" type="text/css">
+	<link href="./puppy.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
 	<div id="container">

--- a/woof-code/rootfs-skeleton/usr/share/doc/index.html
+++ b/woof-code/rootfs-skeleton/usr/share/doc/index.html
@@ -10,6 +10,7 @@
 		}
 	</script-->
 	<link href="./manual.css" rel="stylesheet" type="text/css">
+	<link href="./puppy.css" rel="stylesheet" type="text/css" />
 </head>
 <body>
 	<div id="container">

--- a/woof-code/rootfs-skeleton/usr/share/doc/puppy.css
+++ b/woof-code/rootfs-skeleton/usr/share/doc/puppy.css
@@ -1,0 +1,180 @@
+@charset "utf-8";
+/*
+ CSS Document 
+*/
+
+
+body {
+	
+	font-family: "Myriad Pro", Helvetica, Arial, sans-serif;
+	color: #444;
+	background: url('./puppylogo96-trans.png') repeat fixed top left;
+}
+
+
+.site-title {
+	font-size: 24px;
+	color: #000000 !important;
+}
+
+p { line-height: 175%; }
+
+.site-description {
+	font-size: 14px;
+	color: #000000 !important;
+}
+
+h4 {
+	font-size: 13px;
+	color: #000000 !important;
+}
+.hzline {
+	background-color: #ccc;
+	border: 0;
+	height: 1px;
+}
+.lhs {
+	float: left;
+	margin: 3px;
+}
+.rhs {
+	float: right;
+	margin: 3px;
+}
+#container { 
+	position: relative;
+	width: 96%;
+	max-width: 930px;
+	/*background: #fff;*/
+	padding: 2%;
+	margin: 0 auto;
+	overflow: hidden;
+	/*border-bottom-left-radius: 15px 15px;
+	border-bottom-right-radius: 15px 15px;
+	border-top-right-radius: 15px 15px;
+	border-top-left-radius: 15px 15px;*/
+}
+
+div.transbox {
+	background-color: #fff;
+	opacity: 0.5;
+}
+#stuff0 {
+	position: relative;
+	width: 100%;
+	height: auto;
+	font-family: Helvetica, Arial, sans-serif;
+	font-size: 14px;
+	color: #000;
+}
+.rdrect {
+	margin: 4px;
+	-webkit-border-radius: 3px;
+	-moz-border-radius: 3px;
+	border-radius: 3px;
+}
+#hrz {
+	position: relative;
+}
+/* might use the below in the future */
+img.opacity
+{
+	opacity:0.8;
+	filter:alpha(opacity=80); /* For IE8 and earlier */
+}
+img.opacity:hover
+{
+	opacity:1.0;
+	filter:alpha(opacity=100); /* For IE8 and earlier */
+}
+#leftcol {
+	position: relative;
+	width: 100%;
+	height: auto;
+	font-family: Helvetica, Arial, sans-serif;
+	font-size: 13px;
+}
+#main {
+	position: relative;
+	width: 96%;
+}
+#left_c {
+	width: 75%;
+	margin-right: 3%;
+	float: left;
+	padding-bottom: 2%;
+	font-size: 13px;
+}
+#mediabox {
+	width: 48%;
+	margin-right: 3%;
+	float: left;
+	padding-bottom: 2%;
+	font-size: 15px;
+}
+
+#audbox {
+	width: 40%;
+	float: right;
+	/*padding: 2%;*/
+	font-size: 15px;
+}
+aside {
+	position: relative;
+	width: 22%;
+	float: right;
+	font-size: 13px;
+	/*background: #c3c3c3; debug*/
+}
+#rightcol {
+	position: relative;
+	top: 1%;
+	margin-bottom: 10%;
+	width: 100%;
+	height: auto;
+	font-family: Helvetica, Arial, sans-serif;
+	font-size: 13px;
+}
+#links {
+	height: auto;
+	background: #c3c3c3;
+	font-family: Arial, Helvetica, sans-serif;
+	text-align: left;
+	padding: 2%;
+	bottom: 0;
+	overflow: hidden;
+	border-bottom-left-radius: 15px 15px;
+	border-bottom-right-radius: 15px 15px;
+	border-top-right-radius: 15px 15px;
+	border-top-left-radius: 15px 15px;
+}
+
+#main_text {
+	background-color: #FFFFCC;
+	width: 550px;
+	line-height: 1.1;
+	font-family: "Myriad Pro", Helvetica, Arial, sans-serif;
+	padding: 8px;
+	position: absolute;
+	right: 182px;
+	top: 140px;
+}
+#footnote {
+	height: auto;
+	font-family: Arial, Helvetica, sans-serif;
+	font-size: 9px;
+	color: #000;
+	text-align: center;
+}
+#footer {
+	position: relative;
+	left: 2%;
+	bottom: 0;
+	height: auto;
+	width: 96%;
+	/*padding: 3%;
+	background: #BDA0CB;#c3c3c3; #fff;debug */
+}
+a:link { color: #458B00; /*chartreuse4 (green)*/ }
+a:visited { color: #BDA0CB; /*purple candy*/ }
+a:hover { color: #7e77e7; /*blue*/ }


### PR DESCRIPTION
puppy.css was lost with this commit https://github.com/puppylinux-woof-CE/woof-CE/pull/517
the picture doesn't do it justice, but the home and the help page look a lot nicer with it

<a href="http://s1083.photobucket.com/user/MrFricks/media/snapshot-2015-10-08-10-23-38_zpsy3wqpr7f.png.html" target="_blank"><img src="http://i1083.photobucket.com/albums/j384/MrFricks/snapshot-2015-10-08-10-23-38_zpsy3wqpr7f.png" border="0" alt=" photo snapshot-2015-10-08-10-23-38_zpsy3wqpr7f.png"/></a>
