### PR TITLE
Rationalise - provide support for "psave=" boot parameter to shutdownconfig

### DIFF
--- a/woof-code/boot/initrd-tree0/init
+++ b/woof-code/boot/initrd-tree0/init
@@ -483,7 +483,7 @@ search_func() { #110425
  decode_id "$YDRVID"
  [ "$DEV" ] && { append_needed "$DEV"; YDRVDEV="$DEV"; YDRVID=""; }
  decode_id "$PSAVEID"
- [ "$DEV" ] && { append_needed "$DEV"; SAVEPART="$DEV"; PSAVEID=""; }
+ [ "$DEV" ] && { append_needed "$DEV"; SAVEPART="$DEV"; PSAVEPART="$DEV"; PSAVEID=""; }
 
  if [ "$PMEDIA" ];then #kernel boot param
   case $PMEDIA in
@@ -1675,6 +1675,7 @@ echo '#complete set of modules in the initrd (moved to main f.s.)...' >> /pup_rw
 echo "ZDRVINIT='$ZDRVINIT'" >> /pup_rw/etc/rc.d/PUPSTATE #v4.02
 echo '#Partition no. override on boot drive to which session is (or will be) saved...' >> /pup_rw/etc/rc.d/PUPSTATE
 echo "PSAVEMARK='$PSAVEMARK'" >> /pup_rw/etc/rc.d/PUPSTATE
+echo "PSAVEPART='$PSAVEPART'" >> /pup_rw/etc/rc.d/PUPSTATE
 if [ "$PLANG" ];then #120215 L18L. 120217 bring this back, seems like a good thing!
  echo "#PLANG is written to LANG in /etc/profile by init script initrd...
 PLANG=${PLANG}

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -499,7 +499,7 @@ case $PUPMODE in
   #100917 booted from usbflash, saved to partition other than boot...
   #101020 also allowing in case of frugal install in a sub-directory...
   if [ "$expBOOTDRV" ];then #see choosepartfunc.
-   if [ "$SAVEPART" != "$PDEV1" ];then
+   if [ "$PSAVEPART" = "" -a "$SAVEPART" != "$PDEV1" ];then
     SAVEMARK="`echo -n "$SAVEPART" | rev | sed -e 's%[a-z].*%%' | rev`" #ex: sdc2 becomes 2.
     aPATTERN="/dev/$PDEV1 "
     aMNTPT=`grep "$aPATTERN" /proc/mounts | cut -f 2 -d ' '`

--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -143,6 +143,11 @@ choosepartfunc() {
  if [ "$PSAVEMARK" != "" ];then #see /etc/rc.d/PUPSTATE
   devnameonly="`echo -n "$PDEV1" | sed -e 's/[0-9]*$//'`"
   SAVEPART="${devnameonly}${PSAVEMARK}" #partition that will-have ${DISTRO_FILE_PREFIX}save.
+ fi
+ if [ "$PSAVEPART" != "" ];then #see /etc/rc.d/PUPSTATE
+  SAVEPART="${PSAVEPART}"
+ fi
+ if [ "$SAVEPART" != "" ];then
   spPATTERN='/dev/'"$SAVEPART"'|'
   SAVEFS="`probepart -m | grep "$spPATTERN" | cut -f 2 -d '|'`"
   SAVEFILE="$PSUBDIR/${DISTRO_FILE_PREFIX}save.2fs"
@@ -889,7 +894,8 @@ CRYPTO='${CRYPTO}'
 expBOOTDRV='${expBOOTDRV}'" > /tmp/shutdownconfig_results
 
 # Add a savemark file if we save in a diffrent partition
-if [ "${SAVEPART}" != "${xPDEV}" ];then
+# But not if defined by PSAVEPART in PUPSTATE
+if [ "${PSAVEPART}" = "" -a "${SAVEPART}" != "${xPDEV}" ];then
  SAVEDISK=$(echo "${SAVEPART}" |  sed 's/[0-9]*//g')
  PDEV1DISK=$(echo "${xPDEV}" |  sed 's/[0-9]*//g')
  xSAVEMARK=$(echo "${SAVEPART}" |  sed 's/[^0-9]*//g')


### PR DESCRIPTION
These should be the last in this series.

With these patches shutdownconfig will honour the partition specified with "psave=".
They also stop a SAVEMARK file being written if "psave=" is specified, because with "psave=" the partition could be on a different device. e.g. frugal install on SSD, savefolder on HD.

But, why is there SAVEMARK writing code in both shutdownconfig and rc.shutdown?