### PR TITLE
fix psavemark to work with pmedia and psave code

### DIFF
--- a/woof-code/huge_extras/init
+++ b/woof-code/huge_extras/init
@@ -341,12 +341,12 @@ search_func() { #110425
    *)
     #note: a mistake if have PDEV1 on usb booting, as it can change.
     if [ "$PDEV1" ];then #kernel boot param
-     LESSPAT="$PDEV1"
      if [ "$PSAVEMARK" ];then #kernel boot param
       BOOTDRV="`echo -n "$PDEV1" | grep -o -f /tmp/ALLDRVS0`" #ex: sda1 becomes sda
-      LESSPAT="${PDEV1}|${BOOTDRV}${PSAVEMARK}"
+      LESSPARTS0="`echo "$LESSPARTS0" | grep -E "${PDEV1}|${BOOTDRV}${PSAVEMARK}"`"
+     else
+      LESSPARTS0="`echo "$LESSPARTS0" | grep "${PDEV1}|"`"
      fi
-     LESSPARTS0="`echo "$LESSPARTS0" | grep -E "$LESSPAT"`"
     fi
    ;;
   esac


### PR DESCRIPTION
Unfortunately my original version of this patch was the wrong code.
Both versions work, but this makes the code correspond to that agreed in the forum.