### PR TITLE
Update remasterpup2: change 5 greps for free space calculation

### DIFF
--- a/woof-code/rootfs-packages/pmusic/usr/local/pmusic/func_trackinfo
+++ b/woof-code/rootfs-packages/pmusic/usr/local/pmusic/func_trackinfo
@@ -397,7 +397,7 @@ album_art (){
 	OUTFILE="$1"
 	SITE="$3" #if user want to check out a specified source (amazon.com/albumart.org - or a local file)
 	if [ "$SITE" = "embedded" ]; then
-		ffmpeg -i "$SOURCE_FILE" $WORKDIR/albumart_download.jpg
+		ffmpeg -i "$SOURCE_FILE" -y $WORKDIR/albumart_download.jpg
 		ALBUMART_ID="$(gettext 'Embedded in audio file')"
 	else
 		#define search string


### PR DESCRIPTION
Fixes all instances instead of only the first - ref PR #830 