### PR TITLE
More Raspbian Jessie updates

### DIFF
--- a/woof-distro/arm/raspbian/jessie/DISTRO_PKGS_SPECS-raspbian-jessie
+++ b/woof-distro/arm/raspbian/jessie/DISTRO_PKGS_SPECS-raspbian-jessie
@@ -178,9 +178,9 @@ yes|grep|grep|exe,dev>null,doc,nls
 yes|groff|groff|exe>dev,dev,doc,nls
 yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls| #needs d-conf.
 yes|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
-yes|gtk+|libgtk2.0-0,libgtk2.0-dev|exe,dev,doc,nls
+yes|gtk+|libgtk2.0-0,libgtk2.0-dev,libgtk2.0-common|exe,dev,doc>null,nls>null
 yes|gtk2-engines-pixbuf|gtk2-engines-pixbuf|exe,dev,doc,nls
-yes|gtk3|libgtk-3-0,libgtk-3-dev|exe,dev,doc,nls
+yes|gtk3|libgtk-3-0,libgtk-3-dev,libgtk-3-common|exe,dev,doc>null,nls>null
 yes|gtkam|gtkam|exe,dev>null,doc,nls|
 yes|gtk-chtheme|gtk-chtheme|exe,dev>null,doc,nls
 yes|gtkdialog||exe,dev,doc>dev,nls|

--- a/woof-distro/arm/raspbian/jessie/DISTRO_SPECS
+++ b/woof-distro/arm/raspbian/jessie/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Raspberry Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.0.2
+DISTRO_VERSION=6.0.3
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='raspbian'
 #Prefix for some filenames: exs: raspupsave.2fs, raspup-4.99.0.sfs

--- a/woof-distro/arm/raspbian/jessie/rootfs-skeleton/usr/sbin/gtkdialog3
+++ b/woof-distro/arm/raspbian/jessie/rootfs-skeleton/usr/sbin/gtkdialog3
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec gtkdialog "$@"

--- a/woof-distro/arm/raspbian/jessie/rootfs-skeleton/usr/sbin/gtkdialog4
+++ b/woof-distro/arm/raspbian/jessie/rootfs-skeleton/usr/sbin/gtkdialog4
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec gtkdialog "$@"


### PR DESCRIPTION
Thanks for the suggestion about libgtk-3-common.
The net_setup pet still uses gtkdialog3.