### PR TITLE
fix for STOCK=puppy

### DIFF
--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/xml_button-icon
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/xml_button-icon
@@ -38,7 +38,7 @@ case $1 in
 		ICON="<input file stock=\"${1}\"></input>"
 		;;
 	*) 
-		#stock icon - use either Gtk-stock or Pyppy-stock
+		#stock icon - use either Gtk-stock or Puppy-stock
 		if [ "$STOCK" = "puppy" ]; then
 			if [ -s "/usr/share/pixmaps/puppy/${1}.svg" ]; then
 				ICON="<input file>/usr/share/pixmaps/puppy/${1}.svg</input>"

--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/xml_button-icon
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/xml_button-icon
@@ -39,8 +39,12 @@ case $1 in
 		;;
 	*) 
 		#stock icon - use either Gtk-stock or Pyppy-stock
-		if [ "$STOCK" = "puppy" ] && [ -s "/usr/share/pixmaps/puppy/${1}.svg" ]; then
-			ICON="<input file>/usr/share/pixmaps/puppy/${1}.svg</input>"
+		if [ "$STOCK" = "puppy" ]; then
+			if [ -s "/usr/share/pixmaps/puppy/${1}.svg" ]; then
+				ICON="<input file>/usr/share/pixmaps/puppy/${1}.svg</input>"
+			else
+				ICON="<input file stock=\"gtk-${1}\"></input>"
+			fi
 		else
 			#We have to check if icon is a part of active gtk-theme - if not, use Puppy stock
 			if [ "$(find /usr/share/icons/ -iname "*${1}*")" ]; then #gtk icon themes


### PR DESCRIPTION
If the user uses STOCK=puppy and no Puppy Icon Theme (old style), gtk-yes icon is still not found (Re: https://github.com/puppylinux-woof-CE/woof-CE/commit/ffe9957d609d48c2dafa046bcd4e8ceaddd275f4 ). In this scenario always falling back to gtk works better than a double fallback to non-existent puppy image and no find is needed.