### PR TITLE
kernel-kit: default mksquashfs compression

### DIFF
--- a/kernel-kit/build.conf
+++ b/kernel-kit/build.conf
@@ -78,7 +78,7 @@ LIBRE=0
 ## for extra compression "-comp xz -Xbcj ia64" or "-comp xz -Xbcj x86" etc
 ## Consult the mksquashfs manual for more info.
 ## 'xz' / 'gzip' ..
-COMP="-comp xz"
+#COMP="-comp xz"
 
 ## Firmware tarballs repository
 FW_URL=http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux/firmware


### PR DESCRIPTION
I think just letting it use default is safer (xz is now default in 4.3 I think), as mksquashfs 3.3 and 4.0 fail to create sfs and tar.bz2 kernel package properly when -comp xz parameter is there (and you don't find this out until the very end :laughing: )