### PR TITLE
box_splash: bugfix

### DIFF
--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -321,7 +321,7 @@ dlgPID=$!
 while [ $timeout -ne 0 ];do #100604
 	sleep 1
 	timeout=$(($timeout-1))
-	[ "`busybox ps | tr -s ' ' | grep -E "^${dlgPID} |^ ${dlgPID} "`" == "" ] && exit #already killed.
+	[ "`busybox ps | awk '{print $1}' | grep "^${dlgPID}$"`" == "" ] && exit #already killed.
 done
 kill $dlgPID
 echo 'EXIT="Exit on timeout"'

--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -321,7 +321,7 @@ dlgPID=$!
 while [ $timeout -ne 0 ];do #100604
 	sleep 1
 	timeout=$(($timeout-1))
-	[ "`busybox ps | grep -E "^${dlgPID} |^ ${dlgPID} "`" == "" ] && exit #already killed.
+	[ "`busybox ps | tr -s ' ' | grep -E "^${dlgPID} |^ ${dlgPID} "`" == "" ] && exit #already killed.
 done
 kill $dlgPID
 echo 'EXIT="Exit on timeout"'


### PR DESCRIPTION
busybox ps: the less digits a pid has, the more leading spaces will be

        1 root       0:01 /bin/busybox init
      635 root       0:00 /tmp/yaf-splash --class=gtkdialog-splash ...
     1172 root       0:00 grep yaf
    30053 root       0:00 /bin/bash

solution:  convert multiple spaces to one space