### PR TITLE
slacko 14.0 - use woof-ce sfs_load

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -685,7 +685,7 @@ yes|Send-to-Backgrounds-update||exe
 yes|setvol||exe
 yes|sfontview||exe
 yes|sfs-converter||exe
-yes|sfs_load||exe
+no|sfs_load||exe
 yes|sfs_manager||exe
 no|sgmixer||exe
 no|sgml-base|sgml-base_|exe>dev,dev,doc,nls


### PR DESCRIPTION
having just the woof-ce version seems to be working so far in my tests, so I don't think the pet is needed any more?