### PR TITLE
sns: Re-add signal strength number (short version)

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -436,6 +436,9 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
    </hbox>' >> /tmp/sns_scan_radiobuttons_shield
    echo '
    <hbox space-expand="false" space-fill="false">
+     <text xalign="0" yalign="1" use-markup="true" space-expand="true" space-fill="true">
+       <label>"<small><small>'${CELL_QUALITY}'</small></small>"</label>
+     </text>
      <pixmap height-request="25" space-expand="false" space-fill="false">
        <input file>/usr/share/pixmaps/puppy/'${IMG_QUALITY}'.svg</input>
        <height>25</height>
@@ -473,6 +476,7 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons | sort -t : -k 4 -n -r`'</vbox>
      <text space-expand="true" space-fill="true"><label>""</label></text>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_shield`'</vbox>
+     <text width-request="2" space-expand="false" space-fill="false"><label>""</label></text>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_strength`'</vbox>
      <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_address`'</vbox>
    </hbox>' #170522


### PR DESCRIPTION
This number is handy to see, and doesn't hurt anything I think. I remove the word "Strength" because it is what took up most of the room. The MAC address can still be seen by scrolling over :)

Screenshot:
https://ibb.co/b4YSca