### PR TITLE
sns: sort wireless network display, fix icon name

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -830,7 +830,7 @@ network={
         <window title="'$(gettext 'SNS: Simple Network Setup')'" icon-name="gtk-network">
         <vbox>
           <frame>
-            '"`/usr/lib/gtkdialog/xml_pixmap dialog-complete popup`"'
+            '"`/usr/lib/gtkdialog/xml_pixmap dialog-complete.svg popup`"'
             <text use-markup="true"><label>"<b>'$(gettext 'Successful connection to wireless network')' '${CELL_ESSID}'</b>"</label></text>
             <text><label>""</label></text>
             '${XML_FIREWALL}'

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -32,7 +32,7 @@
 #170402 change check for dhcpcd success, to rely on dhcpcd exit code.
 #170505 use current ifplugstatus (0.28) with 0.18 as alternative if present; correct profile deletion; save connect splash pid for rc.network to kill; rename main dialog with prefix, for kill.
 #170514 add message about already running.
-#170522 display networks in order of signal quality.
+#170522 display networks in order of signal quality. 
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -31,7 +31,8 @@
 #170329 rerwin: set as current network exec, retaining previous exec name.
 #170402 change check for dhcpcd success, to rely on dhcpcd exit code.
 #170505 use current ifplugstatus (0.28) with 0.18 as alternative if present; correct profile deletion; save connect splash pid for rc.network to kill; rename main dialog with prefix, for kill.
-#170514 add message about already running
+#170514 add message about already running.
+#170522 display networks in order of signal quality.
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -469,12 +470,12 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
    WIN2MSG1="$(gettext "Choose which network you want to use, type of encryption, then click <b>Connect</b> button.")"
    RADIOBUTTONS='
    <hbox space-expand="true" space-fill="true">
-     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons`'</vbox>
+     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons | sort -t : -k 4 -n -r`'</vbox>
      <text space-expand="true" space-fill="true"><label>""</label></text>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_shield`'</vbox>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_strength`'</vbox>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_address`'</vbox>
-   </hbox>'
+   </hbox>' #170522
    FRAME1='
     <vbox space-expand="true" space-fill="true">
     <frame '$(gettext 'Wireless networks')'>


### PR DESCRIPTION
The "signal quality" commits are redundant -- the last can be ignored/rejected.
Why is line 834:
'"`/usr/lib/gtkdialog/xml_pixmap dialog-complete.svg popup`"'
while line 979 is:
'"`/usr/lib/gtkdialog/xml_pixmap dialog-complete popup`"' ?
They both appear to be treated the same way by /usr/lib/gtkdialog/xml_pixmap.  And none of the other "dialog-" files have the .svg.  What is that all about?