### PR TITLE
rc.shutdown: saving after first boot, copy all puprw files, including hidden

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -294,8 +294,7 @@ case $PUPMODE in
     chgrp $GRP "/tmp/save1stpup/${BASENAME}"
     touch "/tmp/save1stpup/${BASENAME}" --reference="$ONEDIR"
    fi
-   cp -a $ONEDIR/* /tmp/save1stpup/${BASENAME}/
-   [ "$BASENAME" = "root" ] && cp -a $ONEDIR/.[0-9a-zA-Z]* /tmp/save1stpup/${BASENAME}/
+   cp -a $ONEDIR/ /tmp/save1stpup/
   done
   #copy initmodules config file from /tmp if it exists
   [ -f /tmp/${DISTRO_FILE_PREFIX}initmodules.txt ] && cp -f /tmp/${DISTRO_FILE_PREFIX}initmodules.txt ${SMNTPT}${SAVEPATH}/${DISTRO_FILE_PREFIX}initmodules.txt


### PR DESCRIPTION
When saving after a pfix=ram bootup, any files deleted before the initial save re-appear in the next bootup.  Whiteout and other hidden files are not saved.  Please hold this pull request if you know of a reason to not copy all hidden files.  This change seems consistent with saving in other pup-states.