### PR TITLE
add jwm-xdgmenu for fixmenus

### DIFF
--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -631,7 +631,7 @@ yes|x265|libx265-95,libx265-dev|exe,dev,doc>null,nls>null
 yes|xarchive||exe
 yes|xclip|xclip|exe,dev,doc>null,nls>null
 yes|xdelta||exe
-yes|xdg_puppy||exe
+yes|xdg_puppy_jwm||exe
 yes|xdotool|xdotool,libxdo3|exe,dev,doc>null,nls>null
 yes|xdialog||exe
 yes|xfdiff-cut||exe


### PR DESCRIPTION
"xdg_puppy" downloads:
http://distro.ibiblio.org/puppylinux/pet_packages-common/xdg_puppy-0.7.6-15-binaries_no-JWM-p4.pet
"xdg_puppy_jwm" downloads:
http://distro.ibiblio.org/puppylinux/pet_packages-common/xdg_puppy_jwm-0.7.6-16-i486.pet

2nd one has jwm-xdgmenu (needed for fixmenus by default), so I changed to xdg_puppy_jwm.
1st has fvwm-xdgmenu, icewm-xdgmenu and wm-xdgmenu only. Should that be kept too? :D