### PR TITLE
Add initmodules support for first boot and first shutdown

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -486,6 +486,8 @@ case $PUPMODE in
    cp -a $ONEDIR/* /tmp/save1stpup/${BASENAME}/ #v2.16exp3
    [ "$BASENAME" = "root" ] && cp -a $ONEDIR/.[0-9a-zA-Z]* /tmp/save1stpup/${BASENAME}/ #v2.16exp4
   done
+  #copy initmodules config file from /tmp if it exists
+  [ -f /tmp/${DISTRO_FILE_PREFIX}initmodules.txt ] && cp -f /tmp/${DISTRO_FILE_PREFIX}initmodules.txt ${SMNTPT}${SAVEPATH}/${DISTRO_FILE_PREFIX}initmodules.txt
   sync
   [ -L /tmp/save1stpup ] || umount /tmp/save1stpup
 

--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -849,7 +849,8 @@ if [ "$SET_COUNTRY" ];then
  ###keyboard layout###
  KEYBOARDXML=""
  if [ "$SET_KEYBOARD" ];then
-
+  # Check if the keyboard needs any kernel modules
+  [ "$(which initmodules)" -a ! -f /mnt/home${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt ] && initmodules -q & # [ ... -a "$PUPMODE" = "5" ] could do instead
   #120627
   KMAPPATH='/lib/keymaps'
   [ -d /usr/share/kbd/keymaps/i386 ] && KMAPPATH='/usr/share/kbd/keymaps/i386'


### PR DESCRIPTION
These patches enable first boot to create an initmodules config file and for first shutdown to copy any initmodules config file found in /tmp into the same directory as the save layer.
(mavrothal is the real author of the quicksetup patch.)
