### PR TITLE
dir2pet: pet.specs path; argument parsing; help output; compression default

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/dir2pet
+++ b/woof-code/rootfs-skeleton/usr/bin/dir2pet
@@ -18,36 +18,44 @@
 #131123 changed default to gzip, will change it back in a year or 2
 #141011 add command line args for unattended builds
 #160524 rerwin: correct search for top category in hierarchy.
+#160803 rerwin: correct pet.specs path; sync compression default; simplify parameter parsing
 
 usage() {
 	echo '
+Usage: dir2pet [option]... [<name-of-dir>]
+  
+Create a compressed file containing the content of a directory
+
+Options:
   -h|--help    show this help
   
--------------------------------------------------------------------------------
+--------------------------------------------------------------------
   
 Basic:
-  <name-of-dir>	the directory to be packaged. THIS IS THE PACKAGE.
+  <name-of-dir>	the directory, not path, to be packaged.
+                THIS IS THE PACKAGE.
+                (Omit if specified with -p option)
 
 EXAMPLE:
 # dir2pet my_fun_game-0.1-i486
 
--------------------------------------------------------------------------------
+--------------------------------------------------------------------
 
 Advanced:  
   -s	skip all questions - useful for package build scripts
-  -p	the directory of the program to be packaged. THIS IS THE PACKAGE.
+  -p=<name-of-dir>  directory to be packaged. THIS IS THE PACKAGE.
   
 THE following options are only useful with the "-s" option.
 For best results, use as many as possible: 
-
-Compression: (only use one, default if none chosen is "gz")
-  -x    use xz (high) compression
+' #160803
+	echo "Compression: (only use one, default if none chosen is \"$comp\")" #160803
+	echo '  -x    use xz (high) compression
   -g	use gz (low) compression
   
 Non-compulsory:
-  -w="<description>"	description of the application enclosed in "quotes"
-  -d=<+deps>	comma delimited dependencies, with prepended "+" sign
-  -c=<Category>	category of application; for package manager
+  -w="<description>"  quoted description of the application"
+  -d=<+deps>  comma-delimited dependencies, with prepended "+" sign
+  -c=<Category>  category of application; for package manager
   
 LIST of allowed Categories: (default: BuildingBlock)
 	Desktop
@@ -66,30 +74,28 @@ LIST of allowed Categories: (default: BuildingBlock)
 
 EXAMPLE
 # dir2pet -x -s -w="fun game" -d=+gtk+,+ffmpeg,+cairo -p=my_fun_game-0.1-i486
-'
+' #160803
 }
 
-comp=gz #default
+comp=gz #default - change only this to set new deault. #160803
+arch=`uname -m` #160803
+[ "${arch:0:3}" = "arm" ] && comp=gz #160803
+
 #parameters
-while [ $# != 0 ]; do
-	I=1
-	while [ $I -lt `echo $# | wc -c` ]; do
-		case $1 in
-			-x) comp=xz ;;
-			-g) comp=gz ;;
-			-s) skip=1 ;;
-			-w=*) desc="`echo "$1"|cut -d '=' -f2`" ;;
-			-d=*) deps=`echo $1|cut -d '=' -f2`;;
-			-c=*) category=`echo $1|cut -d '=' -f2`;;
-			-p=*) directory=`echo $1|cut -d '=' -f2`;;
-			[a-z]*|[A-Z]*)dir=$1;;
-			-h|--help|"") usage	 
-				exit;;
-			
-		esac
-		shift
-		I=$(($I+1))
-	done
+while [ $# -gt 0 ]; do #160803
+	case $1 in
+		-x) comp=xz ;;
+		-g) comp=gz ;;
+		-s) skip=1 ;;
+		-w=*) desc="`echo "$1"|cut -d '=' -f2`" ;;
+		-d=*) deps=`echo $1|cut -d '=' -f2`;;
+		-c=*) category=`echo $1|cut -d '=' -f2`;;
+		-p=*) directory=`echo $1|cut -d '=' -f2`;;
+		[a-zA-Z]*)dir=$1;; #160803
+		-h|--help|"") usage; exit;;
+		*) echo "Invalid argument: $1"; usage; exit;;
+	esac
+	shift #also decrements $# 160803
 done
 
 ISDIR=$dir
@@ -116,10 +122,10 @@ PUPCATEGORY=""
 PUPPATH="" #100201
 ARCHDEPENDENT="yes" #100201
 DEFREPO="" #100201
-if [ -f ${1}/pet.specs ];then
+if [ -f $DIRPKG/$BASEPKG/pet.specs ];then #160803
  #new: pkgname|nameonly|version|pkgrelease|category|size|path|fullfilename|dependencies|description|
  #optionally on the end: compileddistro|compiledrelease|repo| (fields 11,12,13)
- PETSPECS="`cat ${1}/pet.specs | head -n 1`"
+ PETSPECS="`cat $DIRPKG/$BASEPKG/pet.specs | head -n 1`" #160803
  DB_pkgname="`echo -n "$PETSPECS" | cut -f 1 -d '|'`"
  DB_nameonly="`echo -n "$PETSPECS" | cut -f 2 -d '|'`"
  NAMEONLY="$DB_nameonly"
@@ -171,9 +177,8 @@ clear
 	echo
 	echo "If any of the above needs to be further sorted out, you can quit this"
 	echo "script right now by pressing CTRL-C, otherwise just press ENTER"
-	arch=`uname -m`
 	default=xz char="g" other=gzip
-	[ "${arch:0:3}" = "arm" ] && default=gzip char="x" other=xz
+	[ "$comp" = "gz" ] && default=gzip char="x" other=xz #160803
 	echo "to use the default \"$default\" compression or \"$char\" then ENTER for "
 	echo "\"$other\" compression."
 	echo -n "Press ENTER key or \"$char\" and ENTER to continue: "


### PR DESCRIPTION
The pet.specs values were not being propagated to new pets.  Argument parsing seemed overly complicated and nonintuitive.  Edited parsing for more standard appearance.

Compression default was inconsistent, in that the xz value was used despite the help output stating 'gz' and 'gz' was used if the 'skip' option was set.  Now, the "comp" variable is used everywhere, with its value being overridden as 'gz' for the "arm" architecture.  It is now set to 'gz'.