### PR TITLE
Update AppRun and rc.sysinit

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -91,6 +91,8 @@
 #130618 3builddistro sets 'DEVTMPFSFLG' variable.
 #130629 need directory /tmp/pup_event_ipc, to support new pup_event IPC.
 #130630 bring back tmpfs on /tmp for full HD installation.
+#160609 rerwin: Add wait for USB3 driver.
+#160609 rerwin: ignore frisbee as default if not active.
 
 #unset TZ #100319 busybox hwclock gives priority to this (rather than /etc/localtime) and 'init' has set it wrong.
 #...comment-out for now. note, TZ now set in rc.country.
@@ -498,7 +500,7 @@ if [ "$PCIPCMCIA" != "" ];then #this may be slow to respond.
   echo -n " $WAITCNT" >/dev/console
  done
 fi
-PCIUSB="`elspci -l | grep -o -E '0C0300|0C0310|0C0320'`"
+PCIUSB="`elspci -l | grep -o -E '0C0300|0C0310|0C0320|0C0330'`" #160609
 #note, if initrd then usb-storage will have already loaded...
 USBBUILTIN='no'
 if [ "`modinfo ehci_hcd 2>/dev/null`" = "" ];then #110712 130201 shut this up.
@@ -509,7 +511,7 @@ else
   echo -n " usb"  >/dev/console
   PCIUSBNUM=`echo "$PCIUSB" | sort -u | wc -l`
   while [ $WAITCNT -lt 10 ];do
-   [ `lsmod | grep -o -E '^uhci_hcd|^ohci_hcd|^ehci_hcd' | wc -l` -ge $PCIUSBNUM ] && break
+   [ `lsmod | grep -o -E '^uhci_hcd|^ohci_hcd|^ehci_hcd|^xhci_hcd' | wc -l` -ge $PCIUSBNUM ] && break #160609
    WAITCNT=`expr $WAITCNT + 1`
    sleep 1
    echo -n " $WAITCNT" >/dev/console
@@ -669,8 +671,9 @@ case $DEFAULTCONNECT in
  sns)
   NETCHOICE='sns'
  ;;
- connectwizard) #try determine which tool was used to setup networking... 101007
-  if [ -s /etc/simple_network_setup/connections ];then #100306
+ connectwizard|frisbee) #try determine which tool was used to setup networking... 101007 160609
+  if [ -f /usr/local/bin/frisbee ] && frisbee --test_active; then #160609
+   NETCHOICE='frisbee' #160609
    NETCHOICE='sns'
   else
    CHECKOLDWIZ="`ls -1 /etc/*[0-9]mode 2>/dev/null`" #ex: eth0mode, wlan0mode.

--- a/woof-code/rootfs-skeleton/usr/local/apps/Connect/AppRun
+++ b/woof-code/rootfs-skeleton/usr/local/apps/Connect/AppRun
@@ -5,18 +5,21 @@
 #110505 support sudo for non-root user.
 #130104 rerwin: add frisbee
 #130117 rerwin: remove redundant CURREXEC test, per shinobar
+#160120 rerwin: add use of new pgprs and frisbee interfaces; correct frisbee check; ignore frisbee if not active.
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
 
 CURREXEC="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`"
-[ "`grep 'gprs' /usr/local/bin/defaultconnect`" != "" ] && CURREXEC='pgprs-connect'
 [ "$CURREXEC" = "gkdial" ] && CURREXEC="pupdial" #for older pups.
 
 #16aug10 shinobar: netchoice... same code in rc.init
 if [ "$CURREXEC" = "connectwizard" ];then #BK
   NETCHOICE=""
   #try determine which tool was used to setup networking...
-  if [ -s /etc/simple_network_setup/connections ];then #100306
+  if [ -x /usr/local/frisbee/frisbee-main ] \
+    && frisbee --test_active; then #130104 160120
+   NETCHOICE='frisbee' #130104 160120
+  elif [ -s /etc/simple_network_setup/connections ];then #100306 160120
    NETCHOICE='sns'
   else
    CHECKOLDWIZ="`ls -1 /etc/*[0-9]mode 2>/dev/null`" #ex: eth0mode, wlan0mode.
@@ -27,7 +30,7 @@ if [ "$CURREXEC" = "connectwizard" ];then #BK
     if [ "$CHECKNEWWIZ" != "" ];then
      NETCHOICE='net-setup.sh'
     else
-     CHECKFRISBEE="`ls -1 /etc/frisbee/interfaces 2>/dev/null`" #130104...
+     CHECKFRISBEE="`cat /etc/frisbee/interface 2>/dev/null`" #160120 130104...
      if [ "$CHECKFRISBEE" != "" ];then
       NETCHOICE='frisbee'
      else #130104 end
@@ -46,28 +49,54 @@ case $RUNMODE in
   --wizard) exec /usr/sbin/connectwizard 1>&2 ;;
   --connect)
    case $CURREXEC in #connect using default tool.
-    net-setup.sh)  exec /etc/rc.d/rc.network connect 1>&2 ;; #Dougal.
-    pgprs-connect) pppd call gprs-disconnect-chatmm; killall pppd; pgprs-connect ;; #guessing, i need help here.
+    net-setup.sh) exec /etc/rc.d/rc.network connect 1>&2 ;; #Dougal.
+    pgprs|pgprs-connect) #160120...
+     if [ -x /usr/sbin/pgprs ];then
+      pgprs --connect >/dev/null
+     else
+      pppd call gprs-disconnect-chatmm
+      killall pppd
+      pgprs-connect
+     fi ;; #guessing, i need help here.
     pupdial) pupdial ;;
     pppoe_gui) pppoe_gui ;;
     connectwizard) connectwizard ;;
     Pwireless2) Pwireless2 ;;
     net_wiz_classic) net_wiz_classic ;;
     sns) /usr/local/simple_network_setup/rc.network ;;
-    frisbee) [ -f /usr/local/bin/frisbee ] && /usr/local/frisbee/connect ;; #130104
+    frisbee) #160120...
+     if [ -x /usr/local/frisbee/connect ];then
+      /usr/local/frisbee/connect
+     else
+      frisbee --connect
+     fi
+     ;; #130104
    esac
    ;;
   --disconnect) #disconnect using default tool.
    case $CURREXEC in
-    net-setup.sh)  exec /etc/rc.d/rc.network stop 1>&2 ;; #Dougal.
-    pgprs-connect) pppd call gprs-disconnect-chatmm; killall pppd ;; #guessing, i need help here.
+    net-setup.sh) exec /etc/rc.d/rc.network stop 1>&2 ;; #Dougal.
+    pgprs|pgprs-connect) #160120...
+     if [ -x /usr/sbin/pgprs ];then
+      pgprs --disconnect >/dev/null
+     else
+      pppd call gprs-disconnect-chatmm
+      killall pppd
+     fi
+     ;; #guessing, i need help here.
     pupdial) killall wvdial; killall pppd ;;
     pppoe_gui) pppoe_gui ;;
     connectwizard) connectwizard ;;
     Pwireless2) Pwireless2 ;;
     net_wiz_classic) net_wiz_classic ;;
     sns) /usr/local/simple_network_setup/rc.network stop ;;
-    frisbee) [ -f /usr/local/bin/frisbee ] && /usr/local/frisbee/disconnect ;; #130104
+    frisbee) #160120...
+     if [ -x /usr/local/frisbee/disconnect ];then
+      /usr/local/frisbee/disconnect
+     else
+      frisbee --disconnect
+     fi
+     ;; #130104
    esac
    ;;
   *) exec /usr/local/bin/defaultconnect 1>&2  ;;


### PR DESCRIPTION
AppRun was left out of the interface updates related to connectwizard.
Rc.sysinit is updated to support USB3 driver module and to check for frisbee as the active network manager.
AppRun requires execute permission, but rc.sysinit does not.