### PR TITLE
Flash 10.3.183.90 - use ibiblio pet

### DIFF
--- a/woof-code/rootfs-packages/getflash/root/.getflash/getflash-conf
+++ b/woof-code/rootfs-packages/getflash/root/.getflash/getflash-conf
@@ -14,9 +14,9 @@ FORUMURL_FLASKPKGS_64=http://www.murga-linux.com/puppy/viewtopic.php?t=84267
 _V11_86_name="flashplayer-11.2.202.540-i386_20151025"
 _V11_86_size="6.6"
 _V11_86_url="http://sourceforge.net/projects/asriedu/files/asriedu_packages/asriedu_packages_31x_base_puppyprecise5xx"
-_V10_86_name="flashplayer-10.3.183.90-i386_20151025"
-_V10_86_size="5.2"
-_V10_86_url="http://sourceforge.net/projects/asriedu/files/asriedu_packages/asriedu_packages_31x_base_puppyprecise5xx"
+_V10_86_name="flashplayer10-10.3.183.90"
+_V10_86_size="5.1"
+_V10_86_url="http://distro.ibiblio.org/quirky/quirky6/x86/packages/pet_packages-quirky6"
 ##_64 arch
 _V11_64_name="flashplayer-11.2.202.540-x86_64_20151027"
 _V11_64_size="6.9"


### PR DESCRIPTION
sourceforge has confusing wrappings of urls to go through to reach the target download url and if any url along the chain breaks the download fails

https://ibb.co/jrhevv

The old ibiblio link to Flash 10 still works (in Slacko 5.7 too). I think it is a better solution so you have multiple avenues to success instead of relying on messy sourceforge for both 11.2 and 10.3 :laughing: