### PR TITLE
enable psavemark to work with pmedia and psave

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -340,7 +340,14 @@ search_func() { #110425
    ;;
    *)
     #note: a mistake if have PDEV1 on usb booting, as it can change.
-    [ "$PDEV1" ] && LESSPARTS0="`echo "$LESSPARTS0" | grep "${PDEV1}|"`" #kernel boot param.
+    if [ "$PDEV1" ];then #kernel boot param
+     LESSPAT="$PDEV1"
+     if [ "$PSAVEMARK" ];then #kernel boot param
+      BOOTDRV="`echo -n "$PDEV1" | grep -o -f /tmp/ALLDRVS0`" #ex: sda1 becomes sda
+      LESSPAT="${PDEV1}|${BOOTDRV}${PSAVEMARK}"
+     fi
+     LESSPARTS0="`echo "$LESSPARTS0" | grep -E "$LESSPAT"`"
+    fi
    ;;
   esac
  fi


### PR DESCRIPTION
Currently, if a SAVEMARK file or psavemark boot parameter is being utilised, and pmedia and pdev1 boot parameters are specified, the psavemark partition is ignored.
This patch ensures that even if pmedia and pdev1 are specified, the psavemark partition remains in the search list.
A save partition specified by a SAVEMARK file only, will still be ignored, but the addition of a psavemark boot parameter will restore the save partition to the search list.