### PR TITLE
slacko 14.0 - update acpid to noarch

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -20,7 +20,7 @@ yes|915resolution||exe,dev,doc,nls
 yes|a52dec||exe,dev,doc,nls
 yes|abiword||exe,dev,doc,nls
 yes|acl|acl|exe,dev,doc,nls
-yes|acpid||exe
+yes|acpid-busibox||exe
 yes|align||exe
 yes|alsa-info||exe
 yes|alsa-lib|alsa-lib|exe,dev,doc,nls


### PR DESCRIPTION
This one seems to work better (even better than in Slacko 5.7, which went through suspend cycle twice when closed the lid on laptop) and is used in other puppies. For full acpid you can install acpid-2.0.16 (slackware) from ppm, errors with acpid-1.0.10-slacko in woof-CE first reported here: http://murga-linux.com/puppy/viewtopic.php?p=989113#989113