### PR TITLE
Added support for nvme ssd drives for puppy-save files

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -299,7 +299,7 @@ $(eval_gettext 'Or, \Zb${T_abort}\ZB to shutdown without saving...')"
   while [ 1 ];do
    /tmp/savedlg
    SAVEPART="`cat /tmp/tag.txt | head -n 1`" #head is in case of errs in output.
-   if [ "`echo -n "$SAVEPART" | grep --extended-regexp '^hd|^sd|^sc|^fd|^mmcblk'`" = "" ];then
+   if [ "`echo -n "$SAVEPART" | grep --extended-regexp '^hd|^sd|^sc|^fd|^mmcblk|^nvme'`" = "" ];then
     ${DIALOGEXE} ${BACKGROUNDPINK} ${TITLEPARAM} "$T_notchosentitle" --colors --yes-label "$T_tryagain" --no-label "${T_abort}" --yesno "$T_yesno" 0 0
     [ ! $? -eq 0 ] && return 1 #abort.
     continue


### PR DESCRIPTION
**Fix for issue:**
https://github.com/puppylinux-woof-CE/woof-CE/issues/1115

**Rootcause:** 
In shutdownconfig, there is a if check to verify valid partitions. In  that check, nvme* is not added, hence even if we select a valid  partition with available space, not able to proceed.

**Fix:**
Added the nvme* in the 'if' check