### PR TITLE
frisbee: correct formatting of scan results for open networks

### DIFF
--- a/woof-code/rootfs-packages/frisbee/pet.specs
+++ b/woof-code/rootfs-packages/frisbee/pet.specs
@@ -1,1 +1,1 @@
-frisbee-1.4.1|frisbee|1.4.1||Network|264K||frisbee-1.4.1.pet||Frisbee network manager||||
+frisbee-1.4.2|frisbee|1.4.2||Network|208K||frisbee-1.4.2.pet|+gtkdialog&ge0.8.4|Frisbee network manager||||

--- a/woof-code/rootfs-packages/frisbee/usr/local/bin/frisbee
+++ b/woof-code/rootfs-packages/frisbee/usr/local/bin/frisbee
@@ -5,7 +5,7 @@
 
 #set -x; exec &>/tmp/debug.log #send feedback and trace to debug.log
 
-export VERSION='1.4.1'  #UPDATE this with each release!
+export VERSION='1.4.2'  #UPDATE this with each release!
 
 export TEXTDOMAIN=frisbee
 export OUTPUT_CHARSET=UTF-8

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/func
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/func
@@ -895,7 +895,7 @@ export -f   get_auth_alg
 function get_scan_results {
 	if_connected || return
 	wpa_cli -i $INTERFACE scan >/dev/null
-	wpa_cli scan_results -i $INTERFACE |grep ^..:..: | awk '{print $1"|"$2"|"$3"|"$5"|"$4}' #140607
+	wpa_cli scan_results -i $INTERFACE | grep ^..:..: | awk -F '\t' '{print $1"|"$2"|"$3"|"$5"|"$4}' #140607 160801
 	
 	for i in 1 2 3 4 5 6 7 8 9 10 11 ; do 
 	echo


### PR DESCRIPTION
Places SSID of open networks in same column as for encrypted networks.