### PR TITLE
Add puppy mime packages

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/mime/packages/custom.xml
+++ b/woof-code/rootfs-skeleton/usr/share/mime/packages/custom.xml
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+
+  <mime-type type="application/x-bin">
+    <comment>Binary File</comment>
+    <glob pattern="*.bin"/>
+  </mime-type>
+
+  <mime-type type="application/x-dll">
+    <comment>MS Windows DLL</comment>
+    <glob pattern="*.dll"/>
+  </mime-type>
+
+  <mime-type type="application/x-msi">
+    <comment>Windows Installer package</comment>
+    <glob pattern="*.msi"/>
+  </mime-type>
+
+  <mime-type type="application/x-win-script">
+    <comment>Windows Shell Script</comment>
+    <glob pattern="*.cmd"/>
+    <glob pattern="*.bat"/>
+  </mime-type>
+
+  <mime-type type="application/x-partclone">
+    <comment>Partclone Backup</comment>
+    <glob pattern="*.partclone"/>
+    <glob pattern="*.partclone.gz"/>
+    <glob pattern="*.partclone.bz2"/>
+    <glob pattern="*.partclone.xz"/>
+    <glob pattern="*.partclone.lzo"/>
+  </mime-type>
+
+  <mime-type type="text/x-linklist">
+    <comment>Link list</comment>
+    <glob pattern="*.links"/>
+    <glob pattern="*.linklist"/>
+  </mime-type>
+
+<!-- GAMES -->
+
+  <mime-type type="application/x-genesis-rom">
+    <comment>Sega Genesis/Megadrive ROM</comment>
+    <glob pattern="*.smd"/>
+    <!-- <glob pattern="*.md"/> -->
+  </mime-type>
+
+  <mime-type type="application/x-gameboy-rom">
+    <comment>Game Boy (Color) ROM</comment>
+    <glob pattern="*.gb"/>
+    <glob pattern="*.gbc"/>
+  </mime-type>
+
+  <mime-type type="application/x-virtualboy-rom">
+    <comment>Virtual Boy ROM</comment>
+    <!-- <glob pattern="*.vb"/> -->
+    <glob pattern="*.vboy"/>
+  </mime-type>
+
+  <mime-type type="application/x-pc-engine-sgx-rom">
+    <comment>SuperGrafx ROM</comment>
+    <glob pattern="*.sgx"/>
+  </mime-type>
+
+  <mime-type type="application/x-atari-lynx-rom">
+    <comment>Atari Lynx ROM</comment>
+    <glob pattern="*.lnx"/>
+  </mime-type>
+
+  <mime-type type="application/x-neogeo-pocket-rom">
+    <comment>NeoGeo Pocket (Color) ROM</comment>
+    <glob pattern="*.npc"/>
+  </mime-type>
+
+  <mime-type type="application/x-wonderswan-rom">
+    <comment>Wonder Swan (Color) ROM</comment>
+    <glob pattern="*.wsc"/>
+    <glob pattern="*.wsr"/>
+  </mime-type>
+
+</mime-info>

--- a/woof-code/rootfs-skeleton/usr/share/mime/packages/puppy.xml
+++ b/woof-code/rootfs-skeleton/usr/share/mime/packages/puppy.xml
@@ -1,0 +1,90 @@
+<?xml version="1.0"?>
+<!-- Puppy-specific mime info -->
+
+<mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
+  <mime-type type="application/pup">
+    <comment>PUP archive</comment>
+    <glob pattern="*.pup"/>
+  </mime-type>
+
+  <mime-type type="application/pet">
+    <comment>PET archive</comment>
+    <glob pattern="*.pet"/>
+  </mime-type>
+
+  <mime-type type="application/x-ext2-image">
+    <comment>ext2 filesystem in a file</comment>
+    <glob pattern="*.2fs"/>
+    <glob pattern="*.ext2"/>
+  </mime-type>
+
+  <mime-type type="application/x-ext3-image">
+    <comment>ext3 filesystem in a file</comment>
+    <glob pattern="*.3fs"/>
+    <glob pattern="*.ext3"/>
+  </mime-type>
+
+  <mime-type type="application/x-ext4-image">
+    <comment>ext4 filesystem in a file</comment>
+    <glob pattern="*.4fs"/>
+    <glob pattern="*.ext4"/>
+  </mime-type>
+
+  <mime-type type="application/x-squashfs-image">
+    <comment>squashfs filesystem in a file</comment>
+    <glob pattern="*.sfs"/>
+  </mime-type>
+
+  <mime-type type="application/x-bfe">
+    <comment>Bcrypt encrypted file</comment>
+    <glob pattern="*.bfe"/>
+  </mime-type>
+
+  <mime-type type="application/x-delta">
+    <comment>Xdelta difference file</comment>
+    <glob pattern="*.delta"/>
+  </mime-type>
+
+  <mime-type type="application/x-pkg">
+    <comment>Arch Linux package</comment>
+    <glob pattern="*.pkg.tar.gz"/>
+  </mime-type>
+
+  <mime-type type="application/x-ccrypt">
+    <comment>Ccrypt encrypted file</comment>
+    <glob pattern="*.cpt"/>
+  </mime-type>
+
+  <mime-type type="text/x-genie">
+    <comment>Genie source file</comment>
+    <glob pattern="*.gs"/>
+  </mime-type>
+
+  <mime-type type="text/x-bacon">
+    <comment>BaCon source file</comment>
+    <glob pattern="*.bac"/>
+  </mime-type>
+
+  <mime-type type="video/webm">
+    <comment>WebM video</comment>
+    <glob pattern="*.webm"/>
+  </mime-type>
+
+  <mime-type type="application/initramfs-gz">
+    <comment>Linux initramfs, compressed</comment>
+    <glob pattern="initrd.gz"/>
+  </mime-type>
+
+  <mime-type type="application/ms-fat-filesystem">
+    <comment>FAT filesystem in a file</comment>
+    <glob pattern="*.fat"/>
+    <glob pattern="*.vfat"/>
+  </mime-type>
+
+  <mime-type type="application/ntfs-filesystem">
+    <comment>NTFS filesystem in a file</comment>
+    <glob pattern="*.ntfs"/>
+  </mime-type>
+
+
+</mime-info>


### PR DESCRIPTION
Two files:
custom.xml
puppy.xml

custom.xml: some mimetypes I myself added...

puppy.xml is currently in shared-mime-info.pet and must be removed from there.

    /usr/share/mime/packages
     freedesktop.org.xml
     puppy.xml

The shared-mime-info.pet contains also a processed [outdated] freedesktop.org.xml (already split into many files)
Should contain only 3 files

    /usr/bin/update-mime-database
    /usr/share/mime/packages/freedesktop.org.xml
    /usr/share/pkgconfig/shared-mime-info.pc

And the post install script should process /usr/share/mime/packages

    update-mime-database /usr/share/mime

In fact, only /usr/bin/update-mime-database should be in shared-mime-info.pet