### PR TITLE
remove apulse

### DIFF
--- a/woof-distro/x86/ubuntu/Packages-puppy-tahr-official
+++ b/woof-distro/x86/ubuntu/Packages-puppy-tahr-official
@@ -2,7 +2,6 @@
 abiword-3.0.0-gtk2|abiword|3.0.0-gtk2||Document|26156K||abiword-3.0.0-gtk2.pet||Abiword word processor|ubuntu|trusty||
 acpi|acpi|||BuildingBlock|44K||acpi.pet||no description provided|ubuntu|trusty||
 alsaequal-0.6-i486|alsaequal|0.6-i486||BuildingBlock|48K||alsaequal-0.6-i486.pet|+caps_eq|equalizer plugin for alsa, used by pequalizer|puppy|wary5||
-apulse-i686|apulse|i686||BuildingBlock|172K||apulse-i686.pet||no description provided|ubuntu|trusty||
 asunder-2.7-i686|asunder|2.7-i686||Multimedia|180K||asunder-2.7-i686.pet||An application to save tracks from an Audio CD as WAV, MP3, OGG, FLAC, and/or Wavpack.|ubuntu|trusty||
 asunder_NLS-2.7-i686|asunder_NLS|2.7-i686||Multimedia|1516K||asunder_NLS-2.7-i686.pet||no description provided||||
 avidemux-2.5.4_QT|avidemux|2.5.4_QT||Multimedia|17392K||avidemux-2.5.4_QT.pet||Edit your Videos|ubuntu|trusty||


### PR DESCRIPTION
now in common32
if not removed this entry takes precedent over the common32 entry even if tahr should have less precedent in pet-repos list
if this cannot be removed - common32 needs to be amended