### PR TITLE
Inactivate ddcprobe if broken. Freezes X startup

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard-automatic
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard-automatic
@@ -14,6 +14,28 @@
 
 . /etc/rc.d/MODULESCONFIG
 
+# ddcprobe hangs in some hardware and the entire X startup freezes.
+# test and inactivate early on
+if [ "$(which ddcprobe)" ]; then
+ for TRY in 1 2 3
+ do
+  ddcprobe &
+  XPID=$!
+  sleep 0.5
+  RUNNING="$(cat /proc/"$XPID"/status | grep -i running)"
+  [ "$RUNNING" = "" ] && break
+  [ "$TRY" = "1" ] && XPID1="$XPID" && RUNNING1="$RUNNING"
+  [ "$TRY" = "2" ] && XPID2="$XPID" && RUNNING2="$RUNNING"
+  [ "$TRY" = "3" ] && XPID3="$XPID" && RUNNING3="$RUNNING"
+ done
+ if [ "$RUNNING1"  -a "$RUNNING2" -a "$RUNNING3" ]; then
+  chmod 644 /usr/sbin/ddcprobe
+ fi
+ kill -9 "$XPID1" 2>/dev/null
+ kill -9 "$XPID2" 2>/dev/null
+ kill -9 "$XPID3" 2>/dev/null
+fi
+
 #120517
 if [ "`which ddcprobe`" = "" ];then
  #running on an arm board...


### PR DESCRIPTION
ddcprobe just hangs in some distros and hardware (Tahr64 in a MacBookPro in my case) and then the X startup (xwin) as well as xorgwizard{,-automatic,-cli} all freeze. Upon inactivation X proceeds straight to Desktop!
Not sure if such an irreversible measure is wise, or should go through the hassle to test in every script that uses ddcprobe and revert at the script exit. 
Given that we move away from xorgwizard is probably an overkill.
Please review. (Also the code could be improved.)