### PR TITLE
Update getflash pet.specs

### DIFF
--- a/woof-code/rootfs-packages/getflash/pet.specs
+++ b/woof-code/rootfs-packages/getflash/pet.specs
@@ -1,1 +1,1 @@
-getflash-1.5-8|getflash|1.5-8||Internet|88K||getflash-1.5-8.pet||GetFlash: install Flashplayer||||
+getflash-1.7-1|getflash|1.7-1||Internet|92K||getflash-1.7-1.pet||GetFlash - install Flashplayer||||

--- a/woof-code/rootfs-packages/getflash/usr/sbin/getflash
+++ b/woof-code/rootfs-packages/getflash/usr/sbin/getflash
@@ -23,7 +23,7 @@
 #161221 v1.6.1 rerwin: update for new version not 11; use only https URL
 #170204 v1.7 rerwin: merge versions 1.5-8 and 1.6.1; return conf and prefs files to ~/.getflashrc
 
-AppVersion=1.7
+AppVersion=1.7-1
 
 
 ## ANL = Application Name writing Lowercase => to be use in different parts of the script


### PR DESCRIPTION
I thought it was a bit strange that my woof-installed-packages still said 1.5-8 :laughing: