### PR TITLE
Move initrd-progs/0sources to local-repositories

### DIFF
--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -728,6 +728,7 @@ echo "Now building initial ramdisk in initrd-tree/..."
 rm -rf initrd-progs initrd-tree
 cp -a ../initrd-progs ./initrd-progs
 ln -s ./initrd-progs/0initrd initrd-tree
+ln -sf ../../initrd-progs/0sources ./initrd-progs/0sources
 cp ../DISTRO_SPECS ./initrd-tree/
 
 #101027 Iguleder reported DISTRO_SPECS did not have a carriage-return on last line...

--- a/woof-code/_00func
+++ b/woof-code/_00func
@@ -84,6 +84,8 @@ function create_local_repos_dirs() {
 	set_binaries_var
 	mkdir -p ../local-repositories/${WOOF_TARGETARCH}/packages-${BINARIES}
 	[ ! -e packages-${BINARIES} ] && ln -s ../local-repositories/${WOOF_TARGETARCH}/packages-${BINARIES} packages-${BINARIES} # check exist.
+	mkdir -p ../local-repositories/initrd-progs/0sources
+	[ ! -e initrd-progs/0sources ] && ln -s ../../local-repositories/initrd-progs/0sources initrd-progs/0sources # check exist.
 	if [ "$DISTRO_TARGETARCH" = "arm" ]; then
 		mkdir -p ../local-repositories/${WOOF_TARGETARCH}/sd-skeleton-images
 		[ ! -e sd-skeleton-images ] && ln -s ../local-repositories/${WOOF_TARGETARCH}/sd-skeleton-images sd-skeleton-images


### PR DESCRIPTION
No need to re-download initrd_progs every time merge2out is run.
Only tested in an arm build, but I still get an initrd.gz in
sandbox3/build