### PR TITLE
initmodules - trim config file line

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -504,7 +504,7 @@ search_func() { #110425
   if [ "$ZDRV" != "" -a "`echo "$ZDRV" | cut -f 1 -d ','`" = "$ONEDEV" ];then
    if [ "$PIMOD" = "" ];then
      PIMODFILE="/mnt/data${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt"
-     [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+     [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE" | tr -d '\r\n'`" 
    fi
    if [ "$PIMOD" = ""  -a "$SAVEPART" != "" ];then
     PIMODFS="`echo "$LESSPARTS0" | grep "$SAVEPART" | cut -f 2 -d '|'`"
@@ -513,7 +513,7 @@ search_func() { #110425
      mntfunc $PIMODFS /dev/$SAVEPART /mnt/dataSMARK
      if [ $? -eq 0 ];then
       PIMODFILE="/mnt/dataSMARK${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt"
-      [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE"`" 
+      [ -f "$PIMODFILE" ] && PIMOD="`head -n1 "$PIMODFILE" | tr -d '\r\n'`" 
       umount /mnt/dataSMARK
      fi
     fi


### PR DESCRIPTION
Trim any residual end-of-line characters from config file line.
The config file can be a dos file or inside an iso, and still work.