### PR TITLE
Update .Xdefaults

### DIFF
--- a/woof-code/rootfs-skeleton/root/.Xdefaults
+++ b/woof-code/rootfs-skeleton/root/.Xdefaults
@@ -16,8 +16,8 @@ urxvt.underlineColor:#ffff00000000
 
 ! fonts
 ! run "fc-list" for a list of available fonts
-urxvt.font: xft:Nimbus Mono L:style=Regular:pixelsize=14
-rxvt.font: xft:Nimbus Mono L:style=Regular:pixelsize=13
+urxvt.font: xft:mono:medium:size=10
+rxvt.font: xft:mono:medium:size=10
 
 urxvt.geometry:80x25
 urxvt.scrollBar: True


### PR DESCRIPTION
I think the Nimbus Mono font has been deleted.
Setting it to a generic mono maps better.