### PR TITLE
pmount: use 'bc scale=1' instead of dc + printf

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -159,20 +159,18 @@ buildpix (){
 		export ONESIZEK=`echo -n "$ONEPART" | cut -f 3 -d '|'`
 		[ "$ONESIZEK" = 0 ] && ONESIZEK=1 #calculation of percent (svg) fails if size is 0 (ie. a blank CD)
 		if [ $ONESIZEK -gt 1073741824 ];then #1024*1024*1024
-			ONESIZE="`dc $ONESIZEK 1073741824 \/ p`"
-			ONESIZE="`printf "%.1f" $ONESIZE`T"
+			ONESIZE=$(bc <<< "scale=1 ; $ONESIZEK / 1073741824")'T'
 		elif [ $ONESIZEK -gt 1048576 ];then #1024*1024
-			ONESIZE="`dc $ONESIZEK 1048576 \/ p`"
-			ONESIZE="`printf "%.1f" $ONESIZE`G"
+			ONESIZE=$(bc <<< "scale=1 ; $ONESIZEK / 1048576")'G'
 		else
 			if [ $ONESIZEK -gt 99 ];then
 				ONESIZE="`expr $ONESIZEK \/ 1024`M"
 			else
-				ONESIZE="`dc $ONESIZEK 1024 \/ p`"
-				ONESIZE="`printf "%.1f" $ONESIZE`M"
+				ONESIZE=$(bc <<< "scale=1 ; $ONESIZEK / 1024")
 			fi
 		fi
 		if [ "$ONESIZE" = "0.0M" ] || [ "$ONESIZE" = "0M" ]; then ONESIZE=""; fi
+		#echo $ONESIZE
 	fi
 
 	#free space
@@ -183,21 +181,19 @@ buildpix (){
 		export FREEK=`df -k | tr -s ' ' | grep -m1 "$DEVPATTERN" | cut -f 4 -d ' '`
 		[ ! "$FREEK" ] && FREEK=$ONESIZEK
 		if [ $FREEK -gt 1073741824 ];then #1024*1024*1024
-			ONEFREE="`dc $FREEK 1073741824 \/ p`"
-			ONEFREE="`printf "%.1f" $ONEFREE`T"
+			ONEFREE=$(bc <<< "scale=1 ; $FREEK / 1073741824")'T'
 		elif [ $FREEK -gt 1048576 ];then #1024*1024
-			ONEFREE="`dc $FREEK 1048576 \/ p`"
-			ONEFREE="`printf "%.1f" $ONEFREE`G"
+			ONEFREE=$(bc <<< "scale=1 ; $FREEK / 1048576")'G'
 		else
 			if [ $FREEK -gt 99 ];then
 				ONEFREE="`expr $FREEK \/ 1024`M"
 			else
-				ONEFREE="`dc $FREEK 1024 \/ p`"
-				ONEFREE="`printf "%.1f" $ONEFREE`M"
+				ONEFREE=$(bc <<< "scale=1 ; $FREEK / 1024")
 			fi
 		fi
 		if [ "$ONEFREE" = "0.0M" ] || [ "$ONEFREE" = "0M" ]; then ONEFREE=""; fi
 		export PIXTEXT="${ONESIZE} / ${ONEFREE}"
+		#echo $ONEFREE
 	fi
 	
 	if [ "$ONECATEGORY" != "optical" ]; then


### PR DESCRIPTION
Partview uses the same commands and works fine here
I don't why this is happening in pmount:

/usr/sbin/pmount: line 166: printf: 6.05168: invalid number
/usr/sbin/pmount: line 190: printf: 4.15246: invalid number
/usr/sbin/pmount: line 166: printf: 4.88281: invalid number
/usr/sbin/pmount: line 166: printf: 1.17188: invalid number
/usr/sbin/pmount: line 166: printf: 6.90723: invalid number
/usr/sbin/pmount: line 190: printf: 3.51178: invalid number
/usr/sbin/pmount: line 166: printf: 4.88281: invalid number
/usr/sbin/pmount: line 166: printf: 5.85938: invalid number
/usr/sbin/pmount: line 166: printf: 1.17188: invalid number
/usr/sbin/pmount: line 166: printf: 16.043: invalid number
/usr/sbin/pmount: line 190: printf: 10.8795: invalid number

bc output:

6.0G
4.1G
4.8G
1.1G
6.9G
3.5G
4.8G
5.8G
1.1G
16.0G
10.8G

..bc scale=1 is basically the same as dc + printf %.1f