### PR TITLE
initmodules - automatically determine needed modules

### DIFF
--- a/woof-code/huge_extras/initmodules
+++ b/woof-code/huge_extras/initmodules
@@ -1,68 +1,224 @@
 #!/bin/ash
 
+. /etc/DISTRO_SPECS
 . /etc/rc.d/PUPSTATE
 
-if [ "$PUPMODE" = "5" ];then
-	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'You must shutdown and create a personal save file first.')" 0 0
-	exit
-fi
+QUIETMODE=""
+[ "${1}" = "-q" ] && QUIETMODE="yes"
 
-INITMNPT="$(grep -m1 "$PDEV1" /proc/mounts | cut -f 2 -d ' ')"
-if [ "$INITMNPT" = "" ]; then
-	mount -t $DEV1FS /dev/$PDEV1 /mnt/data
-	if [ $? -eq 0 ]; then
-		ISTHERE="$(gunzip -c /mnt/data${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
-		umount /mnt/data
+pimod_missing() {
+	ISTHERE=""
+	INITMNPT="$(grep -m1 "$PDEV1" /proc/mounts)"
+	if [ "$INITMNPT" = "" ]; then
+		mount -t $DEV1FS -o ro /dev/$PDEV1 /mnt/data
+		if [ $? -eq 0 ]; then
+			ISTHERE="$(gunzip -c /mnt/data${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
+			umount /mnt/data
+		fi
+	else
+		INITMNPT="${INITMNPT#* }"
+		ISTHERE="$(gunzip -c ${INITMNPT%% *}${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
 	fi
-else
-	ISTHERE="$(gunzip -c ${INITMNPT}${PSUBDIR}/initrd.gz | grep -s pimod | grep matches)"
-fi
+	[ "$ISTHERE" ] && return 1
+	return 0
+}
 
-if [ "$ISTHERE" = "" ]; then
-	Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'The initrd.gz file of your current puppy does not support module loading in the init script.\nSince any configuration file written by initmodules would be ignored at boot time,\ninitmodules will exit at this point.')" 0 0
-	exit 1
-fi
+get_modlist() {
+	MODLIST=""
 
-if [ "`cat /sys/block/$PDEV1/device/type`" = "5" ]; then
-	PUPSAVEDEV="`echo -n $PUPSAVE | cut -f1 -d,`"
-	ZDRVDEV="`echo -n $ZDRV | cut -f1 -d,`"
-	if [ "`cat /sys/block/$PUPSAVEDEV/device/type`" = "5" -o "`cat /sys/block/$ZDRVDEV/device/type`" = "5" ]; then
-		Xdialog --wmclass "module16" --title "$(gettext 'Initmodules: Modules to load in init script')" --msgbox "$(gettext 'You have booted from a CD or DVD.\n\nUnfortunaely initmodules does not support writing the config file to a CD or DVD,\nor reading a zdrv...sfs file that is not in the same directory as the savefile/savefolder.\n\nTo use initmodules, you need to ensure that there is a savefile/savefolder on a disk partition,\nand a copy of the zdrv...sfs file in the same directory as contains the savefile/savefolder.\n\nAlternatively, you could specify the required module as a "pimod=" boot parameter,\nor you could setup isoBooter to boot the original iso file from a usb stick.\n\nSince initmodules cannot work with the current puppy setup, it will exit at this point.')" 0 0
+	#############Get lists of modules loaded from "/hid/" and from "/usb/host"
+
+	HIDLDLIST=""
+	USBLIST=""
+	while read -r MODNAME ONELINE; do
+		MODFILE="$(modinfo -n $MODNAME)"
+		case ${MODFILE} in
+			*"/hid/"*) HIDLDLIST="${HIDLDLIST}${MODNAME} " ;; #contains '/hid/'
+			*"/usb/host/"*) USBLIST="${USBLIST}${MODNAME} " ;; #contains '/usb/host/'
+		esac
+	done < /proc/modules
+
+	[ "$HIDLDLIST" = "" -a "$USBLIST" = "" ] && return
+
+	BASETMPDIR="/tmp/initmodules"
+
+	HIDLIST=""
+	if [ "$HIDLDLIST" ]; then
+
+	#############Find hadware id's of usb attached keyboards
+
+		VENTMPDIR="$BASETMPDIR/vens"
+		[ -d "$VENTMPDIR" ] && rm -r -f "$VENTMPDIR"
+		mkdir -p "$VENTMPDIR"
+
+		#ash bug - can't read "/proc/bus/input/devices" directly
+		grep -E "^I|^H" /proc/bus/input/devices > $BASETMPDIR/inupt_devices.txt
+		while read -r LINETYPE ONELINE; do
+			if [ "$LINETYPE" = "I:" ]; then
+				TVEN="${ONELINE#*r=}" #remove upto first 'r='
+				TVEN="${TVEN%% *}" #remove from first ' '
+				[ "$TVEN" = "0000" ] && continue
+			else
+				[ "$TVEN" = "0000" ] && continue
+				case ${ONELINE} in
+					*"kbd "*) touch "$VENTMPDIR/$TVEN" ;; #contains 'kbd '
+				esac
+			fi
+		done < $BASETMPDIR/inupt_devices.txt
+
+		DEVIDS=""
+		for VEN in $VENTMPDIR/*; do
+			lsusb -d ${VEN##*/}: -v | grep -E "^Bus|bInterfaceProtocol" > $BASETMPDIR/lsusb.txt
+			while read -r LINETYPE ONELINE; do
+				if [ "$LINETYPE" = "Bus" ]; then
+					TID="${ONELINE#*D }" #remove upto first 'D '
+					TID="${TID%% *}" #remove from first ' '
+				else
+					if [ "${ONELINE%% *}" = "1" ]; then
+						DEVIDS="${DEVIDS}$(echo -n $TID | tr '[a-f]' '[A-F]') "
+					fi
+				fi
+			done < $BASETMPDIR/lsusb.txt
+		done
+
+	#############Check hardware id's against aliases of modules loaded from "/hid/"
+
+		#HIDLIST="" #done earlier
+		for MOD in $HIDLDLIST; do
+			for ONEID in $DEVIDS; do
+				VEN="v0000${ONEID%:*}" #remove from last ':'
+				PROD="p0000${ONEID#*:}" #remove upto first ':'
+				if [ "$(modinfo -F 'alias' $MOD | grep "${VEN}${PROD}")" ]; then
+					HIDLIST="${HIDLIST}${MOD} "
+				fi
+			done
+		done
+
+	fi #end - if [ "$HIDLDLIST" ]
+
+	#############Check for module dependencies
+
+	MODTMPDIR="$BASETMPDIR/mods"
+	[ -d "$MODTMPDIR" ] && rm -r -f "$MODTMPDIR"
+	mkdir -p "$MODTMPDIR"
+
+	for ONEMOD in $HIDLIST $USBLIST; do
+		touch "$MODTMPDIR/$ONEMOD"
+		MODDEPLIST="$(modinfo -F 'depends' $ONEMOD)"
+		for MODNAME in ${MODDEPLIST//,/ }; do
+			touch "$MODTMPDIR/$MODNAME"
+		done
+	done
+
+	#############Make module list
+
+	#MODLIST="" #done earlier
+	for MODNAME in $MODTMPDIR/*; do
+		MODLIST="${MODLIST}${MODNAME##*/} " #remove upto last '/'
+	done
+
+	[ -d "$BASETMPDIR" ] && rm -r -f "$BASETMPDIR"
+}
+
+write_modlist() {
+	MODFILELIST=""
+	if [ "${1}" ]; then
+		for MODNAME in ${1}; do
+			MODFILE="$(modinfo -n $MODNAME)"
+			if [ "$MODFILE" ]; then
+				MODFILELIST="$MODFILELIST${MODFILE#*/*/*/*/}," #remove upto first '/', 5 times
+			fi
+		done
+		[ "$MODFILELIST" ] && MODFILELIST="${MODFILELIST%,}" #remove trailing ','
+	fi
+
+	CFGFN="${DISTRO_FILE_PREFIX}initmodules.txt"
+	if [ "$PUPMODE" = "5" ]; then
+		PIMODFILE="/tmp/$CFGFN"
+	else
+		PIMODFILE="/mnt/home${PSUBDIR}/${CFGFN}"
+	fi
+	if [ "$MODFILELIST" ]; then
+		echo "$MODFILELIST" > "$PIMODFILE"
+	else
+		rm -f "$PIMODFILE"
+	fi
+}
+
+if [ "$QUIETMODE" ]; then
+	[ "$PUPMODE" = "77" ] && exit 1
+	if pimod_missing; then
 		exit 1
 	fi
+	get_modlist
+	[ "$MODLIST" ] && write_modlist "$MODLIST"
+	exit 0
 fi
 
-MODLIST=""
-LOADEDMODULES="`lsmod | grep -v '^Module' | cut -f 1 -d ' ' | sort | tr '\n' ' '`"
+is_cd() {
+	if [ "${1}" -a -d "/sys/block/${1}" ]; then
+		[ "$(grep '5' /sys/block/${1}/device/type)" ] && return 0
+	fi
+	return 1
+}
+
+start_splash() {
+	/usr/lib/gtkdialog/box_splash -close never -fontsize large -text "$(gettext 'Checking system, please wait...')" &
+	MSGPID=$!
+}
+
+start_splash
+
+MSGT="$(gettext 'Initmodules: Modules to load in init script')"
+MSGCONT="$(gettext 'You may continue with Initmodules, or exit at this point.')"
+
+if pimod_missing; then
+	kill $MSGPID
+	Xdialog --wmclass "module16" --title "$MSGT" --ok-label "Continue" --cancel-label "Exit" --yesno "$(gettext 'The initrd.gz file of your current puppy does not support module loading in the init script.\nAny configuration file written by initmodules would be ignored at boot time.')\n\n$MSGCONT" 0 0
+	[ $? -ne 0 ] && exit 1
+	start_splash
+fi
+
+if is_cd "${ZDRV%%,*}"; then
+	MSGALT="$(gettext 'To load a module during "init" without changing the current setup,\nyou could specify the module as a "pimod=" boot parameter.\n\nOr you could use a completely different setup,\ne.g. use isoBooter to boot the iso file from a usb stick or drive.')"
+	kill $MSGPID
+	if [ "$PUPMODE" = "77" ]; then
+		Xdialog --wmclass "module16" --title "$MSGT" --left --msgbox "$(gettext 'You have booted from a multi-session CD or DVD.\nInitmodules cannot do anything in this particular setup.')\n\n$MSGALT\n\n$(gettext 'Initmodules will exit at this point.')" 0 0
+		exit 1
+	elif [ "$PUPMODE" = "5" ]; then
+		Xdialog --wmclass "module16" --title "$MSGT" --left --ok-label "Continue" --cancel-label "Exit" --yesno "$(gettext 'You have booted from a CD or DVD in first-boot mode.\nIf Initmodules will work or not depends on what you do at first-shutdown.\n\nIf you choose to save back to a multi-session CD/DVD,\nInitmodules cannot do anything in such a setup.\n\nIf you choose to save to a savefile/savefolder on a HD partition,\nInitmodules will work if you also ensure there is a copy of the zdrv...sfs\nin the same directory as the savefile/savefolder.')\n\n$MSGCONT" 0 0
+		[ $? -ne 0 ] && exit 1
+		start_splash
+	else
+		Xdialog --wmclass "module16" --title "$MSGT" --left --ok-label "Continue" --cancel-label "Exit" --yesno "$(gettext 'You have booted from a CD or DVD with a savefile/savefolder,\nbut with the zdrv...sfs file still on the CD.\n\nInitmodules will work if you copy the zdrv...sfs file\nto the same directory as the savefile/savefolder.')\n\n$MSGALT\n\n$MSGCONT" 0 0
+		[ $? -ne 0 ] && exit 1
+		start_splash
+	fi
+fi
+
+get_modlist
+
+DLGMODLIST=""
+LOADEDMODULES="$(cut -f 1 -d ' ' /proc/modules | sort | tr '\n' ' ')"
 for ONEMOD in $LOADEDMODULES; do
-	MODLIST="$MODLIST $ONEMOD $ONEMOD off"
+	case ${MODLIST} in
+		*"$ONEMOD"*) DLGMODLIST="$DLGMODLIST $ONEMOD $ONEMOD on" ;; #contains $ONEMOD
+		*) DLGMODLIST="$DLGMODLIST $ONEMOD $ONEMOD off" ;; #does not contain $ONEMOD
+	esac
 done
 
-EXECME="Xdialog --wmclass \"module16\" --title \"$(gettext 'Initmodules: Modules to load in init script')\" --left --stdout --separator \" \" --buildlist \"$(gettext 'The left pane shows the modules that are currently loaded.\nThe right pane is initially empty.\n\nMove the module(s) that need to be loaded by init to the right pane.\nWhen the list in the right pane is complete, click the OK button.\nOn reboot, these modules will be loaded by the init script,\nso devices required by the init script will now work. For example,\nthe keyboard might now work to select a savefile/savefolder.\n\nIf you do not know which module(s) need to be loaded by init,\ncheck each modules description, as shown by modinfo or hardinfo.')\" 0 0 8 $MODLIST >/tmp/yesrettags.txt"
-eval $EXECME
-[ ! $? -eq 0 ] && exit 1
+kill $MSGPID
 
-. /etc/DISTRO_SPECS
+if [ "$MODLIST" ]; then
+   MSG_MOD="$(gettext '\nThe right pane shows the modules that Initmodules has determined\nshould be loaded by "init" so the keyboard works during startup.')"
+else
+   MSG_MOD="$(gettext '\nThe right pane is empty because Initmodules did not find any \nkeyboard needed modules that should be loaded by "init".')"
+fi
 
-KERNELVER="`uname -r`"
-PIMODFILE="/mnt/home${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt"
-MODSPATH="/lib/modules/$KERNELVER"
+RESMODLIST="$(Xdialog --wmclass "module16" --title "$MSGT" --left --stdout --separator " " --buildlist "$(gettext 'The left pane shows the modules that are currently loaded.') $MSG_MOD $(gettext '\n\nThis can still be modified by moving modules betweeen panes\nusing the "Add" and "Remove" buttons.\nWhen finished, click the "OK" button, to write a configuration file.\n\nOn reboot, modules shown in the right pane will be loaded during\n"init" so the keyboard may now work to select a savefile/folder.\nNotice that clicking on "OK" while the right pane is empty, will\nremove any previous Initmodules configuration file.\n\nIf you do not know which module(s) need to be loaded by "init",\naccept the defaults as determined by Initmodules, simply click "OK".')" 0 0 8 $DLGMODLIST)"
+[ $? -ne 0 ] && exit 1
 
-LDLIST=""
-for ONEMOD in `head -n1 /tmp/yesrettags.txt`; do
-	CURMOD="`modinfo $ONEMOD | grep 'filename:'`"
-	if [ "$CURMOD" != "" ]; then
-		CURMOD="${CURMOD#*/}"
-		CURMOD="${CURMOD#*/}"
-		CURMOD="${CURMOD#*/}"
-		CURMOD="${CURMOD#*/}"
-	fi
-	if [ "$CURMOD" != "" ]; then
-		if [ "$LDLIST" = "" ]; then
-			LDLIST="$CURMOD"
-		else
-			LDLIST="$LDLIST,$CURMOD"
-		fi
-	fi
-done
-echo "$LDLIST" > $PIMODFILE
+write_modlist "$RESMODLIST"
+[ -f "$PIMODFILE" ] && Xdialog --wmclass "module16" --title "$MSGT" --left --msgbox "$(gettext 'A configuration file for Initmodules has been written to') \"$PIMODFILE\"." 0 0
+
+exit 0


### PR DESCRIPTION
A complete rewrite.
It now determines the modules that need to be loaded in "init", including dependencies, by examining the modules that are loaded in the current running system.
Executed with a "-q" parameter, it displays nothing, but writes a config file if needed, and if it can.
Otherwise it is a GUI utility that displays informative messages and it's list of needed modules. The list can then be modified or accepted as is.