### PR TITLE
remove libtsan0 from x86 xenialpup?

### DIFF
--- a/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
+++ b/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
@@ -254,7 +254,7 @@ yes|galculator||exe,dev,doc,nls
 yes|gamin|gamin,libgamin0,libgamin-dev|exe,dev,doc,nls
 yes|gawk|gawk|exe,dev,doc,nls
 yes|gcc_dev|gcc-5-base,gcc,gcc-5,g++,g++-5,cpp,cpp-5|exe>dev,dev,doc,nls
-yes|gcc_lib|libasan0,libatomic1,libcloog-isl4,libgcc1,libgcc-5-dev,libgomp1,libisl15,libitm1,libquadmath0,libtsan0|exe,dev,doc,nls
+yes|gcc_lib|libasan0,libatomic1,libcloog-isl4,libgcc1,libgcc-5-dev,libgomp1,libisl15,libitm1,libquadmath0|exe,dev,doc,nls
 no|gccmakedep||exe>dev,dev,doc,nls
 yes|gcolor2|gcolor2|exe,dev>null,doc,nls
 yes|gconf|gconf2-common,gconf2,libgconf2-4,libgconf2-dev,libgconf-2-4,gconf-service,gconf-service-backend|exe,dev,doc,nls

--- a/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
+++ b/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
@@ -80,7 +80,7 @@ yes|bbc_provided||exe
 yes|bbe|bbe|exe,dev,doc,nls| #sed-like editor for binary files.
 yes|bc|bc|exe,dev>null,doc,nls
 yes|bcrypt||exe
-yes|bdb|libdb53,libdb-dev,libdb5.3-dev|exe,dev,doc,nls
+yes|bdb|libdb5.3,libdb-dev,libdb5.3-dev|exe,dev,doc,nls
 yes|bin86|bin86|exe>dev,dev,doc,nls
 yes|binutils|binutils,binutils-dev|exe>dev,dev,doc,nls
 no|binutils||exe>dev,dev,doc,nls

--- a/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
+++ b/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
@@ -80,7 +80,7 @@ yes|bbc_provided||exe
 yes|bbe|bbe|exe,dev,doc,nls| #sed-like editor for binary files.
 yes|bc|bc|exe,dev>null,doc,nls
 yes|bcrypt||exe
-yes|bdb|libdb5.3,libdb-dev,libdb5.3-dev|exe,dev,doc,nls
+yes|bdb|libdb53,libdb-dev,libdb5.3-dev|exe,dev,doc,nls
 yes|bin86|bin86|exe>dev,dev,doc,nls
 yes|binutils|binutils,binutils-dev|exe>dev,dev,doc,nls
 no|binutils||exe>dev,dev,doc,nls
@@ -643,7 +643,7 @@ no|mscw||exe|pet:tahr #multiple sound card wizard.
 yes|ms-sys||exe
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls| #needed by synaptics_drv.so in xorg.
 no|mtpaint|mtpaint|exe,dev,doc,nls| #no, very old version (3.34).
-yes|mtpaint||exe,dev,doc,nls|pet:tahr
+yes|mtPaint||exe,dev,doc,nls|pet:tahr
 no|mtpaint-help||exe
 yes|mtp_phone_connect||exe,dev,doc,nls|
 yes|mtr||exe

--- a/woof-distro/x86/ubuntu/xenial/Packages-puppy-xenial-official
+++ b/woof-distro/x86/ubuntu/xenial/Packages-puppy-xenial-official
@@ -87,6 +87,7 @@ pburn-4.3.16|pburn|4.3.16||Multimedia|396K||pburn-4.3.16.pet|+gtkdialog&ge0.8.4,
 pmcputemp-0.63-i686|pmcputemp|0.63-i686||System|68K||pmcputemp-0.63-i686.pet||simple tray cpu temperature monitor|ubuntu|trusty||
 pmcputemp_DOC-0.60-i686_ta|pmcputemp_DOC|0.60-i686_ta||BuildingBlock|24K||pmcputemp_DOC-0.60-i686_ta.pet|+pmcputemp|pmcputemp manual page||||
 pmcputemp_NLS-0.60-i686_ta|pmcputemp_NLS|0.60-i686_ta||BuildingBlock|92K||pmcputemp_NLS-0.60-i686_ta.pet|+pmcputemp|pmcputemp locales||||
+qbat-0.2.2|qbat|0.2.2||BuildingBlock|136K||qbat-0.2.2.pet||qt5 battery monitor|ubuntu|xenial||
 rubix-1.0.6-i686|rubix|1.0.6-i686||Fun|124||rubix-1.0.6-i686.pet||small rubiks cube game|ubuntu|xenial||
 samba-4.4.2-i686|samba|4.4.2-i686||Network|54916||samba-4.4.2-i686.pet||share files with M.S. Windows|ubuntu|xenial||
 samba_DEV-4.4.2-i686|samba_DEV|4.4.2-i686||Network|12668||samba_DEV-4.4.2-i686.pet|+samba|samba development|ubuntu|xenial||


### PR DESCRIPTION
Apparently this cannot be found in 32-bit builds because it doesn't exist
http://www.murga-linux.com/puppy/viewtopic.php?p=918353#918353
http://packages.ubuntu.com/search?arch=any&searchon=names&keywords=libtsan