### PR TITLE
Add support for applying patches in merge2out

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -190,6 +190,15 @@ if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skele
 		cp -a -f --remove-destination woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton/* ${WOOF_OUT}/rootfs-skeleton/
 	fi
 fi
+if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/patches" ];then
+	echo "Applying patches from woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/patches..."
+	for PATCHFILE in \
+	`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/patches -mindepth 1 -maxdepth 1 -type f -iname '*.patch' | tr '\n' ' '`
+	do
+		echo "    $PATCHFILE"
+		patch --unified --forward --silent --input="../woof-CE/$PATCHFILE" --directory=${WOOF_OUT}
+	done
+fi
 
 rm -f ${WOOF_OUT}/c_apps
 cp -a README ${WOOF_OUT}/README.TXT


### PR DESCRIPTION
Uses merge2out to apply patches from
woof-distro/TARGETARCH/COMPATDISTRO/COMPATVERSION/patches

I also have an edited version of mavrothal's patch-generator.sh at  
https://github.com/woodenshoe-wi/woof-tools
If puppylinux-woof-CE wants to fork woof-tools let me know and I will delete it afterwards, that should make puppylinux-woof-CE the owner of woof-tools.