### PR TITLE
remove_builtin: fix handling of directory links & names with spaces

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/remove_builtin
+++ b/woof-code/rootfs-skeleton/usr/sbin/remove_builtin
@@ -6,6 +6,7 @@
 #110505 support sudo for non-root user.
 #120202 rodin.s: internationalized.
 #120329 Xdialog bug --yesno supposed to "yes" "No" buttons, but they are "OK" "Cancel".
+#160928 rerwin: correct handling of links to directories & names with spaces.
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
 
@@ -53,8 +54,22 @@ $(gettext 'For information only, these are dependencies of') '${PKG}':\n
 $(gettext 'Continue?')" 0 0
   if [ $? -eq 0 ];then
    [ "`grep '\.desktop$' ${D}/${PKG}`" != "" ] && FIXMENU='yes' #101222
-   for x in `cat $D/$PKG`; do [ -d $x ] && cd $x || rm $x; done
-   for x in `tac $D/$PKG`; do [ -d $x ] && [ ! "`ls $x`" ] && rmdir $x; done
+   for x in `cat $D/$PKG | tr ' ' '|'`; do #160928...
+    xx="`echo "$x" | tr '|' ' '`"
+    if [ "${xx:0:1}" = "/" ];then
+     if [ -h "$xx" ];then
+      rm "$xx"
+     elif [ -d "$xx" ];then
+      cd "$xx"
+     fi
+    else
+     rm "${xx:1}"
+    fi
+   done
+   for x in `tac $D/$PKG | tr ' ' '|'`; do
+    xx="`echo "$x" | tr '|' ' '`"
+    [ "${xx:0:1}" = "/" ] && [ -d "$xx" ] && [ ! "`ls "$xx"`" ] && rmdir "$xx"
+   done #160928 end
    rm $D/$PKG
    grep -v "$aREGEX" /root/.packages/woof-installed-packages > /tmp/woof-installed-packages-cut2
    mv -f /tmp/woof-installed-packages-cut2 /root/.packages/woof-installed-packages


### PR DESCRIPTION
pburn contains a link named "Burn with pBurn" that links to a directory and is not removed when the pburn package gets removed.  If the name lacked spaces, the removal would treat the link as it does for directories and would not remove it because the target directory is not empty (unless the directory is already deleted).  The fix supports spaces in all names and deletes the link.