### PR TITLE
Update raspbian/jessie to 6.0.4

### DIFF
--- a/woof-distro/arm/raspbian/jessie/DISTRO_PKGS_SPECS-raspbian-jessie
+++ b/woof-distro/arm/raspbian/jessie/DISTRO_PKGS_SPECS-raspbian-jessie
@@ -117,7 +117,7 @@ yes|file|file,libmagic1,libmagic-dev|exe,dev,doc,nls
 yes|findutils|findutils|exe,dev>null,doc,nls
 yes|firmware_linux_module_b43||exe #120919 have taken these out of woof, now pets.
 yes|firmware_linux_module_b43legacy||exe
-yes|firmware_linux_module_brcm||exe
+yes|firmware_linux_module_brcm_pi3||exe
 yes|firmware_linux_module_wl||exe
 yes|flac|flac,libflac8,libflac-dev|exe,dev,doc,nls
 yes|flex|flex|exe>dev,dev,doc,nls

--- a/woof-distro/arm/raspbian/jessie/DISTRO_SPECS
+++ b/woof-distro/arm/raspbian/jessie/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Raspberry Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.0.3
+DISTRO_VERSION=6.0.4
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='raspbian'
 #Prefix for some filenames: exs: raspupsave.2fs, raspup-4.99.0.sfs

--- a/woof-distro/arm/raspbian/jessie/patches/no-delete-brcm_pi3.patch
+++ b/woof-distro/arm/raspbian/jessie/patches/no-delete-brcm_pi3.patch
@@ -1,0 +1,11 @@
+--- 3builddistro-Z	2016-12-12 15:29:12.000000000 -0600
++++ ../../woof-out_x86_arm_raspbian_jessie/3builddistro-Z	2016-12-12 16:45:02.000000000 -0600
+@@ -1383,7 +1383,7 @@
+ echo "Removing redundant firmware as it is in the z drive"
+ rm -rf rootfs-complete/lib/firmware 2>/dev/null
+ #150624 remove redundant stuff from 'all-firmware'
+-for fw in agrsm hso iwlwifi libertas* madwifi* mwl8k mwave* nozomi RTL8192E rt2x00 rtl_nic rtlwifi brcm;do
++for fw in agrsm hso iwlwifi libertas* madwifi* mwl8k mwave* nozomi RTL8192E rt2x00 rtl_nic rtlwifi;do
+ 	echo "removing $fw"
+ 	rm -rf rootfs-complete/lib/modules/all-firmware/${fw} 2>/dev/null
+ done


### PR DESCRIPTION
Add firmware for Pi3 wifi.
raspbian/jessie/patches/no-delete-brcm_pi3.patch is only needed
for raspberry pi builds because they do not have a z drive.

I did a test build and everything seems to work fine with xorg_base_new except I can no longer CTRL+ALT+BACKSPACE to exit X.  I can still CTRL+ALT+F2 to get to the command line so it is not a problem if this is intentional, but /etc/X11/xorg.conf still has `Option "DontZap" "false"`