### PR TITLE
Update Packages-puppy-slacko14.1-official

### DIFF
--- a/woof-distro/x86/slackware/14.1/Packages-puppy-slacko14.1-official
+++ b/woof-distro/x86/slackware/14.1/Packages-puppy-slacko14.1-official
@@ -339,7 +339,6 @@ mm-common_DEV-0.9.3-i686_slk600|mm-common_DEV|0.9.3-i686_slk600||BuildingBlock|7
 mm-common_DOC-0.9.3-i686_slk600|mm-common_DOC|0.9.3-i686_slk600||BuildingBlock|6372||mm-common_DOC-0.9.3-i686_slk600.pet|+mm-common|mm-common documentation||||
 MPlayer-1.1.1-i686_slk600|MPlayer|1.1.1-i686_slk600||Multimedia|11772||MPlayer-1.1.1-i686_slk600.pet|+ffmpeg|Media player for audio and video|slackware|14.1||
 MPlayer_DOC-1.1.1-i686_slk600|MPlayer_DOC|1.1.1-i686_slk600||Multimedia|356||MPlayer_DOC-1.1.1-i686_slk600.pet|+MPlayer|MPlayer documentation||||
-mplayer2-120806-i686|mplayer2|120806-i686||Multimedia|9404K||mplayer2-120806-i686.pet||media player|slackware|14.0||
 mplayerplug-in-3.55-i486-s14|mplayerplug-in|3.55-i486-s14||Multimedia;utility|1572K||mplayerplug-in-3.55-i486-s14.pet||no description provided|slackware|14.0||
 mpscan-0.1.0-kirk-i686_slk600|mpscan|0.1.0-kirk-i686_slk600||BuildingBlock|40||mpscan-0.1.0-kirk-i686_slk600.pet||network scan utility|slackware|14.1||
 mtpaint-3.44.73-i686|mtpaint|3.44.73-i686||Graphic|740K||mtpaint-3.44.73-i686.pet||mtPaint image editor|slackware|14.1||


### PR DESCRIPTION
ppm2 fails to find the mplayer2 when selected, but I found it manually in older folder :santa: 

http://distro.ibiblio.org/puppylinux/pet_packages-slacko/
http://distro.ibiblio.org/puppylinux/pet_packages-slacko14.1/