### PR TITLE
14.0 - Partially revert "noarch pet merge"

### DIFF
--- a/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
+++ b/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
@@ -136,6 +136,7 @@ ipscan-3.0-beta6-a|ipscan|3.0-beta6-a||Network|1068K||ipscan-3.0-beta6-a.pet|+jr
 jre-1.7u15-i586|jre|1.7u15-i586||Utility|139516K||jre-1.7u15-i586.pet||Java runtime environment|slackware|14.0||
 jvnc-1.3.9|jvnc|1.3.9||Network|348K||jvnc-1.3.9.pet|+gtk+2|vnc viewer gui requiring java||||
 jwm-905-i486|jwm|905-i486||BuildingBlock|412K||jwm-905-i486.pet||joes window manager|slackware|14.0||
+jwmconfig3-140121|jwmconfig3|140121||Desktop|272K||jwmconfig3-140121.pet|+jwm|JWM Window Manager Settings||||
 kernel_headers-3.4.82-slacko_4g_f2fs|kernel_headers|3.4.82-slacko_4g_f2fs||BuildingBlock|4784K||kernel_headers-3.4.82-slacko_4g_f2fs.pet||kernel headers||||
 kernel_headers-3.10.32-slacko_PAE|kernel_headers|3.10.32-slacko_PAE||BuildingBlock|5052K||kernel_headers-3.10.32-slacko_PAE.pet||kernel headers||||
 kompozer-0.8b3-i686-s|kompozer|0.8b3-i686-s||Document|27860K||kompozer-0.8b3-i686-s.pet|+gtk+2|Create a Web Site|slackware|14.0||
@@ -268,6 +269,7 @@ tolua++-1.0.93-i486|tolua++|1.0.93-i486||BuildingBlock|284K||tolua++-1.0.93-i486
 transmission-2.60-i486|transmission|2.60-i486||Internet|4912K||transmission-2.60-i486.pet|+libevent,+gtk+2|Download and share files over BitTorrent|slackware|14.0||
 transmission_DOC-2.60-i486|transmission_DOC|2.60-i486||Internet|60K||transmission_DOC-2.60-i486.pet||transmission documentation||||
 transmission_NLS-2.60-i486|transmission_NLS|2.60-i486||Internet|3104K||transmission_NLS-2.60-i486.pet||transmission locales||||
+updates_mgr-0.10|updates_mgr|0.10||Setup|40K||updates_mgr-0.10.pet||Updates Manager -latest from Slackware||||
 usbip-1.2-i486-s|usbip|1.2-i486-s||Network;transfer|116K||usbip-1.2-i486-s.pet||Share USB devices over IP|slackware|14.0||
 vamps-0.99.2-i486|vamps|0.99.2-i486||BuildingBlock|108K||vamps-0.99.2-i486.pet||dvd shrinker|slackware|14.0||
 vattery_acpitool3x-0.0.1|vattery_acpitool3x|0.0.1||System|156K||vattery_acpitool3x-0.0.1.pet||alternative battery tray applet|debian|squeeze||
@@ -305,4 +307,5 @@ yad_DEV-0.19.1-i486-s14|yad_DEV|0.19.1-i486-s14||Utility|20K||yad_DEV-0.19.1-i48
 yad_DOC-0.19.1-i486-s14|yad_DOC|0.19.1-i486-s14||Utility|48K||yad_DOC-0.19.1-i486-s14.pet||yad documentation||||
 yad_NLS-0.19.1-i486-s14|yad_NLS|0.19.1-i486-s14||Utility|204K||yad_NLS-0.19.1-i486-s14.pet||yad locales||||
 z2_walls-0.2|z2_walls|0.2||Desktop;appearance|392K||z2_walls-0.2.pet||desktop wallpapers||||
+z_fixcache-0.1ff-noarch|z_fixcache|0.1ff-noarch||BuildingBlock|28K||z_fixcache-0.1ff-noarch.pet||fixes cache for firefox||||
 z_spup_cups_authentication_fix-002|z_spup_cups_authentication_fix|002||BuildingBlock|16K||z_spup_cups_authentication_fix-002.pet||||||


### PR DESCRIPTION
These 3 work better from 14.0 version (noarch updates_mgr-0.21 does not work at all in it, maybe in 14.1 too)
https://github.com/puppylinux-woof-CE/woof-CE/issues/1133#issuecomment-377586760

The others I did not test fully but are maybe ok/good. Loading devx then making a savefile appeared to load the SFS on next bootup but really didn't too, perhaps a different sfs_load is needed or it was a strange one-off thing :laughing: