### PR TITLE
network_connect: replace connect/disconnect netwiz dependency 

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
@@ -1,0 +1,48 @@
+#!/bin/sh
+#(c) Copyright Dec. 2016, Barry Kauler, www.barryk.org
+#license: gpl v3 (ref: /usr/share/doc/legal)
+#want to test if an active ethernet cable plugged in at first bootup.
+#previously, /etc/rc.d/rc.sysinit called /etc/rc.d/rc.network to
+#do this, ehich is gross overkill. now rc.sysinit calls this script.
+#161215 first release.
+#170718 test if have the old version of ifplugstatus.
+
+export LANG='C'
+
+#170718 test if have the old version (as well as 'ifplugstatus')...
+IFPLUGSTATUS018='ifplugstatus-0.18'
+if ! which ifplugstatus-0.18 >/dev/null ; then
+ IFPLUGSTATUS018='ifplugstatus'
+fi
+
+#code adapted from /usr/local/simple_network_setup/rc.network...
+INTERFACES="`ifconfig -a | grep -F 'Link encap:Ethernet' | cut -f1 -d' ' | tr '\n' ' '`"
+for INTERFACE in $INTERFACES #exs: wlan0 eth0
+do
+ [ -d /sys/class/net/${INTERFACE}/wireless ] && continue #only want wired.
+
+ ifconfig $INTERFACE up
+ [ $? -ne 0 ] && continue
+ 
+ if ! ${IFPLUGSTATUS018} "$INTERFACE" | grep -F -q 'link beat detected' ;then
+  sleep 1
+  if ! ifplugstatus "$INTERFACE" | grep -F -q 'link beat detected' ;then
+   sleep 1
+   if ! ${IFPLUGSTATUS018} "$INTERFACE" | grep -F -q 'link beat detected' ;then
+    sleep 1
+    if ! ifplugstatus "$INTERFACE" | grep -F -q 'link beat detected' ;then
+     sleep 1
+     if ! ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
+      ifconfig $INTERFACE down
+      continue #no network.
+     fi
+    fi
+   fi
+  fi
+ fi
+
+ DHCPCDFIX="-I ''"
+ dhcpcd $DHCPCDFIX $INTERFACE
+ 
+done
+

--- a/woof-code/rootfs-skeleton/usr/local/apps/Connect/AppRun
+++ b/woof-code/rootfs-skeleton/usr/local/apps/Connect/AppRun
@@ -9,14 +9,13 @@
 #170308 rerwin: update filename in frisbee-active test; use only new frisbee (1.4+) and pgprs (2.0+) interfaces; remove gkdial check.
 #170309 rerwin: retain choice in case multiple setups tried; end use of non-default exec when starting default exec.
 #170515 rerwin: add checks for netwiz & sns installed.
+#170724 rerwin: accommodate absence of a current exec, for default eth0, to connect/disconnect without using network wizard component.
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
 
-DEFAULTEXEC="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`" #170309...
+CURRENT_EXEC='' #170309... 170724
 if [ -f /root/.connectwizardrc ];then
  . /root/.connectwizardrc #sets CURRENT_EXEC
-else
- CURRENT_EXEC="$DEFAULTEXEC"
 fi
 
 if [ "$CURRENT_EXEC" = "connectwizard" ];then #BK, 170309 end
@@ -26,10 +25,10 @@ if [ "$CURRENT_EXEC" = "connectwizard" ];then #BK, 170309 end
     && frisbee --test_active; then #130104 160120 170308
    NETCHOICE='frisbee' #130104 160120
   elif [ -x /usr/sbin/sns ] \
-   && [ -s /etc/simple_network_setup/connections ];then #100306 160120 170515
+    && [ -s /etc/simple_network_setup/connections ];then #100306 160120 170515
    NETCHOICE='sns'
   elif [ -x /usr/sbin/net-setup.sh ] \
-   && [ "`ls -1 /etc/network-wizard/network/interfaces 2>/dev/null`" ];then #170515
+    && [ "`ls -1 /etc/network-wizard/network/interfaces 2>/dev/null`" ];then #170515
    NETCHOICE='net-setup.sh'
   fi
   [ -n "$NETCHOICE" ] && CURRENT_EXEC="$NETCHOICE" #170309
@@ -41,7 +40,7 @@ RUNMODE="$1"
 case $RUNMODE in
   --wizard) exec /usr/sbin/connectwizard 1>&2 ;;
   --connect)
-   case $CURRENT_EXEC in #connect using default tool. 170309
+   case "$CURRENT_EXEC" in #connect using default tool. 170309
     net-setup.sh) exec /etc/rc.d/rc.network connect 1>&2 ;; #Dougal.
     pgprs) pgprs --connect >/dev/null ;; #160120 170308
     pupdial) pupdial ;;
@@ -49,10 +48,12 @@ case $RUNMODE in
     connectwizard) connectwizard ;;
     sns) /usr/local/simple_network_setup/rc.network ;;
     frisbee) frisbee --connect ;; #130104 160120 170308
+    ?*) connectwizard ;; #170724
+    *) exec /etc/rc.d/rc.network_eth ;; #170724
    esac
    ;;
   --disconnect) #disconnect using default tool.
-   case $CURRENT_EXEC in #170309
+   case "$CURRENT_EXEC" in #170309
     net-setup.sh) exec /etc/rc.d/rc.network stop 1>&2 ;; #Dougal.
     pgprs) pgprs --disconnect >/dev/null ;;  #160120 170308
     pupdial) killall wvdial; killall pppd ;;
@@ -60,7 +61,8 @@ case $RUNMODE in
     connectwizard) connectwizard ;;
     sns) /usr/local/simple_network_setup/rc.network stop ;;
     frisbee) frisbee --disconnect ;; #130104 160120 170308
-   esac
+    *) networkdisconnect --current-exec ;; #170724
+  esac
    ;;
   *) exec /usr/local/bin/defaultconnect 1>&2 ;;
 esac

--- a/woof-code/rootfs-skeleton/usr/sbin/network_default_connect
+++ b/woof-code/rootfs-skeleton/usr/sbin/network_default_connect
@@ -5,13 +5,23 @@
 #that 'flag' file is created in /usr/sbin/hostname-set, if the hostname was changed and the network connection brought down.
 #170309 rerwin: check currently running network manager, in case multiple setups tried; remove pwireless2 test; remove gkdial test.
 #170515 rerwin: add checks for netwiz & sns installed.
+#170717 update ethernet check per quirky's 161215 fix.
+#170724 accommodate absence of a current exec, for default eth0.
 
 #100227 choose default network tool...
 DEFAULTEXEC="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`" #170309...
-[ -f /root/.connectwizardrc ] \
- || echo "CURRENT_EXEC=$DEFAULTEXEC" > /root/.connectwizardrc
-. /root/.connectwizardrc #sets CURRENT_EXEC
- 
+if [ -f /root/.connectwizardrc ];then #170724...
+ . /root/.connectwizardrc #sets CURRENT_EXEC
+else
+ CURRENT_EXEC="$DEFAULTEXEC" #for this script only, not saved
+fi #170724 end
+
+#170717 correct possible invalid netwiz indication...
+if [ "$CURRENT_EXEC" = 'net-setup.sh' ] \
+  && [ ! "`ls -1 /etc/network-wizard/network/interfaces 2>/dev/null`" ];then
+ CURRENT_EXEC="$DEFAULTEXEC" #for this script only, not saved
+fi
+
 NETCHOICE="$CURRENT_EXEC"
 case "$CURRENT_EXEC" in #170309 end
  connectwizard|frisbee) #try determine which tool was used to setup networking... 101007 160609...
@@ -37,15 +47,9 @@ case $NETCHOICE in
   /usr/local/simple_network_setup/rc.network &
  ;;
  connectwizard) #101007 shinobar
-  #100628 shinobar: launch rc.network if eth0 is usable
-  RCNETWORK=/etc/rc.d/rc.network_basic #this only sets up interface 'lo'.
-  # eth0 usable?
-  if /sbin/ifconfig eth0 &>/dev/null ;then
-    if [ -x /etc/rc.d/rc.network ]; then
-      RCNETWORK=/etc/rc.d/rc.network
-    fi
-  fi
-  $RCNETWORK &
+  #170717 (161215) rewritten...
+  /etc/rc.d/rc.network_basic #this only sets up interface 'lo'.
+  /etc/rc.d/rc.network_eth &   #test for wired network.
  ;;
  *) #101007 shinobar
   /etc/rc.d/rc.network_basic &

--- a/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
+++ b/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
@@ -14,8 +14,13 @@
 #170329 use network choice instead of default, in case multiple setups tried.
 #170402 Move ifconfig, to preserve current link removed by wpa_cli.
 #170412 Deactivate frisbee; convert to case structure. 
+#170724 accommodate absence of a current exec, for default eth0.
 
-. /root/.connectwizardrc #sets CURRENT_EXEC 170329...
+CURRENT_EXEC='' #170724
+if [ -f /root/.connectwizardrc ];then #170724
+ . /root/.connectwizardrc #sets CURRENT_EXEC 170329...
+fi #170724
+
 ARGUMENT="$1"
 case "$ARGUMENT" in
  --current-exec)
@@ -23,9 +28,8 @@ case "$ARGUMENT" in
   ;;
  *)
   DISCONNECTEXEC="`cat /tmp/.connectwizard_previous_exec 2> /dev/null`"
+  [ -z "$DISCONNECTEXEC" ] && DISCONNECTEXEC="$CURRENT_EXEC"
   [ -z "$DISCONNECTEXEC" ] \
-   && DISCONNECTEXEC="$CURRENT_EXEC" \
-   && [ -z "$DISCONNECTEXEC" ] \
    && DISCONNECTEXEC="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`"
   ;;
  esac #170329 end
@@ -56,7 +60,8 @@ case "$DISCONNECTEXEC" in #170412...
  *) for ONENETIF in $NETIFS #170412 end
   do
    ifconfig $ONENETIF down 2> /dev/null
-   [ "`iwconfig | grep "^${ONENETIF}" | grep "ESSID"`" != "" ] && iwconfig $ONENETIF essid off #100309
+   [ "`iwconfig | grep "^${ONENETIF}" | grep "ESSID"`" != "" ] \
+    && iwconfig $ONENETIF essid off #100309
    dhcpcd --release $ONENETIF 2>/dev/null #100309
   done
   ;;


### PR DESCRIPTION
Completes separation of netwiz from skeleton without impact.  The netwiz package can now be safely omitted from a distro.