### PR TITLE
init insmod facility - fix config filename

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -503,7 +503,7 @@ search_func() { #110425
         
   if [ "$PDEV1" != "" -a "$PDEV1" = "$ONEDEV" ];then
    if [ "$PIMOD" = "" ];then
-    PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}_${KERNELVER}_init_modules.txt"
+    PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}_init_modules.txt"
     [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
    fi
    if [ "$PIMOD" != "" ];then


### PR DESCRIPTION
Specifying the module list by a config file, should behave the same way as specifying the module list by kernel parameter, when handling a different kernel version.
This patch removes the kernel version from the config filename. 