### PR TITLE
sfs's - conditionally create mountpoint directories

### DIFF
--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -370,7 +370,7 @@ load_onepupdrv() {
    else
     ONEDEVMNTPT="/mnt/${DRVSFX}drv"
    fi
-   mkdir -p $ONEDEVMNTPT
+   [ -d "$ONEDEVMNTPT" ] || mkdir -p $ONEDEVMNTPT
    mntfunc $DRVFS /dev/$DRVDEV $ONEDEVMNTPT #-t $DRVFS /dev/$DRVDEV $ONEDEVMNTPT
    [ $? -eq 0 ] && UMOUNTME="${UMOUNTME}${ONEDEVMNTPT} " #mark for unmounting.
   fi
@@ -418,6 +418,7 @@ load_onepupdrv() {
   losetup /dev/loop${DRVNUM} ${ONEDEVMNTPT}${DRVFILE}
   UMOUNTME="`echo $UMOUNTME | sed -e "s%$ONEDEVMNTPT%%"`" #remove $ONEDEVMNTPT from $UMOUNTME
  fi
+ [ -d "/pup_${DRVSFX}" ] || mkdir /pup_${DRVSFX}
  mount -r -t squashfs -o noatime /dev/loop${DRVNUM} /pup_${DRVSFX} > /dev/console 2>&1
  [ $? -eq 0 ] && { ONEDRVLAYER="/pup_${DRVSFX}=ro"; ONEDRVFACTOR="$DRVBASENAME"; }
 }


### PR DESCRIPTION
This is not one of the patches I intimated earlier.
It's a small patch to improve the robustness of the code against an "initrd.gz" that's missing any mountpoint directories.
I found this problem when testing this "init" in tahrpup 6.0.5, if doesn't contain a mountpoint for fdrv.
With this patch, just adding "init" to the "initrd.gz" in Tahrpup 6.0.5 enables a specidied fdrv to be loaded.