### PR TITLE
Cross-build fix

### DIFF
--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -1192,7 +1192,7 @@ do
   LINKTO="`readlink rootfs-complete"${xONESYMLINK}"`" #120502 fix for spaces in path.
   [ -e rootfs-complete${LINKTO} ] && continue #absolute path
   UPONE="`dirname "$xONESYMLINK"`"
-  [ -e rootfs-complete${UPONE}/${LINKTO} ] && continue #relative path
+  [ -e "rootfs-complete${UPONE}/${LINKTO}" ] && continue #relative path
   mkdir -p devx${UPONE}
   cp -a -f "$ONESYMLINK" devx${UPONE}/
   rm -f "$ONESYMLINK"


### PR DESCRIPTION
When doing a cross-build of slacko64-14.2 (target x86-64) using slacko-14.1 (host x86) I notice 1000 errors on this line because "Puppy Standard" directory has a space in it: http://oi65.tinypic.com/351x45d.jpg  (line 967 rationalise = line 1195 testing) and most icons in puppy do not display as consequence. Adding "" around it fixes it and cross-build is a success! :)