### PR TITLE
make updatenetmoduleslist.sh a bit faster

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/updatenetmoduleslist.sh
+++ b/woof-code/rootfs-skeleton/usr/sbin/updatenetmoduleslist.sh
@@ -8,8 +8,8 @@
 #120507 improve kernel version test. add 'sdio' interfaces.
 
 KERNVER="`uname -r`"
-KERNSUBVER=`echo -n $KERNVER | cut -f 3 -d '.' | cut -f 1 -d '-'` #29
-KERNMAJVER=`echo -n $KERNVER | cut -f 2 -d '.'` #6
+#KERNSUBVER=`echo -n $KERNVER | cut -f 3 -d '.' | cut -f 1 -d '-'` #29
+#KERNMAJVER=`echo -n $KERNVER | cut -f 2 -d '.'` #6
 DRIVERSDIR="/lib/modules/$KERNVER/kernel/drivers/net"
 
 echo "Updating /etc/networkmodules..."
@@ -48,33 +48,57 @@ r8180/r8180.ko
 RAWLIST="$OFFICIALLIST
 $EXTRALIST"
 
+get_type() {
+	local type
+	while read line ; do
+		case $line in "alias:"*)
+			read -r alias type <<< "$line"
+			type=${type%%:*}
+			break
+		esac
+	done
+	echo $type
+}
+
+get_desc() {
+	while read line ; do
+		case $line in "description:"*)
+			read -r zz desc <<< "$line"
+			break
+		esac
+	done
+	echo $desc
+}
+
 #the list has to be cutdown to genuine network interfaces only...
 echo -n "" > /tmp/networkmodules
 echo "$RAWLIST" |
 while read ONERAW
 do
  [ "$ONERAW" = "" ] && continue #precaution
- ONEBASE="`basename $ONERAW .ko`"
+
+ #ONEBASE="`basename $ONERAW .ko`"
+ ONEBASE=${ONERAW##*/}
+ ONEBASE=${ONEBASE%.ko}
  modprobe -vn $ONEBASE >/dev/null 2>&1
- ONEINFO="`modinfo $ONEBASE 2>/dev/null | tr '\t' ' ' | tr -s ' '`" #111027 make it quiet.
- ONETYPE="`echo "$ONEINFO" | grep '^alias:' | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d ':'`"
- ONEDESCR="`echo "$ONEINFO" | grep '^description:' | head -n 1 | cut -f 2 -d ':'`"
- if [ "$ONETYPE" = "pci" -o "$ONETYPE" = "pcmcia" -o "$ONETYPE" = "usb" ];then
-  echo "Adding $ONEBASE"
-  echo -e "$ONEBASE \"$ONETYPE: $ONEDESCR\"" >> /tmp/networkmodules
- fi
- #v408 add b43legacy.ko...
- if [ "$ONETYPE" = "ssb" ];then
-  echo "Adding $ONEBASE"
-  echo -e "$ONEBASE \"$ONETYPE: $ONEDESCR\"" >> /tmp/networkmodules
- fi
- #120507 add sdio interfaces...
- if [ "$ONETYPE" = "sdio" ];then
-  echo "Adding $ONEBASE"
-  echo -e "$ONEBASE \"$ONETYPE: $ONEDESCR\"" >> /tmp/networkmodules
- fi
+
+ #ONEINFO="`modinfo $ONEBASE 2>/dev/null | tr '\t' ' ' | tr -s ' '`" #111027 make it quiet.
+ #ONETYPE="`echo "$ONEINFO" | grep '^alias:' | head -n 1 | cut -f 2 -d ' ' | cut -f 1 -d ':'`"
+ #ONEDESCR="`echo "$ONEINFO" | grep '^description:' | head -n 1 | cut -f 2 -d ':'`"
+
+ ONEINFO="`modinfo $ONEBASE 2>/dev/null`"
+ ONEDESCR="`echo "$ONEINFO" | get_desc`"
+ ONETYPE="`echo "$ONEINFO" | get_type`"
+
+ case "$ONETYPE" in
+	#ssb=b43legacy.ko...  sdio=sdio interfaces...
+	pci|pcmcia|usb|ssb|sdio)
+	  echo "Adding $ONEBASE"
+	  echo -e "$ONEBASE \"$ONETYPE:  $ONEDESCR\"" >> /tmp/networkmodules
+ esac
+
 done
 
 sort -u /tmp/networkmodules > /etc/networkmodules
 
-###end###
+### END ###


### PR DESCRIPTION
These changes produce the same results, the diffs show very few minimal differences here and there in the description.

$KERNSUBVER and $KERNMAJVER are not used in the script.. commented out

time updatenetmoduleslist.sh
real    0m38.100s
user    0m5.426s
sys 0m15.572s

time ./updatenetmoduleslist.sh
real    0m19.570s
user    0m1.780s
sys 0m3.886s