### PR TITLE
slacko 14.0: fix autohide (use jwmconfig3-2014)

### DIFF
--- a/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
+++ b/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
@@ -141,6 +141,7 @@ ipscan-3.0-beta6-a|ipscan|3.0-beta6-a||Network|1068K||ipscan-3.0-beta6-a.pet|+jr
 jre-1.7u15-i586|jre|1.7u15-i586||Utility|139516K||jre-1.7u15-i586.pet||Java runtime environment|slackware|14.0||
 jvnc-1.3.9|jvnc|1.3.9||Network|348K||jvnc-1.3.9.pet|+gtk+2|vnc viewer gui requiring java||||
 jwm-905-i486|jwm|905-i486||BuildingBlock|412K||jwm-905-i486.pet||joes window manager|slackware|14.0||
+jwmconfig3-140121|jwmconfig3|140121||Desktop|272K||jwmconfig3-140121.pet|+jwm|JWM Window Manager Settings||||
 kernel_headers-3.4.82-slacko_4g_f2fs|kernel_headers|3.4.82-slacko_4g_f2fs||BuildingBlock|4784K||kernel_headers-3.4.82-slacko_4g_f2fs.pet||kernel headers||||
 kernel_headers-3.10.32-slacko_PAE|kernel_headers|3.10.32-slacko_PAE||BuildingBlock|5052K||kernel_headers-3.10.32-slacko_PAE.pet||kernel headers||||
 kompozer-0.8b3-i686-s|kompozer|0.8b3-i686-s||Document|27860K||kompozer-0.8b3-i686-s.pet|+gtk+2|Create a Web Site|slackware|14.0||


### PR DESCRIPTION
The 2015 version in noarch list is not compatible with this jwm's autohide syntax so nothing happens when you try to use autohide option. This one (also used in slacko 5.7) works