### PR TITLE
merge2out: rootfs-skeleton bug fix

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -213,7 +213,7 @@ if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-packa
 fi
 if [ -d "woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton" ];then
 	echo "Copying woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton..."
-	SKELETONFILES=`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton/ -type f -printf '    %f\n'`
+	SKELETONFILES=`find woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton/* \( -type f -or -type d -or -type l \) -printf '    %f\n'`
 	if [ -n "$SKELETONFILES" ];then
 		echo "$SKELETONFILES"
 		cp -a -f --remove-destination woof-distro/${TARGETARCH}/${COMPATDISTRO}/${COMPATVERSION}/rootfs-skeleton/* ${WOOF_OUT}/rootfs-skeleton/


### PR DESCRIPTION
If woof-distro/.../rootfs-skeleton/ contained only links and
directories but no regular files it was ignored.