### PR TITLE
init insmod facility - improve finding files

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -501,7 +501,7 @@ search_func() { #110425
   fi #101103 moved up.
   echo "  IGNORE=$IGNORE PSUBDIR=$PSUBDIR SAVEPART=$SAVEPART VMLINUZ=$VMLINUZ PDEV1=$PDEV1 PUPSFS=$PUPSFS" >> /tmp/puppy-file-search.log #101127 for debugging.
         
-  if [ "$PDEV1" != "" -a "$PDEV1" = "$ONEDEV" ];then
+  if [ "$ZDRV" != "" -a "`echo "$ZDRV" | cut -f 1 -d ','`" = "$ONEDEV" ];then
    if [ "$PIMOD" = "" ];then
     if [ "$PSAVEMARK" != "" -a "$BOOTDRV" != "" ];then
      PIMODDEV="${BOOTDRV}${PSAVEMARK}"
@@ -519,7 +519,7 @@ search_func() { #110425
     fi
    fi
    if [ "$PIMOD" != "" ];then
-    ZDRVPATH="/mnt/data${PSUBDIR}/${DISTRO_ZDRVSFS}"
+    ZDRVPATH="/mnt/data`echo "$ZDRV" | cut -f 3 -d ','`"
     if [ -f "$ZDRVPATH" ];then
      [ -d /mnt/dataZDRV ] || mkdir /mnt/dataZDRV
      ZDRVLOOP="`losetup -f`"

--- a/woof-code/huge_extras/initmodules
+++ b/woof-code/huge_extras/initmodules
@@ -2,18 +2,15 @@
 
 . /etc/rc.d/PUPSTATE
 
-INITDEV="$(echo $PUPSFS | cut -f1 -d,)"
-if [ "$(grep -m1 "$INITDEV" /proc/mounts)" = "" ]; then
-	INITFS="$(echo $PUPSFS | cut -f2 -d,)"
-	mount -t $INITFS /dev/$INITDEV /mnt/data
+INITMNPT="$(grep -m1 "$PDEV1" /proc/mounts | cut -f 2 -d ' ')"
+if [ "$INITMNPT" = "" ]; then
+	mount -t $DEV1FS /dev/$PDEV1 /mnt/data
 	if [ $? -eq 0 ]; then
-		INITPATH="/mnt/data$(dirname $(echo $PUPSFS | cut -f3 -d,))"
-		ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+		ISTHERE="$(gunzip -c /mnt/data${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
 		umount /mnt/data
 	fi
 else
-	INITPATH="/mnt/home$(dirname $(echo $PUPSFS | cut -f3 -d,))"
-	ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+	ISTHERE="$(gunzip -c ${INITMNPT}${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
 fi
 if [ "$ISTHERE" = "" ]; then
 	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'The initrd.gz file of your current puppy does not support module loading in the init script.\nSince any configuration file written by this program would be ignored at boot time,\n initmodules will exit at this point.')" 0 0

--- a/woof-code/rootfs-skeleton/usr/sbin/bootmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/bootmanager
@@ -421,18 +421,15 @@ initlist_func () {
     initmodules &
 }
 
-INITDEV="$(echo $PUPSFS | cut -f1 -d,)"
-if [ "$(grep -m1 "$INITDEV" /proc/mounts)" = "" ]; then
-	INITFS="$(echo $PUPSFS | cut -f2 -d,)"
-	mount -t $INITFS /dev/$INITDEV /mnt/data
+INITMNPT="$(grep -m1 "$PDEV1" /proc/mounts | cut -f 2 -d ' ')"
+if [ "$INITMNPT" = "" ]; then
+	mount -t $DEV1FS /dev/$PDEV1 /mnt/data
 	if [ $? -eq 0 ]; then
-		INITPATH="/mnt/data$(dirname $(echo $PUPSFS | cut -f3 -d,))"
-		ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+		ISTHERE="$(gunzip -c /mnt/data${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
 		umount /mnt/data
 	fi
 else
-	INITPATH="/mnt/home$(dirname $(echo $PUPSFS | cut -f3 -d,))"
-	ISTHERE="$(gunzip -c $INITPATH/initrd.gz | grep -s pimod | grep matches)"
+	ISTHERE="$(gunzip -c ${INITMNPT}${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
 fi
 if [ "$ISTHERE" -a "$(which initmodules)" ]; then
    INITBUTTON='<hbox>


### PR DESCRIPTION
'init' now uses the ZDRV variable to decide when to act, and to access the found zdrv...sfs.
'initmodules' and 'bootmanager' now use PDEV1 to find the 'initrd.gz' file.