### PR TITLE
slacko 14.2: add libserf (to devx only)

### DIFF
--- a/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
+++ b/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
@@ -767,6 +767,7 @@ no|seamonkey|seamonkey|exe,dev,doc>null| #from patches repo
 no|seamonkey-solibs|seamonkey-solibs|exe,dev>null,doc,nls| #from patches repo
 no|searchmonkey||exe
 yes|sed|sed|exe,dev>null,doc,nls
+yes|serf|serf|exe>dev,dev,doc,nls
 no|setserial||exe,dev>null,doc,nls
 yes|sfontview||exe,dev
 yes|sfs-converter||exe

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
@@ -767,6 +767,7 @@ no|seamonkey|seamonkey|exe,dev,doc>null| #from patches repo
 no|seamonkey-solibs|seamonkey-solibs|exe,dev>null,doc,nls| #from patches repo
 no|searchmonkey||exe
 yes|sed|sed|exe,dev>null,doc,nls
+yes|serf|serf|exe>dev,dev,doc,nls
 no|setserial||exe,dev>null,doc,nls
 yes|sfontview||exe,dev
 yes|sfs-converter||exe


### PR DESCRIPTION
It looks like this 65kb txz is needed for the svn binaries in the devx.

svn: error while loading shared libraries: libserf-1.so.1: cannot open shared object file: No such file or directory

/usr/bin/svn
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found

/usr/bin/svnbench
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found

/usr/bin/svnmucc
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found

/usr/bin/svnrdump
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found

/usr/bin/svnsync
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found
	libserf-1.so.1 => not found