### PR TITLE
radkys fix for rox pinboard error and resulting mayhem.

### DIFF
--- a/woof-code/rootfs-packages/wallpaper/usr/local/apps/Wallpaper/set_bg
+++ b/woof-code/rootfs-packages/wallpaper/usr/local/apps/Wallpaper/set_bg
@@ -6,11 +6,11 @@ APPDIR=`dirname "$0"`
 cd "${APPDIR}"
 APPDIR="`pwd`"
 cd "${CURDIR}"
-
+	
 if [ "$1" = "-clear" ];then
- cat $HOME/.config/rox.sourceforge.net/ROX-Filer/pb_default | grep -v '<backdrop' > $HOME/.config/wallpaper/pb
- mv -f $HOME/.config/wallpaper/pb $HOME/.config/rox.sourceforge.net/ROX-Filer/pb_default
- rox -p=default
+ cat $HOME/Choices/ROX-Filer/PuppyPin | grep -v '<backdrop' > /tmp/tmp
+ mv -f /tmp/tmp $HOME/Choices/ROX-Filer/PuppyPin
+ rox -p=$HOME/Choices/ROX-Filer/PuppyPin
  echo "[none]" > $HOME/.config/wallpaper/bg_img
  exit
 fi
@@ -25,6 +25,7 @@ MODE="`cat $HOME/.config/wallpaper/backgroundmode`"
 if [ -x /usr/sbin/background_reshape ];then #legacy compatibility
  if [ "$MODE" = "Stretch" ];then
   /usr/sbin/background_reshape ${1}
+  feh --bg-scale $1
  fi
 fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/set_bg
+++ b/woof-code/rootfs-skeleton/usr/sbin/set_bg
@@ -1,6 +1,4 @@
 #!/bin/sh
-#100704 this was originally in Nathan's Wallpaper package.
-# called by 'pwallpaper' wallpaper setter.
 
 # Determine the path to this application.
 CURDIR="`pwd`"
@@ -8,11 +6,11 @@ APPDIR=`dirname "$0"`
 cd "${APPDIR}"
 APPDIR="`pwd`"
 cd "${CURDIR}"
-
+	
 if [ "$1" = "-clear" ];then
- grep -v '<backdrop' $HOME/.config/rox.sourceforge.net/ROX-Filer/pb_default  > $HOME/.config/wallpaper/pb
- mv -f $HOME/.config/wallpaper/pb $HOME/.config/rox.sourceforge.net/ROX-Filer/pb_default
- rox -p=default
+ cat $HOME/Choices/ROX-Filer/PuppyPin | grep -v '<backdrop' > /tmp/tmp
+ mv -f /tmp/tmp $HOME/Choices/ROX-Filer/PuppyPin
+ rox -p=$HOME/Choices/ROX-Filer/PuppyPin
  echo "[none]" > $HOME/.config/wallpaper/bg_img
  exit
 fi
@@ -24,8 +22,11 @@ MODE="`cat $HOME/.config/wallpaper/backgroundmode`"
 
 #w482 BK now have script that truncates an image vertically so that it has the right dimensions
 #for a widescreen...
-if [ "$MODE" = "Stretch" ];then
- /usr/sbin/background_reshape ${1}
+if [ -x /usr/sbin/background_reshape ];then #legacy compatibility
+ if [ "$MODE" = "Stretch" ];then
+  /usr/sbin/background_reshape ${1}
+  feh --bg-scale $1
+ fi
 fi
 
 rox --RPC << EOF


### PR DESCRIPTION
thr error was "No pinboard …was in use... the 'Default' pinboard has been selected. Use 'rox -p=Default' to turn it on in future." and caused two pinboards to be active at the same time!

 feh --bg-scale $1 is a fix for conky transparency  to change on background changes
