### PR TITLE
slacko 14.0 - bring back sfs_manager-0.8

### DIFF
--- a/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
+++ b/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
@@ -175,6 +175,7 @@ sdl_DEV-1.2.15-i486|sdl_DEV|1.2.15-i486||BuildingBlock|740K||sdl_DEV-1.2.15-i486
 sdl_DOC-1.2.15-i486|sdl_DOC|1.2.15-i486||BuildingBlock|2144K||sdl_DOC-1.2.15-i486.pet||sdl docs||||
 Send-to-Backgrounds-update-01|Send-to-Backgrounds-update|01||BuildingBlock|8K||Send-to-Backgrounds-update-01.pet||rox right click||||
 sfontview-0.1.1-i468-s|sfontview|0.1.1-i468-s||Desktop|44K||sfontview-0.1.1-i468-s.pet||font viewer|slackware|14.0||
+sfs_manager-0.8|sfs_manager|0.8||Setup|52K||sfs_manager-0.8.pet||Sfs Manager download and install sfs files||||
 squashfs-tools4-4.3-i686|squashfs-tools4|4.3-i686||BuildingBlock|276K||squashfs-tools4-4.3-i686.pet||tools for squash filesystem|slackware|14.1||
 sylpheed-3.3.0-i486-s14.0|sylpheed|3.3.0-i486-s14.0||Internet|2060K||sylpheed-3.3.0-i486-s14.0.pet|+gtk+2|E-Mail client|slackware|14.0||
 sylpheed_DEV-3.3.0-i486-s14.0|sylpheed_DEV|3.3.0-i486-s14.0||Internet|260K||sylpheed_DEV-3.3.0-i486-s14.0.pet|+sylpheed|sylpheed dev headers|slackware|14.0||


### PR DESCRIPTION
The ones in noarch are too new (program entries and urls) and only work with Slacko 632 and 700.