### PR TITLE
merge2out: make sure woof-out is owned by root

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -216,6 +216,10 @@ ls rootfs-packages|while read pkg;do
 	echo -e "$pkg=\"true\"" >> support/rootfs-packages.conf-backup
 done)
 
+if [ "`stat -c %U:%G $0`" != 'root:root' ] ; then
+	[ "${WOOF_OUT}" != "/" ] && chown -R root:root ${WOOF_OUT}
+fi
+
 echo -e "\nUndoing VCS-friendly stuff..."
 (
 cd ${WOOF_OUT}


### PR DESCRIPTION
If running woof-CE in a multi-user environment using run_woof
it is possible that the woof-CE repo has been cloned
as an ordinary user.