### PR TITLE
fdrv - remove EXTRAFW conditionals and pfix=fw_drv

### DIFF
--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -474,10 +474,8 @@ search_func() { #110425
  fi
  decode_id "$ZDRVID"
  [ "$DEV" ] && { append_needed "$DEV"; ZDRVDEV="$DEV"; ZDRVID=""; }
- if [ "$EXTRAFW" = "yes" ];then
-  decode_id "$FDRVID"
-  [ "$DEV" ] && { append_needed "$DEV"; FDRVDEV="$DEV"; FDRVID=""; }
- fi
+ decode_id "$FDRVID"
+ [ "$DEV" ] && { append_needed "$DEV"; FDRVDEV="$DEV"; FDRVID=""; }
  decode_id "$ADRVID"
  [ "$DEV" ] && { append_needed "$DEV"; ADRVDEV="$DEV"; ADRVID=""; }
  decode_id "$YDRVID"
@@ -553,12 +551,10 @@ search_func() { #110425
    [ "$ONEPUPDRV" ] || find_onepupdrv "$ZDRVSFS"
    [ "$ONEPUPDRV" ] && { ZDRV="$ONEPUPDRV"; ZDRVSPEC=""; }
   fi
-  if [ "$EXTRAFW" = "yes" ];then
-   if [ "$FDRVDEV" = "$ONEDEV" ];then
-    find_onepupdrv "$FDRVSPEC" "f"
-    [ "$ONEPUPDRV" ] || find_onepupdrv "$FDRVSFS" "f"
-    [ "$ONEPUPDRV" ] && { FDRV="$ONEPUPDRV"; FDRVSPEC=""; }
-   fi
+  if [ "$FDRVDEV" = "$ONEDEV" ];then
+   find_onepupdrv "$FDRVSPEC" "f"
+   [ "$ONEPUPDRV" ] || find_onepupdrv "$FDRVSFS" "f"
+   [ "$ONEPUPDRV" ] && { FDRV="$ONEPUPDRV"; FDRVSPEC=""; }
   fi
   if [ "$ADRVDEV" = "$ONEDEV" ];then
    find_onepupdrv "$ADRVSPEC" "a"
@@ -615,9 +611,7 @@ search_func() { #110425
    
    [ "$PUPSFS" = "" ] && { find_onepupdrv "$PUPXXXSFS"; PUPSFS="$ONEPUPDRV"; }
    [ "$ZDRV" = "" ] && { find_onepupdrv "$ZDRVSFS"; ZDRV="$ONEPUPDRV"; }
-   if [ "$EXTRAFW" = "yes" ];then
-    [ "$FDRV" = "" ] && { find_onepupdrv "$FDRVSFS" "f"; FDRV="$ONEPUPDRV"; }
-   fi
+   [ "$FDRV" = "" ] && { find_onepupdrv "$FDRVSFS" "f"; FDRV="$ONEPUPDRV"; }
    [ "$ADRV" = "" ] && { find_onepupdrv "$ADRVSFS" "a"; ADRV="$ONEPUPDRV"; }
    [ "$YDRV" = "" ] && { find_onepupdrv "$YDRVSFS" "y"; YDRV="$ONEPUPDRV"; }
   
@@ -813,13 +807,10 @@ if [ "$pfix" ];then
    copy)    PCOPY="yes";;         #copy .sfs files into ram.
    nocopy)  PNOCOPY="yes";;        #do not copy .sfs files into ram (default is copy if enough ram).
    fsck)    PFSCK="yes";;         #do a fsck of ${DISTRO_FILE_PREFIX}save file.
-   fw_drv)  EXTRAFW="yes";;       #Load sfs with additional firmware
    [0-9]*)  PIGNORELAST=$ONEFIX;; #blacklist last $ONEFIX folders (multisession).
   esac
  done
 fi
-
-[ "$EXTRAFW" = "yes" ] && FDRVSFS="$DISTRO_FDRVSFS" || FDRVSFS=""
 
 #for backwards naming compatibility... ex: idehd becomes atahd 101021: atacd,scsicd,usbcd to become just cd...
 PMEDIA="`echo -n "$PMEDIA" | sed -e 's%ide%ata%' -e 's%sata%ata%' -e 's%.*cd$%cd%'`"
@@ -970,7 +961,7 @@ KERNELNAME='vmlinuz'
 
 [ "$PUPSFS" ] && { decode_spec "$PUPSFS"; PUPSFSID="$DID"; PUPSFSSPEC="$SPEC"; PUPSFS=""; }
 [ "$ZDRV" ] && { decode_spec "$ZDRV"; ZDRVID="$DID"; ZDRVSPEC="$SPEC"; ZDRV=""; }
-[ "$FDRV" -a "$EXTRAFW" = "yes" ] && { decode_spec "$FDRV"; FDRVID="$DID"; FDRVSPEC="$SPEC"; FDRV=""; }	
+[ "$FDRV" ] && { decode_spec "$FDRV"; FDRVID="$DID"; FDRVSPEC="$SPEC"; FDRV=""; }	
 [ "$ADRV" ] && { decode_spec "$ADRV"; ADRVID="$DID"; ADRVSPEC="$SPEC"; ADRV=""; }
 [ "$YDRV" ] && { decode_spec "$YDRV"; YDRVID="$DID"; YDRVSPEC="$SPEC"; YDRV=""; }
 if [ "$PSAVE" ];then
@@ -983,7 +974,7 @@ fi
 #first look inside initrd...
 [ -f /${PUPXXXSFS} ] && PUPSFS="rootfs,rootfs,/${PUPXXXSFS}"
 [ -f /${ZDRVSFS} ] && ZDRV="rootfs,rootfs,/${ZDRVSFS}"
-[ "$EXTRAFW" = "yes" -a -f /${FDRVSFS} ] && FDRV="rootfs,rootfs,/${FDRVSFS}"
+[ -f /${FDRVSFS} ] && FDRV="rootfs,rootfs,/${FDRVSFS}"
 [ -f /${ADRVSFS} ] && ADRV="rootfs,rootfs,/${ADRVSFS}"
 [ -f /${YDRVSFS} ] && YDRV="rootfs,rootfs,/${YDRVSFS}"
 
@@ -1015,8 +1006,7 @@ if [ -s /tmp/flag-usb-ready ];then #110710 has stuff in it if usb drives exist.
    echo $FS | grep -q -E 'iso9660|udf' && PUPSFS_OPT=$PUPSFS && PUPSFS=""
  fi
  MOREIDS=""
- [ "$ZDRVID" -o "$ADRVID" -o "$YDRVID" ] && MOREIDS="yes"
- [ "$EXTRAFW" = "yes" -a "$FDRVID" ] && MOREIDS="yes"
+ [ "$ZDRVID" -o "$FDRVID" -o "$ADRVID" -o "$YDRVID" ] && MOREIDS="yes"
  if [ "$VMLINUZ" = "" -o "$PUPSFS" = "" -o "$SAVEPART" = "" -o "$MOREIDS" = "yes" ];then
   search_func usb
  fi
@@ -1998,7 +1988,7 @@ mkdir -p /pup_new/initrd/pup_ro8
 mkdir -p /pup_new/initrd/pup_ro9
 mkdir -p /pup_new/initrd/pup_rw
 mkdir -p /pup_new/initrd/pup_z
-[ "$EXTRAFW" = "yes" ] && mkdir -p /pup_new/initrd/pup_f
+mkdir -p /pup_new/initrd/pup_f
 mkdir -p /pup_new/initrd/pup_a
 mkdir -p /pup_new/initrd/pup_y
 mkdir -p /pup_new/initrd/mnt
@@ -2011,9 +2001,9 @@ mkdir -p /pup_new/initrd/mnt/tmpfs
 mkdir -p /pup_new/initrd/mnt/tmpfs2
 mkdir -p /pup_new/initrd/mnt/tmpfs3
 mkdir -p /pup_new/initrd/mnt/tmpfs4
-[ "$EXTRAFW" = "yes" ] && mkdir -p /pup_new/initrd/mnt/tmpfs5
+mkdir -p /pup_new/initrd/mnt/tmpfs5
 mkdir -p /pup_new/initrd/mnt/zdrv
-[ "$EXTRAFW" = "yes" ] && mkdir -p /pup_new/initrd/mnt/fdrv
+mkdir -p /pup_new/initrd/mnt/fdrv
 mkdir -p /pup_new/initrd/mnt/adrv
 mkdir -p /pup_new/initrd/mnt/ydrv
 mkdir -p /pup_new/initrd/tmp


### PR DESCRIPTION
This makes fdrv like other drv files, if "init" finds an fdrv file, it gets loaded into the aufs stack.
No extra "pfix=" boot parameter is required.