### PR TITLE
Dead link in PPM help

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/help.htm
+++ b/woof-code/rootfs-skeleton/usr/local/petget/help.htm
@@ -231,7 +231,7 @@ hard drive, it will consist of just three files, vmlinuz, initrd.gz and
 the main Puppy filesystem (for example precise-5.3.sfs). There is also a
  fourth file known as the "devx" (for example devx_precise_5.3.sfs). To 
 upgrade, all you do is replace those files. It is a totally different 
-system to a package-by-package upgrade. This page has more details: <a href="http://puppylinux.com/hard-puppy.htm">http://puppylinux.com/hard-puppy.htm</a> <br>
+system to a package-by-package upgrade. This page has more details: <a href="http://barryk.org/puppylinux/hard-puppy.htm">http://barryk.org/puppylinux/hard-puppy.htm</a> <br>
 <br>
 Regards,<br>
 


### PR DESCRIPTION
Is linking to old version wise? Or maybe creating a newer info page on puppylinux.com would be more appropriate? :octocat: 