### PR TITLE
support/findpkgs - Fix for FALLBACKS_COMPAT_VERSIONS

### DIFF
--- a/woof-code/support/findpkgs
+++ b/woof-code/support/findpkgs
@@ -76,7 +76,7 @@ fi
 KERNELVER3="`echo -n "$DISTRO_KERNEL_PET" | cut -f 2 -d '-' | cut -f 1,2,3 -d '.' | cut -f 1 -d '_'`" #ex: 2.6.32
 
 #modify compat-distro fallback list...
-if [ "$FALLBACKS_COMPAT_VERSIONS" != "" ];then
+if [ "`echo -n "$FALLBACKS_COMPAT_VERSIONS" | grep "$DISTRO_COMPAT_VERSION"`" != "" ];then
 	FALLBACKS_COMPAT_VERSIONS="`echo -n "$FALLBACKS_COMPAT_VERSIONS" | grep -o "${DISTRO_COMPAT_VERSION}.*"`"
 	#ex: 'koala jaunty intrepid' gets reduced to 'jaunty intrepid' if DISTRO_COMPAT_VERSION=jaunty
 fi


### PR DESCRIPTION
If FALLBACKS_COMPAT_VERSIONS did not list DISTRO_COMPAT_VERSION
it would end up set to FALLBACKS_COMPAT_VERSIONS=''

If you want the original behavior just set
FALLBACKS_COMPAT_VERSIONS=''