### PR TITLE
Allow symlinks in build a .pet with all builtin files

### DIFF
--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -1306,7 +1306,7 @@ echo "which is a PET package with lists of all packages and files builtin to the
 rm -rf 0builtin_files_${DISTRO_FILE_PREFIX}-${DISTRO_VERSION} 2>/dev/null
 mkdir 0builtin_files_${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}
 mkdir /tmp/0builtin_files_${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}
-GENDIRS=$(find ../packages-${DISTRO_FILE_PREFIX} -maxdepth 1 -type d | sort)
+GENDIRS=$(find -H ../packages-${DISTRO_FILE_PREFIX} -maxdepth 1 -type d | sort)
 for ONEGENDIR in ${GENDIRS}
 do
  ONEGENNAME=${ONEGENDIR##*/} #basename $ONEGENDIR


### PR DESCRIPTION
Allows packages-${DISTRO_FILE_PREFIX} to be a symlink so that it can be shared between multiple builds