### PR TITLE
pet2tgz and tgz2pet: comestic changes

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/pet2tgz
+++ b/woof-code/rootfs-skeleton/usr/bin/pet2tgz
@@ -1,28 +1,43 @@
-#!/bin/sh
+#!/bin/bash
 #by BarryK 2006 for Puppy Linux v2.13+
 #passed param is file to be converted.
 #converts a .pet file to .tar.gz.
 #131122 support xz compressed pets (see dir2pet, installpkg.sh)
-[ "$(cat /var/local/petget/nt_category 2>/dev/null)" != "true" ] && \
- [ -f /tmp/install_quietly ] && set -x
- #; mkdir -p /tmp/PPM_LOGs ; NAME=$(basename "$0"); exec 1>> /tmp/PPM_LOGs/"$NAME".log 2>&1
-DL_SAVE_FLAG=$(cat /var/local/petget/nd_category)
-chmod +w "$1" #make it writable.
+
+PFILE=$1
+[ ! -f "$PFILE" ] && exit 1
+
+if [ -s /var/local/petget/nd_category ] ; then
+  DL_SAVE_FLAG=$(cat /var/local/petget/nd_category)
+fi
+[ "$DL_SAVE_FLAG" != "true" ] && [ -f /tmp/install_quietly ] && set -x
+#; mkdir -p /tmp/PPM_LOGs ; NAME=$(basename "$0"); exec 1>> /tmp/PPM_LOGs/"$NAME".log 2>&1
+
+chmod +w "$PFILE" #make it writable.
 FOOTERSIZE="32"
 export LC_ALL=C
 
 #determine the compression, extend test to 'XZ'
-file -b "$1" | grep -i -q "^xz" && EXT=xz || EXT=gz #131122 #140108 add -i for 'XZ'
+#file -b "$PFILE" | grep -i -q "^xz" && EXT=xz || EXT=gz #131122 #140108 add -i for 'XZ'
+finfo=$(file -b "$PFILE")
+case $finfo in
+  gz*) EXT=gz ;;
+  xz*) EXT=xz ;;
+  *)   exit 1 ;; # error
+esac
 
-MD5SUM="`tail -c $FOOTERSIZE \"$1\"`"
+MD5SUM="`tail -c $FOOTERSIZE \"$PFILE\"`"
 
-NEWNAME="`echo -n \"$1\" | sed -e "s/\\.pet$/\\.tar\\.$EXT/g"`" #131122
+#NEWNAME="`echo -n \"$PFILE\" | sed -e "s/\\.pet$/\\.tar\\.$EXT/g"`" #131122
+NEWNAME=${PFILE%pet}tar.${EXT}
 
-head -c -$FOOTERSIZE "$1" > $NEWNAME
+head -c -$FOOTERSIZE "$PFILE" > $NEWNAME
 NEWMD5SUM="`md5sum \"$NEWNAME\" | cut -f 1 -d ' '`"
 
 sync
-[ "$DL_SAVE_FLAG" != "true" ] && rm -f "$1"
+[ "$DL_SAVE_FLAG" != "true" ] && rm -f "$PFILE"
 [ ! "$MD5SUM" = "$NEWMD5SUM" ] && exit 1
+
 exit 0
 
+### END ###

--- a/woof-code/rootfs-skeleton/usr/bin/tgz2pet
+++ b/woof-code/rootfs-skeleton/usr/bin/tgz2pet
@@ -1,70 +1,77 @@
-#!/bin/sh
-
+#!/bin/bash
 #convert a .tar.gz file to .pet...
 #passed param is file to be converted.
 #this works for md5sum returning 8-bit characters!
-# 131122 add support for tar.xz
+
+TARBALL=$1
+[ ! -f "$TARBALL" ] && exit 1
 
 sync
-TARBALL=$1
 #chmod +w $TARBALL #make it writable.
 chmod 644 $TARBALL #make it writable.
 
-#only accept .tgz or .tar.gz files...
-#add txz and tar.xz
+# only accept .tgz .tar.gz .txz tar.xz files...
 EXT=''
-echo -n "$TARBALL" | grep -q '\.tar\.gz$' && EXT='.tar.gz'
-echo -n "$TARBALL" | grep -q '\.tgz$' && EXT='.tgz'
-echo -n "$TARBALL" | grep -q '\.tar\.xz$' && EXT='.tar.xz'
-echo -n "$TARBALL" | grep -q '\.txz$' && EXT='.txz'
-[ "$EXT" ] || exit 1
+case ${TARBALL,,} in
+  *.tar.gz) EXT='.tar.gz' ;;
+  *.tgz)    EXT='.tgz'    ;;
+  *.tar.xz) EXT='.tar.xz' ;;
+  *.txz)    EXT='.txz'	  ;;
+  *)        exit 1        ;;
+esac
 
-#split TARBALL path/filename into components...
+# split TARBALL path/filename into components...
 BASEPKG="`basename $TARBALL $EXT`"
 DIRPKG="`dirname $TARBALL`"
 [ "$DIRPKG" = "/" ] && DIRPKG=""
 
 case $EXT in
-*gz)OPT=-z;;
-*xz)OPT=-J;;
+  *gz) OPT=-z ;;
+  *xz) OPT=-J ;;
 esac
 
 case $EXT in
-*tgz)mv -f $TARBALL $DIRPKG/${BASEPKG}.tar.gz
- TARBALL="$DIRPKG/${BASEPKG}.tar.gz"
- EXT='.tar.gz';;
-*txz)mv -f $TARBALL $DIRPKG/${BASEPKG}.tar.xz
- TARBALL="$DIRPKG/${BASEPKG}.tar.xz"
- EXT='.tar.xz';;
+  *tgz)
+    mv -f $TARBALL $DIRPKG/${BASEPKG}.tar.gz
+    TARBALL="$DIRPKG/${BASEPKG}.tar.gz"
+    EXT='.tar.gz'
+    ;;
+  *txz)
+    mv -f $TARBALL $DIRPKG/${BASEPKG}.tar.xz
+    TARBALL="$DIRPKG/${BASEPKG}.tar.xz"
+    EXT='.tar.xz'
+    ;;
 esac
 
 #exit
-#if tarball expands direct to '/' want to wrap around it (slackware pkg)... 100628 add -z ...
-#man bad bug here... the thing isn't expanded! #131122
+
+# if tarball expands direct to '/' want to wrap around it (slackware pkg)... 100628 add -z ...
+# man bad bug here... the thing isn't expanded! #131122
 if [ "`tar ${OPT} --list -f $TARBALL | head -n 1`" = "./" ];then
-# [ -d $DIRPKG/$BASEPKG ] && rm -rf $DIRPKG/$BASEPKG #a bit radical 
- [ -d $DIRPKG/$BASEPKG ] && exit 1
- mkdir $DIRPKG/$BASEPKG
- mv $TARBALL $DIRPKG/$BASEPKG/
- (cd $DIRPKG/$BASEPKG/;tar xf $TARBALL;rm $TARBALL)
- #rm $DIRPKG/$BASEPKG/${BASEPKG}${EXT}
- #can put other files in here if want...
+  #[ -d $DIRPKG/$BASEPKG ] && rm -rf $DIRPKG/$BASEPKG #a bit radical 
+  [ -d $DIRPKG/$BASEPKG ] && exit 1
+  mkdir $DIRPKG/$BASEPKG
+  mv $TARBALL $DIRPKG/$BASEPKG/
+  (cd $DIRPKG/$BASEPKG/ ; tar xf $TARBALL ; rm $TARBALL)
+  #rm $DIRPKG/$BASEPKG/${BASEPKG}${EXT}
+  # can put other files in here if want...
  
- tar --remove-files -c -f $DIRPKG/${BASEPKG}.tar $DIRPKG/$BASEPKG/
- case $EXT in
- *gz)gzip --best $DIRPKG/${BASEPKG}.tar ;;
- *xz)xz -z -9 -e $DIRPKG/${BASEPKG}.tar ;;
- esac
- #[ -d $DIRPKG/$BASEPKG ] && rmdir $DIRPKG/$BASEPKG
+  tar --remove-files -c -f $DIRPKG/${BASEPKG}.tar $DIRPKG/$BASEPKG/
+  case $EXT in
+    *gz) gzip --best $DIRPKG/${BASEPKG}.tar ;;
+    *xz) xz -z -9 -e $DIRPKG/${BASEPKG}.tar ;;
+  esac
+  #[ -d $DIRPKG/$BASEPKG ] && rmdir $DIRPKG/$BASEPKG
 fi
 
 FULLSIZE="`stat --format=%s ${TARBALL}`"
 MD5SUM="`md5sum $TARBALL | cut -f 1 -d ' '`"
 echo -n "$MD5SUM" >> $TARBALL
 sync
+
 #NEWNAME="`echo -n "${TARBALL}" | sed -e 's/\\.tar\\.gz$/\\.pet/g'`"
 #mv -f $TARBALL $NEWNAME
 mv -f $TARBALL $DIRPKG/${BASEPKG}.pet
 sync
 
-###END###
+### END ###


### PR DESCRIPTION
A few cosmetic changes and a few more checks..

The results are the same as before
 tgz2pet abiword-2.9.4-precise-upx.tar.gz
 pet2tgz abiword-2.9.4-precise-upx.pet
 tgz2pet abiword-2.9.4-precise-upx.tar.gz
 pet2tgz abiword-2.9.4-precise-upx.pet

 tgz2pet abiword-2.9.4-precise-upx.tar.xz
 pet2tgz abiword-2.9.4-precise-upx.pet
 tgz2pet abiword-2.9.4-precise-upx.tar.xz
 pet2tgz abiword-2.9.4-precise-upx.pet

There are no errors when I decompress a tar.gz or tar.xz file.. looks ok