### PR TITLE
rc.update/sysinit: use busybox depmod as a last resort

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -257,10 +257,11 @@ if [ "$NEEDDEPMOD" = "yes" ];then
   [ -f /tmp/rc_sysinit_dump/modules.builtin ] && mv -f /tmp/rc_sysinit_dump/modules.builtin /lib/modules/${KERNVER}/
   [ -f /tmp/rc_sysinit_dump/modules.order ] && mv -f /tmp/rc_sysinit_dump/modules.order /lib/modules/${KERNVER}/
   rm -f /tmp/rc_sysinit_dump/modules.*
-  if [ "`busybox | grep 'depmod'`" != "" ];then
-   busybox depmod #use busybox depmod if available.
+  #depmod can be a symlink to busybox.. or not
+  if which depmod ;then
+    depmod
   else
-   depmod
+    busybox depmod
   fi
  fi
 fi

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -63,10 +63,11 @@ depmod_func() { #130217 extracted as a function.
   [ -f /tmp/rc_update_dump/modules.builtin ] && mv -f /tmp/rc_update_dump/modules.builtin /lib/modules/${KERNVER}/
   [ -f /tmp/rc_update_dump/modules.order ] && mv -f /tmp/rc_update_dump/modules.order /lib/modules/${KERNVER}/
   rm -f /tmp/rc_update_dump/modules.*
-  if [ "`busybox | grep 'depmod'`" != "" ];then
-   busybox depmod #use busybox depmod if available.
+  #depmod can be a symlink to busybox.. or not
+  if which depmod ;then
+    depmod
   else
-   depmod
+    busybox depmod
   fi
  fi
 }


### PR DESCRIPTION
If kmod is there, then busybox depmod  is not used at all
However busybox depmod has a higher priority than depmod itself.
If I remember correctly, depmod was a symlink to busybox in older versions,
 so it makes sense to use depmod as is.

Besides, it seems that busybox needs to be patched for the depmod applet to work with puppy?

I wrote something about this a long time ago:
http://murga-linux.com/puppy/viewtopic.php?t=99162