### PR TITLE
devuan: fix +autopoint and use more recent "file"

### DIFF
--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -48,7 +48,7 @@ yes|audiofile|libaudiofile1,libaudiofile-dev|exe,dev,doc>null,nls>null
 yes|audit|libaudit-common,libaudit1,libaudit-dev|exe,dev,doc>null,nls>null #needed by xorg.
 yes|autoconf|autoconf|exe>dev,dev,doc>null,nls>null
 yes|automake|automake,autotools-dev|exe>dev,dev,doc>null,nls>null
-+yes|autopoint|autopoint|exe>dev,dev,doc>null,nls>null
+yes|autopoint|autopoint|exe>dev,dev,doc>null,nls>null
 yes|avahi|libavahi-client3,libavahi-client-dev,libavahi-glib1,libavahi-glib-dev,libavahi-common3,libavahi-common-data,libavahi-common-dev,libavahi-compat-libdnssd1,libavahi-compat-libdnssd-dev|exe,dev,doc>null,nls>null
 yes|axel|axel|exe,dev>null,doc>null,nls>null
 ##--yes|baconrecorder||exe,dev
@@ -131,8 +131,8 @@ yes|faac|libfaac0|exe,dev,doc>null,nls>null
 yes|faad|faad,libfaad2|exe,dev,doc>null,nls>null
 yes|ffconvert||exe,dev,doc>null,nls>null
 yes|ffmpeg|ffmpeg,libavcodec57,libavcodec-extra57,libavcodec-dev,libavutil55,libavdevice57,libavdevice-dev,libswresample2,libswresample-dev,libavresample3,libavresample-dev,libavfilter-extra6,libpostproc54,libpostproc-dev,libavutil-dev,libavutil-dev,libavformat57,libavformat-dev,libavdevice-dev,libavfilter6,libavfilter-dev,libbs2b0,libbs2b-dev,libflite1,libgme0,libiec61883-0,libjack-jackd2-0,libjack-jackd2-dev,libnuma1,libnuma-dev,libopenal1,libopenal-data,libopenal-dev,libshine3,libshine-dev,libsnappy1v5,libsodium18,libsodium-dev,libsoxr0,libsoxr-dev,libssh-gcrypt-4,libssh-gcrypt-dev,libswscale4,libswscale-dev,libwavpack1,libwavpack-dev,libzmq5,libsndio6.1,libsndio-dev,libsdl2-2.0-0,libsdl2-dev,libavc1394-0,libtwolame0,libmodplug1,librubberband2,libebur128-1,libass5,libass-dev,libchromaprint1,libzvbi0,libzvbi-common,libwebpmux2,libwebp6,libcrystalhd3,libjson-c3,libjson-c-dev,libspeex1,libcaca0,libopenmpt0,libmpg123-0,libpgm-5.2-0|exe,dev,doc>null,nls>null
-no|file|file,libmagic1,libmagic-mgc,libmagic-dev|exe,dev,doc>null,nls>null #libmagic is big..
-yes|file||exe,dev,doc>null,nls>null
+yes|file|file,libmagic1,libmagic-mgc,libmagic-dev|exe,dev,doc>null,nls>null #libmagic is big..
+no|file||exe,dev,doc>null,nls>null
 yes|file_sharing-curlftpfs-mpscan||exe
 yes|findutils|findutils|exe,dev>null,doc>null,nls>null
 yes|firmware_linux_module_b43||exe| #120919 have taken these out of woof, now pets.


### PR DESCRIPTION
file-5.30 (devuan ascii) is working for me instead of file-5.03w5 (wary5) and recognizes more file types. It is ~140k larger squashed but I think the trade-off is OK, do you agree? :laughing: