### PR TITLE
Extra privacy

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/pman
+++ b/woof-code/rootfs-skeleton/usr/bin/pman
@@ -176,6 +176,6 @@ fi
 #exec defaulthtmlviewer http://threads.seas.gwu.edu/cgi-bin/man2web?program=${NAME}
 #v431 fix thanks to technosaurus...
 [ "${SECTION}" != "" ] && exec $HTMLVIEWER "http://linux.die.net/man/${SECTION}/${NAME}"
-exec $HTMLVIEWER "http://www.google.com/search?&q=man+\"${NAME}\"+site:linux.die.net&btnI=Search"
+exec $HTMLVIEWER "http://www.duckduckgo.com/?q=man+\"${NAME}\"+site:linux.die.net"
  
 ###END###

--- a/woof-code/rootfs-skeleton/usr/local/petget/service_pack.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/service_pack.sh
@@ -10,10 +10,10 @@
 
 IFCONFIG="`ifconfig | grep '^[pwe]' | grep -v 'wmaster'`"
 [ ! "$IFCONFIG" ] && exit 1 #no network connection.
-ping -4 -c 1 www.google.com
+ping -4 -c 1 www.duckduckgo.com
 if [ $? -ne 0 ];then
  sleep 1
- ping -4 -c 1 www.google.com
+ ping -4 -c 1 www.duckduckgo.com
  [ $? -ne 0 ] && exit 1 #no internet.
 fi
 

--- a/woof-code/rootfs-skeleton/usr/local/video_upgrade/video_upgrade_wizard
+++ b/woof-code/rootfs-skeleton/usr/local/video_upgrade/video_upgrade_wizard
@@ -27,7 +27,7 @@ case $DISTRO_COMPAT_VERSION in
    INSERT1="<text><label>`eval_gettext \"Xorg server version '\\\${XORGVER}' is currently running, so it seems that you have already upgraded Xorg.\"`</label></text>"
   else
    #offer to upgrade...
-   ping -4 -c 1 www.google.com
+   ping -4 -c 1 www.duckduckgo.com
    if [ $? -ne 0 ];then
     INSERT0="<text use-markup=\"true\"><label>\"<b>`gettext \"Currently not connected to the Internet. If you wish to connect later, you can run this Video Upgrade Wizard again via the 'setup' icon on the desktop or the 'Setup' category in the menu. Note, to connect to the Internet, click 'connect' icon on left of desktop.\"`</b>\"</label></text>"
    fi

--- a/woof-code/rootfs-skeleton/usr/sbin/check_internet
+++ b/woof-code/rootfs-skeleton/usr/sbin/check_internet
@@ -8,10 +8,7 @@ export LANG=C
 IFCONFIG="`ifconfig | grep '^[pwe]' | grep -v 'wmaster'`"
 [ ! "$IFCONFIG" ] && exit 1 #no network connection.
 
-ping -4 -c 1 8.8.8.8 #64.233.169.103 #google 111110 address no longer responding.
-[ $? -ne 0 ] && exit 2 #ip address not accessable.
-
-ping -4 -c 1 www.google.com
+ping -4 -c 1 www.duckduckgo.com
 [ $? -ne 0 ] && exit 3 #domain name address not accessable.
 
 exit 0 #success

--- a/woof-code/rootfs-skeleton/usr/sbin/ipinfo
+++ b/woof-code/rootfs-skeleton/usr/sbin/ipinfo
@@ -14,7 +14,7 @@ export OUTPUT_CHARSET=UTF-8
 # functions
 # --------------
 
-[ -f $HOME/.ipinfo ] && . $HOME/.ipinfo || CB0=true
+[ -f $HOME/.ipinfo ] && . $HOME/.ipinfo || CB0=false
 
 #---------------
 get_ip()


### PR DESCRIPTION
I don't like the fact Puppy "phones home", for two reasons:
- Security - if you have the ability to capture the traffic of a Linux machine, it's easy to identify Puppy. As fingerprinting is one of the first steps an attacker performs (for example, when trying to find an exploit that works against a remote Linux machine), we want to make it harder. However, this ping call is our way to test a network connection, so we have to keep it.
- Privacy - using a different site (that is known to respect the user's privacy, unlike Google) is all we can do to improve privacy in this respect.

@01micko @mavrothal Is there any additional anti-privacy feature that most users don't use? If yes, we should disable it by default.