### PR TITLE
alsa-base.conf: Keep HDA HDMI from being loaded as first soundcard

### DIFF
--- a/woof-code/rootfs-skeleton/etc/modprobe.d/alsa-base.conf
+++ b/woof-code/rootfs-skeleton/etc/modprobe.d/alsa-base.conf
@@ -42,3 +42,7 @@ options snd-cmipci mpu_port=0x330 fm_port=0x388
 options snd-pcsp index=-2
 # Keep snd-usb-audio from beeing loaded as first soundcard
 options snd-usb-audio index=-2
+# Keep HDA HDMI from being loaded as first soundcard
+options snd-hda-intel id=PCH,HDMI index=0,1
+options snd-hda-intel-hdmi index=-2
+options snd-hda-codec-hdmi index=-2


### PR DESCRIPTION
This fixes a common issue reported many times over the years..