### PR TITLE
redshiftgui_wrapper: add wrapper and auto startup for RedshiftGUI

### DIFF
--- a/woof-code/rootfs-packages/redshiftgui_wrapper/pet.specs
+++ b/woof-code/rootfs-packages/redshiftgui_wrapper/pet.specs
@@ -1,0 +1,1 @@
+redshiftgui_wrapper-20171120|redshiftgui_wrapper|20171120||BuildingBlock|10K||redshiftgui_wrapper-20171120.pet||redshiftgui automatic startup & map fix||||

--- a/woof-code/rootfs-packages/redshiftgui_wrapper/pinstall.sh
+++ b/woof-code/rootfs-packages/redshiftgui_wrapper/pinstall.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+if [ "$(pwd)" = '/' ];then
+	if grep -qsE 'Exec=redshiftgui$' \
+	  usr/share/applications/redshiftgui.desktop; then
+		sed -i 's/Exec=redshiftgui$/&.sh/' usr/share/applications/redshiftgui.desktop
+	fi
+fi

--- a/woof-code/rootfs-packages/redshiftgui_wrapper/root/Startup/redshiftgui_tray
+++ b/woof-code/rootfs-packages/redshiftgui_wrapper/root/Startup/redshiftgui_tray
@@ -1,0 +1,17 @@
+#!/bin/sh
+# redshiftgui_tray - Part of wrapper for RedshiftGUI (redshiftgui)
+# Points menu item to wtapper.
+# Automatic minimized startup only if a location other than 0:0 specified.
+
+if which redshiftgui &>/dev/null; then
+	if grep -qsE 'Exec=redshiftgui$' \
+	  /usr/share/applications/redshiftgui.desktop; then
+		sed -i 's/Exec=redshiftgui$/&.sh/' \
+		  /usr/share/applications/redshiftgui.desktop
+		fixmenus
+	fi
+	if [ -f ~/.redshiftgrc ] \
+	  && ! grep 'latlon=' ~/.redshiftgrc | grep -q '0.000000:0.000000' ~/.redshiftgrc; then
+		exec redshiftgui.sh  --min
+	fi
+fi

--- a/woof-code/rootfs-packages/redshiftgui_wrapper/usr/bin/redshiftgui.sh
+++ b/woof-code/rootfs-packages/redshiftgui_wrapper/usr/bin/redshiftgui.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+# redshiftgui.sh - Wrapper for RedshiftGUI (redshiftgui)
+# Kills any running redshiftGUI.
+# Ensures correct "map" separators (',', not |).
+# Ensures normal invocation not minimized (in case set during  a save).
+
+# To disable automatic starting, remove execute permissions of
+# /root/Startup/redshiftgui_tray.
+
+if which redshiftgui &>/dev/null; then
+	if [ "$1" = '--help' -o "$1" = '-h' ];then
+		export TEXTDOMAIN=redshiftgui.sh
+		export OUTPUT_CHARSET=UTF-8
+		echo "$(gettext 'To activate automatic startup, specify a location in redshiftGUI.')"
+		echo "$(gettext 'To de-activate automatic startup, set location to 0, 0 in redshiftGUI.')"
+		echo #then append redshiftgui help
+	else
+		[ "$(pidof redshiftgui)" ] && kill $(pidof redshiftgui)
+		if grep -qsE '^min$|\|' ~/.redshiftgrc; then
+			if [ -x /root/Startup/redshiftgui_tray ];then
+				sed -i -e '/^min/d' -e '/map=/ s/|/,/g' ~/.redshiftgrc
+			else
+				grep -q '|' ~/.redshiftgrc \
+				  && sed -i '/map=/ s/|/,/g' ~/.redshiftgrc
+			fi
+		fi
+	fi
+	exec redshiftgui "$@"
+fi


### PR DESCRIPTION
This supports automatic execution of RedshiftGUI, if present, to adjust display color for nighttime.  It does nothing if RedshiftGUI is not installed or has not been given the user's location, which determines the times of day/night transition.