### PR TITLE
Update raspbian/jessie to 6.0.5

### DIFF
--- a/woof-distro/arm/raspbian/jessie/DISTRO_PKGS_SPECS-raspbian-jessie
+++ b/woof-distro/arm/raspbian/jessie/DISTRO_PKGS_SPECS-raspbian-jessie
@@ -115,6 +115,11 @@ yes|ffconvert||exe,dev,doc,nls
 no|ffmpeg|ffmpeg|exe,dev,doc,nls
 yes|file|file,libmagic1,libmagic-dev|exe,dev,doc,nls
 yes|findutils|findutils|exe,dev>null,doc,nls
+yes|firmware-atheros|firmware-atheros|exe
+yes|firmware-brcm80211|firmware-brcm80211|exe
+yes|firmware-libertas|firmware-libertas|exe
+yes|firmware-ralink|firmware-ralink|exe
+yes|firmware-realtek|firmware-realtek|exe
 yes|firmware_linux_module_b43||exe #120919 have taken these out of woof, now pets.
 yes|firmware_linux_module_b43legacy||exe
 yes|firmware_linux_module_brcm_pi3||exe

--- a/woof-distro/arm/raspbian/jessie/DISTRO_SPECS
+++ b/woof-distro/arm/raspbian/jessie/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Raspberry Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.0.4
+DISTRO_VERSION=6.0.5
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='raspbian'
 #Prefix for some filenames: exs: raspupsave.2fs, raspup-4.99.0.sfs


### PR DESCRIPTION
Since /lib/firmware is not deleted for arm builds now,
Add firmware debs for USB wifi adapters.

I did discover a problem with loading firmware from /lib/modules/all-firmware when using two different kernels.  On the first boot /etc/modules/firmware.dep gets renamed to firmware.dep._kernel-version_.  When the SD card is booted in a Pi that needs the other kernel version there is no firmware.dep file to rename and /sbin/pup-event-backend-modprobe can't find firmware.dep._kernel-version_ for the other kernel.

I don't know if the best solution is to copy firmware.dep instead of renaming it or to move the Pi3 wifi firmware to /lib/firmware and give up on using /lib/modules/all-firmware for arm builds.