### PR TITLE
slacko 14.0: try slackware "file"

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -165,8 +165,8 @@ no|faad2||exe,dev,doc,nls
 no|fbpanel||exe,dev>null,doc,nls
 yes|ffconvert||exe
 yes|ffmpeg||exe,dev,doc,nls
-no|file|file|exe,dev,doc,nls
-yes|file||exe,dev,doc,nls
+yes|file|file|exe,dev,doc,nls
+no|file||exe,dev,doc,nls
 no|file_sharing-curlftpfs-mpscan||exe
 yes|findutils|findutils|exe,dev>null,doc,nls
 no|firewallstate||exe


### PR DESCRIPTION
The file-5.03-w5.pet show newer sfs dates and blocksize with random values (file created in 1907, 1934... blocksize 1...). The slackware 14.0 one (file-5.11) shows them correctly

I don't know why puppy version was used originally, the 14.1 and 14.2 uses slackware version too.