### PR TITLE
Slacko 14.2 - Switch to jwm 2.3.6

### DIFF
--- a/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
+++ b/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
@@ -195,7 +195,7 @@ yes|isomaster||exe,dev,doc,nls
 yes|iw|iw|exe,dev,doc,nls
 yes|jasper|jasper|exe,dev,doc,nls
 yes|jimtcl||exe,dev,doc
-yes|jwm||exe,dev,doc,nls
+yes|jwm|jwm|exe,dev,doc,nls
 yes|keyutils|keyutils|exe,dev,doc,nls
 yes|kernel_headers_musl||exe>dev
 yes|kmod|kmod|exe,dev,doc,nls

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
@@ -194,7 +194,7 @@ yes|isomaster||exe,dev,doc,nls
 yes|iw|iw|exe,dev,doc,nls
 yes|jasper|jasper|exe,dev,doc,nls
 yes|jimtcl||exe,dev,doc
-yes|jwm||exe,dev,doc,nls
+yes|jwm|jwm|exe,dev,doc,nls
 yes|keyutils|keyutils|exe,dev,doc,nls
 yes|kernel_headers_musl||exe>dev
 yes|kmod|kmod|exe,dev,doc,nls


### PR DESCRIPTION
There seems to be some incompatibility with these new themes and jwm 2.3.2
https://github.com/puppylinux-woof-CE/woof-CE/tree/testing/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes

Using jwm 2.3.6 from slackware seems to fix it, and hasn't caused me any issues yet.

I added to master because I think it is a bug, is this a good idea? :cat2: 

![screenshot](https://user-images.githubusercontent.com/5408521/40886873-97149376-670d-11e8-9fcb-9fc668d45148.png)
