### PR TITLE
Implement an 'insmod' facility in 'init' script

### DIFF
--- a/woof-code/boot/boot-dialog/help2.msg
+++ b/woof-code/boot/boot-dialog/help2.msg
@@ -13,12 +13,12 @@ then each boot option. Some boot options:
 0dzdrv=sdc1:/puppies/wary501/zdrv.sfs07    Override auto search.
 0dunderdog=sda907   Mount an entire Linux distro (in sda9) underneath Puppy.
 0dpmedia=cd pfix=ram07 Ignore saved session and do not look in other drives
-
 0bThe following are for debugging, for experts only:07
 0dloglevel=<n>07    Bootup verbosity. 7 is high verbosity for debugging.
 0dpfix=rdsh07       Execute 'init' then dropout to prompt in initramfs.
 0dpfix=rdsh007      Dropout early, before loading kernel drivers.
 0dpfix=rdsh607      Dropout just before mount layered filesystem.
+0dpimod=a.ko,b.ko07 'insmod' these kernel module files.
 
 More help here: http://kernel.org/doc/Documentation/kernel-parameters.txt
 

--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -501,6 +501,49 @@ search_func() { #110425
   fi #101103 moved up.
   echo "  IGNORE=$IGNORE PSUBDIR=$PSUBDIR SAVEPART=$SAVEPART VMLINUZ=$VMLINUZ PDEV1=$PDEV1 PUPSFS=$PUPSFS" >> /tmp/puppy-file-search.log #101127 for debugging.
         
+  if [ "$PDEV1" != "" -a "$PDEV1" = "$ONEDEV" ];then
+   if [ "$PIMOD" = "" ];then
+    PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}_${KERNELVER}_init_modules.txt"
+    [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+   fi
+   if [ "$PIMOD" != "" ];then
+    ZDRVPATH="/mnt/data${PSUBDIR}/${DISTRO_ZDRVSFS}"
+    if [ -f "$ZDRVPATH" ];then
+     [ -d /mnt/dataZDRV ] || mkdir /mnt/dataZDRV
+     ZDRVLOOP="`losetup -f`"
+     losetup $ZDRVLOOP $ZDRVPATH
+     mount -r -t squashfs -o noatime $ZDRVLOOP /mnt/dataZDRV
+     if [ $? -eq 0 ];then
+      MODNEWLN="yes"
+      MODSPATH="/mnt/dataZDRV/lib/modules/$KERNELVER"
+      for ONEMOD in `echo -n "$PIMOD" | tr ',' ' '`;do
+       CURMOD=""
+       if [ -f "${MODSPATH}/${ONEMOD}" ];then
+        CURMOD="$ONEMOD"
+       else
+        CURMOD="`grep -m1 $ONEMOD $MODSPATH/modules.order`"
+        if [ "$CURMOD" = "" ];then
+         MODPATN="`echo -n "$ONEMOD" | tr '_' '-'`"
+         CURMOD="`grep -m1 "$MODPATN" $MODSPATH/modules.order`"
+        fi
+        [ -f "${MODSPATH}/${CURMOD}" ] || CURMOD=""
+       fi
+       if [ "$CURMOD" != "" ];then
+        if [ "$MODNEWLN" = "yes" ];then
+         echo "" > /dev/console
+         MODNEWLN=""
+        fi
+        echo "Adding module $CURMOD" > /dev/console
+        insmod "${MODSPATH}/${CURMOD}" > /dev/console 2>&1
+       fi
+      done
+      umount /mnt/dataZDRV
+     fi
+     losetup -d $ZDRVLOOP
+    fi   
+   fi
+  fi
+
   FND_PUPSAVES=""
   ONEFS_IS_LINUX=""
   case $ONEFS in
@@ -604,6 +647,9 @@ mnt_enc_pupsave_func() {
 [ $zdrv ] && ZDRV=$zdrv #ex: sda2:/wary071/zdrv_071.sfs
 [ $adrv ] && ADRV=$adrv
 [ $ydrv ] && YDRV=$ydrv
+
+#list of kernel modules to load, ex: pimod=hid-logitech-dj.ko,kernel/drivers/hid/hid-multitouch.ko 
+[ $pimod ] && PIMOD=$pimod
 
 [ $underdog ] && UNDERDOG=$underdog #120130 specify partition for Underdog Linux (refer also underdog.lnx).
 


### PR DESCRIPTION
This facility provides a workaround when the keyboard does not work during the 'init' script because a kernel module is not available yet.
The module files to 'insmod' can be specified as either a 'pimod' kernel parameter, or the first line of the text file '/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}_${KERNELVER}_init_modules.txt'