### PR TITLE
slacko 14.0 - inkscapelite slacko->slacko14

### DIFF
--- a/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
+++ b/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
@@ -132,6 +132,7 @@ imlib2-1.4.5-i486|imlib2|1.4.5-i486||BuildingBlock|1304K||imlib2-1.4.5-i486.pet|
 inkscape-0.48.3.1-i486-s|inkscape|0.48.3.1-i486-s||Graphic|68396K||inkscape-0.48.3.1-i486-s.pet|+gsl,+aspell,+gtk+2|Create and edit Scalable Vector Graphics images|slackware|14.0||
 inkscape_DOC-0.48.3.1-i486-s|inkscape_DOC|0.48.3.1-i486-s||Graphic|2004K||inkscape_DOC-0.48.3.1-i486-s.pet||inkscape docs||||
 inkscape_NLS-0.48.3.1-i486-s|inkscape_NLS|0.48.3.1-i486-s||Graphic|18552K||inkscape_NLS-0.48.3.1-i486-s.pet||inkscape locales||||
+inkscapelite-0.36.3-i486|inkscapelite|0.36.3-i486||Graphic|2140K||inkscapelite-0.36.3-i486.pet||InkLite vector editor|slackware|13.1||
 ipscan-3.0-beta6-a|ipscan|3.0-beta6-a||Network|1068K||ipscan-3.0-beta6-a.pet|+jre,+gtk+2|Fast and friendly network scanner||||
 jre-1.7u15-i586|jre|1.7u15-i586||Utility|139516K||jre-1.7u15-i586.pet||Java runtime environment|slackware|14.0||
 jvnc-1.3.9|jvnc|1.3.9||Network|348K||jvnc-1.3.9.pet|+gtk+2|vnc viewer gui requiring java||||


### PR DESCRIPTION
With Packages-puppy-slacko-official removed (https://github.com/puppylinux-woof-CE/woof-CE/commit/9e76ea3f89e6a4871748847913cab6b3cffb3364) woof-CE picks inkscapelite-0.36.3-no_gnomeprint-q1.pet from puppy-common which works almost as good as slacko one that was grabbed before but seems to complains about this: 

/usr/bin/inkscapelite
		libpopt.so.0 (LIBPOPT_0) => not found

Both pets still have redrawing rulers bug (patched in slacko 6.3.2 and 7) though I think regular slacko inkscapelite-0.36.3-i486 seems slightly better to use than common due to not warning about missing lib. Thoughts? :)

edit: I found fixed inkscapelite-0.36.3_patched-glib-rulers.tar.xz source if it makes more sense to upload an "improved" pet instead of either option http://distro.ibiblio.org/puppylinux/sources/i/