### PR TITLE
fixmenus: shorten code

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/fixmenus
+++ b/woof-code/rootfs-skeleton/usr/sbin/fixmenus
@@ -47,10 +47,7 @@ do
  while read ONELINE
  do
    EXECMENU=""
-   if [[ "$ONELINE" == PUPPYMENU* ]] ; then
-     read -r one two three four five <<< "$ONELINE"
-     EXECMENU="$two $three $four $five"
-   fi
+   [[ "$ONELINE" == PUPPYMENU* ]] && EXECMENU="${ONELINE#PUPPYMENU }"
    if [[ "$ONELINE" == *MENHEIGHT* ]] ; then #131213 designed to be backward compatible
      if [ "$MENHEIGHT" ] ; then
        echo ${ONELINE//MENHEIGHT/$MENHEIGHT} #>> $ONEDEST


### PR DESCRIPTION
This was
    EXECMENU="`echo -n "$ONELINE" | grep -o '^PUPPYMENU.*' | cut -f 2-5 -d ' '`"

Then it became
    if [[ "$ONELINE" == PUPPYMENU* ]] ; then
        read -r one two three four five <<< "$ONELINE"
        EXECMENU="$two $three $four $five"
    fi

Which is basically the same, but I forgot to add 'six <<<' to make it behave exactly as cut -f 2-5 -d

But I see that this 'cut -f 2-5' is actually *not* needed.