### PR TITLE
init insmod modules - initmodules - add extra error messages

### DIFF
--- a/woof-code/huge_extras/initmodules
+++ b/woof-code/huge_extras/initmodules
@@ -2,6 +2,11 @@
 
 . /etc/rc.d/PUPSTATE
 
+if [ "$PUPMODE" = "5" ];then
+	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'You must shutdown and create a personal save file first.')" 0 0
+	exit
+fi
+
 INITMNPT="$(grep -m1 "$PDEV1" /proc/mounts | cut -f 2 -d ' ')"
 if [ "$INITMNPT" = "" ]; then
 	mount -t $DEV1FS /dev/$PDEV1 /mnt/data
@@ -12,10 +17,21 @@ if [ "$INITMNPT" = "" ]; then
 else
 	ISTHERE="$(gunzip -c ${INITMNPT}${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
 fi
+
 if [ "$ISTHERE" = "" ]; then
-	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'The initrd.gz file of your current puppy does not support module loading in the init script.\nSince any configuration file written by this program would be ignored at boot time,\n initmodules will exit at this point.')" 0 0
+	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'The initrd.gz file of your current puppy does not support module loading in the init script.\nSince any configuration file written by initmodules would be ignored at boot time,\ninitmodules will exit at this point.')" 0 0
 	exit 1
 fi
+
+if [ "`cat /sys/block/$PDEV1/device/type`" = "5" ]; then
+	PUPSAVEDEV="`echo -n $PUPSAVE | cut -f1 -d,`"
+	ZDRVDEV="`echo -n $ZDRV | cut -f1 -d,`"
+	if [ "`cat /sys/block/$PUPSAVEDEV/device/type`" = "5" -o "`cat /sys/block/$ZDRVDEV/device/type`" = "5" ]; then
+		Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'You have booted from a CD or DVD.\n\nUnfortunaely initmodules does not support writing the config file to a CD or DVD,\nor reading a zdrv...sfs file that is not in the same directory as the savefile/savefolder.\n\nTo use initmodules, you need to ensure that there is a savefile/savefolder on a disk partition,\nand a copy of the zdrv...sfs file in the same directory as contains the savefile/savefolder.\nAlternatively, you could setup isoBooter to boot the original iso file from a usb stick.\n\nSince initmodules cannot work with the current puppy setup, it will exit at this point.')" 0 0
+		exit 1
+	fi
+fi
+
 MODLIST=""
 LOADEDMODULES="`lsmod | grep -v '^Module' | cut -f 1 -d ' ' | sort | tr '\n' ' '`"
 for ONEMOD in $LOADEDMODULES; do


### PR DESCRIPTION
This adds detection of a CD/DVD boot and provides an explanation message if it can't work with the current setup.
I also adds the standard bootmanager error message if there is no savefile/savefolder defined yet.