### PR TITLE
Do not include 'truncate' in any WoofCE based Puppy (issue #667)

### DIFF
--- a/woof-code/support/HISTORY-debian-squeeze/DISTRO_PKGS_SPECS-debian-squeeze-VERSION4.99.0
+++ b/woof-code/support/HISTORY-debian-squeeze/DISTRO_PKGS_SPECS-debian-squeeze-VERSION4.99.0
@@ -586,7 +586,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 #debian lenny: needed by libdirectfb->cairo ...
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev||exe

--- a/woof-code/support/HISTORY-debian-squeeze/DISTRO_PKGS_SPECS-debian-squeeze-VERSION4.99.1
+++ b/woof-code/support/HISTORY-debian-squeeze/DISTRO_PKGS_SPECS-debian-squeeze-VERSION4.99.1
@@ -599,7 +599,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 #debian lenny: needed by libdirectfb->cairo ...
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev||exe

--- a/woof-code/support/HISTORY-debian-squeeze/DISTRO_PKGS_SPECS-debian-squeeze-VERSION4.99.2
+++ b/woof-code/support/HISTORY-debian-squeeze/DISTRO_PKGS_SPECS-debian-squeeze-VERSION4.99.2
@@ -594,7 +594,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 #debian lenny: needed by libdirectfb->cairo ...
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev||exe

--- a/woof-code/support/HISTORY-puppy-wary5/DISTRO_PKGS_SPECS-puppy-wary5-VERSION5.1.2
+++ b/woof-code/support/HISTORY-puppy-wary5/DISTRO_PKGS_SPECS-puppy-wary5-VERSION5.1.2
@@ -630,7 +630,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe
+no|truncate||exe
 no|udev||exe
 no|udev_151||exe,dev,doc,nls
 yes|udev_167p||exe,dev,doc,nls

--- a/woof-distro/arm/debian/squeeze/DISTRO_PKGS_SPECS-debian-squeeze
+++ b/woof-distro/arm/debian/squeeze/DISTRO_PKGS_SPECS-debian-squeeze
@@ -643,7 +643,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe,dev,doc,nls
+no|truncate||exe,dev,doc,nls
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls| #debian lenny: needed by libdirectfb->cairo.
 no|udev_167||exe,dev,doc,nls
 yes|udev_167pe||exe,dev,doc,nls| #has libgudev

--- a/woof-distro/arm/gentoo/gap6/DISTRO_PKGS_SPECS-gentoo-gap6
+++ b/woof-distro/arm/gentoo/gap6/DISTRO_PKGS_SPECS-gentoo-gap6
@@ -561,7 +561,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|time|time|exe,dev>null,doc,nls
 no|transmission1||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe,dev,doc,nls
+no|truncate||exe,dev,doc,nls
 yes|udev|udev|exe,dev,doc,nls
 yes|unclutter||exe,dev>null,doc,nls
 yes|unionfs_utils||exe,dev,doc,nls

--- a/woof-distro/arm/raspbian/wheezy/DISTRO_PKGS_SPECS-raspbian-wheezy
+++ b/woof-distro/arm/raspbian/wheezy/DISTRO_PKGS_SPECS-raspbian-wheezy
@@ -674,7 +674,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|tile||exe
 yes|time|time|exe,dev>null,doc,nls
 no|transmission||exe,dev,doc,nls| #need to compile this.
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev_167||exe
 no|udev_167pe||exe,dev,doc,nls| #has libgudev

--- a/woof-distro/arm/ubuntu/lucid/DISTRO_PKGS_SPECS-ubuntu-lucid
+++ b/woof-distro/arm/ubuntu/lucid/DISTRO_PKGS_SPECS-ubuntu-lucid
@@ -601,7 +601,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 yes|udev_167||exe
 no|udev_lib|libudev0,libudev-dev|exe,dev,doc,nls

--- a/woof-distro/arm/ubuntu/precise/DISTRO_PKGS_SPECS-ubuntu-precise
+++ b/woof-distro/arm/ubuntu/precise/DISTRO_PKGS_SPECS-ubuntu-precise
@@ -680,7 +680,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|tile||exe
 yes|time|time|exe,dev>null,doc,nls
 no|transmission||exe,dev,doc,nls| #need to compile this.
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev_167||exe
 yes|udev_167pe||exe,dev,doc,nls| #has libgudev

--- a/woof-distro/x86/arch/rolling-release/DISTRO_PKGS_SPECS-arch
+++ b/woof-distro/x86/arch/rolling-release/DISTRO_PKGS_SPECS-arch
@@ -559,7 +559,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 no|udev||exe
 yes|udev_167pe||exe,dev,doc,nls| #no, using eudev. no, eudev is broken.
 yes|unclutter||exe,dev>null,doc,nls

--- a/woof-distro/x86/debian/DISTRO_PKGS_SPECS-debian
+++ b/woof-distro/x86/debian/DISTRO_PKGS_SPECS-debian
@@ -557,7 +557,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 #debian lenny: needed by libdirectfb->cairo ...
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev||exe

--- a/woof-distro/x86/debian/squeeze/DISTRO_PKGS_SPECS-debian-squeeze
+++ b/woof-distro/x86/debian/squeeze/DISTRO_PKGS_SPECS-debian-squeeze
@@ -642,7 +642,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls| #debian lenny: needed by libdirectfb->cairo.
 no|udev||exe
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86/debian/wheezy/DISTRO_PKGS_SPECS-debian-wheezy
+++ b/woof-distro/x86/debian/wheezy/DISTRO_PKGS_SPECS-debian-wheezy
@@ -650,7 +650,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls| #debian lenny: needed by libdirectfb->cairo.
 no|udev||exe
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86/devuan/jessie/DISTRO_PKGS_SPECS-devuan-jessie
+++ b/woof-distro/x86/devuan/jessie/DISTRO_PKGS_SPECS-devuan-jessie
@@ -672,7 +672,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|tile||exe
 yes|time|time|exe,dev>null,doc,nls
 # silly dependency of PPM, can be easily replaced with head and tail
-yes|truncate||exe
+no|truncate||exe
 no|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls| #debian lenny: needed by libdirectfb->cairo.
 no|udev||exe
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86/mageia/1/DISTRO_PKGS_SPECS-mageia-1
+++ b/woof-distro/x86/mageia/1/DISTRO_PKGS_SPECS-mageia-1
@@ -602,7 +602,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls|
 yes|tile||exe|
 yes|time|time|exe,dev>null,doc,nls|
 yes|transmission||exe,dev,doc,nls|
-yes|truncate||exe|
+no|truncate||exe|
 yes|udev_167p||exe,dev,doc,nls|
 yes|unclutter||exe,dev>null,doc,nls| #no mageia pkg
 yes|unionfs_utils||exe|

--- a/woof-distro/x86/mageia/cauldron/DISTRO_PKGS_SPECS-mageia-cauldron
+++ b/woof-distro/x86/mageia/cauldron/DISTRO_PKGS_SPECS-mageia-cauldron
@@ -624,7 +624,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls|
 yes|tile||exe|
 yes|time|time|exe,dev>null,doc,nls|
 yes|transmission||exe,dev,doc,nls|
-yes|truncate||exe|
+no|truncate||exe|
 yes|udev_167p||exe,dev,doc,nls|
 yes|unclutter||exe,dev>null,doc,nls| #no mageia pkg
 yes|unionfs_utils||exe|

--- a/woof-distro/x86/pet-based/racy/DISTRO_PKGS_SPECS-puppy-wary5
+++ b/woof-distro/x86/pet-based/racy/DISTRO_PKGS_SPECS-puppy-wary5
@@ -688,7 +688,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe
+no|truncate||exe
 no|udev||exe
 no|udev_151||exe,dev,doc,nls
 yes|udev_167p||exe,dev,doc,nls

--- a/woof-distro/x86/pet-based/wary/DISTRO_PKGS_SPECS-puppy-wary5
+++ b/woof-distro/x86/pet-based/wary/DISTRO_PKGS_SPECS-puppy-wary5
@@ -691,7 +691,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe
+no|truncate||exe
 no|udev||exe
 no|udev_151||exe,dev,doc,nls
 yes|udev_167p||exe,dev,doc,nls

--- a/woof-distro/x86/slackware/13.1/DISTRO_PKGS_SPECS-slackware-13.1
+++ b/woof-distro/x86/slackware/13.1/DISTRO_PKGS_SPECS-slackware-13.1
@@ -569,7 +569,7 @@ no|tile||exe
 no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 no|traytemp||exe
-yes|truncate||exe
+no|truncate||exe
 no|udev||exe
 yes|udev_151||exe,dev,doc,nls
 yes|unclutter||exe,dev>null,doc,nls

--- a/woof-distro/x86/slackware/13.37/DISTRO_PKGS_SPECS-slackware-13.37
+++ b/woof-distro/x86/slackware/13.37/DISTRO_PKGS_SPECS-slackware-13.37
@@ -652,7 +652,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission1||exe
 no|traytemp||exe
-yes|truncate||exe
+no|truncate||exe
 no|Tulliana||exe| #icon theme, battleshooter
 no|udev||exe
 yes|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -730,7 +730,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe,dev,doc,nls
+no|truncate||exe,dev,doc,nls
 no|udev|udev|exe,dev,doc,nls
 no|udev_s||exe,dev,doc,nls
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86/slackware/14.1/DISTRO_PKGS_SPECS-slackware-14.1
+++ b/woof-distro/x86/slackware/14.1/DISTRO_PKGS_SPECS-slackware-14.1
@@ -781,7 +781,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe,dev,doc,nls
+no|truncate||exe,dev,doc,nls
 yes|udev|udev|exe,dev,doc,nls
 no|udev_s||exe,dev,doc,nls
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86/t2/quirky6/DISTRO_PKGS_SPECS-t2-quirky6
+++ b/woof-distro/x86/t2/quirky6/DISTRO_PKGS_SPECS-t2-quirky6
@@ -470,7 +470,7 @@ yes|sysvinit||exe
 yes|tar|tar|exe,dev>null,doc,nls|compat:quirky6
 yes|texinfo|texinfo|exe>dev,dev,doc,nls|compat:quirky6
 yes|transmission||exe,dev,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|tslib|exe,dev,doc,nls|compat:quirky6| #needed by Xfbdev framebuffer server.
 yes|udev_167p||exe,dev,doc,nls
 no|udev|udev|exe,dev,doc,nls|compat:quirky6| #t2 quirky6, this also v167

--- a/woof-distro/x86/t2/racy6/DISTRO_PKGS_SPECS-t2-racy6
+++ b/woof-distro/x86/t2/racy6/DISTRO_PKGS_SPECS-t2-racy6
@@ -478,7 +478,7 @@ yes|sysvinit||exe
 yes|tar|tar|exe,dev>null,doc,nls|compat:racy6
 yes|texinfo|texinfo|exe>dev,dev,doc,nls|compat:racy6
 yes|transmission||exe,dev,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|tslib|exe,dev,doc,nls|compat:racy6| #needed by Xfbdev framebuffer server.
 yes|tzdata|tzdata|exe,dev,doc,nls|compat:racy6| #hmmm, seems zoneinfo stuff not in glibc anymore. using tzdata.
 yes|udev_167p||exe,dev,doc,nls

--- a/woof-distro/x86/trisquel/belenos/DISTRO_PKGS_SPECS-trisquel-belenos
+++ b/woof-distro/x86/trisquel/belenos/DISTRO_PKGS_SPECS-trisquel-belenos
@@ -846,7 +846,7 @@ yes|time|time|exe,dev>null,doc,nls
 yes|transmission||exe,dev,doc,nls|pet:common| #gtk2
 no|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls| #needs gtk3, libappindicator
 yes|tree|tree|exe,dev,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev|udev-16*,udev_DEV-16*|exe,dev,doc,nls|pet:wary5
 no|udev_167pe||exe,dev,doc,nls| #configured with libgudev, but pkg very cutdown.

--- a/woof-distro/x86/ubuntu/jaunty/DISTRO_PKGS_SPECS-ubuntu-jaunty
+++ b/woof-distro/x86/ubuntu/jaunty/DISTRO_PKGS_SPECS-ubuntu-jaunty
@@ -571,7 +571,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 yes|udev||exe
 yes|unclutter|unclutter|exe,dev>null,doc,nls

--- a/woof-distro/x86/ubuntu/karmic/DISTRO_PKGS_SPECS-ubuntu-karmic
+++ b/woof-distro/x86/ubuntu/karmic/DISTRO_PKGS_SPECS-ubuntu-karmic
@@ -561,7 +561,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 yes|udev||exe
 yes|udev_lib|libudev0,libudev-dev|exe,dev,doc,nls

--- a/woof-distro/x86/ubuntu/lucid/DISTRO_PKGS_SPECS-ubuntu-lucid
+++ b/woof-distro/x86/ubuntu/lucid/DISTRO_PKGS_SPECS-ubuntu-lucid
@@ -646,7 +646,7 @@ no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 yes|udev||exe
 yes|udev_lib|libudev0,libudev-dev|exe,dev,doc,nls

--- a/woof-distro/x86/ubuntu/precise/DISTRO_PKGS_SPECS-ubuntu-precise
+++ b/woof-distro/x86/ubuntu/precise/DISTRO_PKGS_SPECS-ubuntu-precise
@@ -786,7 +786,7 @@ yes|texinfo|texinfo|exe>dev,dev,doc,nls
 yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
 yes|transmission||exe,dev,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev|udev-16*,udev_DEV-16*|exe,dev,doc,nls|pet:wary5
 yes|udev_167pe||exe,dev,doc,nls| #configured with libgudev, but pkg very cutdown.

--- a/woof-distro/x86/ubuntu/raring/DISTRO_PKGS_SPECS-ubuntu-raring
+++ b/woof-distro/x86/ubuntu/raring/DISTRO_PKGS_SPECS-ubuntu-raring
@@ -766,7 +766,7 @@ yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
 no|transmission||exe,dev,doc,nls
 yes|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls|
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev|udev-16*,udev_DEV-16*|exe,dev,doc,nls|pet:wary5
 no|udev_167pe||exe,dev,doc,nls| #configured with libgudev, but pkg very cutdown.

--- a/woof-distro/x86/ubuntu/saucy/DISTRO_PKGS_SPECS-ubuntu-saucy
+++ b/woof-distro/x86/ubuntu/saucy/DISTRO_PKGS_SPECS-ubuntu-saucy
@@ -769,7 +769,7 @@ yes|tile||exe
 yes|time|time|exe,dev>null,doc,nls
 no|transmission||exe,dev,doc,nls
 yes|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls|
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev|udev-16*,udev_DEV-16*|exe,dev,doc,nls|pet:wary5
 no|udev_167pe||exe,dev,doc,nls| #configured with libgudev, but pkg very cutdown.

--- a/woof-distro/x86/ubuntu/trusty/DISTRO_PKGS_SPECS-ubuntu-trusty
+++ b/woof-distro/x86/ubuntu/trusty/DISTRO_PKGS_SPECS-ubuntu-trusty
@@ -871,7 +871,7 @@ yes|time|time|exe,dev>null,doc,nls
 yes|transmission||exe,dev,doc,nls|pet:tahr| #qt
 no|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls| #needs gtk3, libappindicator
 yes|tree|tree|exe,dev,doc,nls
-yes|truncate||exe
+no|truncate||exe
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev|udev-16*,udev_DEV-16*|exe,dev,doc,nls|pet:wary5
 no|udev_167pe||exe,dev,doc,nls| #configured with libgudev, but pkg very cutdown.

--- a/woof-distro/x86_64/slackware64/14.0/DISTRO_PKGS_SPECS-slackware64-14.0
+++ b/woof-distro/x86_64/slackware64/14.0/DISTRO_PKGS_SPECS-slackware64-14.0
@@ -748,7 +748,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,doc
 no|traytemp||exe
-yes|truncate||exe,dev,doc,nls
+no|truncate||exe,dev,doc,nls
 yes|udev|udev|exe,dev,doc,nls
 no|udev_s||exe,dev,doc,nls
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86_64/slackware64/14.1/DISTRO_PKGS_SPECS-slackware64-14.1
+++ b/woof-distro/x86_64/slackware64/14.1/DISTRO_PKGS_SPECS-slackware64-14.1
@@ -778,7 +778,7 @@ no|time|time|exe,dev>null,doc,nls
 no|toppler||exe
 yes|transmission||exe,dev,doc,nls
 no|traytemp||exe
-yes|truncate||exe,dev,doc,nls
+no|truncate||exe,dev,doc,nls
 yes|udev|udev|exe,dev,doc,nls
 no|udev_s||exe,dev,doc,nls
 no|udev_151||exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PKGS_SPECS-ubuntu-trusty
+++ b/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PKGS_SPECS-ubuntu-trusty
@@ -888,7 +888,7 @@ yes|time|time|exe,dev>null,doc,nls
 yes|transmission||exe,dev,doc,nls|pet:tahr64| #gtk2
 no|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls| #needs gtk3, libappindicator
 yes|tree|tree|exe,dev,doc,nls
-yes|truncate||exe|pet:tahr64|
+no|truncate||exe|pet:tahr64|
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
 no|udev|udev-16*,udev_DEV-16*|exe,dev,doc,nls|pet:wary5
 no|udev_167pe||exe,dev,doc,nls| #configured with libgudev, but pkg very cutdown.


### PR DESCRIPTION
The truncate utility is deprecated, it was used in /usr/bin/pet2tgz but not anymore
The things is, truncate is a GNU coreutils app, all the more reason to remove this package