### PR TITLE
slacko 14.1: fix/revert dbus_slack

### DIFF
--- a/woof-code/packages-templates/dbus_slack/FIXUPHACK
+++ b/woof-code/packages-templates/dbus_slack/FIXUPHACK
@@ -4,6 +4,9 @@
 mkdir -p etc/init.d
 mv etc/rc.d/* etc/init.d/
 find etc/init.d -type f -name '*.new' -delete # may or may not be there
-mkdir -p var/lib/dbus/ 
-touch var/lib/dbus/machine-id 
-ln -s ../var/lib/dbus/machine-id etc/machine-id
+
+if [ ! "$DISTRO_COMPAT_VERSION" = '14.1' ];then
+  mkdir -p var/lib/dbus/ 
+  touch var/lib/dbus/machine-id 
+  ln -s ../var/lib/dbus/machine-id etc/machine-id
+fi

--- a/woof-distro/x86/slackware/14.1/DISTRO_PKGS_SPECS-slackware-14.1
+++ b/woof-distro/x86/slackware/14.1/DISTRO_PKGS_SPECS-slackware-14.1
@@ -228,7 +228,7 @@ no|gedit||exe
 yes|get_libreoffice||exe
 yes|getcurpos||exe
 no|getdir||exe,dev>null,doc,nls
-yes|getflash||exe
+no|getflash||exe
 yes|gettext|gettext|exe,dev>null,doc>null,nls>null
 yes|gettext-tools|gettext-tools|exe>dev,dev,doc,nls
 yes|gexec||exe,dev>null,doc,nls


### PR DESCRIPTION
The "machine-id" part of this patch has never worked for me in 14.1: https://github.com/puppylinux-woof-CE/woof-CE/commit/d23a3ed987320f8bde804c47530e1d2e2b6a1270

https://ibb.co/d0W3Lw

Ignoring the code for 14.1 with if statement (behavior before patch) is one way that seems to fix.