### PR TITLE
explain rootfs-packages.conf only if doesn't exist

### DIFF
--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -109,7 +109,10 @@ cp DISTRO_SPECS sandbox3/rootfs-complete/etc/
 #copy the skeleton...
 cp -a rootfs-skeleton/* sandbox3/rootfs-complete/
 cat sandbox3/rootfs-complete/pinstall.sh >> sandbox3/pinstall.sh
+
 # extra packages
+CHOICE=/tmp/rootfs_choice$$
+if [ ! -f support/rootfs-packages.conf ];then
 echo
 echo "If you know what packages you want included from rootfs-packages
 you can bypass the checkbox GUI by renaming 
@@ -127,8 +130,6 @@ or hit Enter/Return to continue."
 
 read carry_on
 
-CHOICE=/tmp/rootfs_choice$$
-if [ ! -f support/rootfs-packages.conf ];then
 	for d in $(ls rootfs-packages)
 	do  
 	       state=true


### PR DESCRIPTION
I think if the user creates rootfs-packages.conf, they don't have to see the message again and need to press Enter on it to continue.