### PR TITLE
Update quality_2.svg

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/pixmaps/puppy/quality_2.svg
+++ b/woof-code/rootfs-skeleton/usr/share/pixmaps/puppy/quality_2.svg
@@ -2,11 +2,11 @@
 <svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="100" width="100">
 
   <g style="fill:#ffffff;stroke:#222222;stroke-width:1.5;fill-opacity:0.4">
-    <rect style="fill:#09B209;fill-opacity:1" width="12" height="-15" x="2" y="98"/>
-    <rect style="fill:#09B209;fill-opacity:1" width="12" height="-35" x="22" y="98"/>
-    <rect width="12" height="-55" x="42" y="98"/>
-    <rect width="12" height="-76" x="62" y="98"/>
-    <rect width="12" height="-95" x="82" y="98"/>
+    <rect style="fill:#09B209;fill-opacity:1" width="12" height="15" x="2" y="83"/>
+    <rect style="fill:#09B209;fill-opacity:1" width="12" height="35" x="22" y="63"/>
+    <rect width="12" height="55" x="42" y="43"/>
+    <rect width="12" height="76" x="62" y="22"/>
+    <rect width="12" height="95" x="82" y="3"/>
   </g>
 
 </svg>


### PR DESCRIPTION
negative height is deprecated as of librsvg-2.40 https://github.com/puppylinux-woof-CE/woof-CE/issues/849