### PR TITLE
xenial64: update for new missing deps

### DIFF
--- a/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
+++ b/woof-distro/x86/ubuntu/xenial/DISTRO_PKGS_SPECS-ubuntu-xenial
@@ -411,6 +411,7 @@ yes|libcanberra|libcanberra0,libcanberra-dev|exe,dev,doc,nls| #libbonobui needs 
 yes|libcaca|libcaca0,libcaca-dev|exe,dev,doc,nls|
 yes|libcap|libcap2,libcap-dev|exe,dev,doc,nls
 yes|libcap-ng|libcap-ng0|exe,dev,doc,nls|
+yes|libcapnp|libcapnp-0.5.3|exe,dev,doc,nls|
 yes|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls| #debian/ubuntu pkg missing 'cddb_query', also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.
 no|libcddb||exe,dev,doc,nls|pet:wary5| #120907 gone back to deb.
 yes|libcdio|libcdio13,libcdio-dev,libcdio-cdda1,libcdio-cdda-dev,libcdio-paranoia1,libcdio-paranoia-dev,libcdio-utils,libiso9660-8,libiso9660-dev,libudf0,libudf-dev|exe,dev,doc,nls| #not compatible with my libcddb pet, use my pet. 120907 yes.
@@ -490,6 +491,7 @@ yes|libltdl|libltdl7,libltdl-dev|exe,dev,doc,nls| #note, this is really part of 
 yes|libmad|libmad0,libmad0-dev|exe,dev,doc,nls
 yes|libmcrypt|libmcrypt4,libmcrypt-dev|exe,dev,doc,nls
 yes|libmirclient|libmirclient9,libmirclient-dev,libmircommon5,libmircommon-dev,libmirprotobuf3,libprotobuf-lite9v5,libwayland-egl1-mesa|exe,dev,doc,nls
+yes|libmircommon7|libmircommon7,libmircore1|exe,dev,doc,nls
 yes|libmng|libmng2,libmng-dev|exe,dev,doc,nls
 yes|libmnl|libmnl0,libmnl-dev|exe,dev,doc,nls
 yes|libmpcdec|libmpcdec6,libmpcdec-dev|exe,dev,doc,nls
@@ -519,6 +521,7 @@ yes|librevenge|librevenge-0.0-0,librevenge-dev|exe,dev,doc,nls
 yes|librsvg|librsvg2-bin,librsvg2-2,librsvg2-common,librsvg2-dev|exe,dev,doc,nls| #MERGED 20150717-08. 20151204 removed ,librsvg2-bin GTK3 --RESTORED 20160402. need rsvg-convert
 yes|libsamplerate|libsamplerate0,libsamplerate0-dev|exe,dev,doc,nls
 yes|libselinux|libselinux1|exe,dev>null,doc,nls
+yes|libsensors4|libsensors4|exe,dev,doc,nls
 yes|libsepol|libsepol1,libsepol1-dev|exe,dev,doc,nls
 yes|libsigc++|libsigc++-2.0-0v5,libsigc++-2.0-dev|exe,dev,doc,nls
 yes|libsigsegv|libsigsegv2,libsigsegv-dev|exe,dev,doc,nls
@@ -577,7 +580,7 @@ no|linux_module_hsfmodem||exe,dev,doc,nls| #needs firmware_linux_module_hsfmodem
 no|linux_module_wl||exe,dev,doc,nls
 yes|lirc|liblircclient0,liblircclient-dev|exe,dev,doc,nls
 yes|ListDD||exe,dev,doc,nls|
-yes|llvm|libllvm3.8|exe,dev,doc,nls| #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
+yes|llvm|libllvm4.0|exe,dev,doc,nls| #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
 no|llvm|libclang1-3.8,liblldb-3.8,libllvm3.8,lldb-3.8,llvm-3.8-runtime,llvm-3.8|exe,dev,doc,nls
 yes|lsb-base|lsb-base|exe,dev,doc,nls
 yes|lvm2|dmsetup,liblvm2-dev|exe,dev,doc,nls|

--- a/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PKGS_SPECS-ubuntu-xenial
+++ b/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PKGS_SPECS-ubuntu-xenial
@@ -415,6 +415,7 @@ yes|libcanberra|libcanberra0,libcanberra-dev|exe,dev,doc,nls| #libbonobui needs 
 yes|libcaca|libcaca0,libcaca-dev|exe,dev,doc,nls|
 yes|libcap|libcap2,libcap-dev|exe,dev,doc,nls
 yes|libcap-ng|libcap-ng0|exe,dev,doc,nls|
+yes|libcapnp|libcapnp-0.5.3|exe,dev,doc,nls| #needed by mpv, florence, rsvg-view-3, transmission-gtk, immodules
 yes|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls| #debian/ubuntu pkg missing 'cddb_query', also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.
 no|libcddb||exe,dev,doc,nls|pet:wary5| #120907 gone back to deb.
 yes|libcdio|libcdio13,libcdio-dev,libcdio-cdda1,libcdio-cdda-dev,libcdio-paranoia1,libcdio-paranoia-dev,libcdio-utils,libiso9660-8,libiso9660-dev,libudf0,libudf-dev|exe,dev,doc,nls| #not compatible with my libcddb pet, use my pet. 120907 yes.
@@ -496,6 +497,7 @@ yes|libltdl|libltdl7,libltdl-dev|exe,dev,doc,nls| #note, this is really part of 
 yes|libmad|libmad0,libmad0-dev|exe,dev,doc,nls
 yes|libmcrypt|libmcrypt4,libmcrypt-dev|exe,dev,doc,nls
 yes|libmirclient|libmirclient9,libmirclient-dev,libmircommon5,libmircommon-dev,libmirprotobuf3,libprotobuf-lite9v5,libwayland-egl1-mesa|exe,dev,doc,nls
+yes|libmircommon7|libmircommon7,libmircore1|exe,dev,doc,nls #needed by mpv, florence, rsvg-view-3, transmission-gtk, immodules
 yes|libmng|libmng2,libmng-dev|exe,dev,doc,nls
 yes|libmnl|libmnl0,libmnl-dev|exe,dev,doc,nls
 yes|libmpcdec|libmpcdec6,libmpcdec-dev|exe,dev,doc,nls
@@ -528,6 +530,7 @@ yes|librevenge|librevenge-0.0-0,librevenge-dev|exe,dev,doc,nls
 yes|librsvg|librsvg2-bin,librsvg2-2,librsvg2-common,librsvg2-dev|exe,dev,doc,nls| #MERGED 20150717-08. 20151204 removed ,librsvg2-bin GTK3 --RESTORED 20160402. need rsvg-convert
 yes|libsamplerate|libsamplerate0,libsamplerate0-dev|exe,dev,doc,nls
 yes|libselinux|libselinux1|exe,dev>null,doc,nls
+yes|libsensors4|libsensors4|exe,dev,doc,nls
 yes|libsepol|libsepol1,libsepol1-dev|exe,dev,doc,nls
 yes|libsigc++|libsigc++-2.0-0v5,libsigc++-2.0-dev|exe,dev,doc,nls
 yes|libsigsegv|libsigsegv2,libsigsegv-dev|exe,dev,doc,nls
@@ -587,7 +590,7 @@ no|linux_module_hsfmodem||exe,dev,doc,nls| #needs firmware_linux_module_hsfmodem
 no|linux_module_wl||exe,dev,doc,nls
 yes|lirc|liblircclient0,liblircclient-dev|exe,dev,doc,nls
 yes|ListDD||exe,dev,doc,nls|
-yes|llvm|libllvm3.8|exe,dev,doc,nls| #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
+yes|llvm|libllvm4.0|exe,dev,doc,nls| #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
 no|llvm|libclang1-3.8,liblldb-3.8,libllvm3.8,lldb-3.8,llvm-3.8-runtime,llvm-3.8|exe,dev,doc,nls
 yes|lsb-base|lsb-base|exe,dev,doc,nls
 yes|lvm2|dmsetup,liblvm2app2.2,liblvm2cmd2.02,liblvm2-dev|exe,dev,doc,nls|


### PR DESCRIPTION
Some ubuntu repo dependencies have changed when I build this with latest woof-CE.

Before spec update: http://txt.do/d62gs
After spec update: http://txt.do/d62ga