### PR TITLE
network_connect: increase wait for ethtool in rc.network_eth, SNS & netwiz

### DIFF
--- a/woof-code/rootfs-packages/network_wizard/pet.specs
+++ b/woof-code/rootfs-packages/network_wizard/pet.specs
@@ -1,1 +1,1 @@
-network_wizard-2.0|network_wizard|2.0||Network|376K||network_wizard-2.0.pet|+gtkdialog|Dougal's Network Wizard||||
+network_wizard-2.0.1|network_wizard|2.0.1||Network|376K||network_wizard-2.0.1.pet|+gtkdialog|Dougal's Network Wizard||||

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
@@ -1034,7 +1034,7 @@ $ERROR
 			LINK_DETECTED="yes"
 			break
 		fi
-		sleep 1.3
+		sleep 1 #190204
 		echo "X"
 	done
 	if [ "$LINK_DETECTED" = "no" ] ; then

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
@@ -75,6 +75,7 @@
 #170509 rerwin: replace gtkdialog3 with gtkdialog.
 #170514 add message about already running
 #180923 move network wizard to its package directory.
+#190204 v2.0.1: increase wait for ethtool link detected (5 > 8 seconds).
 
 # $1: interface
 interface_is_wireless() {
@@ -1028,7 +1029,7 @@ $ERROR
 
 	echo "X"
 	LINK_DETECTED=no
-	for i in 1 2 3 4 5 ; do
+	for i in 1 2 3 4 5 6 7 8 ; do #190204
 		if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
 			LINK_DETECTED="yes"
 			break

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
@@ -75,7 +75,7 @@
 #170509 rerwin: replace gtkdialog3 with gtkdialog.
 #170514 add message about already running
 #180923 move network wizard to its package directory.
-#190204 v2.0.1: increase wait for ethtool link detected (5 > 8 seconds).
+#190209 v2.0.1: increase wait for ethtool link detected, to 7.5 secs).
 
 # $1: interface
 interface_is_wireless() {
@@ -1029,12 +1029,12 @@ $ERROR
 
 	echo "X"
 	LINK_DETECTED=no
-	for i in 1 2 3 4 5 6 7 8 ; do #190204
+	for i in 1 2 3 4 5 ; do
 		if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
 			LINK_DETECTED="yes"
 			break
 		fi
-		sleep 1 #190204
+		sleep 1.5 #190209
 		echo "X"
 	done
 	if [ "$LINK_DETECTED" = "no" ] ; then

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
@@ -59,7 +59,7 @@
 # 9mar2017: ensure current exec name set
 #170612 verify wifi country of regulation matches user specified country.
 #180923 move network wizard to its package directory.
-#190204 v2.0.1: increase wait for ethtool link detected (5 > 8 seconds); make connectwizardrc usage conditional on presence of connectwizard_exec, for use outside of woofCE pups.
+#190209 v2.0.1: increase wait for ethtool link detected, to 7.5 secs total); make connectwizardrc usage conditional on presence of connectwizard_exec, for use outside of woofCE pups.
 
 ######### TODO ###########
 #- need to find out about static ip... can we check somehow (arp)? maybe use
@@ -145,12 +145,12 @@ testInterface()
   echo -n "checking if interface $INTERFACE is alive..."
 	echo "X"
 	LINK_DETECTED=no
-	for i in 1 2 3 4 5 6 7 8 ; do #190204
+	for i in 1 2 3 4 5 ; do
 		if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
 			LINK_DETECTED="yes"
 			break
 		fi
-		sleep 1 #190204
+		sleep 1.5 #190209
 		echo "X"
 	done
 	if [ "$LINK_DETECTED" = "no" ] ; then
@@ -314,11 +314,11 @@ if [ "$ACTION" = "restart" ] ; then # connect
   pidof X >/dev/null && HAVEX="yes"
   exec 1>/tmp/network-connect.log 2>&1
 else # below only done at boot
-  if which connectwizard_exec >/dev/null; then #190204
+  if which connectwizard_exec >/dev/null; then #190209
     [ -f /root/.connectwizardrc ] \
      || echo 'CURRENT_EXEC=net-setup.sh' > /root/.connectwizardrc # 9mar2017
-  fi #190204
-  which connectwizard_crd >/dev/null && connectwizard_crd #170612 190204
+  fi #190209
+  which connectwizard_crd >/dev/null && connectwizard_crd #170612 190209
   ifconfig lo 127.0.0.1
   route add -net 127.0.0.0 netmask 255.0.0.0 lo
   #rewrite_mac_address  # 9feb10 moved

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
@@ -59,6 +59,7 @@
 # 9mar2017: ensure current exec name set
 #170612 verify wifi country of regulation matches user specified country.
 #180923 move network wizard to its package directory.
+#190204 v2.0.1: increase wait for ethtool link detected (5 > 8 seconds); make connectwizardrc usage conditional on presence of connectwizard_exec, for use outside of woofCE pups.
 
 ######### TODO ###########
 #- need to find out about static ip... can we check somehow (arp)? maybe use
@@ -144,7 +145,7 @@ testInterface()
   echo -n "checking if interface $INTERFACE is alive..."
 	echo "X"
 	LINK_DETECTED=no
-	for i in 1 2 3 4 5 ; do
+	for i in 1 2 3 4 5 6 7 8 ; do #190204
 		if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
 			LINK_DETECTED="yes"
 			break
@@ -313,9 +314,11 @@ if [ "$ACTION" = "restart" ] ; then # connect
   pidof X >/dev/null && HAVEX="yes"
   exec 1>/tmp/network-connect.log 2>&1
 else # below only done at boot
-  [ -f /root/.connectwizardrc ] \
-   || echo 'CURRENT_EXEC=net-setup.sh' > /root/.connectwizardrc # 9mar2017
-  [ -x /usr/sbin/connectwizard_crd ] && connectwizard_crd #170612
+  if [ which connectwizard_exec >/dev/null ];then #190204
+    [ -f /root/.connectwizardrc ] \
+     || echo 'CURRENT_EXEC=net-setup.sh' > /root/.connectwizardrc # 9mar2017
+  fi #190204
+  [ which connectwizard_crd >/dev/null ] && connectwizard_crd #170612 190204
   ifconfig lo 127.0.0.1
   route add -net 127.0.0.0 netmask 255.0.0.0 lo
   #rewrite_mac_address  # 9feb10 moved

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
@@ -150,7 +150,7 @@ testInterface()
 			LINK_DETECTED="yes"
 			break
 		fi
-		sleep 1.3
+		sleep 1 #190204
 		echo "X"
 	done
 	if [ "$LINK_DETECTED" = "no" ] ; then
@@ -314,11 +314,11 @@ if [ "$ACTION" = "restart" ] ; then # connect
   pidof X >/dev/null && HAVEX="yes"
   exec 1>/tmp/network-connect.log 2>&1
 else # below only done at boot
-  if [ which connectwizard_exec >/dev/null ];then #190204
+  if which connectwizard_exec >/dev/null; then #190204
     [ -f /root/.connectwizardrc ] \
      || echo 'CURRENT_EXEC=net-setup.sh' > /root/.connectwizardrc # 9mar2017
   fi #190204
-  [ which connectwizard_crd >/dev/null ] && connectwizard_crd #170612 190204
+  which connectwizard_crd >/dev/null && connectwizard_crd #170612 190204
   ifconfig lo 127.0.0.1
   route add -net 127.0.0.0 netmask 255.0.0.0 lo
   #rewrite_mac_address  # 9feb10 moved

--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.1|simple_network_setup|2.1||Network|136K||simple_network_setup-2.1.pet|+gtkdialog|sns as package||||
+simple_network_setup-2.1.1|simple_network_setup|2.1.1||Network|136K||simple_network_setup-2.1.1.pet|+gtkdialog|sns as package||||

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -31,6 +31,7 @@
 #180125 unblock wlan softblock.
 #180706 Accommodate large network list, by omitting unneeded iwlist lines and limiting search for 'Scan completed'.
 #181109 Replace module-loading & MAC-address loop logic with greps of lists; speed up scan result processing & sort by strength.
+#190204 v2.1.1: increase wait for ethtool link detected (5 > 8 seconds).
 
 export TEXTDOMAIN=sns___rc.network
 export OUTPUT_CHARSET=UTF-8
@@ -320,7 +321,7 @@ do
  [ $? -ne 0 ] && continue
 
  LINK_DETECTED=no
- for i in 1 2 3 4 5 ; do
+ for i in 1 2 3 4 5 6 7 8 ; do #190204
    if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
      LINK_DETECTED="yes"
      break

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -31,7 +31,7 @@
 #180125 unblock wlan softblock.
 #180706 Accommodate large network list, by omitting unneeded iwlist lines and limiting search for 'Scan completed'.
 #181109 Replace module-loading & MAC-address loop logic with greps of lists; speed up scan result processing & sort by strength.
-#190204 v2.1.1: increase wait for ethtool link detected (5 > 8 seconds).
+#190209 v2.1.1: increase wait for ethtool link detected, to 7.5 secs total).
 
 export TEXTDOMAIN=sns___rc.network
 export OUTPUT_CHARSET=UTF-8
@@ -321,12 +321,12 @@ do
  [ $? -ne 0 ] && continue
 
  LINK_DETECTED=no
- for i in 1 2 3 4 5 6 7 8 ; do #190204
+ for i in 1 2 3 4 5 ; do
    if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
      LINK_DETECTED="yes"
      break
    fi
-   sleep 1
+   sleep 1.5 #190209
  done
  if [ "$LINK_DETECTED" = "no" ] ; then
    ifconfig $INTERFACE down

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -35,7 +35,7 @@
 #170619 display networks in order of signal quality.
 #170924 add short sleep to allow time for dhcpcd to write to resolv.conf.
 #180706 Accommodate large network list, by omitting unneeded iwlist lines and limiting search for 'Scan completed'.
-#190204 v2.1.1: increase wait for ethtool link detected (5 > 8 seconds).
+#190209 v2.1.1: increase wait for ethtool link detected, to 7.5 secs total).
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -973,12 +973,12 @@ if [ "$IF_INTTYPE" == "Wired" ];then
  [ $? -eq 0 ] && IFACEUP=true || IFACEUP=false #170402
  if [ $IFACEUP = true ];then #170402
   LINK_DETECTED=no
-  for i in 1 2 3 4 5 6 7 8 ; do #190204
+  for i in 1 2 3 4 5 ; do
      if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
        LINK_DETECTED="yes"
        break
      fi
-     sleep 1
+     sleep 1.5 #190209
   done
   if [ "$LINK_DETECTED" = "no" ] ; then
      ifconfig $INTERFACE down

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -35,6 +35,7 @@
 #170619 display networks in order of signal quality.
 #170924 add short sleep to allow time for dhcpcd to write to resolv.conf.
 #180706 Accommodate large network list, by omitting unneeded iwlist lines and limiting search for 'Scan completed'.
+#190204 v2.1.1: increase wait for ethtool link detected (5 > 8 seconds).
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -972,7 +973,7 @@ if [ "$IF_INTTYPE" == "Wired" ];then
  [ $? -eq 0 ] && IFACEUP=true || IFACEUP=false #170402
  if [ $IFACEUP = true ];then #170402
   LINK_DETECTED=no
-  for i in 1 2 3 4 5 ; do
+  for i in 1 2 3 4 5 6 7 8 ; do #190204
      if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
        LINK_DETECTED="yes"
        break

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
@@ -9,6 +9,7 @@
 #171226 use lspci to detect ethernet hardware, replacing 170730.
 #180104 check for ethernet bridge hardware if controller not detected; increase wait for detection; move sleep to after test; change report of wait time.
 #180624 add check for predictable network interface device names (e.g. enp0s25).
+#190204 increase wait for ethtool link detected (5 > 8 seconds).
 
 export LANG='C'
 
@@ -57,7 +58,7 @@ do
  [ $? -ne 0 ] && continue
 
  LINK_DETECTED=no
- for i in 1 2 3 4 5 ; do
+ for i in 1 2 3 4 5 6 7 8 ; do #190204
    if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
      LINK_DETECTED="yes"
      break

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
@@ -9,7 +9,7 @@
 #171226 use lspci to detect ethernet hardware, replacing 170730.
 #180104 check for ethernet bridge hardware if controller not detected; increase wait for detection; move sleep to after test; change report of wait time.
 #180624 add check for predictable network interface device names (e.g. enp0s25).
-#190204 increase wait for ethtool link detected (5 > 8 seconds).
+#190209 increase wait for ethtool link detected, to 7.5 secs total).
 
 export LANG='C'
 
@@ -58,12 +58,12 @@ do
  [ $? -ne 0 ] && continue
 
  LINK_DETECTED=no
- for i in 1 2 3 4 5 6 7 8 ; do #190204
+ for i in 1 2 3 4 5 ; do
    if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
      LINK_DETECTED="yes"
      break
    fi
-   sleep 1
+   sleep 1.5 #190209
  done
  if [ "$LINK_DETECTED" = "no" ] ; then
    ifconfig $INTERFACE down


### PR DESCRIPTION
Received a report of ethernet connection failures apparently due to ethtool not responding within the 5 seconds allowed.  Wait increased to 8 seconds max.