### PR TITLE
Remove unwanted asound.conf from devx

### DIFF
--- a/woof-code/packages-templates/alsa-lib_FIXUPHACK
+++ b/woof-code/packages-templates/alsa-lib_FIXUPHACK
@@ -1,2 +1,3 @@
 
 rm -rf etc
+[ -e ../alsa-lib_DEV/etc/asound.conf ] && rm ../alsa-lib_DEV/etc/asound.conf


### PR DESCRIPTION
alsa-lib from Slackware puts unwanted /etc/asound.conf into the devx and this kills aplay.