### PR TITLE
pup_event_frontend: remove free_func() and free_flash_func()

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_funcs
@@ -324,59 +324,7 @@ remove_pinboard_func() { #needs DRV_NAME (name of entire drive)
  done
 }
 
-free_func() { #called every 4 seconds.
- case $PUPMODE in
-  6|12)
-   pup_rw="$(stat -c %m $(readlink -f /initrd/pup_rw))" #get mountpoint regardless of filetype
-   SIZEFREEM=`df -m | grep " ${pup_rw}$" | tr -s ' ' | cut -f 4 -d ' '`
-  ;;
-  *)
-   SIZEFREEM=`df -m | grep ' /$' | head -n 1 | tr -s ' ' | cut -f 4 -d ' '` #110509 rerwin: insert head -n 1
-  ;;
- esac
- WARNMSG=""
- [ -s /tmp/pup_event_sizefreem ] && read -r PREVSIZEFREEM < /tmp/pup_event_sizefreem
- [ $PREVSIZEFREEM -eq $SIZEFREEM ] && return
- if [ $SIZEFREEM -lt 10 ];then
-   WARNMSG="$(gettext 'WARNING: Personal storage getting full, strongly recommend you resize it or delete files!')" #130208
- fi
- VIRTUALFREEM=$SIZEFREEM
- #save to a file, freememapplet can read this...
- echo "$VIRTUALFREEM" > /tmp/pup_event_sizefreem
- [ $PUPMODE -eq 5 -o $PUPMODE -eq 2 ] && return 0 #5=first boot, no msgs at top of screen.
- if [ "$WARNMSG" != "" ];then
-  killall yaf-splash
-  yaf-splash -bg red -placement top -text "$WARNMSG" &
- fi
-}
-
-free_flash_func() { #PUPMODE 3,7,13. called every 4 seconds.
- WARNMSG=""
- pup_ro1="$(stat -c %m $(readlink -f /initrd/pup_ro1))" #get mountpoint regardless of filetype
- pup_rw="$(stat -c %m $(readlink -f /initrd/pup_rw))" #get mountpoint regardless of filetype
- SIZEFREEM=`df -m | grep " ${pup_ro1}$" | tr -s ' ' | cut -f 4 -d ' '`
- SIZETMPM=`df -m | grep " ${pup_rw}$" | tr -s ' ' | cut -f 4 -d ' '`
- [ -s /tmp/pup_event_sizefreem ] && read -r PREVSIZEFREEM < /tmp/pup_event_sizefreem
- [ -s /tmp/pup_event_sizetmpm ] && read -r PREVSIZETMPM < /tmp/pup_event_sizetmpm
- [ -z "$PREVSIZETMPM" -o -z  "$SIZETMPM" ] && return #failsafe
- [ $PREVSIZEFREEM -eq $SIZEFREEM -a $PREVSIZETMPM -eq $SIZETMPM ] && return
- if [ $SIZEFREEM -lt 10 ];then
-   WARNMSG="$(gettext 'WARNING: Personal storage file getting full, strongly recommend you resize it or delete files!')" #130208
- fi
- if [ $SIZETMPM -lt 5 ];then
-   WARNMSG="$(gettext 'WARNING: RAM working space only') ${SIZETMPM}$(gettext 'MB, recommend a reboot which will flush the RAM')"
- fi
- VIRTUALFREEM=$SIZEFREEM
- echo "$SIZETMPM" > /tmp/pup_event_sizetmpm
- #save to a file, freememapplet can read this...
- echo "$VIRTUALFREEM" > /tmp/pup_event_sizefreem
- if [ "$WARNMSG" != "" ];then
-  killall yaf-splash
-  yaf-splash -bg red -placement top -text "$WARNMSG" &
- fi
-}
-
-savepuppy_func() { #called every 4 seconds.
+savepuppy_func() { #called every 6 seconds.
  if [ -f /tmp/snapmergepuppyrequest ];then #by request.
   rm -f /tmp/snapmergepuppyrequest
   #yaf-splash -font "8x16" -outline 0 -margin 4 -bg orange -placement top -text "Saving RAM to 'pup_save' file..." &

--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_timeout
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_timeout
@@ -79,13 +79,7 @@ do
 
 	#monitor free memory, periodic save of tmpfs top layer...
 	case $PUPMODE in
-		3|7|13)
-			free_flash_func
-			savepuppy_func
-			;;
-		*)   
-			free_func
-			;;
+		3|7|13) savepuppy_func ;;
 	esac
 
 	[ "$HOTPLUGON" = "false" ] && continue #see /etc/eventmanager


### PR DESCRIPTION
there is the freememapplet_tray app running in every pup
so you have an idea about storage usage.

if the icon turns red, it means the personal storage is getting full

frontend_timeout already runs a lot of apps every 6 seconds, including ps, grep
and cddetect_quick needed for an optical drv + systemd-udevd
greps /proc/mounts

this extra code is overkill

@gyrog has patches for these functions for his overlayfs stuff

if this is merged those patches are probably not needed anymore...

maybe these functions should be moved to somewhere else?