### PR TITLE
Unbreak rox uri handling

### DIFF
--- a/woof-code/rootfs-packages/rox_config/usr/local/bin/rox
+++ b/woof-code/rootfs-packages/rox_config/usr/local/bin/rox
@@ -1,2 +1,2 @@
 #!/bin/sh
-exec /usr/local/apps/ROX-Filer/AppRun "${@#*file://}"
+exec /usr/local/apps/ROX-Filer/AppRun "$@"


### PR DESCRIPTION
Rox is perfectly capable of handling URIs, with the -U switch.  Someone either didn't know about this switch, or wanted to make it work without the switch.  But they actually broke URI handling, because a file URI isn't just a file path with file:// prefixed - e.g. spaces are converted to "%20"
See www.murga-linux.com/puppy/viewtopic.php?t=115381 to see the sort of chaos this has caused (TLDR = bug ticket erroneously filed against another project and a bunch of people's time wasted).