### PR TITLE
box_splash: use shell code / assume BOX_SPLASH_BG_GRADIENT=false if n…

### DIFF
--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -1,4 +1,4 @@
-#!/bin/ash
+#!/bin/sh
 #splash window - compatible with yaf-splash
 #built upon gtkdialog-splash, written by mave, june 2010.
 #other contributors: BarryK, shinobar, 01micko
@@ -10,9 +10,17 @@ export OUTPUT_CHARSET=UTF-8   # even if not gettext.
 
 [ ! -f /tmp/yaf-splash ] && ln -s "`which gtkdialog`" /tmp/yaf-splash
 
-ROOTGEOM="`xwininfo -root | grep -o ' \\-geometry .*' | cut -f 3 -d ' '`" #ex: 1280x800+0+0
-ROOTX=`echo -n "$ROOTGEOM" | cut -f 1 -d 'x'`
-ROOTY=`echo -n "$ROOTGEOM" | cut -f 1 -d '+' | cut -f 2 -d 'x'`
+while read line ; do
+	if [[ $line == *\** ]] ; then
+		for word in $line; do res=$word ; break ; done #1st word & break
+	fi
+done <<< "$(xrandr -q 2>/dev/null)"
+ROOTX=${res%x*}
+ROOTY=${res#*x}
+
+#ROOTGEOM="`xwininfo -root | grep -o ' \\-geometry .*' | cut -f 3 -d ' '`" #ex: 1280x800+0+0
+#ROOTX=`echo -n "$ROOTGEOM" | cut -f 1 -d 'x'`
+#ROOTY=`echo -n "$ROOTGEOM" | cut -f 1 -d '+' | cut -f 2 -d 'x'`
 
 MAX_CHAR_WIDTH=40 #Maximum number of chars in one line
 MARGIN_DESKTOP=40 #WM bars could conflict if pushing splashes all into the corner
@@ -59,7 +67,7 @@ WRAP=true
 #now, let's see if the default colors is set in config file
 [ -s $HOME/.config/ptheme/gtkdialog_active ] && . $HOME/.config/ptheme/gtkdialog_active
 [ ! "$BOX_SPLASH_BG" ]	&& BOX_SPLASH_BG=grey
-[ ! "$BOX_SPLASH_BG_GRADIENT" ]	&& BOX_SPLASH_BG_GRADIENT=true
+[ ! "$BOX_SPLASH_BG_GRADIENT" ]	&& BOX_SPLASH_BG_GRADIENT=false
 [ ! "$BOX_SPLASH_FG" ]	&& BOX_SPLASH_FG=black
 bg=$BOX_SPLASH_BG
 bg_gradient=$BOX_SPLASH_BG_GRADIENT
@@ -67,9 +75,8 @@ fg=$BOX_SPLASH_FG
 
 #parameters
 if [ $# = 0 ]; then echo "$helptext"; exit; fi #no parameters
-while [ $# != 0 ]; do
-	I=1
-	while [ $I -le `echo $# | wc -c` ]; do 
+for arg in "$@" ; do
+	if [ "$2" ] ; then
 		case $1 in
 			-align)
 				case $2 in
@@ -133,8 +140,7 @@ while [ $# != 0 ]; do
 				;;
 		esac
 		shift
-		I=$(($I+1))
-	done
+	fi
 done
 
 #put it here in case command have -icon_width specified after -icon
@@ -143,10 +149,13 @@ if [ "$ICON" ]; then
 	  <width>$ICON_WIDTH</width>
 	  <input file stock=\"$ICON\"></input>
 	</pixmap>"
-	[ "`echo $ICON | grep '^gtk'`" = "" ] && icon="<pixmap width-request=\"$ICON_WIDTH\" space-expand=\"false\" space-fill=\"false\"> 
+	case $ICON in
+	gtk*) ok=1 ;;
+	*) icon="<pixmap width-request=\"$ICON_WIDTH\" space-expand=\"false\" space-fill=\"false\">
 	  <width>$ICON_WIDTH</width>
 	  <input file>\"$ICON\"</input>
-	</pixmap>"
+	</pixmap>" ;;
+	esac
 fi
 
 #define height and width of the window 
@@ -156,13 +165,23 @@ if [ "$border" = "true" ]; then
 	WIDTH=$(($WIDTH+10))
 	HEIGHT=$(($HEIGHT+10))
 fi
-NR_CHARS="`echo "$text" | wc -c`"
-NR_LINES=`awk -v VAR1=$NR_CHARS -v VAR2=$MAX_CHAR_WIDTH 'BEGIN{print int((VAR1/VAR2)+1)}'`
+
+#NR_CHARS="`echo "$text" | wc -c`"
+NR_CHARS="$((${#text}+1))"
+
+#NR_LINES=`awk -v VAR1=$NR_CHARS -v VAR2=$MAX_CHAR_WIDTH 'BEGIN{print int((VAR1/VAR2)+1)}'`
+NR_LINES=$(($NR_CHARS / $MAX_CHAR_WIDTH + 1))
+
 [ $NR_CHARS -gt $MAX_CHAR_WIDTH ] && CHAR_WIDTH=$MAX_CHAR_WIDTH || CHAR_WIDTH=$NR_CHARS
-TMP=`awk -v VAR1=$CHAR_WIDTH -v VAR2=$fontsize 'BEGIN{print int(VAR1*(VAR2*1.0))}'`
+
+#TMP=`awk -v VAR1=$CHAR_WIDTH -v VAR2=$fontsize 'BEGIN{print int(VAR1*(VAR2*1.0))}'`
+TMP=$(( $CHAR_WIDTH * ($fontsize * 1) ))
 WIDTH=$(($WIDTH+$TMP))
-TMP=`awk -v VAR1=$NR_LINES -v VAR2=$fontsize 'BEGIN{print int(VAR1*(VAR2*2.0))}'`
+
+#TMP=`awk -v VAR1=$NR_LINES -v VAR2=$fontsize 'BEGIN{print int(VAR1*(VAR2*2.0))}'`
+TMP=$(( $NR_LINES * ($fontsize * 2) ))
 HEIGHT=$(($HEIGHT+$TMP+5))
+
 [ $NR_LINES -gt 1 ] && HEIGHT=$(($HEIGHT+$fontsize)) #gtkdialog <text> widgets does not has such accurate wrapping as we calculate. It wraps words, not chars
 if [ "$icon" ]; then
 	WIDTH=$(($WIDTH+$ICON_WIDTH+10))
@@ -296,12 +315,10 @@ case $WINTYPE in
 esac
 dlgPID=$!
 
-pidPATTERN="^${dlgPID} "
 while [ $timeout -ne 0 ];do #100604
 	sleep 1
-	ALLPS="`ps`"
-	timeout=`expr $timeout - 1`
-	[ "`echo "$ALLPS" | sed -e 's%^ *%%' | grep "$pidPATTERN"`" == "" ] && exit #already killed.
+	timeout=$(($timeout-1))
+	[ "`busybox ps | grep "^${dlgPID} "`" == "" ] && exit #already killed.
 done
 kill $dlgPID
 echo 'EXIT="Exit on timeout"'

--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -64,9 +64,14 @@ ALIGN=0 #left
 WRAP=true
 #now, let's see if the default colors is set in config file
 [ -s $HOME/.config/ptheme/gtkdialog_active ] && . $HOME/.config/ptheme/gtkdialog_active
-[ ! "$BOX_SPLASH_BG" ]	&& BOX_SPLASH_BG=grey
+if [ ! "$BOX_SPLASH_BG" -a ! "$BOX_SPLASH_BG_GRADIENT" -a ! "$BOX_SPLASH_FG" ] ; then
+	BOX_SPLASH_BG=grey90
+elif [ ! "$BOX_SPLASH_BG" ] ; then
+	BOX_SPLASH_BG=grey
+fi
 [ ! "$BOX_SPLASH_BG_GRADIENT" ]	&& BOX_SPLASH_BG_GRADIENT=false
 [ ! "$BOX_SPLASH_FG" ]	&& BOX_SPLASH_FG=black
+
 bg=$BOX_SPLASH_BG
 bg_gradient=$BOX_SPLASH_BG_GRADIENT
 fg=$BOX_SPLASH_FG

--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -10,17 +10,15 @@ export OUTPUT_CHARSET=UTF-8   # even if not gettext.
 
 [ ! -f /tmp/yaf-splash ] && ln -s "`which gtkdialog`" /tmp/yaf-splash
 
-while read line ; do
-	if [[ $line == *\** ]] ; then
-		for word in $line; do res=$word ; break ; done #1st word & break
-	fi
-done <<< "$(xrandr -q 2>/dev/null)"
-ROOTX=${res%x*}
-ROOTY=${res#*x}
+geometry=$(xwininfo -root | grep ' \-geometry ')
+geometry=${geometry%%\+*}
+geometry=${geometry##* }
+ROOTX=${geometry%x*}
+ROOTY=${geometry#*x}
 
-#ROOTGEOM="`xwininfo -root | grep -o ' \\-geometry .*' | cut -f 3 -d ' '`" #ex: 1280x800+0+0
-#ROOTX=`echo -n "$ROOTGEOM" | cut -f 1 -d 'x'`
-#ROOTY=`echo -n "$ROOTGEOM" | cut -f 1 -d '+' | cut -f 2 -d 'x'`
+#read ROOTDIMS ROOTX ROOTY << EOF
+#`xwininfo -root | grep ' \-geometry ' | cut -f 1 -d '+' | tr 'x' ' '`
+#EOF
 
 MAX_CHAR_WIDTH=40 #Maximum number of chars in one line
 MARGIN_DESKTOP=40 #WM bars could conflict if pushing splashes all into the corner


### PR DESCRIPTION
…ot set

This takes up 3 seconds to load in a considerably slow machine.

I made several edits to speed up the process, but then I realized that it wasn't enough. This:

    BOX_SPLASH_BG_GRADIENT=true

is what makes it a bit slow. I guess SVG processing is heavy here.

You can use '-bg_gradient true' to get that shiny gradient back.

BOX_SPLASH_BG_GRADIENT can also be set in $HOME/.config/ptheme/gtkdialog_active

    mkdir -p $HOME/.config/ptheme
    echo "BOX_SPLASH_BG_GRADIENT=true" > $HOME/.config/ptheme/gtkdialog_active

    mkdir -p $HOME/.config/ptheme
    echo "BOX_SPLASH_BG=gray
    BOX_SPLASH_BG_GRADIENT=true
    BOX_SPLASH_FG=black" > $HOME/.config/ptheme/gtkdialog_active

So there's nothing to worry about... and puppy will be faster by default