### PR TITLE
Use new APIs for frisbee-1.4 and pgprs-2.0; add get...devices 'ALL' option

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard
@@ -24,6 +24,7 @@
 #121112 rerwin: change indicator of frisbee.
 #130111 rerwin: change name of frisbee invocation for integrated version, add disable when appropriate.
 #131214 zigbert: gui (gtkdialog) improvements.
+#160120 rerwin: add use of new pgprs and frisbee interfaces.
 
 export TEXTDOMAIN=connectwizard
 export OUTPUT_CHARSET=UTF-8
@@ -50,7 +51,6 @@ fi
 
 #v411 commandline param, this section irrelevant...
 DEFAULTCONNECT="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`"
-[ "`grep 'gprs' /usr/local/bin/defaultconnect`" != "" ] && DEFAULTCONNECT='pgprs-connect'
 [ "$DEFAULTCONNECT" = "gkdial" ] && DEFAULTCONNECT="pupdial" #for older pups.
 #radiobuttons...
 DEFGNOMEPPP="no"
@@ -74,7 +74,7 @@ case $DEFAULTCONNECT in
  pppoe_gui)
   DEFRPPPPOE="yes"
   ;;
- pgprs-connect)
+ pgprs|pgprs-connect) #160120
   DEFMTGPRS="yes"
   ;;
  pppoeconf) #v409
@@ -133,13 +133,13 @@ if [ -h /dev/modem ];then
 fi
 
 FLAGGNOMEPPP=""
-if [ ! "`which gnome-ppp`" = "" ];then
+if [ ! "`which gnome-ppp 2>/dev/null`" = "" ];then
  FLAGGNOMEPPP="<radiobutton><label>$(gettext 'GnomePPP (modem dialup)')</label><variable>RADIOGNOMEPPP</variable><default>$DEFGNOMEPPP</default></radiobutton>"
 fi
 
 FLAGROARINGPENGUIN=""
 CONNECTROARINGPENGUIN="" #v409
-if [ "`which pppoe_gui`" != "" ];then
+if [ "`which pppoe_gui 2>/dev/null`" != "" ];then
  FLAGROARINGPENGUIN="<radiobutton><label>$(gettext 'Roaring Penguin (PPPoE)')</label><variable>RADIORPPPPOE</variable><default>$DEFRPPPPOE</default></radiobutton>"
  CONNECTROARINGPENGUIN='
  <hbox space-expand="true" space-fill="true">
@@ -156,7 +156,7 @@ fi
 #v411...
 FLAGPPPOECONF=""
 CONNECTPPPOECONF=""
-if [ "`which pppoeconf`" != "" ];then
+if [ "`which pppoeconf 2>/dev/null`" != "" ];then
  FLAGPPPOECONF="<radiobutton><label>$(gettext 'Pppoeconf (PPPOE)')</label><variable>RADIOPPPOECONF</variable><default>$DEFPPPOECONF</default></radiobutton>"
  CONNECTPPPOECONF='
  <hbox space-expand="true" space-fill="true">
@@ -171,17 +171,18 @@ if [ "`which pppoeconf`" != "" ];then
 fi
 
 FLAGMTGPRS=""
-if [ "`which pgprs-setup`" != "" ];then
+if [ -x /usr/sbin/pgprs -o -x /usr/sbin/pgprs-shell ];then #160120
  CONNECTMTGPRS='
  <hbox space-expand="true" space-fill="true">
    <button space-expand="false" space-fill="false">
      '"`/usr/lib/gtkdialog/xml_button-icon wireless.svg big`"'
-     <action>/usr/sbin/pgprs-shell &</action>
+     <action>test -x /usr/sbin/pgprs && /usr/sbin/pgprs --setup &</action>
+     <action>test -x /usr/sbin/pgprs || /usr/sbin/pgprs-shell &</action>
      <action type="exit">exit</action>
    </button>
    <text space-expand="false" space-fill="false"><label>'$(gettext "Wireless GPRS modem")'</label></text>
    <text space-expand="true" space-fill="true"><label>""</label></text>
- </hbox>'
+ </hbox>' #160120
  FLAGMTGPRS="<radiobutton><label>$(gettext "GPRS Connect")</label><variable>RADIOMTGPRS</variable><default>$DEFMTGPRS</default></radiobutton>"
 fi
 
@@ -189,7 +190,7 @@ if [ -d /usr/local/Pwireless2 ];then #100227 Jemimah's wireless connection gui.
  FLAGPWIRELESS="<radiobutton><label>$(gettext "Pwireless (wireless networking)")</label><variable>RADIOPWIRELESS</variable><default>$DEFPWIRELESS</default></radiobutton>"
 fi
 
-if [ -f /usr/local/bin/frisbee ];then #100227 121112 130111 Jemimah's wireless connection gui.
+if [ -x /usr/local/bin/frisbee ];then #100227 121112 130111 Jemimah's wireless connection gui. 160120
  FLAGFRISBEE="<radiobutton><label>$(gettext "Frisbee (wireless networking)")</label><variable>RADIOFRISBEE</variable><default>$DEFFRISBEE</default></radiobutton>"
 fi
 
@@ -341,7 +342,7 @@ RADIOBUT="`echo "$RETSTR" | grep '^RADIO' | grep '"true"' | cut -f 1 -d '='`"
 [ "$RADIOBUT" = "RADIOGNOMEPPP" ] && echo -e '#!/bin/sh\nexec gnomepppshell' > /usr/local/bin/defaultconnect
 [ "$RADIOBUT" = "RADIOPUPDIAL" ] && echo -e '#!/bin/sh\nexec pupdial' > /usr/local/bin/defaultconnect
 [ "$RADIOBUT" = "RADIORPPPPOE" ] && echo -e '#!/bin/sh\nexec pppoe_gui' > /usr/local/bin/defaultconnect
-[ "$RADIOBUT" = "RADIOMTGPRS" ] && echo -e '#!/bin/sh\nexec rxvt -title "pgprs-connect PRESS CTRL+C TO DISCONNECT" -e pgprs-connect' > /usr/local/bin/defaultconnect
+[ "$RADIOBUT" = "RADIOMTGPRS" ] && ( echo -e '#!/bin/sh' > /usr/local/bin/defaultconnect; [ -x /usr/sbin/pgprs ] && echo -e 'exec pgprs --connect' >> /usr/local/bin/defaultconnect || echo -e 'exec rxvt -title "pgprs-connect PRESS CTRL+C TO DISCONNECT" -e pgprs-connect' >> /usr/local/bin/defaultconnect ) #160120
 [ "$RADIOBUT" = "RADIOICW" ] && echo -e '#!/bin/sh\nexec connectwizard' > /usr/local/bin/defaultconnect
 [ "$RADIOBUT" = "RADIOPPPOECONF" ] && echo -e '#!/bin/sh\nexec pppoeconf' > /usr/local/bin/defaultconnect #v409
 [ "$RADIOBUT" = "RADIOPWIRELESS" ] && echo -e '#!/bin/sh\nexec Pwireless2' > /usr/local/bin/defaultconnect #100227
@@ -351,8 +352,13 @@ RADIOBUT="`echo "$RETSTR" | grep '^RADIO' | grep '"true"' | cut -f 1 -d '='`"
 [ "$RADIOBUT" = "RADIOSNS" ] && echo -e '#!/bin/sh\nexec sns' > /usr/local/bin/defaultconnect #100227
 
 if [ "$FLAGFRISBEE" ];then #130111 precaution...
- echo -n "$RADIOBUT" | grep -q -E 'CW$|FRISBEE|PUPDIAL|MTGPRS' \
-  || frisbee_mode_disable
+ if ! echo -n "$RADIOBUT" | grep -q -E 'CW$|FRISBEE|PUPDIAL|MTGPRS';then #160120...
+  if [ -x /usr/local/bin/frisbee_mode_disable ];then
+   frisbee_mode_disable
+  else
+   frisbee --deactivate
+  fi
+ fi
 fi
 
 ###end###

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard_2nd
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard_2nd
@@ -10,6 +10,7 @@
 #121122 rerwin: change indicator of frisbee; ensure frisbee stopped if not chosen.
 #130103 rerwin: change name of frisbee invocations for integrated version.
 #131216 zigbert: gui (gtkdialog) improvements.
+#160120 rerwin: add use of new frisbee interface; remove irrelevant dialup code.
 
 export TEXTDOMAIN=connectwizard_2nd
 export TEXTDOMAINDIR=/usr/share/locale
@@ -59,7 +60,7 @@ if [ -d /usr/local/Pwireless2 ];then #Jemimah's wireless connection gui.
 fi
 
 FRISBEE="" #121029...
-if [ -f /usr/local/bin/frisbee ];then #Jemimah's wireless connection gui. 121122 130103
+if [ -x /usr/local/bin/frisbee ];then #Jemimah's wireless connection gui. 121122 130103 160120
  FRISBEE='
  <vbox>
    <button>
@@ -137,9 +138,13 @@ export Network_Connection_Wizard='
 RETSTRING="`gtkdialog -p Network_Connection_Wizard`" 
 
 if [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'FLAG'`" != "" ];then
- CHOSENWIZ="`echo "$RETSTRING" | grep '^EXIT' | grep 'FLAG' | cut -f 2 -d '"'`"
- if [ "$FRISBEE" ];then #130103...
-  [ "$CHOSENWIZ" != "FLAGFRISBEE" ] && frisbee_mode_disable
+ CHOSENWIZ="$(echo "$RETSTRING" | grep '^EXIT' | grep 'FLAG' | cut -f 2 -d \")"
+ if [ "$FRISBEE" ] && [ "$CHOSENWIZ" != "FLAGFRISBEE" ];then #130103 160120...
+  if [ -x /usr/local/bin/frisbee_mode_disable ];then
+   frisbee_mode_disable
+  else
+   frisbee --deactivate
+  fi
  fi
  case $CHOSENWIZ in
   FLAGPWIRELESS) #Pwireless2

--- a/woof-code/rootfs-skeleton/usr/sbin/get_modem_alternate_device
+++ b/woof-code/rootfs-skeleton/usr/sbin/get_modem_alternate_device
@@ -2,9 +2,11 @@
 #Barry Kauler 2010 LGPL
 
 #Find another candidate for USB modem, for device in argument 1.
+#130428 Add option to return all candidates (for pgprs).
 DEVM=$1
 DEVMALT=""
-if [ "`echo "$DEVM" | grep -E 'ttyACM[0-9]|ttyHS[0-9]|ttyUSB[0-9]|rfcomm[0-9]'`" != "" ];then
+if [ "`echo "$DEVM" | grep -E 'ttyACM[0-9]|ttyHS[0-9]|ttyUSB[0-9]|rfcomm[0-9]'`" != "" ] \
+ || [ "$DEVM" = "ALL" ];then #130428
 
  INTERRUPTLIST="`grep -H -s 'Interrupt' /sys/bus/usb/devices/*-*:*.*/ep_??/type | cut -f 1-6 -d /`"
  DEVLISTACM="`ls -1 -d /sys/bus/usb/devices/*-*:*.*/tty/tty????* 2>/dev/null | sed 's/ /\n/g' | grep -F "$INTERRUPTLIST" | cut -f 8 -d / | sed 's/\(tty...\)\([0-9]$\)/\10\2/' | sort | sed 's/\(tty...\)\(0\)/\1/'`"
@@ -21,14 +23,17 @@ if [ "`echo "$DEVM" | grep -E 'ttyACM[0-9]|ttyHS[0-9]|ttyUSB[0-9]|rfcomm[0-9]'`"
   echo "Modemtest/probe: DUNPATTERN: $DUNPATTERN  DUNRFCLIST: $DUNRFCLIST" >> /tmp/udevtrace-modem.log #DEBUG
  fi
  DEVLISTALL="`echo "$DUNRFCLIST $DEVLISTACM $DEVLISTHS $DEVLISTUSB" | tr ' ' '\n' | sed /^$/d`"
- SEDSCRIPT1="/${DEVM}/"'{n;p;q}'
- DEVMALT="`echo "$DEVLISTALL" | sed -n "$SEDSCRIPT1"`"
- [ "$DEVMALT" = "" ] \
-  && SEDSCRIPT2="/${DEVM}/"'!{p;q}' \
-  && DEVMALT="`echo "$DEVLISTALL" | sed -n "$SEDSCRIPT2"`"
- echo -e "Modemtest/probe: DEVM: $DEVM  DEVMALT: $DEVMALT  DEVLISTALL:\n$DEVLISTALL" >> /tmp/udevtrace-modem.log #DEBUG
+ if [ "$DEVM" = "ALL" ];then #130428
+  echo "$DEVLISTALL" #130428
+ else #130428
+  SEDSCRIPT1="/${DEVM}/"'{n;p;q}'
+  DEVMALT="`echo "$DEVLISTALL" | sed -n "$SEDSCRIPT1"`"
+  [ "$DEVMALT" = "" ] \
+   && SEDSCRIPT2="/${DEVM}/"'!{p;q}' \
+   && DEVMALT="`echo "$DEVLISTALL" | sed -n "$SEDSCRIPT2"`"
+  echo "$DEVMALT" #130428
+ fi #130428
 fi
-echo "$DEVMALT"
 exit 0
 
 ###END###


### PR DESCRIPTION
These changes support new APIs of the frisbee-1.4 and pgprs-2.0 packages.  They are invoked by the commands, frisbee and pgprs.  They take a single argument for a specific action.  The connectwizard scripts will use them if present.  If an older version of frisbee is installed, the old interface is used.  For pgprs, only the new package is supported, because the old version should be removed from woof-CE and a new pgprs package option added to woof-CE.

Although the results from get_modem_alternate_device omit an argument-specified device name, the new option requests that all found devices be returned, as needed by the new frisbee and pgprs.