### PR TITLE
0setup: use ./support debdb2pupdb|find_cat if building from woof

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -89,8 +89,13 @@ if [ -f ./DISTRO_SPECS ];then
       echo -e "\n\nlib64 directories created in packages-templates."
     fi
   fi
+  DEBDB2PUPDB="$(pwd)/support/debdb2pupdb"
+  FIND_CAT="$(pwd)/support/find_cat"
+  #note, 3builddistro copies it into rootfs-complete/usr/local/petget when building a pup.
 else
   #want to run this script in running puppy, to update db's...
+  DEBDB2PUPDB='/usr/local/petget/debdb2pupdb'
+  FIND_CAT='/usr/local/petget/find_cat'
   . /etc/DISTRO_SPECS
   . /root/.packages/DISTRO_COMPAT_REPOS #v431
   . /root/.packages/DISTRO_PKGS_SPECS
@@ -108,25 +113,6 @@ if [ "$RUNNINGPUP" = "no" ];then
  ./support/fix-puppy-dbs
  [ $? -eq 1 ] && exit
 fi
-#BAD bug, woof should not invade the running system
-#[ -f ./support/debdb2pupdb ] && cp -f ./support/debdb2pupdb /usr/local/petget/ #121111 0setup needs it here, when run from PPM.
-#note, 3builddistro copies it into rootfs-complete/usr/local/petget when building a pup.
-#121112 note, debdb2pupdb no longer calls find_cat.
-
-
-#w015 to speed things up, this func replaced by compiled app support/find_cat ...
-#[ -f ./support/find_cat ] && cp -f ./support/find_cat /usr/local/petget/ #130126
-
-#130126 make sure have latest in host system...
-#if [ -f rootfs-skeleton/usr/local/petget/categories.dat -a -f /usr/local/petget/debdb2pupdb ];then
- #echo "Your system is OK"
-#else
- #echo "Your system is incompatible or too old"
- #sleep 5
- #exit 1 #&& cp -f rootfs-skeleton/usr/local/petget/categories.dat /usr/local/petget/
-#fi
-[ -f /usr/local/petget/find_cat ] && FIND_CAT="/usr/local/petget/find_cat" \
-|| FIND_CAT='./support/find_cat' #140116
 
 if [ -f ./support/rpm2ppm ];then #110612
  RPM2PPM='./support/rpm2ppm'
@@ -505,7 +491,7 @@ do
  case ${DISTRO_BINARY_COMPAT} in
   ubuntu|trisquel|debian|devuan|raspbian)
   
-   if [ -f /usr/local/petget/debdb2pupdb ];then #121111
+   if [ -f $DEBDB2PUPDB ];then #121111
     #new fast compiled app...
     #create an intermediate-converted file...
     LANG=${LANGORG} echo " please wait..."
@@ -515,7 +501,7 @@ do
     #call new app. note, this in turn calls /usr/local/petget/find_pkgs...
     if [ -n "$MANIPULATED1" ];then
      echo "$MANIPULATED1" > /tmp/woof-debdb.in
-     /usr/local/petget/debdb2pupdb ${DISTRO_BINARY_COMPAT} ${DISTRO_COMPAT_VERSION} > /tmp/${ONE_PKGLISTS_COMPAT}temp #130126 $ONE_PKGLISTS_COMPAT
+     ${DEBDB2PUPDB} ${DISTRO_BINARY_COMPAT} ${DISTRO_COMPAT_VERSION} > /tmp/${ONE_PKGLISTS_COMPAT}temp #130126 $ONE_PKGLISTS_COMPAT
      ${FIND_CAT} /tmp/${ONE_PKGLISTS_COMPAT}temp > $ONE_PKGLISTS_COMPAT #130126
     else
      touch $ONE_PKGLISTS_COMPAT


### PR DESCRIPTION
otherwise /usr/local/petget/* to update dbs in a running pup

the files in ./support are supposed to be always the latest version