### PR TITLE
puppyapps: simplify command line parsing

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/puppyapps
+++ b/woof-code/rootfs-skeleton/usr/sbin/puppyapps
@@ -347,99 +347,81 @@ list_active (){
     ############################
 
 #parameters
-while [ $# != 0 ]; do
-	I=1
-	while [ $I -lt `echo $# | wc -c` ]; do
-		case $1 in
-			default*)
-				RUNAPP="`sed 's%default%%' <<< "$1"`"
-				shift
-				echo -n > /tmp/puppyapps/puppyapps_exec2
-				while [ $# != 0 ]; do
-					echo -n ' ' > /tmp/puppyapps/puppyapps_exec2
-					echo -n "$1" | sed 's/ /\\ /g' >> /tmp/puppyapps/puppyapps_exec2
-					shift
-				done
-				#---
-				apps_array $RUNAPP > /tmp/puppyapps/puppyapps_items_$RUNAPP
-				#build command
-				RUNAPP_EXEC="`get_default "$RUNAPP"`"
-				if [ "$RUNAPP_EXEC" ]; then
-					echo -n "exec $RUNAPP_EXEC" > /tmp/puppyapps/puppyapps_exec
-					[ -s /tmp/puppyapps/puppyapps_exec2 ] && cat /tmp/puppyapps/puppyapps_exec2 >> /tmp/puppyapps/puppyapps_exec
-				else
-					echo ". /usr/lib/gtkdialog/box_ok \"$(gettext 'Default apps')\" error \"$(gettext 'Generic app not found on your system'): <b>default$RUNAPP</b>\"" > /tmp/puppyapps/puppyapps_exec
-
-				fi
-				chmod 722 /tmp/puppyapps/puppyapps_exec
-				/tmp/puppyapps/puppyapps_exec &
-				exit 0
-				;;
-			-c) change_default "$2" "$3" "$newroot"
-				exit
-				;;
-			-l)
-				if [ "`grep "^-" <<< "$2"`" ] || [ ! "$2" ]; then
-					TMP=$(default_apps)
-				else
-					TMP="$2"
-					shift
-				fi
-				for I in $TMP; do
-					echo -n "$I: "
-					apps_array $I > /tmp/puppyapps/puppyapps_items_$I 2> /dev/null
-					get_default $I
-				done
-				exit
-				;;
-			-ll)
-				if [ "`grep "^-" <<< "$2"`" ] || [ ! "$2" ]; then
-					TMP=$(default_apps)
-				else
-					TMP="$2"
-					shift
+for arg in "$@" ; do
+	case $1 in
+		default*)
+			RUNAPP=${1#default} #RUNAPP="`sed 's%default%%' <<< "$1"`"
+			shift
+			apps_array $RUNAPP > /tmp/puppyapps/puppyapps_items_$RUNAPP
+			RUNAPP_EXEC="`get_default "$RUNAPP"`"
+			if [ "$RUNAPP_EXEC" ]; then
+				exec $RUNAPP_EXEC "$@"
+			else
+				. /usr/lib/gtkdialog/box_ok "$(gettext 'Default apps')" error "$(gettext 'Generic app not found on your system'): <b>default$RUNAPP</b>"
+			fi
+			exit 0
+			;;
+		-c) change_default "$2" "$3" "$newroot"
+			exit
+			;;
+		-l)
+			case "$2" in
+				-*|"") TMP=$(default_apps) ;;
+				*) TMP="$2" ; shift ;;
+			esac
+			for I in $TMP; do
+				echo -n "$I: "
+				apps_array $I > /tmp/puppyapps/puppyapps_items_$I 2> /dev/null
+				get_default $I
+			done
+			exit
+			;;
+		-ll)
+			case "$2" in
+				-*|"") TMP=$(default_apps) ;;
+				*)	TMP="$2" ; shift
 					if [ ! "`grep "$TMP" <<< $(default_apps)`" ]; then
 						echo "Error: $TMP is not a valid type"
 						TMP=""
 					fi
-				fi
-				for I in $TMP; do
-					echo -e "\n-----------------------\n$I\n-----------------------"
-					apps_array $I 2> /dev/null
-				done
-				exit
-				;;
-			-lll)
-				if [ "`grep "^-" <<< "$2"`" ] || [ ! "$2" ]; then
-					TMP=$(default_apps)
-				else
-					TMP="$2"
-					shift
+					;;
+			esac
+			for I in $TMP; do
+				echo -e "\n-----------------------\n$I\n-----------------------"
+				apps_array $I 2> /dev/null
+			done
+			exit
+			;;
+		-lll)
+			case "$2" in
+				-*|"") TMP=$(default_apps) ;;
+				*)	TMP="$2" ; shift
 					if [ ! "`grep "$TMP" <<< $(default_apps)`" ]; then
 						echo "Error: $TMP is not a valid type"
 						TMP=""
 					fi
-				fi
-				for I in $TMP; do
-					echo -e "\n-----------------------\n$I\n-----------------------"
-					SKIP_INSTALLED_CHECK=true
-					apps_array $I 2> /dev/null
-				done
-				exit
-				;;
-			-m) 
-				shift
-				DEFAULTAPPS="$@"
-				while [ $# -gt 0 ]; do shift; done
-				;;
-			-r)	#chroot into a new root, then run stuff, if the new root exists
-				export newroot="$2"
-				export prefix="chroot $newroot "
-				echo "using a new root: $newroot..."
-				shift
-				;;
-			-h|--help)
-				echo 'Usage: puppyapps [OPTION(S)]
+					;;
+			esac
+			for I in $TMP; do
+				echo -e "\n-----------------------\n$I\n-----------------------"
+				SKIP_INSTALLED_CHECK=true
+				apps_array $I 2> /dev/null
+			done
+			exit
+			;;
+		-m)
+			shift
+			DEFAULTAPPS="$@"
+			while [ "$1" ]; do shift; done
+			;;
+		-r)	#chroot into a new root, then run stuff, if the new root exists
+			export newroot="$2"
+			export prefix="chroot $newroot "
+			echo "using a new root: $newroot..."
+			shift
+			;;
+		-h|--help)
+			echo 'Usage: puppyapps [OPTION(S)]
 
  Options
   default*       Starts the app based on the array in defaultapps
@@ -472,12 +454,10 @@ supported TYPEs:
 ----------------'
 default_apps | tr ' ' '\n'
 
-				exit
-				;;
-		esac
-		shift
-		I=$(($I+1))
-	done
+			exit
+			;;
+	esac
+	shift
 done
 
 #check if -m switch has been used


### PR DESCRIPTION
This implements the same behavior as before and fixes possible issues in default*)

All switches seem to work as before, no problems so far.

default*)
I have tested this in command line, rox and pcmanfm and passes the test in all of them.

tested apps: defaultaudioplayer, defaultmediaplayer

The previous method worked randomly, some files with long names and/or unusual chars failed to open. In fact it wasn't working at all in pcmanfm.

Now any file or multiple files passed through puppyapps work perfectly and really works like a wrapper.

I added exec in the same script because some apps might expect the app to terminate when the job is done, making it a wrapper indeed.