### PR TITLE
remove extra sfs's from LASTUNIONRECORD on shutdown

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -1968,28 +1968,19 @@ if [ "$STARTSCRIPT" ]; then
     #v1.9.6: fix was everytime rc.update run when the number of additional sfs > 3
     #v2.1.8: MAXEXTRANUM=0
     cp -f $BOOTCONFIG $BOOTCONFIG.save #v2.1.8: always save backup
-    N=$(echo $LOADEDLIST|wc -w)
-    debug "$N: $LOADEDLIST"
-    [ $N -le $MAXEXTRANUM ] && exit	#v2.0.9, v2.1.8
+    debug "$LOADEDLIST"
     if [ $MAXEXTRANUM -eq 0 ]; then
       EXTRASFSLIST=""
       LASTUNIONRECORD=$(echo $LASTUNIONRECORD | tr ' ' "\n" | grep -E "^(${DISTRO_FILE_PREFIX}save|$DISTRO_PUPPYSFS|zdrv|fdrv|adrv|ydrv)"| tr "\n" ' ')
       save_bootconfig
       exit
     fi
-    # trim the excessives not to run rc.update
+    # trim the extra sfs's, to not run rc.update
     NEWUNIONRECORD=""
-    NEWEXTRASFSLIST=""
-    COUNT=0
     for F in $LASTUNIONRECORD; do
-      NEWUNIONRECORD="$NEWUNIONRECORD $F"
-      echo "$LOADEDLIST"| grep -qw $F || continue
-      NEWEXTRASFSLIST="$NEWEXTRASFSLIST $F"
-      COUNT=$(($COUNT + 1))
-      [ $COUNT -lt $MAXEXTRANUM ] && break
+      [ "$(echo "$LOADEDLIST" | grep $F)" ] || NEWUNIONRECORD="$NEWUNIONRECORD $F"
     done
     LASTUNIONRECORD=$NEWUNIONRECORD
-    EXTRASFSLIST=$NEWEXTRASFSLIST
     save_bootconfig
     exit
   fi


### PR DESCRIPTION
This is a fudge so that the "init" script doesn't have to handle extra sfs's in LASTUNIONRECORD.
Part of separating responsibility of sfs's:
init handles puppy...sfs, fdrv, zdrv, ydrv, adrv
sfs_load handles all extra sfs's