### PR TITLE
SNS, frisbee, firewall_ng: suppress error messages from kills of splash processes

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1309,7 +1309,7 @@ gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &
 urxvt -bg yellow -fg black -geometry 60X10+1+1 --hold -e /etc/init.d/rc.firewall start &
 p=$!
 sleep 6
-kill -9 $p
+kill -9 $p 2>/dev/null
 
 # start the status icon
 pidof firewallstatus && exit

--- a/woof-code/rootfs-packages/frisbee/pet.specs
+++ b/woof-code/rootfs-packages/frisbee/pet.specs
@@ -1,1 +1,1 @@
-frisbee-1.4.7|frisbee|1.4.7||Network|264K||frisbee-1.4.7.pet|+gtkdialog&ge0.8.4|Frisbee network manager||||
+frisbee-1.4.9|frisbee|1.4.9||Network|264K||frisbee-1.4.9.pet|+gtkdialog&ge0.8.4|Frisbee network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
+++ b/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
@@ -1,5 +1,5 @@
 # Accumulate list of modules to be loaded, for use by rc.network.
 
 ENV{MODALIAS}=="?*", ACTION=="add", SUBSYSTEM=="?*", \
-  PROGRAM="/bin/grep '=sns' /root/.connectwizardrc", \
+  PROGRAM="/bin/grep -sq '=sns' /root/.connectwizardrc", \
   RUN+="/usr/local/simple_network_setup/build_udevmodulelist"

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -367,7 +367,7 @@ if [ "`ifconfig | grep "$ifPATTERN"`" != "" ];then
  dhcpcd --release $INTERFACE 2>/dev/null
  ip route flush dev $INTERFACE #100703
  sleep 1
- kill $PIDX1
+ kill $PIDX1 2>/dev/null
 fi
 
 fPATTERN='^'"${INTERFACE}"'|'
@@ -590,7 +590,7 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
    </button>'
   fi
 
-  kill $PIDXMSG ; PIDXMSG=""
+  kill $PIDXMSG 2>/dev/null ; PIDXMSG=""
 
   export SNS_setup='<window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network" height-request="400">
   <vbox space-expand="true" space-fill="true">
@@ -754,7 +754,7 @@ network={
      fi
      if [ $FLAGERR ];then
       if [ $fuCNT -ne 0 ];then
-       kill $PIDX
+       kill $PIDX 2>/dev/null
        case $fuCNT in
         1) BGCOLOR="HotPink" ;;
         2) BGCOLOR="pink" ;;
@@ -791,7 +791,7 @@ network={
       done
       if [ $FLAGERR ];then
        if [ $fuCNT -ne 0 ];then
-        kill $PIDX
+        kill $PIDX 2>/dev/null
         case $fuCNT in
          1) BGCOLOR="HotPink" ;;
          2) BGCOLOR="pink" ;;
@@ -859,7 +859,7 @@ network={
          </checkbox>
          <hseparator></hseparator>'
         fi
-        kill $PIDX
+        kill $PIDX 2>/dev/null
         export SNS_complete='
         <window title="'$(gettext 'SNS: Simple Network Setup')'" icon-name="gtk-network">
         <vbox>
@@ -904,8 +904,8 @@ network={
  fi #end test ifconfig up
 
  if [ $FLAGERR ];then
-  [ $PIDXMSG ] && kill $PIDXMSG
-  [ $PIDX ] && kill $PIDX
+  [ $PIDXMSG ] && kill $PIDXMSG 2>/dev/null
+  [ $PIDX ] && kill $PIDX 2>/dev/null
   case $SEC_MGMT in
   WPA*) ERR_EXTRA1="$(gettext 'Note: the network card and/or Linux driver might not support WPA2, in which case you will need to set the wireless router to WPA. Or, WPA might not be supported at all, in which case you will have to set the router and network card to use WEP.')" ;;
   *)    ERR_EXTRA1="" ;;
@@ -981,7 +981,7 @@ if [ "$IF_INTTYPE" == "Wired" ];then
   done
   if [ "$LINK_DETECTED" = "no" ] ; then
      ifconfig $INTERFACE down
-     kill $PIDXX
+     kill $PIDXX 2>/dev/null
      /usr/lib/gtkdialog/box_ok "$(gettext 'Simple Network Setup')" error "<b>$(gettext 'There does not seem to be any network connected to') ${INTERFACE}</b>" " " "$(gettext "Is the network cable unplugged? Modem router turned off? If you can fix it, great, otherwise try a different interface.")"
      exec sns
      exit
@@ -1004,7 +1004,7 @@ if [ "$IF_INTTYPE" == "Wired" ];then
    fi #170402
   fi
  fi
- kill $PIDXX
+ kill $PIDXX 2>/dev/null
 
  if [ $IFACEUP = true ] \
    && [ -f /tmp/sns_interface_success ];then #170402


### PR DESCRIPTION
The "no process killed" messages for splash messages are unneeded clutter in xerrs.log.
Also adds grep options to SNS rule and corrects frisbee version in pet.specs.