### PR TITLE
probepart: dot not check sort version, replace code

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/probepart
+++ b/woof-code/rootfs-skeleton/sbin/probepart
@@ -53,7 +53,7 @@ ALLDRVS="`ls -1 /sys/block | grep -E '^scd|^sd|^mmc|^sr'`"
 
 #all drives and partitions... 120602 sort...
 ALLDEVS=$(echo "${PARTNAMES}
-${ALLDRVS}" | grep -v 'sd[a-z]$' | sort -u)
+${ALLDRVS}" | sort -u)
 
 # guess_fstype really sucks for extended partitions - use fdisk but not in the main loop - too slow #140714
 EXTD=''

--- a/woof-code/rootfs-skeleton/sbin/probepart
+++ b/woof-code/rootfs-skeleton/sbin/probepart
@@ -52,15 +52,8 @@ ALLDRVS="`ls -1 /sys/block | grep -E '^scd|^sd|^mmc|^sr'`"
 `ls -1 /proc/ide | grep '^hd'`"
 
 #all drives and partitions... 120602 sort...
-#120516 sort in old coreutils (as in wary/racy) does not have -V option...
-COREUTILSVER="$(sort --version | head -n 1 | rev | cut -f 1 -d ' ' | rev)"
-if vercmp $COREUTILSVER le 6.12;then
- ALLDEVS="`echo "${PARTNAMES}
-${ALLDRVS}" | tr '\n' ' '`"
-else
- ALLDEVS="`echo "${PARTNAMES}
-${ALLDRVS}" | sort -V -u | tr '\n' ' '`"
-fi
+ALLDEVS=$(echo "${PARTNAMES}
+${ALLDRVS}" | grep -v 'sd[a-z]$' | sort -u)
 
 # guess_fstype really sucks for extended partitions - use fdisk but not in the main loop - too slow #140714
 EXTD=''


### PR DESCRIPTION
if vercmp $COREUTILSVER le 6.12;then

    sda1 sda2 sda3 sda4 sdb1 sdb2 sdb3 sdb4 sda sdb sr0

else

    sda sda1 sda2 sda3 sda4 sdb sdb1 sdb2 sdb3 sdb4 sr0

fi

New approach

    sda1 sda2 sda3 sda4 sdb1 sdb2 sdb3 sr0

bash

    ALLDEVS=$(
      for dev in ${PARTNAMES} ${ALLDRVS} ; do
        [[ $dev != sd[a-z] ]] && echo $dev
      done
    )