### PR TITLE
SNS: show Access Point MAC address

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-skeleton/usr/local/simple_network_setup/sns
@@ -365,6 +365,7 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
  rm -f /tmp/sns_scan_radiobuttons
  rm -f /tmp/sns_scan_radiobuttons_shield
  rm -f /tmp/sns_scan_radiobuttons_strength
+ rm -f /tmp/sns_scan_radiobuttons_address
  rm -f /tmp/sns_scan_rawoneline
  rm -f /tmp/sns_scan_oneline
  yaf-splash -placement center -bg orange -text "$(gettext 'Please wait, scanning for wireless networks...')" &
@@ -439,14 +440,17 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
    </hbox>' >> /tmp/sns_scan_radiobuttons_shield
    echo '
    <hbox space-expand="false" space-fill="false">
-     <text xalign="0" yalign="1" use-markup="true" space-expand="true" space-fill="true">
-       <label>"<small><small>'$(gettext 'Strength')': '${CELL_QUALITY}'  </small></small>"</label>
-     </text>
      <pixmap height-request="25" space-expand="false" space-fill="false">
        <input file>/usr/share/pixmaps/puppy/'${IMG_QUALITY}'.svg</input>
        <height>25</height>
      </pixmap>
    </hbox>' >> /tmp/sns_scan_radiobuttons_strength
+   echo '
+   <hbox space-expand="false" space-fill="false" height-request="25">
+     <text xalign="1" yalign="1" use-markup="true" space-expand="true" space-fill="true">
+       <label>"'${CELL_ADDRESS}'"</label>
+     </text>
+   </hbox>' >> /tmp/sns_scan_radiobuttons_address
    #---
    
    echo "$ONELINE" >> /tmp/sns_scan_rawoneline
@@ -473,8 +477,8 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons`'</vbox>
      <text space-expand="true" space-fill="true"><label>""</label></text>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_shield`'</vbox>
-     <text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_strength`'</vbox>
+     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_address`'</vbox>
    </hbox>'
    FRAME1='
     <vbox space-expand="true" space-fill="true">


### PR DESCRIPTION
This helps identifying the correct network.
ex: when the SSID is hidden (#756)

To make room, the 'Strength: XX/XX' string has been removed,
there is already a nice image...