### PR TITLE
woof-code/support/findpkgs

### DIFF
--- a/woof-code/support/findpkgs
+++ b/woof-code/support/findpkgs
@@ -334,6 +334,12 @@ search_func() {
 				#in wary, i have many pkgs that are _DEV only, need to find these, a hack fix to find most...
 				if [ ! "$FNDSPECS" ] ; then
 					FNDSPECS="`grep "$devnamePTN" $STATUSDIR/$PKGLIST-cols | grep "$acompiledPTN"`"
+					if [ "$FNDSPECS" ] ; then # if devnamePTN was found,
+						# but namePTN exists with a different acompiledPTN
+						if [ "`grep "$namePTN" $STATUSDIR/$PKGLIST-cols`" ] ; then
+							FNDSPECS='' # do not include devnamePTN
+						fi
+					fi
 					[ "$excludePTNS" ] && [ "$FNDSPECS" ] && \
 						FNDSPECS="`echo "$FNDSPECS" | grep -v -f /tmp/findpkgs_tmp/excludePTNS`"
 				fi


### PR DESCRIPTION
If a _DEV version of a pet is found before the main pet ignore it.

See issue #933