### PR TITLE
sns: Set key entry visibility to 'false'.

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-skeleton/usr/local/simple_network_setup/sns
@@ -515,7 +515,7 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
            <text space-expand="true" space-fill="true"><label>""</label></text>
            <hbox space-expand="true" space-fill="true">
              <text space-expand="false" space-fill="false"><label>'$(gettext 'Key:')'</label></text>
-             <entry space-expand="true" space-fill="true">
+             <entry space-expand="true" space-fill="true" visibility="false">
                <variable>BOX_KEY</variable>
                <action signal="activate" type="activate">BTN_CONNECT</action>
              </entry>


### PR DESCRIPTION
Erm.. minor patch for SNS to hide the characters when user enters the network key. 

I was having problems of people snooping over my network passwords while logging in, please accept. :pray:  