### PR TITLE
slacko 14.0 - use woof-ce mscw

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -486,7 +486,7 @@ no|mplayerplug-in||exe| #hacked for opera only use 20130213
 yes|mplayer_codecs_basic||exe
 yes|mpscan||exe
 yes|ms-sys||exe
-yes|mscw||exe
+no|mscw||exe
 yes|mtpaint||exe
 yes|mtr|mtr|exe
 yes|nasm|nasm|exe>dev,dev,doc,nls
@@ -685,7 +685,7 @@ yes|Send-to-Backgrounds-update||exe
 yes|setvol||exe
 yes|sfontview||exe
 yes|sfs-converter||exe
-yes|sfs_load||exe
+no|sfs_load||exe
 yes|sfs_manager||exe
 no|sgmixer||exe
 no|sgml-base|sgml-base_|exe>dev,dev,doc,nls


### PR DESCRIPTION
This one seems to work ok without the pet too. Sound works and I try the "Test Sound" and "Report" button with no issues