### PR TITLE
Fix pmount root dev detection for Raspberry Pi

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -358,7 +358,12 @@ PMOUNTQUIT="false" #"true" v404 change to false
 
 #v3.96 'mount' misreports which partition mounted on '/'...
 ROOTDEV2=""
-[ "$PUPMODE" = "2" ] && ROOTDEV2="`df | grep ' /$' | grep '^/dev/' | cut -f 1 -d ' '`"
+if [ "$PUPMODE" = "2" ] ; then
+ ROOTDEV2="`df | grep ' /$' | grep '^/dev/' | cut -f 1 -d ' '`"
+ if [ "$ROOTDEV2" = "/dev/root" ] ; then # raspberry pi
+  ROOTDEV2="$(expr match "`cat /proc/cmdline`" '.*root=\([^ ]*\)')"
+ fi
+fi
 
 DISKINFO="`$PROBEDISK | sort -k 2 --field-separator='|'`" #v4.01
 PARTSINFO="`$PROBEPART -k | grep -v 'none' | tr ' ' '_' | tr '\t' '_' | cut -f 1-3 -d '|'`" #v3.98 fix for mut2.


### PR DESCRIPTION
Find which partition is mounted on / by looking in /proc/cmdline