### PR TITLE
remove all references to /tmp/rc_d_rc_services_alsa_ok

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.services
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.services
@@ -19,7 +19,6 @@ while [ $BRKCNT -lt 7 ];do
   GOODFLAG=1
  fi
 done
-[ $GOODFLAG -eq 1 ] && touch /tmp/rc_d_rc_services_alsa_ok #read by /usr/sbin/delayedrun, /etc/init.d/10alsa.
 
 for service_script in /etc/init.d/*
 do

--- a/woof-code/rootfs-skeleton/usr/sbin/delayedrun
+++ b/woof-code/rootfs-skeleton/usr/sbin/delayedrun
@@ -129,12 +129,8 @@ fi
 
 #101121 handle multiple sound cards...
 if [ $PUPMODE -eq 5 ];then
- if [ -f /tmp/rc_d_rc_services_alsa_ok ];then #see /etc/rc.d/rc.services
-  if [ `find /tmp/pup_event_backend -maxdepth 1 -type f -name 'pup_event_alsa_cnt*' | wc -l` -gt 1 ];then
-   #run kirk's Multiple Sound Card Wizard...
-   Multiple-Sound-Card-Wizard
-  fi
- fi
+  scards=`grep '\[.*\]' /proc/asound/cards | grep -v 'pcsp' | wc -l`
+  [ $scards -qt 1 ] && Multiple-Sound-Card-Wizard #by kirk
 fi
 
 # give xchat unique username based on distro

--- a/woof-code/rootfs-skeleton/usr/sbin/delayedrun
+++ b/woof-code/rootfs-skeleton/usr/sbin/delayedrun
@@ -130,7 +130,7 @@ fi
 #101121 handle multiple sound cards...
 if [ $PUPMODE -eq 5 ];then
   scards=`grep '\[.*\]' /proc/asound/cards | grep -v 'pcsp' | wc -l`
-  [ $scards -qt 1 ] && Multiple-Sound-Card-Wizard #by kirk
+  [ $scards -gt 1 ] && Multiple-Sound-Card-Wizard #by kirk
 fi
 
 # give xchat unique username based on distro


### PR DESCRIPTION
/tmp/rc_d_rc_services_alsa_ok is created by rc.services and read
by 10alsa (removed long time ago) and delayedrun

There is a more standard way to handle the situation in delayedrun.

http://murga-linux.com/puppy/viewtopic.php?p=885747#885747