### PR TITLE
slacko 14.0 - woof-CE defaults chooser

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -110,7 +110,7 @@ no|dconf|dconf|exe,dev,doc,nls
 yes|dconf||exe,dev,doc,nls
 yes|ddcprobe||exe,dev>null,doc,nls
 yes|defaultmixer||exe
-yes|defaults-chooser||exe
+no|defaults-chooser||exe
 no|desk_icon_theme_jq8flat||exe
 no|desk_icon_theme_original||exe
 no|desk_icon_theme_silver_marble||exe

--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -109,7 +109,7 @@ yes|dbus-glib||exe,dev,doc,nls
 no|dconf|dconf|exe,dev,doc,nls
 yes|dconf||exe,dev,doc,nls
 yes|ddcprobe||exe,dev>null,doc,nls
-yes|defaultmixer||exe
+no|defaultmixer||exe
 no|defaults-chooser||exe
 no|desk_icon_theme_jq8flat||exe
 no|desk_icon_theme_original||exe


### PR DESCRIPTION
defaults-chooser seems to be an older version of puppyapps default chooser that is now part of woof-CE skeleton. I think the puppyapps one is working ok now, I test changing geany to leafpad as default text editor and it worked, so older pet looks like "extra duplicate" menu entry (it can still be found in PPM if needed)