### PR TITLE
dpup: Add UEFI support by default

### DIFF
--- a/woof-distro/x86/debian/stretch/_00build.conf
+++ b/woof-distro/x86/debian/stretch/_00build.conf
@@ -31,7 +31,7 @@ STRIP_BINARIES=no
 ## UEFI_ISO also supports legacy BIOS booting
 ##    On 32 bit systems this will still boot legacy BIOS however it
 ##      Will not boot 32 bit UEFI machines. These are rare anyway.
-UFEI_ISO=no
+UFEI_ISO=yes
 G4DOS_ISO=yes
 
 ## Kernel tarballs repo URL

--- a/woof-distro/x86/devuan/ascii/_00build.conf
+++ b/woof-distro/x86/devuan/ascii/_00build.conf
@@ -31,7 +31,7 @@ STRIP_BINARIES=no
 ## UEFI_ISO also supports legacy BIOS booting
 ##    On 32 bit systems this will still boot legacy BIOS however it
 ##      Will not boot 32 bit UEFI machines. These are rare anyway.
-UFEI_ISO=no
+UFEI_ISO=yes
 G4DOS_ISO=yes
 
 ## Kernel tarballs repo URL


### PR DESCRIPTION
Someone here (gyro maybe?) said UEFI compatibility should be there by default. It adds about 4MB (1-2%) to the size of the iso I think. I don't have UEFI machine but I think this makes sense. Do you agree? :)