### PR TITLE
'osrelease' script

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/osrelease
+++ b/woof-code/rootfs-skeleton/usr/sbin/osrelease
@@ -1,0 +1,46 @@
+#!/bin/sh
+# https://www.freedesktop.org/software/systemd/man/os-release.html
+#
+# Usage:
+# <script> [/path/to/DISTRO_SPECS]
+
+if [ -f "$1" ] ; then
+	OR_FILE="$1"
+else
+	if [ -f /etc/DISTRO_SPECS ] ; then
+		OR_FILE="/etc/DISTRO_SPECS"
+	elif [ -f /initrd/DISTRO_SPECS ] ; then
+		OR_FILE="/initrd/DISTRO_SPECS"
+	fi
+fi
+
+if [ -f "$OR_FILE" ] ; then
+	echo "Using $OR_FILE as a reference"
+else
+	echo "Need a Puppy DISTRO_SPECS"
+	exit 1
+fi
+
+. $OR_FILE
+
+(
+  echo 'NAME="'${DISTRO_NAME}'"'
+  echo 'PRETTY_NAME="'${DISTRO_NAME}'"'
+  echo 'VERSION="'${DISTRO_VERSION}'"'
+  echo 'ID="'${DISTRO_BINARY_COMPAT}'"'
+  echo 'VERSION_ID="'${DISTRO_FILE_PREFIX}'"'
+  echo 'BUILD_ID="'${DISTRO_IDSTRING}'"'
+  echo 'HOME_URL="'http://puppylinux.com/'"'
+  echo 'BUG_REPORT_URL="'https://github.com/puppylinux-woof-CE/woof-CE'"'
+) > /etc/os-release
+echo "/etc/os-release has been created"
+
+(
+  echo 'DISTRIB_ID="'${DISTRO_NAME}'"'
+  echo 'DISTRIB_RELEASE="'${DISTRO_VERSION}'"'
+  echo 'DISTRIB_CODENAME="'${DISTRO_BINARY_COMPAT}'"'
+  echo 'DISTRIB_DESCRIPTION="'${DISTRO_NAME}'"'
+) > /etc/lsb-release
+echo "/etc/lsb-release has been created"
+
+### END ###


### PR DESCRIPTION
Nowadays /etc/os-release has been adopted by most distributions
(ex https://sources.gentoo.org/cgi-bin/viewvc.cgi/baselayout/trunk/etc.Linux/os-release?revision=3203&view=markup&pathrev=3203 )

Many tools rely on this file to get the distro info,
patching apps to recognize DISTRO_SPECS is not that way to go.

This creates a /etc/os-release file using a DISTRO_SPECS file as a reference.
It also creates a /etc/lsb-release file, which is a very old standard, just in case.

This can be used in the final steps in 3builddistro

    chroot <dir> osrelease

Or anytime before or after remastering a puppy distro.