### PR TITLE
initmodules - look in zdrv partition first

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -503,19 +503,19 @@ search_func() { #110425
         
   if [ "$ZDRV" != "" -a "`echo "$ZDRV" | cut -f 1 -d ','`" = "$ONEDEV" ];then
    if [ "$PIMOD" = "" ];then
-    if [ "$PSAVEMARK" != "" -a "$BOOTDRV" != "" ];then
-     PIMODDEV="${BOOTDRV}${PSAVEMARK}"
-     PIMODFS="`echo "$LESSPARTS0" | grep "$PIMODDEV" | cut -f 2 -d '|'`"
+     PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt"
+     [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+   fi
+   if [ "$PIMOD" = ""  -a "$SAVEPART" != "" ];then
+    PIMODFS="`echo "$LESSPARTS0" | grep "$SAVEPART" | cut -f 2 -d '|'`"
+    if [ "$PIMODFS" ];then
      [ -d /mnt/dataSMARK ] || mkdir /mnt/dataSMARK
-     mntfunc $PIMODFS /dev/$PIMODDEV /mnt/dataSMARK
+     mntfunc $PIMODFS /dev/$SAVEPART /mnt/dataSMARK
      if [ $? -eq 0 ];then
       PIMODFILE="/mnt/dataSMARK${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt"
       [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
       umount /mnt/dataSMARK
      fi
-    else
-     PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt"
-     [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
     fi
    fi
    if [ "$PIMOD" != "" ];then


### PR DESCRIPTION
Always look in the zdrv partition for the config file first.
When 'savemark' is active, performance can be improved by copying the config file to be beside the zdrv...sfs, instead of beside the savefile/savefolder. This avoids an extra mount of the savefile/savefolder partition.