### PR TITLE
sns: Do not overflow the display

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -400,7 +400,7 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
    CELL_CHANNEL="`echo -n "$ONELINE" | grep -o ' Channel:.*' | cut -f2 -d':' | cut -f1 -d'|'`"
    [ "$CELL_CHANNEL" == "" ] && CELL_CHANNEL="`echo -n "$ONELINE" | grep -o ' (Channel .*' | cut -f 3 -d ' ' | cut -f 1 -d')'`"
    CELL_QUALITY="`echo -n "$ONELINE" | grep -o ' Quality[:=].*' | cut -f 2 -d ' ' | cut -f 2 -d '=' | cut -f 2 -d ':'`"
-   CELL_ESSID="`echo -n "$ONELINE" | grep -o ' ESSID:.*' | cut -f 2 -d '"'`" #'geany
+   CELL_ESSID="`echo -n "$ONELINE" | grep -o ' ESSID:.*' | cut -f 2 -d '"' | head -c20`" #'geany
    CELL_ENCRYPTIONKEY="`echo -n "$ONELINE" | grep -o 'Encryption key:.*' | cut -f 2 -d ':' | cut -f1 -d '|'`" #ex: off
 
    #build network list


### PR DESCRIPTION
There is this problematic wifi name in my neighbourhood that is 96 CHARACTERS LONG ( :laughing: ) and whenever sns finds it you need to expand to full window or scroll over to see the rest of the fields. Putting a limit of 20 on to the display seems to show all other names without the issue and gives enough room to add short quality 68/70 field back later.

Before:
https://ibb.co/fpNHAv

After:
https://ibb.co/bVJqVv