### PR TITLE
probedisk: simplify code

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -6,27 +6,47 @@
 #v406 support for old kernel, /proc/ide, /dev/hd*.
 # DEVICE|TYPE|INFO
 
-if [ -f $HOME/.usb-drive-log-probedisk ] ; then #force /proc upate mechanism
-  while read ONEUSBDRV ; do
-    dd if=/dev/$ONEUSBDRV of=/dev/null bs=512 count=1 &>/dev/null
-  done < $HOME/.usb-drive-log-probedisk
-fi
+output=1
+case $1 in
+	-alt)  output=2 ; shift ;;
+	-type) output=3 ; shift ;;
+	-desc) output=4 ; shift ;;
+	-size) output=5 ; shift ;;
+esac
 
-# mounted drives/partitions...
-MNTDDEVS="`mount | cut -f 1 -d ' ' | cut -f 3 -d '/' | grep -E '^hd|^sd|^scd|^sr|^mmc' | tr '\n' ' '`"
+device=$1
 
-ALLDRVS=$(ls /sys/block | grep -E '^scd|^sd|^mmc|^sr')
-if [ -e /proc/ide ] ; then
-  PROCIDE=1
-  ALLDRVS="$ALLDRVS
+if [ -b "$device"  ] ; then
+	ONLYONE=1
+	[ -e /proc/ide ] && PROCIDE=1
+	ALLDRVS=${device##*/}
+else
+	if [ -f $HOME/.usb-drive-log-probedisk ] ; then #force /proc upate mechanism
+	  while read ONEUSBDRV ; do
+		dd if=/dev/$ONEUSBDRV of=/dev/null bs=512 count=1 &>/dev/null
+	  done < $HOME/.usb-drive-log-probedisk
+	fi
+
+	# mounted drives/partitions...
+	MNTDDEVS="`mount | cut -f 1 -d ' ' | cut -f 3 -d '/' | grep -E '^hd|^sd|^scd|^sr|^mmc' | tr '\n' ' '`"
+
+	ALLDRVS=$(ls /sys/block | grep -E '^scd|^sd|^mmc|^sr')
+	if [ -e /proc/ide ] ; then
+	  PROCIDE=1
+	  ALLDRVS="$ALLDRVS
 $(ls /proc/ide | grep '^hd')"
+	fi
 fi
+
+###############################################################
 
 for p in ${ALLDRVS} ; do
+
 	#case $p in ram*|nbd*|loop*) continue;; esac
 	vendor="" model="" type="drive"
 	[ -f /sys/block/$p/device/vendor ] && read vendor < /sys/block/$p/device/vendor
 	[ -f /sys/block/$p/device/model ] && read model < /sys/block/$p/device/model
+	[ -f /sys/block/$p/size ] && read size < /sys/block/$p/size
 	info="$vendor $model"
 	case $p in
 		hd*) ## ide device, look in /proc/ide for info
@@ -34,11 +54,10 @@ for p in ${ALLDRVS} ; do
 			[ "$media" = "cdrom" ] && type="optical"
 			[ -f /proc/ide/$p/model ] && read info < /proc/ide/$p/model
 			;;
-		sd*) [ "$PROCIDE" ] && type=usbdrv ;; ## /proc/ide: flash drives appear as sdX)
+		sd*) [ "$PROCIDE" ] && type=usbdrv ;; ## /proc/ide: usb drives appear as sdX)
 		fd*)      type=floppy  ;;
 		scd*|sr*) type=optical ;; #scd*: probably old stuff
 		mmc*)     type=card ; info="MMC/SD: $info" ;;
-
 	esac
 	readlink /sys/block/$p | grep -q usb && type=usbdrv
 
@@ -47,7 +66,7 @@ for p in ${ALLDRVS} ; do
 		echo "$p" >> $HOME/.usb-drive-log-probedisk
 		sorted="$(sort -u $HOME/.usb-drive-log-probedisk)"
 		echo "$sorted" > $HOME/.usb-drive-log-probedisk
-			# find out if a usb floppy drive...
+		# find out if a usb floppy drive...
 		if [ -e /sys/block/${p}/size ];then
 			[ "`cat /sys/block/${p}/size`" = "2880" ] && type=floppy
 		fi
@@ -66,20 +85,31 @@ for p in ${ALLDRVS} ; do
 		esac
 	fi
 
-	echo "/dev/$p|$type|$info"
+	case $output in
+		1) echo "/dev/$p|$type|$info" ;;
+		2) echo "/dev/$p $type $size $info" ;;
+		3) echo "$type" ;;
+		4) echo "$info" ;;
+		5) echo "$size" ;;
+	esac
+
 done
 
-# find out if a mounted device has been unplugged...
-# for hotplug drives, remove it and it will disappear from /sys/block, however
-# still shows up in 'mount' if hasn't been unmounted.
-for ONEMNTD in $MNTDDEVS ; do
-	case $ONEMNTD in
-		hd*|sd*|sr*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-3` " ;;
-		scd*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-4` " ;;
-		mmc*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-7` " ;;
-	esac
-	#prints to system log and to stderr...
-	[ "`echo $ALLDRVS | grep "$MNTDDRVs"`" = "" ] && logger -s "PROBEDISK ERROR: MOUNTED UNPLUGGED $ONEMNTD"
-done
+###############################################################
+
+if [ ! "$ONLYONE" ] ; then
+	# find out if a mounted device has been unplugged...
+	# for hotplug drives, remove it and it will disappear from /sys/block, however
+	# still shows up in 'mount' if hasn't been unmounted.
+	for ONEMNTD in $MNTDDEVS ; do
+		case $ONEMNTD in
+			hd*|sd*|sr*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-3` " ;;
+			scd*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-4` " ;;
+			mmc*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-7` " ;;
+		esac
+		#prints to system log and to stderr...
+		[ "`echo $ALLDRVS | grep "$MNTDDRVs"`" = "" ] && logger -s "PROBEDISK ERROR: MOUNTED UNPLUGGED $ONEMNTD"
+	done
+fi
 
 ### END ###

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -12,6 +12,9 @@ case $1 in
 	-type) output=3 ; shift ;;
 	-desc) output=4 ; shift ;;
 	-size) output=5 ; shift ;;
+	-alt512) output=6 ; shift ;;
+	-alt2048)output=7 ; shift ;;
+	-alt4096)output=8 ; shift ;;
 esac
 
 device=${1##*/}
@@ -30,11 +33,11 @@ else
 	# mounted drives/partitions...
 	MNTDDEVS="`mount | cut -f 1 -d ' ' | cut -f 3 -d '/' | grep -E '^hd|^sd|^scd|^sr|^mmc' | tr '\n' ' '`"
 
-	ALLDRVS=$(ls /sys/block | grep -E '^scd|^sd|^mmc|^sr')
 	if [ -e /proc/ide ] ; then
-	  PROCIDE=1
-	  ALLDRVS="$ALLDRVS
-$(ls /proc/ide | grep '^hd')"
+		PROCIDE=1
+		ALLDRVS="`ls -1 /sys/block | grep -E '^scd|^sd|^mmc|^sr' | tr '\n' ' '``ls -1 /proc/ide | grep '^hd' | tr '\n' ' '`"
+	else
+		ALLDRVS="`ls -1 /sys/block | grep -E '^scd|^sd|^mmc|^sr' | tr '\n' ' '`"
 	fi
 fi
 
@@ -91,6 +94,9 @@ for p in ${ALLDRVS} ; do
 		3) echo "$type" ;;
 		4) echo "$info" ;;
 		5) echo "$size" ;;
+		6) echo "/dev/$p $type $(filesize -format512 $size) $info" ;;
+		7) echo "/dev/$p $type $(filesize -format2048 $size) $info" ;;
+		8) echo "/dev/$p $type $(filesize -format4096 $size) $info" ;;
 	esac
 
 done
@@ -108,7 +114,7 @@ if [ ! "$ONLYONE" ] ; then
 			mmc*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-7` " ;;
 		esac
 		#prints to system log and to stderr...
-		[ "`echo $ALLDRVS | grep "$MNTDDRVs"`" = "" ] && logger -s "PROBEDISK ERROR: MOUNTED UNPLUGGED $ONEMNTD"
+		[ "`echo "$ALLDRVS" | grep "$MNTDDRVs"`" = "" ] && logger -s "PROBEDISK ERROR: MOUNTED UNPLUGGED $ONEMNTD"
 	done
 fi
 

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -14,12 +14,12 @@ case $1 in
 	-size) output=5 ; shift ;;
 esac
 
-device=$1
+device=${1##*/}
 
-if [ -b "$device"  ] ; then
+if [ -b "/dev/$device"  ] ; then
 	ONLYONE=1
 	[ -e /proc/ide ] && PROCIDE=1
-	ALLDRVS=${device##*/}
+	ALLDRVS=${device}
 else
 	if [ -f $HOME/.usb-drive-log-probedisk ] ; then #force /proc upate mechanism
 	  while read ONEUSBDRV ; do

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -12,6 +12,9 @@ if [ -f $HOME/.usb-drive-log-probedisk ] ; then #force /proc upate mechanism
   done < $HOME/.usb-drive-log-probedisk
 fi
 
+# mounted drives/partitions...
+MNTDDEVS="`mount | cut -f 1 -d ' ' | cut -f 3 -d '/' | grep -E '^hd|^sd|^scd|^sr|^mmc' | tr '\n' ' '`"
+
 ALLDRVS=$(ls /sys/block | grep -E '^scd|^sd|^mmc|^sr')
 if [ -e /proc/ide ] ; then
   PROCIDE=1
@@ -34,15 +37,49 @@ for p in ${ALLDRVS} ; do
 		sd*) [ "$PROCIDE" ] && type=usbdrv ;; ## /proc/ide: flash drives appear as sdX)
 		fd*)      type=floppy  ;;
 		scd*|sr*) type=optical ;; #scd*: probably old stuff
-		mmc*)     type=card    ;;
+		mmc*)     type=card ; info="MMC/SD: $info" ;;
+
 	esac
 	readlink /sys/block/$p | grep -q usb && type=usbdrv
+
+	## Legacy stuff
 	if [ "$type" = "usbdrv" ] ; then
 		echo "$p" >> $HOME/.usb-drive-log-probedisk
 		sorted="$(sort -u $HOME/.usb-drive-log-probedisk)"
 		echo "$sorted" > $HOME/.usb-drive-log-probedisk
+			# find out if a usb floppy drive...
+		if [ -e /sys/block/${p}/size ];then
+			[ "`cat /sys/block/${p}/size`" = "2880" ] && type=floppy
+		fi
+		# if the floppy diskette not inserted, try this fallback test...
+		# some examples: Vendor: NEC Model: USB UF000x Rev: 1.50, Sony USB Floppy Drive, rev 1.10/5.01,
+		# MITUMI USB FDD, VenDor: TEAC Model: FD-05PUB, Vendor: COMPAQ Model: USB EXT FLOPPY
+		if [ -e /sys/block/${p}/device/model ];then
+			[ "`grep -E ' FDD| UF000x|Floppy|USB\-FDU|^FD\-|FLOPPY' /sys/block/${p}/device/model`" != "" ] && type=floppy
+		fi	
+	else
+		case $p in sd*)
+			# find out if it is a removable internal drive (zip, ls120, etc)...
+			if [ -e /sys/block/${p}/removable ];then
+				[ "$(< /sys/block/${p}/removable)" = "1" ] && type=floppy
+			fi
+		esac
 	fi
+
 	echo "/dev/$p|$type|$info"
+done
+
+# find out if a mounted device has been unplugged...
+# for hotplug drives, remove it and it will disappear from /sys/block, however
+# still shows up in 'mount' if hasn't been unmounted.
+for ONEMNTD in $MNTDDEVS ; do
+	case $ONEMNTD in
+		hd*|sd*|sr*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-3` " ;;
+		scd*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-4` " ;;
+		mmc*) MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-7` " ;;
+	esac
+	#prints to system log and to stderr...
+	[ "`echo $ALLDRVS | grep "$MNTDDRVs"`" = "" ] && logger -s "PROBEDISK ERROR: MOUNTED UNPLUGGED $ONEMNTD"
 done
 
 ### END ###

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -1,4 +1,9 @@
 #!/bin/sh
+#LGPL 2007 Puppy Linux www.puppyos.com
+#based on probedisk3 written by Dougal.
+# 21 Jun 2007 BK: force /proc update for usb drives.
+#v3.93 10 dec 2007 BK: updated for 2.6.24 kernel, no /dev/hd*.
+#v406 support for old kernel, /proc/ide, /dev/hd*.
 # DEVICE|TYPE|INFO
 
 if [ -f $HOME/.usb-drive-log-probedisk ] ; then #force /proc upate mechanism
@@ -9,31 +14,36 @@ fi
 
 ALLDRVS=$(ls /sys/block | grep -E '^scd|^sd|^mmc|^sr')
 if [ -e /proc/ide ] ; then
+  PROCIDE=1
   ALLDRVS="$ALLDRVS
 $(ls /proc/ide | grep '^hd')"
 fi
 
 for p in ${ALLDRVS} ; do
 	#case $p in ram*|nbd*|loop*) continue;; esac
+	USB=0
 	vendor="" model="" type="drive"
-	read vendor < /sys/block/$p/device/vendor
-	read model < /sys/block/$p/device/model
+	[ -f /sys/block/$p/device/vendor ] && read vendor < /sys/block/$p/device/vendor
+	[ -f /sys/block/$p/device/model ] && read model < /sys/block/$p/device/model
 	info="$vendor $model"
 	case $p in
 		hd*) ## ide device, look in /proc/ide for info
-			read -r media < /proc/ide/$ONEDRV/media
+			read -r media < /proc/ide/$p/media
 			[ "$media" = "cdrom" ] && type="optical"
+			[ -f /proc/ide/$p/model ] && read info < /proc/ide/$p/model
 			;;
-		fd*)  type=floppy  ;;
-		sr*)  type=optical ;;
-		mmc*) type=card ; info="MMC/SD: $info" ;;
+		sd*) [ "$PROCIDE" ] && type=usbdrv && USB=1 ;; ## /proc/ide: flash drives appear as sdX)
+		fd*)      type=floppy  ;;
+		scd*|sr*) type=optical ;; #scd*: probably old stuff
+		mmc*)     type=card    ;;
 	esac
-	readlink /sys/block/$p | grep -q usb && {
+	readlink /sys/block/$p | grep -q usb && USB=1
+	if [ $USB -eq 1 ] ; then
 		type=usbdrv
 		echo "$p" >> $HOME/.usb-drive-log-probedisk
 		sorted="$(sort -u $HOME/.usb-drive-log-probedisk)"
 		echo "$sorted" > $HOME/.usb-drive-log-probedisk
-	}
+	fi
 	echo "/dev/$p|$type|$info"
 done
 

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -1,118 +1,40 @@
 #!/bin/sh
-#LGPL 2007 Puppy Linux www.puppyos.com
-#based on probedisk3 written by Dougal.
-#small mods by BK 16 june 2007
-# 21 Jun 2007 BK: force /proc update for usb drives.
-#v3.93 10 dec 2007 BK: updated for 2.6.24 kernel, no /dev/hd*.
-#v3.97 31jan2008 BK: refinement for detecting kernels with /dev/hd* drives.
-#v4.01 10may2008 BK: bugfix for detecting if usb drive.
-#v4.01 10may2008 BK: new 2nd-param categories. named 'probedisk2'.
-#v4.01 21may2008 BK: zip and ls120 now categorized as 'floppy'.
-#v4.02 9jun08 BK: correct detection of usb floppy.
-#v403 fixed excessive spaces in description field.
-#v406 support for old kernel, /proc/ide, /dev/hd*.
-#110126 no longer using SATADRIVES variable in PUPSTATE.
-#130201 this script no longer named 'probedisk2' (had probedisk symlink to it). now named 'probedisk'.
+# DEVICE|TYPE|INFO
 
-. /etc/rc.d/PUPSTATE
-#110126 ATADRIVES is all ide/pata/sata drives (not usb, not optical).
-
-if [ -f /root/.usb-drive-log-probedisk ];then #force /proc upate mechanism
- for ONEUSBDRV in `cat /root/.usb-drive-log-probedisk | tr '\n' ' '`
- do
-  #disktype /dev/$ONEUSBDRV > /dev/null 2>&1
-  dd if=/dev/$ONEUSBDRV of=/dev/null bs=512 count=1 >/dev/null 2>&1 #v4.01 faster.
- done
+if [ -f $HOME/.usb-drive-log-probedisk ] ; then #force /proc upate mechanism
+  while read ONEUSBDRV ; do
+    dd if=/dev/$ONEUSBDRV of=/dev/null bs=512 count=1 &>/dev/null
+  done < $HOME/.usb-drive-log-probedisk
 fi
 
-#mounted drives/partitions...
-MNTDDEVS="`mount | cut -f 1 -d ' ' | cut -f 3 -d '/' | grep -E '^hd|^sd|^scd|^sr|^mmc' | tr '\n' ' '`"
-
-#crap, right now, /sys/block does not show my hdb cd/dvd drive, but it is in
-#/proc/ide. pathetic kernel! oh well...
-if [ ! -e /proc/ide ];then #v3.97
- ALLDRVS="`ls -1 /sys/block | grep -E '^scd|^sd|^mmc|^sr' | tr '\n' ' '`"
-else
- ALLDRVS="`ls -1 /sys/block | grep -E '^scd|^sd|^mmc|^sr' | tr '\n' ' '``ls -1 /proc/ide | grep '^hd' | tr '\n' ' '`"
+ALLDRVS=$(ls /sys/block | grep -E '^scd|^sd|^mmc|^sr')
+if [ -e /proc/ide ] ; then
+  ALLDRVS="$ALLDRVS
+$(ls /proc/ide | grep '^hd')"
 fi
-#note: after further testing, the 2.6.21.5 kernel exhibits inconsistent behaviour for hd devices, best to avoid.
 
-for ONEDRV in $ALLDRVS
-do
-  case $ONEDRV in
-   hd*) # ide device, look in /proc/ide for info
-     MEDIA="`cat /proc/ide/$ONEDRV/media`"
-     [ "$MEDIA" = "disk" ] && MEDIA="drive"
-     [ "$MEDIA" = "cdrom" ] && MEDIA="optical"
-     INFO="`cat /proc/ide/$ONEDRV/model`"
-   ;;
-   sd*) # scsi devices, look in /sys/block (all appear as Direct-Access)
-     MEDIA="drive"
-     VENDOR="`cat /sys/block/$ONEDRV/device/vendor | tr -s ' '`"
-     MODEL="`cat /sys/block/$ONEDRV/device/model | tr -s ' '`"
-     INFO="$VENDOR$MODEL"
-     DRVNAMES="$DRVNAMES `echo -n "$ONEDRV" | cut -b 1-3` "
-     
-     #log if usb drive (not a ata drive)... v4.01... 110126...
-     if [ "`echo "$ATADRIVES" | grep "$ONEDRV"`" = "" ];then
-      MEDIA="usbdrv" #v4.01
-      echo "$ONEDRV" >> /root/.usb-drive-log-probedisk
-      sort -u /root/.usb-drive-log-probedisk > /tmp/usb-drive-log-probedisk-tmp
-      mv -f /tmp/usb-drive-log-probedisk-tmp /root/.usb-drive-log-probedisk
-      #find out if a usb floppy drive...
-      if [ -e /sys/block/${ONEDRV}/size ];then
-       [ "`cat /sys/block/${ONEDRV}/size`" = "2880" ] && MEDIA="floppy"
-      fi
-      #if the floppy diskette not inserted, try this fallback test...
-      #some examples: Vendor: NEC Model: USB UF000x Rev: 1.50, Sony USB Floppy Drive, rev 1.10/5.01,
-      # MITUMI USB FDD, VenDor: TEAC Model: FD-05PUB, Vendor: COMPAQ Model: USB EXT FLOPPY
-      if [ -e /sys/block/${ONEDRV}/device/model ];then
-       [ "`grep -E ' FDD| UF000x|Floppy|USB\-FDU|^FD\-|FLOPPY' /sys/block/${ONEDRV}/device/model`" != "" ] && MEDIA="floppy"
-      fi
-     else
-      #find out if it is a removable internal drive (zip, ls120, etc)...
-      if [ -e /sys/block/${ONEDRV}/removable ];then
-       [ "`cat /sys/block/${ONEDRV}/removable`" = "1" ] && MEDIA="floppy"
-      fi
-     fi
-
-   ;;
-   scd*|sr*) #  scsi cdroms
-     MEDIA="optical"
-     VENDOR="`cat /sys/block/$ONEDRV/device/vendor | tr -s ' '`"
-     MODEL="`cat /sys/block/$ONEDRV/device/model | tr -s ' '`"
-     INFO="$VENDOR$MODEL"
-   ;;
-   mmc*) #/dev/mmcblk0
-     MEDIA="card"
-     INFO="MMC/SD: `cat /sys/block/$ONEDRV/device/name`"
-   ;;
-   *)
-     continue
-   ;;
-  esac
-  echo "/dev/$ONEDRV|$MEDIA|$INFO"
-
+for p in ${ALLDRVS} ; do
+	#case $p in ram*|nbd*|loop*) continue;; esac
+	vendor="" model="" type="drive"
+	read vendor < /sys/block/$p/device/vendor
+	read model < /sys/block/$p/device/model
+	info="$vendor $model"
+	case $p in
+		hd*) ## ide device, look in /proc/ide for info
+			read -r media < /proc/ide/$ONEDRV/media
+			[ "$media" = "cdrom" ] && type="optical"
+			;;
+		fd*)  type=floppy  ;;
+		sr*)  type=optical ;;
+		mmc*) type=card ; info="MMC/SD: $info" ;;
+	esac
+	readlink /sys/block/$p | grep -q usb && {
+		type=usbdrv
+		echo "$p" >> $HOME/.usb-drive-log-probedisk
+		sorted="$(sort -u $HOME/.usb-drive-log-probedisk)"
+		echo "$sorted" > $HOME/.usb-drive-log-probedisk
+	}
+	echo "/dev/$p|$type|$info"
 done
 
-#find out if a mounted device has been unplugged...
-#for hotplug drives, remove it and it will disappear from /sys/block, however
-#still shows up in 'mount' if hasn't been unmounted.
-for ONEMNTD in $MNTDDEVS
-do
- case $ONEMNTD in
-  hd*|sd*|sr*)
-   MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-3` "
-   ;;
-  scd*)
-   MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-4` "
-   ;;
-  mmc*)
-   MNTDDRVs="`echo -n "$ONEMNTD" | cut -b 1-7` "
-   ;;
- esac
- #prints to system log and to stderr...
- [ "`echo "$ALLDRVS" | grep "$MNTDDRVs"`" = "" ] && logger -s "PROBEDISK ERROR: MOUNTED UNPLUGGED $ONEMNTD"
-done
-
-###END###
+### END ###

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -21,7 +21,6 @@ fi
 
 for p in ${ALLDRVS} ; do
 	#case $p in ram*|nbd*|loop*) continue;; esac
-	USB=0
 	vendor="" model="" type="drive"
 	[ -f /sys/block/$p/device/vendor ] && read vendor < /sys/block/$p/device/vendor
 	[ -f /sys/block/$p/device/model ] && read model < /sys/block/$p/device/model
@@ -32,14 +31,13 @@ for p in ${ALLDRVS} ; do
 			[ "$media" = "cdrom" ] && type="optical"
 			[ -f /proc/ide/$p/model ] && read info < /proc/ide/$p/model
 			;;
-		sd*) [ "$PROCIDE" ] && type=usbdrv && USB=1 ;; ## /proc/ide: flash drives appear as sdX)
+		sd*) [ "$PROCIDE" ] && type=usbdrv ;; ## /proc/ide: flash drives appear as sdX)
 		fd*)      type=floppy  ;;
 		scd*|sr*) type=optical ;; #scd*: probably old stuff
 		mmc*)     type=card    ;;
 	esac
-	readlink /sys/block/$p | grep -q usb && USB=1
-	if [ $USB -eq 1 ] ; then
-		type=usbdrv
+	readlink /sys/block/$p | grep -q usb && type=usbdrv
+	if [ "$type" = "usbdrv" ] ; then
 		echo "$p" >> $HOME/.usb-drive-log-probedisk
 		sorted="$(sort -u $HOME/.usb-drive-log-probedisk)"
 		echo "$sorted" > $HOME/.usb-drive-log-probedisk

--- a/woof-code/rootfs-skeleton/sbin/probedisk
+++ b/woof-code/rootfs-skeleton/sbin/probedisk
@@ -94,9 +94,9 @@ for p in ${ALLDRVS} ; do
 		3) echo "$type" ;;
 		4) echo "$info" ;;
 		5) echo "$size" ;;
-		6) echo "/dev/$p $type $(filesize -format512 $size) $info" ;;
-		7) echo "/dev/$p $type $(filesize -format2048 $size) $info" ;;
-		8) echo "/dev/$p $type $(filesize -format4096 $size) $info" ;;
+		6) echo "/dev/$p $type $(filesize -bytes=512 $size) $info" ;;
+		7) echo "/dev/$p $type $(filesize -bytes=2048 $size) $info" ;;
+		8) echo "/dev/$p $type $(filesize -bytes=4096 $size) $info" ;;
 	esac
 
 done


### PR DESCRIPTION
This uses the code posted by jamesbond here:
http://murga-linux.com/puppy/viewtopic.php?t=101946&start=19

And adds puppy code. But I wonder if this /proc/ide stuff really worth being there?
Wary uses a very old kernel and does not have /proc/ide

Also this: usb-drive-log-probedisk

Is this really needed?