### PR TITLE
eventmanager: cleanup

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/eventmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/eventmanager
@@ -433,12 +433,9 @@ CONFIG="`echo "$CONFIG" | sed -e "$psPATTERN"`"
 echo "$CONFIG" > /etc/eventmanager
 
 #update drive icons
-PID=`grep '/bin/ash.*/sbin/pup_event_frontend_d' <<< $(ps -eo pid,command) | awk '{print $1}'`
-kill -9 $PID
-echo 'ICONWIPE' > /tmp/pup_event_icon_change_flag
+kill $(pidof pup_event_frontend_d)
 /sbin/clean_desk_icons
 rox -p "$HOME/Choices/ROX-Filer/PuppyPin"
-kill $(pidof pup_event_frontend_d)
 pup_event_frontend_d &
 
 ###END###

--- a/woof-code/rootfs-skeleton/usr/sbin/eventmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/eventmanager
@@ -433,7 +433,7 @@ CONFIG="`echo "$CONFIG" | sed -e "$psPATTERN"`"
 echo "$CONFIG" > /etc/eventmanager
 
 #update drive icons
-kill $(pidof pup_event_frontend_d)
+kill -9 $(pidof pup_event_frontend_d)
 /sbin/clean_desk_icons
 rox -p "$HOME/Choices/ROX-Filer/PuppyPin"
 pup_event_frontend_d &


### PR DESCRIPTION
why do we kill twice?
why do we echo ICONWIPE to a file not in use?

Seems to work normally here, but maybe there exist some reason...