### PR TITLE
glib and zzz_glib conflict

### DIFF
--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -174,7 +174,7 @@ yes|gifsicle|gifsicle|exe,dev>null,doc>null,nls>null
 yes|git|git|exe>dev,dev,doc>null,nls>null
 no|glade3|glade,libgladeui-2-4,libgladeui-common,libgladeui-dev|exe>dev,dev,doc>null,nls>null #needs gtk3. note, have libglade-2.so runtime that does not need gtk3.
 yes|glade2|glade,libgladeui-2-6,libgladeui-common,libgladeui-dev|exe>dev,dev,doc>null,nls>null
-yes|glib|libglib2.0-bin,libglib2.0-0,libglib2.0-data,libglib2.0-dev|exe,dev,doc>null,nls>null
+##yes|glib|libglib2.0-bin,libglib2.0-0,libglib2.0-data,libglib2.0-dev|exe,dev,doc>null,nls>null #does not work with pup-volume-monitor and should not be used if pup-volume-monitor is installed
 yes|glibc|libc-bin,libc6,libc6-dev,tzdata|exe,dev,doc>null,nls>null
 yes|glibc_locales|locales|exe,dev,doc>null,nls>exe
 yes|gmeasures||exe,dev>null,doc>null,nls>null


### PR DESCRIPTION
Things seem to work better (but still a few terminal warnings) without debian version of glib. Thanks to pemasu
http://murga-linux.com/puppy/viewtopic.php?p=946215#946215