### PR TITLE
momanager & pfontview

### DIFF
--- a/woof-distro/x86/ubuntu/upupbb/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86/ubuntu/upupbb/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -485,7 +485,6 @@ yes|miniupnpc|libminiupnpc10,libminiupnpc-dev|exe,dev,doc,nls| #needed by transm
 yes|mirdir||exe
 yes|mm_view||exe
 yes|modem_stats||exe
-yes|momanager||exe
 yes|mpclib3|libmpc3,libmpc-dev|exe>dev,dev,doc,nls| #needed by gcc.
 yes|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls| #needed by mplayer.
 yes|mp||exe
@@ -569,7 +568,6 @@ yes|perl_tiny|perl,perl-base,perl-modules-5.26|exe,dev>null,doc>null,nls>null
 yes|perl-uri|liburi-perl|exe>dev,dev,doc,nls
 yes|perl-xml-parser|libxml-parser-perl|exe>dev,dev,doc,nls
 yes|perl-xml-simple|libxml-simple-perl|exe>dev,dev,doc,nls
-yes|pfontview||exe
 yes|picocom|picocom|exe,dev,doc,nls
 yes|picpuz||exe
 yes|pixman|libpixman-1-0,libpixman-1-dev|exe,dev,doc,nls


### PR DESCRIPTION
momanager now apparently in rootfs_skeleton
pfontview should be in rootfs_skeleton (??) but isn't for master