### PR TITLE
puppyapps: do not run build_items in the background

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/puppyapps
+++ b/woof-code/rootfs-skeleton/usr/sbin/puppyapps
@@ -491,7 +491,7 @@ if [ ! "$DEFAULTAPPS" ]; then
 	XPID=$!
 fi
 
-build_items &
+build_items
 
 #build help GUI
 gettext "<b>Helpful Tips</b>


### PR DESCRIPTION
This fixes two issues visible in slow machines I suppose

1) The splash window is there after the main dialog appears, for about 3 seconds +/-
Now the splash window disappears just before the main dialog is displayed

--

2) When /tmp/puppyapps* do no exist yet and I run puppyapps, I get random errors like this:

    widget_comboboxtext_input_by_file(): Couldn't open '/tmp/puppyapps_items_spreadsheet' for reading.

All comboboxes are somehow affected and display and blank option first.

After that, if I run puppyapps again there are no errors because all the files are already there

--

In short:

By not backgrounding build_items all files will be created before there is any attempt to use them.