### PR TITLE
xorg.conf-auto-pc: comment out HorizSync and VertRefresh

### DIFF
--- a/woof-code/rootfs-skeleton/etc/X11/xorg.conf-auto-pc
+++ b/woof-code/rootfs-skeleton/etc/X11/xorg.conf-auto-pc
@@ -122,8 +122,8 @@ Section "Monitor"
 	Identifier   "Monitor0"
 	VendorName   "Monitor Vendor"
 	ModelName    "Monitor Model"
-	HorizSync    35-81
-	VertRefresh  59-76
+#	HorizSync    35-81
+#	VertRefresh  59-76
 	#UseModes     "Modes0" #monitor0usemodes
 #	Option      "PreferredMode" "1024x768" #monitor0prefmode
 	EndSection


### PR DESCRIPTION
In some hardware xorg works better without these options.
I think it might be being forced to try some values not supported by some hardware and thus fails....