### PR TITLE
Update Packages-puppy-slacko14-official

### DIFF
--- a/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
+++ b/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
@@ -233,9 +233,6 @@ pciutils-3.1.7-w5c|pciutils|3.1.7-w5c||BuildingBlock|820K||pciutils-3.1.7-w5c.pe
 pciutils_DEV-3.1.7-w5c|pciutils_DEV|3.1.7-w5c||BuildingBlock|164K||pciutils_DEV-3.1.7-w5c.pet|+pciutils|Linux PCI Utilities|slackware|14.0||
 pciutils_DOC-3.1.7-w5c|pciutils_DOC|3.1.7-w5c||BuildingBlock|52K||pciutils_DOC-3.1.7-w5c.pet||Linux PCI Utilities|slackware|14.0||
 pcmanfm-1.0-i686-s|pcmanfm|1.0-i686-s||BuildingBlock|1448K||pcmanfm-1.0-i686-s.pet|+libfm,+gvfs,+menu-cache,+lxde-icon-theme,+lxmenu-data|Browse the file system and manage the files|slackware|14.0||
-peasypdf-2.4|peasypdf|2.4||Document|36K||peasypdf-2.4.pet||Manipulate PDF documents||||
-peasyport-1.8|peasyport|1.8||Network|64K||peasyport-1.8.pet||Network port scanner||||
-peasyscale-1.51|peasyscale|1.51||Graphic|40K||peasyscale-1.51.pet||JPEG image resizer|slackware|14.0||
 pfilesearch-1.34|pfilesearch|1.34||BuildingBlock|84K||pfilesearch-1.34.pet|+gtkdialog4|file finder engine||||
 pfontview-0.1.3-s|pfontview|0.1.3-s||BuildingBlock|84K||pfontview-0.1.3-s.pet|+gtkdialog&ge0.8.2|font viewer||||
 pipepanic-0.1.3-i486|pipepanic|0.1.3-i486||Fun|1712K||pipepanic-0.1.3-i486.pet|+sdl,+gtk+2|Pipepanic join the pipes|slackware|14.0||


### PR DESCRIPTION
To download newer peasypdf-4.2, peasyport-2.3, and peasyscale-2.0 from noarch (these do no rely on mini-icons)