### PR TITLE
slacko 14.0: xvkbd needed for X-Virtual Keyboard

### DIFF
--- a/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PKGS_SPECS-slackware-14.0
@@ -421,6 +421,7 @@ yes|x-keyboard||exe
 yes|xsoldier||exe
 yes|xtrans|xtrans|exe>dev,dev,doc,nls
 yes|xvidcore|xvidcore|exe,dev,doc,nls
+yes|xvkbd||exe,dev
 yes|xwd|xwd|exe,dev,doc,nls
 yes|xz|xz|exe,dev,doc,nls
 yes|yad||exe

--- a/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
+++ b/woof-distro/x86/slackware/14.0/Packages-puppy-slacko14-official
@@ -208,6 +208,8 @@ xsane-0.999-i686_slack14.0|xsane|0.999-i686_slack14.0||graphic|2416||xsane-0.999
 xsane_DEV-0.999-i686_slack14.0|xsane_DEV|0.999-i686_slack14.0||graphic|20||xsane_DEV-0.999-i686_slack14.0.pet|+xsane|xsane development|slackware|14.0||
 xsane_DOC-0.999-i686_slack14.0|xsane_DOC|0.999-i686_slack14.0||graphic|1832||xsane_DOC-0.999-i686_slack14.0.pet|+xsane|xsane documentation||||
 xsoldier-1.8-i686_slack14.0|xsoldier|1.8-i686_slack14.0||Fun|788||xsoldier-1.8-i686_slack14.0.pet||galaxian clone shooter game|slackware|14.0||
+xvkbd-3.7-i686_s630|xvkbd|3.7-i686_s630||Desktop|280||xvkbd-3.7-i686_s630.pet||a virtual keyboard for the desktop|slackware|14.1||
+xvkbd_DEV-3.7-i686_s630|xvkbd_DEV|3.7-i686_s630||Desktop|20||xvkbd_DEV-3.7-i686_s630.pet|+xvkbd|xvkbd development||||
 z_fixcache-0.1ff-noarch|z_fixcache|0.1ff-noarch||BuildingBlock|28K||z_fixcache-0.1ff-noarch.pet||fixes cache for firefox||||
 z2_walls-0.2|z2_walls|0.2||Desktop;appearance|392K||z2_walls-0.2.pet||desktop wallpapers||||
 zarfy-0.1.0-i686_slack14.0|zarfy|0.1.0-i686_slack14.0||Setup|204||zarfy-0.1.0-i686_slack14.0.pet||A graphical tool for controlling multiple monitors using xrandr|slackware|14.0||


### PR DESCRIPTION
The one from 14.1 sort of works, though gives warning about font

![screenshot 2](https://user-images.githubusercontent.com/5408521/46918374-843add00-cf9f-11e8-8636-bb92a8fe11d8.png)
![screenshot 1](https://user-images.githubusercontent.com/5408521/46918376-90269f00-cf9f-11e8-8d4a-e2b8e9849406.png)
