### PR TITLE
slacko 14.0 - remove duplicate FFConvert in OpenWith

### DIFF
--- a/woof-distro/x86/slackware/14.0/_00build.conf
+++ b/woof-distro/x86/slackware/14.0/_00build.conf
@@ -243,6 +243,7 @@ rm usr/bin/rsvg-view-3
 rm usr/bin/x264
 rm -rf usr/lib/xmms
 rm root/.config/rox.sourceforge.net/OpenWith/pMusic
+rm root/.config/rox.sourceforge.net/OpenWith/FFConvert
 ln -rs usr/local/bin/7z usr/local/bin/7za
 ln -rs usr/share/applications/gnome-mplayer.desktop root/.config/rox.sourceforge.net/OpenWith/gnome-mplayer
 mkdir root/.config/rox.sourceforge.net/MIME-icons


### PR DESCRIPTION
There seems to be two entries in right-click OpenWith list that point to the same place

Screenshot: https://ibb.co/cQHmcH