### PR TITLE
10alsa stop: change grep '0 $' to grep -E '0 $|0$'

### DIFF
--- a/woof-code/rootfs-skeleton/etc/init.d/10alsa
+++ b/woof-code/rootfs-skeleton/etc/init.d/10alsa
@@ -86,7 +86,7 @@ EOF
   #lsmod | grep "^snd" | grep -Ev "(snd-page-alloc|snd_page_alloc)" |
   c=0
   while [ "`lsmod | grep 'snd_'`" ];do
-   lsmod | grep "^snd" | grep '0 $' | grep -Ev "(snd-page-alloc|snd_page_alloc)" |
+   lsmod | grep "^snd" | grep -E '0 $|0$' | grep -Ev "(snd-page-alloc|snd_page_alloc)" |
    while read line
    do
     #rmmod `echo $line | cut -d ' ' -f 1`


### PR DESCRIPTION
The script assumes there is always a space after 0

    snd_via82xx            14561  0[extra space]

The I've encountered a case where that is not true...

    snd_via82xx            14561  0

--