### PR TITLE
slacko 14.0: optimize

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -726,7 +726,7 @@ yes|sysvinit||exe
 yes|tar|tar|exe,dev>null,doc,nls| #slackware tar 1.23 slightly broken, use my pet 1.22... no using 1.26
 no|tar||exe
 yes|tas||exe,nls
-yes|tcpdump|tcpdump|exe,dev,doc,nls
+no|tcpdump|tcpdump|exe,dev,doc,nls
 no|teagtk||exe
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
 no|tile||exe

--- a/woof-distro/x86/slackware/14.0/_00build.conf
+++ b/woof-distro/x86/slackware/14.0/_00build.conf
@@ -242,6 +242,10 @@ EXTRA_COMMANDS="rm usr/bin/memusagestat
 rm usr/bin/rsvg-view-3
 rm usr/bin/x264
 rm -rf usr/lib/xmms
+rm -rf usr/share/libtool
+rm usr/bin/libtool*
+rm usr/share/i18n/locales/translit_hangul
+rm usr/bin/*db44*
 rm root/.config/rox.sourceforge.net/OpenWith/pMusic
 ln -rs usr/local/bin/7z usr/local/bin/7za
 ln -rs usr/share/applications/gnome-mplayer.desktop root/.config/rox.sourceforge.net/OpenWith/gnome-mplayer


### PR DESCRIPTION
A few larger things that were removed in slacko 5.7 package-templates to save size