### PR TITLE
no|desksetup

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -65,7 +65,6 @@ yes|dejavu_fonts|dejavu-fonts-ttf|exe,dev,doc,nls
 yes|desk_icon_theme_smooth_color||exe
 yes|desk_icon_theme_stardust||exe
 yes|desk_icon_theme_yasis||exe
-yes|desksetup||exe
 yes|dhcpcd||exe
 yes|dialog|dialog|exe,dev>null,doc,nls
 yes|dictd||exe


### PR DESCRIPTION
This has been removed from noarch list
https://github.com/puppylinux-woof-CE/woof-CE/commit/fe2e50b85431e375293c2a9b1f4e13a0236a422e