### PR TITLE
init insmod facility - support psavemark

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -503,8 +503,20 @@ search_func() { #110425
         
   if [ "$PDEV1" != "" -a "$PDEV1" = "$ONEDEV" ];then
    if [ "$PIMOD" = "" ];then
-    PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}_init_modules.txt"
-    [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+    if [ "$PSAVEMARK" != "" -a "$BOOTDRV" != "" ];then
+     PIMODDEV="${BOOTDRV}${PSAVEMARK}"
+     PIMODFS="`echo "$LESSPARTS0" | grep "$PIMODDEV" | cut -f 2 -d '|'`"
+     [ -d /mnt/dataSMARK ] || mkdir /mnt/dataSMARK
+     mntfunc $PIMODFS /dev/$PIMODDEV /mnt/dataSMARK
+     if [ $? -eq 0 ];then
+      PIMODFILE="/mnt/dataSMARK${PSUBDIR}/${DISTRO_FILE_PREFIX}_init_modules.txt"
+      [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+      umount /mnt/dataSMARK
+     fi
+    else
+     PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}_init_modules.txt"
+     [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+    fi
    fi
    if [ "$PIMOD" != "" ];then
     ZDRVPATH="/mnt/data${PSUBDIR}/${DISTRO_ZDRVSFS}"

--- a/woof-code/huge_extras/initmodules
+++ b/woof-code/huge_extras/initmodules
@@ -2,8 +2,19 @@
 
 . /etc/rc.d/PUPSTATE
 
-INITPATH=/mnt/home$(dirname $(echo $PUPSFS| cut -f3 -d,))
-ISTHERE=$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)
+INITDEV="$(echo $PUPSFS | cut -f1 -d,)"
+if [ "$(grep -m1 "$INITDEV" /proc/mounts)" = "" ]; then
+	INITFS="$(echo $PUPSFS | cut -f2 -d,)"
+	mount -t $INITFS /dev/$INITDEV /mnt/data
+	if [ $? -eq 0 ]; then
+		INITPATH="/mnt/data$(dirname $(echo $PUPSFS | cut -f3 -d,))"
+		ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+		umount /mnt/data
+	fi
+else
+	INITPATH="/mnt/home$(dirname $(echo $PUPSFS | cut -f3 -d,))"
+	ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+fi
 if [ "$ISTHERE" = "" ]; then
 	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'The initrd.gz file of your current puppy does not support module loading in the init script.\nSince any configuration file written by this program would be ignored at boot time,\n initmodules will exit at this point.')" 0 0
 	exit 1

--- a/woof-code/rootfs-skeleton/usr/sbin/bootmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/bootmanager
@@ -421,8 +421,19 @@ initlist_func () {
     initmodules &
 }
 
-INITPATH=/mnt/home$(dirname $(echo $PUPSFS| cut -f3 -d,))
-ISTHERE=$(gunzip -c $INITPATH/initrd.gz | grep -s PIMOD | grep matches)
+INITDEV="$(echo $PUPSFS | cut -f1 -d,)"
+if [ "$(grep -m1 "$INITDEV" /proc/mounts)" = "" ]; then
+	INITFS="$(echo $PUPSFS | cut -f2 -d,)"
+	mount -t $INITFS /dev/$INITDEV /mnt/data
+	if [ $? -eq 0 ]; then
+		INITPATH="/mnt/data$(dirname $(echo $PUPSFS | cut -f3 -d,))"
+		ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+		umount /mnt/data
+	fi
+else
+	INITPATH="/mnt/home$(dirname $(echo $PUPSFS | cut -f3 -d,))"
+	ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+fi
 if [ "$ISTHERE" -a "$(which initmodules)" ]; then
    INITBUTTON='<hbox>
             <text><label>'$(gettext 'Load  the specified module(s) early in the boot process')'</label></text>


### PR DESCRIPTION
These patches enable the "init insmod facilty" config file to work when 'psavemark' is specified.