### PR TITLE
Change mount for /dev/pts

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -244,7 +244,7 @@ ln -sv /proc/mounts /etc/mtab
 
 #120503 if kernel mounts a f.s. on /dev, removes my skeleton /dev
 mkdir -p /dev/pts
-mount -o dev,suid /dev/pts ;STATUS=$((STATUS+$?))
+mount -t devpts -o dev,suid,gid=2,mode=620 none /dev/pts ;STATUS=$((STATUS+$?))
 
 mkdir /sys 2>/dev/null
 mount -t sysfs none /sys ;STATUS=$((STATUS+$?))


### PR DESCRIPTION
The /dev/pts mount is the only one in rc.sysinit that relies on an entry in /etc/fstab. The change make this mount compatible with the other mounts in rc.sysinit. End result and behaviour is identical.