### PR TITLE
Add support for copying more things from woof-distro

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -151,10 +151,46 @@ for ONETOP in \
 `find woof-distro -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '` \
 `find woof-distro/${TARGETARCH} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '` \
 `find woof-distro/${TARGETARCH}/${COMPATDISTRO} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '` \
-`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION} -mindepth 1 -maxdepth 1 | tr '\n' ' '`
+`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '`
 do
 	cp -a -f --remove-destination $ONETOP ${WOOF_OUT}/
 done
+
+if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/packages-templates" ];then
+	echo "Copying woof-distro/${COMPATDISTRO}/${COMPATVERSION}/packages-templates..."
+	for ONEDIRECTORY in \
+	`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/packages-templates -mindepth 1 -maxdepth 1 -type d | tr '\n' ' '`
+	do
+		TEMPLATEDIR=`expr "$ONEDIRECTORY" : "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/packages-templates/\(.*\)"`
+		echo "    $TEMPLATEDIR"
+		if [ -n "$TEMPLATEDIR" -a -d "${WOOF_OUT}/packages-templates/${TEMPLATEDIR}" ];then
+			rm -r ${WOOF_OUT}/packages-templates/${TEMPLATEDIR}
+		fi
+		cp -a ${ONEDIRECTORY} ${WOOF_OUT}/packages-templates/
+	done
+fi
+if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-packages" ];then
+	echo "Copying woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-packages..."
+	for ONEDIRECTORY in \
+	`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-packages -mindepth 1 -maxdepth 1 -type d | tr '\n' ' '`
+	do
+		PACKAGEDIR=`expr "$ONEDIRECTORY" : "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-packages/\(.*\)"`
+		echo "    $PACKAGEDIR"
+		if [ -n "$PACKAGEDIR" -a -d "${WOOF_OUT}/rootfs-packages/${PACKAGEDIR}" ];then
+			rm -r ${WOOF_OUT}/rootfs-packages/${PACKAGEDIR}
+		fi
+		cp -a ${ONEDIRECTORY} ${WOOF_OUT}/rootfs-packages/
+	done
+fi
+if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton" ];then
+	echo "Copying woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton..."
+	SKELETONFILES=`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton/ -type f -printf '    %f\n'`
+	if [ -n "$SKELETONFILES" ];then
+		echo "$SKELETONFILES"
+		cp -a -f --remove-destination woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton/* ${WOOF_OUT}/rootfs-skeleton/
+	fi
+fi
+
 rm -f ${WOOF_OUT}/c_apps
 cp -a README ${WOOF_OUT}/README.TXT
 sync


### PR DESCRIPTION
Uses merge2out to overlay packages-templates, rootfs-packages and
rootfs-skeleton with files from woof-distro.