### PR TITLE
network_connect_update: detect predictable network device names

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
@@ -9,6 +9,7 @@
 #170730 add conditional later attempt to detect interfaces.
 #171226 use lspci to detect ethernet hardware, replacing 170730.
 #180104 check for ethernet bridge hardware if controller not detected; increase wait for detection; move sleep to after test; change report of wait time.
+#180624 add check for predictable network interface device names (e.g. enp0s25).
 
 export LANG='C'
 
@@ -24,7 +25,7 @@ ethCNT=$(lspci -n | grep ' 0200: ' | wc -l)
 [ $ethCNT -eq 0 ] \
  && ethCNT=$(lspci -nn | grep ' \[0680\]: .* Ethernet ' | wc -l) #180104
 while [ $ifCNT -lt $ethCNT ];do
- ifCNT=$(ifconfig -a | grep '^eth[0-9] ' | wc -l)
+ ifCNT=$(ifconfig -a | grep -E '^eth[0-9] |^en[oPps][0-9]|^enx[0-9a-f]' | wc -l) #180624
  [ $ifCNT -gt 0 -o $loopCNT -ge 30 ] && break #finding one i/f is enough, other may not have a driver. 180104
  sleep 1 #180104
  loopCNT=$(($loopCNT+1))

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard_2nd
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard_2nd
@@ -14,6 +14,7 @@
 #170309 rerwin: retain choice in case multiple setups tried; disconnect any unchosen network setup.
 #170418 rerwin: leave defaultconnect unchanged when trying another tool.
 #170510 rerwin: exit if executable/dialog killed.
+#180624 add check for predictable network interface device names (e.g. enp0s25).
 
 export TEXTDOMAIN=connectwizard_2nd
 export OUTPUT_CHARSET=UTF-8
@@ -107,7 +108,7 @@ if [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'FLAG'`" != "" ];then
  fi #170309 end
  [ $? -gt 2 ] && exit #170510 exec killed
 
- IFSUP="`ifconfig | grep -E '^eth|^wlan'`"
+ IFSUP="`ifconfig | grep -E '^eth|^wlan|^en[oPpsx]|^wl[oPpsx]'`" #180624
  if [ "$IFSUP" != "" ];then
   IFSUP="`echo "$IFSUP" | cut -f 1 -d ' ' | tr '\n' ' '`"
   MSG1="$(gettext 'These interfaces are active:')


### PR DESCRIPTION
Avoids delay in default ethernet startup (rc.network_eth).
Restores correct "active interfaces" message after use of a network manager (connectwizard_2nd).