### PR TITLE
devuan devx: don't include sysprof by default

### DIFF
--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -586,7 +586,7 @@ yes|synclient||exe
 yes|sysfsutils|libsysfs2,libsysfs-dev,sysfsutils|exe,dev,doc>null,nls>null
 no|syslinux|syslinux,syslinux-common|exe,dev>null,doc>null,nls>null
 yes|syslinux||exe,dev| #must use pet syslinux pkg.
-yes|sysprof|sysprof|exe>dev,dev,doc>null,nls>null
+no|sysprof|sysprof|exe>dev,dev,doc>null,nls>null
 yes|sysvinit||exe
 yes|taglib|libtag1v5,libtag1-dev,libtag1v5-vanilla|exe,dev,doc>null,nls>null #needed by lots of media apps.
 yes|tar|tar|exe,dev>null,doc>null,nls>null


### PR DESCRIPTION
This needs policykit/libpolkit to run without error, which seems large to add. Better to not have non-working entry in the menu and let PPM sort out dependencies if the user wants it I think?

https://ibb.co/fwhDxk