### PR TITLE
sfs's - make "pupsfs=" partition sticky

### DIFF
--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -450,6 +450,7 @@ decode_spec() {
  DID="`echo "$1" | cut -f 1 -d ':'`"
  SPEC="`echo "$1" | cut -f 2 -d ':'`"
  [ "$SPEC" = "$DID" ] && SPEC=""
+ [ "$DID" ] || DID="$PUPSFSID"
 }
 
 search_func() { #110425


### PR DESCRIPTION
This patch enables specifications like "adrv=:pcmanfm.sfs" to work.
If "pupsfs=sdc2" is specified then "adrv=:pcmanfm.sfs" is equivalent to "adrv=sdc2:pcmanfm.sfs"