### PR TITLE
findpkgs: Increase priority of common32/64

### DIFF
--- a/woof-code/support/findpkgs
+++ b/woof-code/support/findpkgs
@@ -182,11 +182,12 @@ echo -n "" > /tmp/findpkgs_tmp/FINAL_PKGS
 #   compile-environment of the compat-distro...
 # * ||| means architecture-independent pkg, needs high preference, 
 #   immediately after exact-compiled match...
-petcompiledPTNS="|${DISTRO_BINARY_COMPAT}|${DISTRO_COMPAT_VERSION}| |||" #ex: '|ubuntu|intrepid|' '|||'
+petcompiledPTNS="|${DISTRO_BINARY_COMPAT}|${DISTRO_COMPAT_VERSION}|" #ex: '|ubuntu|intrepid|'
 case ${DISTRO_TARGETARCH} in
 	x86)	petcompiledPTNS="${petcompiledPTNS} |common32|" ;;
 	x86_64)	petcompiledPTNS="${petcompiledPTNS} |common64|" ;;
 esac
+petcompiledPTNS="${petcompiledPTNS} |||"
 for ONECOMPATVERSION in $FALLBACKS_COMPAT_VERSIONS #sliding scale, ex: koala jaunty intrepid
 do
 	[ "$ONECOMPATVERSION" = "$DISTRO_COMPAT_VERSION" ] && continue


### PR DESCRIPTION
Some Packages-puppy-*-official package lists have pets marked as
noarch, even though they are not noarch.  @peabee asked for this.