### PR TITLE
Packages-common64: Remove pets that contain libraries

### DIFF
--- a/woof-distro/x86_64/Packages-puppy-common64-official
+++ b/woof-distro/x86_64/Packages-puppy-common64-official
@@ -4,17 +4,11 @@ busybox-1.29.3-x86_64_musl_static|busybox|1.29.3-x86_64_musl_static||BuildingBlo
 cryptsetup-1.7.5-musl_static_x86_64|cryptsetup|1.7.5-musl_static_x86_64||BuildingBlock|1196||cryptsetup-1.7.5-musl_static_x86_64.pet||No description provided||||
 dosfstools-4.1-x86_64_common64|dosfstools|4.1-x86_64_common64||BuildingBlock|148||dosfstools-4.1-x86_64_common64.pet||dosfstools||||
 dosfstools_DOC-4.1-x86_64_common64|dosfstools_DOC|4.1-x86_64_common64||BuildingBlock|84||dosfstools_DOC-4.1-x86_64_common64.pet|+dosfstools|dosfstools documentation||||
-e2fsprogs-1.43.9-x86_64_common64|e2fsprogs|1.43.9-x86_64_common64||BuildingBlock|2924||e2fsprogs-1.43.9-x86_64_common64.pet||ext2/3/4 filesystem utilities||||
-e2fsprogs_DOC-1.43.9-x86_64_common64|e2fsprogs_DOC|1.43.9-x86_64_common64||BuildingBlock|452||e2fsprogs_DOC-1.43.9-x86_64_common64.pet|+e2fsprogs|e2fsprogs documentation||||
 exfat-utils-1.2.8-x86_64_common64|exfat-utils|1.2.8-x86_64_common64||BuildingBlock|192||exfat-utils-1.2.8-x86_64_common64.pet||exfat-utils||||
 exfat-utils_DOC-1.2.8-x86_64_common64|exfat-utils_DOC|1.2.8-x86_64_common64||BuildingBlock|36||exfat-utils_DOC-1.2.8-x86_64_common64.pet|+exfat-utils|exfat-utils documentation||||
-f2fs-tools-1.10.0-x86_64_common64|f2fs-tools|1.10.0-x86_64_common64||BuildingBlock|308||f2fs-tools-1.10.0-x86_64_common64.pet||tools for f2fs file system||||
-f2fs-tools_DEV-1.10.0-x86_64_common64|f2fs-tools_DEV|1.10.0-x86_64_common64||BuildingBlock|144||f2fs-tools_DEV-1.10.0-x86_64_common64.pet|+f2fs-tools|f2fs-tools development||||
-f2fs-tools_DOC-1.10.0-x86_64_common64|f2fs-tools_DOC|1.10.0-x86_64_common64||BuildingBlock|48||f2fs-tools_DOC-1.10.0-x86_64_common64.pet|+f2fs-tools|f2fs-tools documentation||||
 fuse-exfat-1.2.8-x86_64_common64|fuse-exfat|1.2.8-x86_64_common64||BuildingBlock|60||fuse-exfat-1.2.8-x86_64_common64.pet||fuse-exfat||||
 fuse-exfat_DOC-1.2.8-x86_64_common64|fuse-exfat_DOC|1.2.8-x86_64_common64||BuildingBlock|24||fuse-exfat_DOC-1.2.8-x86_64_common64.pet|+fuse-exfat|fuse-exfat documentation||||
 gptfdisk-1.0.3-x86_64_common64|gptfdisk|1.0.3-x86_64_common64||BuildingBlock|644||gptfdisk-1.0.3-x86_64_common64.pet||A text-mode partitioning tool that works on GUID Partition Table (GPT) disks||||
-gtk-server-2.4.4-x86_64_common64|gtk-server|2.4.4-x86_64_common64||BuildingBlock|520||gtk-server-2.4.4-x86_64_common64.pet||gtk-server||||
 grsync-1.2.6-x86_64_common64|grsync|1.2.6-x86_64_common64||BuildingBlock|260||grsync-1.2.6-x86_64_common64.pet|+rsync|rsync frontend|common64|||
 grsync_DOC-1.2.6-x86_64_common64|grsync_DOC|1.2.6-x86_64_common64||BuildingBlock|28||grsync_DOC-1.2.6-x86_64_common64.pet|+grsync|grsync documentation|common64|||
 grsync_NLS-1.2.6-x86_64_common64|grsync_NLS|1.2.6-x86_64_common64||BuildingBlock|500||grsync_NLS-1.2.6-x86_64_common64.pet|+grsync|grsync locales|common64|||
@@ -26,10 +20,6 @@ sdparm-1.10-x86_64_common64|sdparm|1.10-x86_64_common64||BuildingBlock|308||sdpa
 sdparm_DOC-1.10-x86_64_common64|sdparm_DOC|1.10-x86_64_common64||BuildingBlock|72||sdparm_DOC-1.10-x86_64_common64.pet|+sdparm|sdparm documentation||||
 shared-mime-info-1.9-x86_64_2|shared-mime-info|1.9-x86_64_2||BuildingBlock|400||shared-mime-info-1.9-x86_64_2.pet||mimetype information||||
 shared-mime-info_DEV-1.9-x86_64_2|shared-mime-info_DEV|1.9-x86_64_2||BuildingBlock|20||shared-mime-info_DEV-1.9-x86_64_2.pet|+shared-mime-info|shared-mime-info development||||
-sudo-1.8.21p2-x86_64_common64|sudo|1.8.21p2-x86_64_common64||BuildingBlock|652||sudo-1.8.21p2-x86_64_common64.pet||give limited root privileges to certain users||||
-sudo_DEV-1.8.21p2-x86_64_common64|sudo_DEV|1.8.21p2-x86_64_common64||BuildingBlock|48||sudo_DEV-1.8.21p2-x86_64_common64.pet|+sudo|sudo development||||
-usb-modeswitch-2.5.2-x86_64_common64-2|usb-modeswitch|2.5.2-x86_64_common64-2||BuildingBlock|372||usb-modeswitch-2.5.2-x86_64_common64-2.pet||No description provided||||
-usb-modeswitch_DOC-2.5.2-x86_64_common64|usb-modeswitch_DOC|2.5.2-x86_64_common64||BuildingBlock|36||usb-modeswitch_DOC-2.5.2-x86_64_common64.pet|+usb-modeswitch|usb-modeswitch documentation||||
 yad-0.40.3-x86_64_common64|yad|0.40.3-x86_64_common64||BuildingBlock|336||yad-0.40.3-x86_64_common64.pet||Yet Another Dialog||||
 yad_DEV-0.40.3-x86_64_common64|yad_DEV|0.40.3-x86_64_common64||BuildingBlock|20||yad_DEV-0.40.3-x86_64_common64.pet|+yad|yad development||||
 yad_DOC-0.40.3-x86_64_common64|yad_DOC|0.40.3-x86_64_common64||BuildingBlock|64||yad_DOC-0.40.3-x86_64_common64.pet|+yad|yad documentation||||


### PR DESCRIPTION
The apulse pet also contains libs, but they are not in a standard
path and should work whether there is a lib64 or not.

The original idea was that common64 should only have pets that
didn't have libraries, but these slipped in.