### PR TITLE
puduan: use libprocps6

### DIFF
--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -532,7 +532,7 @@ yes|popt|libpopt0,libpopt-dev|exe,dev
 yes|powerapplet_tray||exe
 yes|ppp|ppp|exe,dev>null
 yes|pptp|pptp-linux|exe,dev,doc>null,nls>null
-yes|procps|procps,libprocps4,libprocps4-dev|exe,dev,doc>null,nls>null
+yes|procps|procps,libprocps6,libprocps6-dev|exe,dev,doc>null,nls>null
 yes|programchooser||exe
 no|pschedule||exe
 yes|psmisc|psmisc|exe,dev>null,doc>null,nls>null

--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -532,7 +532,7 @@ yes|popt|libpopt0,libpopt-dev|exe,dev
 yes|powerapplet_tray||exe
 yes|ppp|ppp|exe,dev>null
 yes|pptp|pptp-linux|exe,dev,doc>null,nls>null
-yes|procps|procps,libprocps6,libprocps6-dev|exe,dev,doc>null,nls>null
+yes|procps|procps,libprocps6,libprocps-dev|exe,dev,doc>null,nls>null
 yes|programchooser||exe
 no|pschedule||exe
 yes|psmisc|psmisc|exe,dev>null,doc>null,nls>null


### PR DESCRIPTION
puduan is now in-sync with stretch and uses libprocps6

> Puduan-7.0.0b1
> Start: Fri Jan  5 06:42:42 EST 2018
> * Checking system dirs: /bin /usr/libexec /sbin /usr/bin /usr/sbin /usr/games /usr/local/bin
> 
> /bin/ps-FULL
> 	libprocps.so.6 => not found
> 		libprocps.so.6 (LIBPROCPS_0) => not found
> 
> /sbin/sysctl
> 	libprocps.so.6 => not found