### PR TITLE
puduan: remove netpbm?

### DIFF
--- a/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
+++ b/woof-distro/x86/devuan/ascii/DISTRO_PKGS_SPECS-devuan-ascii
@@ -427,7 +427,6 @@ yes|nbtscan||exe,dev
 yes|ncurses|ncurses-base,ncurses-bin,libncurses5,libncurses5-dev,libncursesw5,libncursesw5-dev,libtinfo5,libtinfo-dev|exe,dev,doc>null,nls>null
 yes|ndiswrapper|ndiswrapper,ndiswrapper-utils-1.9|exe,dev>null,doc>null,nls>null
 yes|nenscript||exe
-yes|netpbm|netpbm|exe,dev,doc>null,nls>null
 yes|net-tools|net-tools|exe,dev,doc>null,nls>null
 yes|nettle|libnettle6,nettle-dev,libhogweed4|exe,dev,doc>null,nls>null #needed by libarchive.
 yes|netmon_wce||exe,dev


### PR DESCRIPTION
This doesn't really work, because of missing libnetpbm10:

/usr/bin/giftopnm
	libnetpbm.so.10 => not found

/usr/bin/jpegtopnm
	libnetpbm.so.10 => not found

/usr/bin/pamcut
	libnetpbm.so.10 => not found

/usr/bin/pamdice
	libnetpbm.so.10 => not found

/usr/bin/pamfile
	libnetpbm.so.10 => not found

/usr/bin/pamstretch
	libnetpbm.so.10 => not found

/usr/bin/pbmtext
	libnetpbm.so.10 => not found

/usr/bin/pbmtoxbm
	libnetpbm.so.10 => not found

/usr/bin/pgmramp
	libnetpbm.so.10 => not found

/usr/bin/pgmslice
	libnetpbm.so.10 => not found

/usr/bin/pgmtopbm
	libnetpbm.so.10 => not found

/usr/bin/pgmtoppm
	libnetpbm.so.10 => not found

/usr/bin/pngtopnm
	libnetpbm.so.10 => not found

/usr/bin/pnmalias
	libnetpbm.so.10 => not found

/usr/bin/pnmcat
	libnetpbm.so.10 => not found

/usr/bin/pnmcolormap
	libnetpbm.so.10 => not found

/usr/bin/pnmconvol
	libnetpbm.so.10 => not found

/usr/bin/pnmcut
	libnetpbm.so.10 => not found

/usr/bin/pnmnlfilt
	libnetpbm.so.10 => not found

/usr/bin/pnmremap
	libnetpbm.so.10 => not found

/usr/bin/pnmrotate
	libnetpbm.so.10 => not found

/usr/bin/pnmscale
	libnetpbm.so.10 => not found

/usr/bin/pnmsmooth
	libnetpbm.so.10 => not found

/usr/bin/pnmsplit
	libnetpbm.so.10 => not found

/usr/bin/pnmtojpeg
	libnetpbm.so.10 => not found

/usr/bin/pnmtopng
	libnetpbm.so.10 => not found

/usr/bin/pnmtops
	libnetpbm.so.10 => not found

/usr/bin/ppmdither
	libnetpbm.so.10 => not found

/usr/bin/ppmlabel
	libnetpbm.so.10 => not found

/usr/bin/ppmquant
	libnetpbm.so.10 => not found

/usr/bin/ppmtobmp
	libnetpbm.so.10 => not found

/usr/bin/ppmtogif
	libnetpbm.so.10 => not found

/usr/bin/ppmtopgm
	libnetpbm.so.10 => not found

/usr/bin/ppmtoxpm
	libnetpbm.so.10 => not found

/usr/bin/pstopnm
	libnetpbm.so.10 => not found

/usr/bin/tifftopnm
	libnetpbm.so.10 => not found

/usr/bin/xbmtopbm
	libnetpbm.so.10 => not found

/usr/bin/xpmtoppm
	libnetpbm.so.10 => not found

/usr/bin/xwdtopnm
	libnetpbm.so.10 => not found

I removed it with no ill affects yet. With the removal of screeny ( https://github.com/puppylinux-woof-CE/woof-CE/commit/c27145d8fb06bb6d378ab70aa8014724b60bbade ) is it needed any more?