### PR TITLE
Remove Rox link creation

### DIFF
--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -1201,7 +1201,6 @@ if [ -f rootfs-complete/usr/local/bin/rox ] ; then
 	mv -f rootfs-complete/usr/local/bin/rox rootfs-complete/usr/local/bin/roxfiler
 fi
 ln -sv defaultfilemanager rootfs-complete/usr/local/bin/rox
-[ -f rootfs-complete/usr/local/bin/roxfiler ] && ln -sv roxfiler rootfs-complete/usr/local/bin/Rox
 sed -i 's|Exec=rox|Exec=roxfiler|' rootfs-complete/usr/share/applications/ROX-Filer-file-manager.desktop
 
 if [ "$JWM_XLOAD" = "no" ] ; then #build.conf


### PR DESCRIPTION
Rox was a LxPup only feature which is now redundant with the advent of roxfiler so it's creation can be deleted from 3builddistro