### PR TITLE
Delete /var/log/packages/pgprs-2.0-1 - unnecessary

### DIFF
--- a/woof-code/rootfs-packages/pgprs/var/log/packages/pgprs-2.0-1
+++ b/woof-code/rootfs-packages/pgprs/var/log/packages/pgprs-2.0-1
@@ -1,1 +1,0 @@
-PACKAGE NAME:     pgprs-2.0-1


### PR DESCRIPTION
I believe the log/packages files are an old artifact from slacko.  Please correct me if they are somehow necessary in woof.