### PR TITLE
faster seamonkey edit

### DIFF
--- a/woof-code/packages-templates/mozilla-seamonkey/FIXUPHACK
+++ b/woof-code/packages-templates/mozilla-seamonkey/FIXUPHACK
@@ -14,7 +14,7 @@ cat > ${PREFDIR}/local-settings.js <<_EOF
 pref("browser.startup.homepage", "data:text/plain,browser.startup.homepage=file:///usr/share/doc/home.htm");
 _EOF
 
-(cd usr/lib/seamonkey*
+(cd ${SM}
 [ -f omni.ja ] && mkdir omnidir
 mv omni.ja omnidir/omni.zip
 cd omnidir


### PR DESCRIPTION
cd usr/lib/seamonkey* got confused and failed to cd for me then made 105MB omni.ja of all seamonkey in packages-slacko folder instead (and 18MB omni.ja was untouched) :laughing: changing it to cd ${SM} fixed

Screenshot: https://ibb.co/fwQ1Za