### PR TITLE
xml_info: bugfix

### DIFF
--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/xml_info
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/xml_info
@@ -22,12 +22,16 @@ case $1 in
 		#. $HOME/.theme_nnnnn #this to allow some kind of theming in the future
 		case $2 in
 			green|yes|1)
-				COLOR1='#BED1C1'
-				COLOR2='#006F04'
+				XML_INFO_COLOR1='#BED1C1'
+				XML_INFO_COLOR2='#006F04'
 				;;
 			red|no|0)
-				COLOR1='#DFCECE'
-				COLOR2='#8E0000'
+				XML_INFO_COLOR1='#DFCECE'
+				XML_INFO_COLOR2='#8E0000'
+				;;
+			"") #use default config
+				XML_INFO_COLOR1=""
+				XML_INFO_COLOR2=""
 				;;
 		esac
 		#if no theme-values is defined - use the default


### PR DESCRIPTION
xml_info always produces the same /tmp/xml_info.svg

when you want a red or pink xml_info.svg

. /usr/lib/gtkdialog/xml_info gtk red

it doesn't work..

These changes makes it behave properly..