### PR TITLE
Update raspbian/stretch to 7.0.2

### DIFF
--- a/woof-distro/arm/raspbian/stretch/DISTRO_PKGS_SPECS-raspbian-stretch
+++ b/woof-distro/arm/raspbian/stretch/DISTRO_PKGS_SPECS-raspbian-stretch
@@ -64,6 +64,7 @@ yes|caps|caps|exe,dev,doc,nls| #needed by zigberts pequalizer, refer t=31206&sta
 yes|cdparanoia|cdparanoia,libcdparanoia0,libcdparanoia-dev|exe,dev,doc,nls
 yes|cdrkit|genisoimage,icedax|exe,dev,doc,nls
 yes|chmlib|libchm1,libchm-bin|exe,dev,doc,nls| #pzchmview is gui frontend.
+yes|cifs-utils|cifs-utils|exe,dev,doc,nls
 yes|coreutils|coreutils|exe,dev>null,doc,nls
 yes|cmake|cmake,cmake-data,libuv1|exe>dev,dev,doc,nls
 yes|cpio|cpio|exe,dev>null,doc,nls
@@ -114,7 +115,7 @@ yes|expat|libexpat1,libexpat1-dev|exe,dev,doc,nls
 yes|f2fs-tools||exe,dev,doc,nls
 yes|faad|faad,libfaad2,libfaad-dev|exe,dev,doc,nls
 yes|ffconvert||exe,dev,doc,nls
-yes|ffmpeg|ffmpeg,libswresample2,libswresample-dev,libzmq5|exe,dev,doc,nls
+yes|ffmpeg|ffmpeg,libswresample2,libswresample-dev,libzmq5,libopenmpt0|exe,dev,doc,nls
 yes|file|file,libmagic-mgc,libmagic1,libmagic-dev|exe,dev,doc,nls
 yes|findutils|findutils|exe,dev>null,doc,nls
 yes|firmware-atheros|firmware-atheros|exe
@@ -315,7 +316,8 @@ yes|libical|libical2,libical-dev|exe,dev,doc,nls
 yes|libicu|libicu57,libicu-dev|exe,dev,doc,nls
 yes|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls
 yes|libidl|libidl-2-0,libidl-dev|exe,dev,doc,nls
-yes|libidn|libidn11,libidn11-dev|exe,dev,doc,nls
+yes|libidn|libidn11|exe,dev,doc,nls
+yes|libidn2|libidn2-0,libidn2-0-dev|exe,dev,doc,nls
 yes|libiec61883|libiec61883-0,libiec61883-dev|exe,dev,doc,nls
 yes|libieee1284|libieee1284-3,libieee1284-3-dev|exe,dev,doc,nls
 yes|libjpeg62|libjpeg62-turbo|exe,dev,doc,nls
@@ -323,7 +325,7 @@ yes|libjpeg8|libjpeg8|exe,dev,doc,nls
 yes|libjpeg|libjpeg9,libjpeg9-dev,libjpeg-progs|exe,dev,doc,nls
 yes|libjson-glib|libjson-glib-1.0-0,libjson-glib-dev|exe,dev,doc,nls
 yes|libldb|libldb1,libldb-dev|exe,dev,doc,nls
-yes|libllvm|libllvm3.8|exe,dev,doc,nls
+yes|libllvm|libllvm3.9|exe,dev,doc,nls
 yes|libloudmouth|libloudmouth1-0,libloudmouth1-dev|exe,dev,doc,nls
 yes|libltdl|libltdl7,libltdl-dev|exe,dev,doc,nls| #note, this is really part of libtool pkg, but libs needed at runtime.
 yes|liblua|liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
@@ -454,6 +456,7 @@ yes|mpscan||exe,dev,doc,nls| #needed by pcurlftp_file_sharing.
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls| #needed by synaptics_drv.so in xorg.
 yes|mtpaint|mtpaint|exe,dev,doc,nls
 yes|mtr|mtr|exe,dev,doc,nls
+yes|nbd-client|nbd-client|exe>dev,dev,doc,nls
 yes|nbtscan|nbtscan|exe,dev,doc,nls
 yes|ncurses|ncurses-base,ncurses-bin,libncurses5,libncurses5-dev,libncursesw5,libncursesw5-dev,libtinfo5,libtinfo-dev|exe,dev,doc,nls
 yes|ndiswrapper|ndiswrapper-dkms|exe,dev>null,doc,nls

--- a/woof-distro/arm/raspbian/stretch/DISTRO_SPECS
+++ b/woof-distro/arm/raspbian/stretch/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Raspberry Puppy'
 #version number of this distribution:
-DISTRO_VERSION=7.0.1
+DISTRO_VERSION=7.0.2
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='raspbian'
 #Prefix for some filenames: exs: raspupsave.2fs, raspup-4.99.0.sfs

--- a/woof-distro/arm/raspbian/stretch/_00build.conf
+++ b/woof-distro/arm/raspbian/stretch/_00build.conf
@@ -46,7 +46,7 @@ KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 #KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-3.14.55-slacko_noPAE.tar.bz2
 
 ## compression method to be used (SFS files)
-SFSCOMP='-comp xz -Xbcj x86 -b 512K'
+SFSCOMP='-comp xz -Xbcj arm -b 512K'
 #SFSCOMP='-comp xz'
 #SFSCOMP='-comp gzip'
 #SFSCOMP='-noI -noD -noF -noX'


### PR DESCRIPTION
 - Add cifs-utils, mounting samba shares now works.
 - Add nbd-client to devx, I use this for network swap
   when making pets xz needs more RAM than a pi1 has.
 - Changed SFSCOMP to arm instead of x86.
 - Update a few missing dependencies.