### PR TITLE
remove support for PUPMODES 6 7

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -8,8 +8,6 @@
 #Aufs layers setup by this script...
 #aufs layers:            RW (top)      RO1             RO2              PUPMODE
 #First boot (or pfix=ram):  tmpfs                         pup_xxx.sfs      5
-#pup_save is a partition:   PDEV1                         pup_xxx.sfs      6
-#ditto, but flash drive:    tmpfs         PDEV1           pup_xxx.sfs      7
 #Normal running puppy:      pup_save.3fs                  pup_xxx.sfs      12
 #ditto, but flash drive:    tmpfs         pup_save.3fs    pup_xxx.sfs      13
 #Multisession cd/dvd:       tmpfs         folders         pup_xxx.sfs      77
@@ -599,13 +597,6 @@ setup_save_file(){
  fi
 }
 
-setup_save_part() {
- rm -r -f $SAVE_LAYER
- ln -sv ${SAVE_MP} $SAVE_LAYER
- SAVE_FN="${SAVE_MP}" #for after switch symbolic link
- SAVE_NAME="$SAVEPART"
-}
-
 copy_folders() { #SAVE_LAYER=/pup_ro1
  echo -e "\n-------------------- copy_folders" #debug
  echo "SAVE_MP=$SAVE_MP"
@@ -1142,8 +1133,13 @@ if [ "${SAVE_MP}" != "" -a "$PRAMONLY" != "yes" ];then #have mounted save? parti
  if [ "$ONE_FS_IS_LINUX" = "yes" -a "$PSUBDIR" = "" -a -f "${SAVE_MP}/etc/rc.d/PUPSTATE" ];then
   # make sure it's not a full install
   if ! grep -q 'PUPMODE=2' ${SAVE_MP}/etc/rc.d/PUPSTATE ; then
-    PUPMODE=6
-    PUPSAVE="${SAVEPART},${SAVE_FS},/"
+    # PUPMODE=6 PUPMODE=7 - unsupported
+    dialog --backtitle "$DISTRODESC" --title "'Savepartition': unsupported - ${SAVE_MP}" \
+      --msgbox "A savepartition is not supported: it will be ignored.
+
+However you can save session again using a savefolder - which is basically the same thing, except that it does not 'pollute' the boot partition.
+
+And then copy all the relevant files from ${SAVE_MP} tp the new pupsave (${DISTRO_FILE_PREFIX}save)" 0 0 &>/dev/console
   fi
  fi
  #not sorted yet, may be pupmode=12
@@ -1266,15 +1262,15 @@ if [ "$PUPSAVE" ];then #refine pupmode
  if [ ! -d "/sys/block/$PUPSAVE_DRV" ];then #not device e.g. sr0, assume partition
   PUPSAVE_DRV=$(fx_get_drvname $PUPSAVE_DRV)
  fi
- if probedisk ${PUPSAVE_DRV} -card-as-usbflash | grep -q '|usbflash|' ; then
+ if probedisk -card-as-usbflash ${PUPSAVE_DRV} | grep -q '|usbflash|' ; then
    echo "*** Pupsave is located in a flash storage device: $PUPSAVE_DRV" #debug
    PUPSAVE_MEDIA=usbflash
  fi
  # refine pupmode
- if [ $PUPMODE -eq 6 -o $PUPMODE -eq 12 ];then
+ if [ $PUPMODE -eq 12 ];then
   SAVE_LAYER="/pup_rw"
   if [ "${PMEDIA:3}" = "flash" -o "${PUPSAVE_MEDIA:3}" = "flash" ];then
-   PUPMODE=$(expr $PUPMODE + 1) #PUPMODE=7 PUPMODE=13
+   PUPMODE=$(expr $PUPMODE + 1) #PUPMODE=13
    echo "Setting PUPMODE $PUPMODE" #debug
    SAVE_LAYER="/pup_ro1"
   fi
@@ -1297,14 +1293,6 @@ case $PUPMODE in
  12) #replace rw
   setup_save_file
   [ "$PUPSAVE" ] && replace_dir
- ;;
- 7) #prepend ro1
-  setup_save_part
-  prepend_dir
- ;;
- 6) #replace rw
-  setup_save_part
-  replace_dir
  ;;
  5)
   SAVE_MP=""

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1134,12 +1134,12 @@ if [ "${SAVE_MP}" != "" -a "$PRAMONLY" != "yes" ];then #have mounted save? parti
   # make sure it's not a full install
   if ! grep -q 'PUPMODE=2' ${SAVE_MP}/etc/rc.d/PUPSTATE ; then
     # PUPMODE=6 PUPMODE=7 - unsupported
-    dialog --backtitle "$DISTRODESC" --title "'Savepartition': unsupported - ${SAVE_MP}" \
-      --msgbox "A savepartition is not supported: it will be ignored.
-
-However you can save session again using a savefolder - which is basically the same thing, except that it does not 'pollute' the boot partition.
-
-And then copy all the relevant files from ${SAVE_MP} tp the new pupsave (${DISTRO_FILE_PREFIX}save)" 0 0 &>/dev/console
+    if [ "$ONE_FS_IS_LINUX" = "yes" ] ; then #savefolder is a full partition
+      PUPSAVE="$SAVEPART,$SAVE_FS,"
+      PUPMODE=12
+      ONE_PART="$(echo -n "$PUPSAVE" | cut -f 1 -d ',')"
+      [ "$ONE_PART" != "$SAVEPART" ] && { SAVEPART="$ONE_PART"; ensure_save_mounted; }
+    fi
   fi
  fi
  #not sorted yet, may be pupmode=12

--- a/woof-code/rootfs-skeleton/bin/plogin
+++ b/woof-code/rootfs-skeleton/bin/plogin
@@ -45,13 +45,13 @@ USER_HOME=$(awk -F: '$1=="'${LOGIN_USER}'" {print $6}' /etc/passwd)
 . /etc/rc.d/PUPSTATE
 
 case $PUPMODE in
-	77)   APP='savesession-dvd' ;;
-	7|13) APP='save2flash'      ;;
+	77) APP='savesession-dvd' ;;
+	13) APP='save2flash'      ;;
 esac
 
 if [ -f ${USER_HOME}/Choices/ROX-Filer/PuppyPin ] ; then
 	case $PUPMODE in
-	77|7|13) #77=multisession cd/dvd. 7|13=#pup_rw is tmpfs. pmedia=usbflash
+	77|13) #77=multisession cd/dvd. 13=#pup_rw is tmpfs. pmedia=usbflash
 		if [ "`cat ${USER_HOME}/Choices/ROX-Filer/PuppyPin | grep "${APP}"`" = "" ];then
 			echo "<icon x=\"768\" y=\"128\" label=\"save\">/usr/sbin/${APP}</icon>" >> ${USER_HOME}/Choices/ROX-Filer/PuppyPin
 			grep -v '/pinboard' ${USER_HOME}/Choices/ROX-Filer/PuppyPin  > /tmp/PuppyPin-CPY
@@ -66,7 +66,7 @@ if [ -f ${USER_HOME}/Choices/ROX-Filer/PuppyPin ] ; then
 fi
 
 case $PUPMODE in
-	77|7|13) #77=multisession cd/dvd. 7|13=#pup_rw is tmpfs. pmedia=usbflash
+	77|13) #77=multisession cd/dvd. 13=#pup_rw is tmpfs. pmedia=usbflash
 		if [ ! -f ${USER_HOME}/Desktop/${APP}.desktop ] ; then
 			mkdir -p ${USER_HOME}/Desktop
 			echo "[Desktop Entry]

--- a/woof-code/rootfs-skeleton/etc/rc.d/functions_x
+++ b/woof-code/rootfs-skeleton/etc/rc.d/functions_x
@@ -63,7 +63,7 @@ fx_personal_storage_free_mb() {
 	[ $SAVE_LAYER ] || . /etc/rc.d/PUPSTATE
 	local F1 F2 F3 F4 F5plus SIZEFREEM
 	case $PUPMODE in
-		3|7|13|6|12|21|93)
+		12|13|21|93)
 			# PTN=" /initrd/mnt/dev_save" (savefolder)
 			# PTN=" /initrd/pup_rw"       (savefile)
 			#    -get mountpoint regardless of filetype-

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -192,28 +192,6 @@ case $PUPMODE in
   [ ! "$SMNTPT" = "" ] && umount $SMNTPT 2>/dev/null
   #...well, fixed it, changed mntpt so not in /tmp. Leave above line here.
   ;;
- 32) #first shutdown, save back to PDEV1. v3.97: xPDEV
-  echo "$(printf "$(gettext 'Saving session to %s...')" "$xPDEV")" >/dev/console
-  DEV1MNT=`grep "/dev/${xPDEV} " /proc/mounts | cut -f 2 -d " "`
-  if [ "$DEV1MNT" = "" ];then
-   mkdir -p /mnt/$xPDEV
-   mount -t $xDEVFS /dev/$xPDEV /mnt/$xPDEV
-   if [ ! $? -eq 0 ];then
-    echo "$(printf "$(gettext 'ERROR: unable to mount /dev/%s, cannot save.')" "$xPDEV")" >/dev/console
-    exit 1
-   fi
-   DEV1MNT="/mnt/$xPDEV"
-  fi
-  RDIRS="`find /initrd/pup_rw/ -maxdepth 1 -mount -type d | grep -v "/$" |grep -v "/mnt"|grep -v "/tmp"|grep -v "/proc"|grep -v "/sys"|grep -v "/var"|grep -v "/dev" | grep -v "/lost" |tr "\n" " "`"
-  for ONEDIR in $RDIRS ; do cp -a $ONEDIR ${DEV1MNT}/ ; done
-  mkdir -p ${DEV1MNT}/var
-  cp -a /initrd/pup_rw/var/local ${DEV1MNT}/var/ #puppy data here that must be saved.
-  #DISTRO_SPECS must be saved, init script looks for it to determine if
-  #there is a saved session...
-  cp -af /etc/DISTRO_SPECS ${DEV1MNT}/etc/
-  sync
-  umount $DEV1MNT 2> /dev/null
-  ;;
  128) #1st shutdown, save to ${DISTRO_FILE_PREFIX}save.2fs.
   #partition already mounted on $SMNTPT.
   echo "$(printf "$(gettext 'Saving session to %s file on %s partition...')" "${SAVEFILE}" "${SAVEPART}")" >/dev/console
@@ -265,16 +243,7 @@ case $PUPMODE in
 
  77) /usr/sbin/savesession-dvd ;; #requires /tmp/rc.shutdown_config - save to folder on multisession CD/DVD (including 1st shutdown)
  2)  echo -n ;; #echo "$(printf "$(gettext '%s mounted directly, session already saved.')" "$PDEV1")" >/dev/console
- 6)  echo "$(printf "$(gettext '%s mounted directly top layer, session already saved.')" "$PDEV1")" >/dev/console ;;
  12) echo "$(printf "$(gettext '%s mounted directly top layer, session already saved.')" "${SAVEFILE##*/}")" >/dev/console ;;
-
- 7) #PDEV1 and PUPSFS.
-  asktosave_func
-  if [ $? -eq 0 ]; then 
-    echo "$(printf "$(gettext 'Saving session to %s...')" "$PDEV1")" >/dev/console
-    /usr/sbin/snapmergepuppy /initrd/pup_ro1 /initrd/pup_rw
-  fi
-  ;;
  13) #PDEV1 and PUPSFS and PUPSAVE 
   #/initrd/pup_rw has tmpfs, pup_ro1 has ${DISTRO_FILE_PREFIX}save.2fs file (PUPSAVE), pup_ro2 has PUPSFS file. 
   #the above are in aufs at /.

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -75,9 +75,12 @@ loadswap_func() { #w481 made into a function.
  done
  [ "$SWAPON" = "yes" ] && return
  #if no go, try for a swap file...
- pupswap validate /initrd${PUP_HOME}/pupswap.swp && SWF="/initrd${PUP_HOME}/pupswap.swp"
- pupswap validate /pupswap.swp && SWF="$SWF /pupswap.swp"
- for SWAPFILE in $SWF ; do
+ if [ -f /initrd${PUP_HOME}/pupswap.swp ] ; then
+   pupswap validate /initrd${PUP_HOME}/pupswap.swp && SWAPFILE="/initrd${PUP_HOME}/pupswap.swp"
+ else
+   pupswap validate /pupswap.swp && SWAPFILE="/pupswap.swp"
+ fi
+ if [ "${SWAPFILE}" ] ; then
   SWAPSIZEBYTES=`stat -c %s ${SWAPFILE}` #bytes
   [ $SWAPSIZEBYTES ] && EXTRAALLOCK=$(($EXTRAALLOCK + $SWAPSIZEBYTES))
   echo -n "Loading swap file ${SWAPFILE} ("$(fx_format_bytes $SWAPSIZEBYTES)")..." >/dev/console
@@ -85,7 +88,7 @@ loadswap_func() { #w481 made into a function.
   swapon ${SWAPFILE}
   status_func $?
   [ $? -eq 0 ] && SWAPON="yes"
- done
+ fi
 }
 
 #================================================================

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -235,18 +235,8 @@ if [ $PUPMODE -eq 2 -o $PUPMODE -eq 77 ] ; then
  ln -sv / /mnt/home
 else
  if [ "$PUP_HOME" ];then #see /etc/rc.d/PUPSTATE
-  if [ "$PUP_HOME" = "/pup_ro1" -o "$PUP_HOME" = "/pup_rw" ];then
-   [ ! -d "$PUP_HOME" ] && echo "ERROR: $PUP_HOME does not exist"
-   #note, PUPMODE=6 will have PUP_HOME=/pup_rw.
-   #in the case of the persistent storage being the partition itself, this will be mounted
-   #on /initrd/pup_ro1 (tmpfs on pup_rw for restricted writes) or directly on /initrd/pup_rw
-   #and we do not really want users to access it as it is an aufs layer. Instead, they are
-   #already accessing it as "/".
-   ln -sv / /mnt/home
-  else
    [ ! -d "/initrd${PUP_HOME}" ] && echo "ERROR: $PUP_HOME does not exist"
    ln -sv /initrd${PUP_HOME} /mnt/home
-  fi
  fi
 fi
 

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -106,16 +106,6 @@ if [ -f /initrd/tmp/rc_update_force_pm5 ] ; then
 fi
 
 case $PUPMODE in
- "7") #tmpfs (pup_rw), hd for persistent storage (pup_ro1), ${DISTRO_PUPPYSFS} (pup_ro2).
-  NEWFILESMNTPT="/initrd/pup_ro2"
-  OLDFILESMNTPT="/initrd/pup_ro1"
- ;;
- "6") #no tmpfs, PDEV1 (pup_rw), ${DISTRO_PUPPYSFS} (pup_ro2) 
-  #have booted from PDEV1 partition, which has initrd.gz & ${DISTRO_PUPPYSFS} files on it, and
-  #session has been saved direct to the partition. (very similar to mode 12)
-  NEWFILESMNTPT="/initrd/pup_ro2"
-  OLDFILESMNTPT="/initrd/pup_rw"
- ;;
  "12") #no tmpfs, ${DISTRO_FILE_PREFIX}save.3fs (pup_rw), nothing (pup_ro1), ${DISTRO_PUPPYSFS} (pup_ro2)
   #example: boot from live-cd, ${DISTRO_FILE_PREFIX}save.3fs on a fast h.d. partition.
   NEWFILESMNTPT="/initrd/pup_ro2"

--- a/woof-code/rootfs-skeleton/usr/local/petget/configure.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/configure.sh
@@ -63,7 +63,7 @@ else
 	SIZEBOX=''
 fi
 
-if [ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ]; then
+if [ $PUPMODE -eq 13 ]; then
 	[ -f /var/local/petget/sc_category ] && \
      CATEGORY_IM=$(cat /var/local/petget/install_mode) || CATEGORY_IM="false"
 	IMODE="<checkbox>
@@ -261,7 +261,7 @@ echo -n "$RETPARAMS" | grep 'CATEGORY_SD' | cut -d= -f2 | tr -d '"' > /var/local
 echo -n "$RETPARAMS" | grep 'CATEGORY_SI' | cut -d= -f2 | tr -d '"' > /var/local/petget/si_category
 
 # handle install mode
-if [ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ]; then
+if [ $PUPMODE -eq 13 ]; then
   echo -n "$RETPARAMS" | grep 'CATEGORY_IM' | cut -d= -f2 | tr -d '"' > /var/local/petget/install_mode
 fi
 

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -178,7 +178,7 @@ if [ "$PUPMODE" = "2" ]; then # from BK's quirky6.1
 	fi
 
 #boot from flash: bypass tmpfs top layer, install direct to pup_save file... #170623 reverse this!
-elif [ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ];then
+elif [ $PUPMODE -eq 13 ];then
 	# SFR: let user chose...
 	if [ -f /var/local/petget/install_mode ] ; then
 	 IM="`cat /var/local/petget/install_mode`"

--- a/woof-code/rootfs-skeleton/usr/local/petget/removepreview.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/removepreview.sh
@@ -52,7 +52,7 @@ fi
 
 #111228 if snapmergepuppy running, wait for it to complete (see also /usr/local/petget/installpkg.sh)...
 #note, inverse true, /sbin/pup_event_frontend_d will not run snapmergepuppy if removepreview.sh running.
-if [ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ];then
+if [ $PUPMODE -eq 13 ];then
   while [ "`pidof snapmergepuppy`" != "" ];do
    sleep 1
   done
@@ -78,7 +78,7 @@ if [ -f /root/.packages/${DB_pkgname}.files ];then
      #restore the original pristine file...
      cp -a --remove-destination "$S" "$ONESPEC" #120103 shinobar.
      #120103 apparently for odd# PUPMODEs, save layer may have a lurking old file and/or whiteout...
-     if [ $PUPMODE -eq 3 -o $PUPMODE -eq 7 -o $PUPMODE -eq 13 ];then
+     if [ $PUPMODE -eq 13 ];then
       [ -f "/initrd${SAVE_LAYER}${ONESPEC}" ] && rm -f "/initrd${SAVE_LAYER}${ONESPEC}" #normally /pup_ro1
       BN="`basename "$ONESPEC"`"
       DN="`dirname "$ONESPEC"`"

--- a/woof-code/rootfs-skeleton/usr/local/pup_event/pup_event_timeout60
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/pup_event_timeout60
@@ -19,7 +19,7 @@ fi
 [ "$RAMSAVEINTERVAL" = "" ] && RAMSAVEINTERVAL=30
 [ "$POWERTIMEOUT" = "" ] && POWERTIMEOUT=0
 
-case $PUPMODE in 7|13)
+case $PUPMODE in 13)
 	SAVECNT=$(( $SAVECNT + 1 ))
 	if [ $RAMSAVEINTERVAL -ne 0 -a $SAVECNT -ge $RAMSAVEINTERVAL ];then
 		#periodic save of tmpfs top layer...

--- a/woof-code/rootfs-skeleton/usr/sbin/download_file
+++ b/woof-code/rootfs-skeleton/usr/sbin/download_file
@@ -123,7 +123,7 @@ if [ "$SIZEB_ONLINE" != "" ] ; then
 
 	SIZEK_ONLINE=$(( $SIZEB_ONLINE / 1024 ))
 	case $PUPMODE in
-		3|7|13|77) #tmpfs on top
+		13|77) #tmpfs on top
 			#when install pkg, it writes direct to save-layer.
 			SIZEK_REQUEST=$(( $SIZEK_ONLINE + 6000 )) #6MB slack.
 			;;
@@ -138,10 +138,10 @@ if [ "$SIZEB_ONLINE" != "" ] ; then
 			MSGs="$(gettext 'You need to shutdown and create a save-file, then you will have more space.
 See menu Shutdown -> Reboot')"
 			;;
-		2|6)
+		2)
 			MSGs="$(gettext 'The partition is full, you will have to delete something.')"
 			;;
-		3|7|77) #tmpfs on top, full partition underneath
+		77) #tmpfs on top, full partition underneath
 			MSGs="$(gettext 'Do not have enough space in the RAM. Maybe you need a swap file
 or swap partition (or it needs to be bigger)')"
 			;;

--- a/woof-code/rootfs-skeleton/usr/sbin/eventmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/eventmanager
@@ -63,7 +63,7 @@ if [ "$ROX_DESKTOP" ] ; then
 fi
 
 #disable RAM save interval and floppy icon if logical
-case $PUPMODE in 7|13) SENSITIVE_RAMSAVE="true";; *) SENSITIVE_RAMSAVE="false";; esac
+case $PUPMODE in 13) SENSITIVE_RAMSAVE="true";; *) SENSITIVE_RAMSAVE="false";; esac
 [ -e /sys/block/fd0 ] && SENSITIVE_FD0="true" || SENSITIVE_FD0="false"
 
 #===============================================================

--- a/woof-code/rootfs-skeleton/usr/sbin/pupsave-backup
+++ b/woof-code/rootfs-skeleton/usr/sbin/pupsave-backup
@@ -48,12 +48,15 @@ case $PUPMODE in
 	12|13) ok=1 ;;
 	*) ERRORMSG="Hot Backup can only be used if there is an active pupsave..." ;;
 esac
+
+
 if [ "$ERRORMSG" ] ; then
 	cleanup
 	echo "$ERRORMSG"
 	ERRORMSG="<b><span foreground='"'red'"'>${ERRORMSG}</span></b>
 "
 	[ $DISPLAY ] && help_box
+	cleanup
 	exit 1
 fi
 
@@ -254,6 +257,13 @@ ${destfile}"
 
 #Find and verify path of currently mounted save file.
 SF="`echo $PUPSAVE | cut -f 3 -d ","`" # /savefilename or /xxx/savefilename
+
+if [ ! "$SF" ] ; then
+	/usr/lib/gtkdialog/box_ok "Pupsave Backup" error "Currently using a full partition..."
+	cleanup
+	exit
+fi
+
 #SF=${SF#/}
 if [ ! -e "/mnt/home${SF}" ]; then
 	/usr/lib/gtkdialog/box_ok "Pupsave Backup" error "'/mnt/home${SF}' does not exist!"

--- a/woof-code/rootfs-skeleton/usr/sbin/save2flash
+++ b/woof-code/rootfs-skeleton/usr/sbin/save2flash
@@ -2,7 +2,7 @@
 #2007 Lesser GPL licence v2 (http://www.fsf.org/licensing/licenses/lgpl.html)
 
 . /etc/rc.d/PUPSTATE
-if [ $PUPMODE -ne 7 -a $PUPMODE -ne 13 ] ; then
+if [ $PUPMODE -ne 13 ] ; then
 	echo "save2flash: Wrong PUPMODE ($PUPMODE)"
 	exit 1
 fi

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -15,7 +15,6 @@
 # 17 Mar 2011 v1.1: load/unload under PUPMODE=5, launcher
 # 22 Sep 2011 v1.1.1: free(busybox) version compatible
 # 26 Sep 2011 v1.2: fix was undesired mount (thanks to mories), fix was fleezed input in combobox, fix ramsize
-# 13 Nov 2011 v1.3: fix could not unload excess sfs(>6) with some version of busybox, PUPMODE=7(same as PUPMODE=2), error message at unload failure, wait before removing layer 
 # v1.3.9: fix was not perform Startup scripts at load
 # v1.3.9: HAS_ICONS, HAS_GLIB_SCHEMA (jemimah)
 # v1.3.9: wipe out the masking files in save layers at load
@@ -38,7 +37,7 @@
 #26 Jun 2014 v2.0.9: init script in initramfs may not handle extra sfs
 #27 Jun 2014 v2.0.10: afterwork at boot
 #3 Jul 2014 v2.0.11: fix save-to-directry(gyro), fix was ydrv on loadable list
-#8 Jul 2014 v2.0.12: no extra sfs but layers can be changed, rewrite cleanwhite, WIPEWHITEONINIT, PUPMODE7SUPPORT
+#8 Jul 2014 v2.0.12: no extra sfs but layers can be changed, rewrite cleanwhite, WIPEWHITEONINIT
 #12 Jul 2014 v2.0.13: cleanwhite fix(SFR)
 #v2.1.8: all extra sfs by sfs_load not by initramfs
 #v2.1.9: fix loop device conflict with irregular initramfs
@@ -73,7 +72,6 @@ ORGOPT="$@"
 WIPEWHITEONINIT="true"	# true/false
 WIPEWHITEONLOAD="true"	# true/false
 WIPEWHITEUNLOAD="true"	# recommend 'true'
-PUPMODE7SUPPORT="false" # PUPMODE=7 is buggy
 RESERVHDD=131072 # kb rest #v1.9.3: increased to 128MB
 RESERVRAM=131072 # kB rest #v1.9.3: increased to 96MB, v2.0: 128MB
 
@@ -1081,7 +1079,6 @@ exit 0' >$MYTMPDIR/cleanup
 	chmod +x $MYTMPDIR/cleanup
 }
 
-# 14feb2011: clean up whiteout # 13 Nov 2011: except PUPMODE=7
 # v1.9: rewrite, v1.9.7: fix was failed for flash, v1.9.8: fix was skipped PUPMODE=5
 cleanwhite() {
 	PARAM=$1  # layer path to be removed, example: '/initrd/pup_ro4'
@@ -1091,8 +1088,7 @@ cleanwhite() {
 	case "$PUPMODE" in
 		5|12) SLAYER="/pup_rw"
 			RAMSAVEINTERVAL=-1;;
-		3|13|7)	# ataflash/usbflash, PUPMODE=7 is unsupported
-			[ "$PUPMODE" = "7" ] && [ "$PUPMODE7SUPPORT" != 'true' ] && return
+		13)	# ataflash/usbflash
 			# periodical save may be disabled
 			[ -s /etc/eventmanager ] && source /etc/eventmanager
 			[ "$RAMSAVEINTERVAL" ] || RAMSAVEINTERVAL=-1 # ignore if not available
@@ -1649,20 +1645,14 @@ if [ "$PUPMODE_dummy" ] ; then ############ for debugging
 	case "$PUPMODE_dummy" in
 		2) SAVE_LAYER=''; PUP_HOME='/'; PUPSAVE="";;
 		5) SAVE_LAYER=''; PUP_HOME=''; PUPSAVE="";;
-		6) SAVE_LAYER='/pup_rw'; PUP_HOME='/pup_rw'; PUPSAVE='sda1,ext2,/';;
 		12) SAVE_LAYER='/pup_rw'; PUP_HOME='/mnt/dev_save';;
 		13) SAVE_LAYER='/pup_ro1'; PUP_HOME='/mnt/dev_save';;
 		77) SAVE_LAYER='/pup_ro1'; PUP_HOME=''; PUPSAVE='sr0,iso9660,/2011-01-27-20-26';;
 	esac
 fi ############ for debugging end
 
-if [ "$PUPMODE" = "6" ];then
-	INITRDHOME=/
-	MNTHOME=/
-else
-	INITRDHOME=/initrd$PUP_HOME
-	MNTHOME=/mnt/home
-fi
+INITRDHOME=/initrd$PUP_HOME
+MNTHOME=/mnt/home
 
 # see what pup_*.sfs file is used
 SFSPART=$(echo $PUPSFS|cut -d',' -f1)
@@ -1723,7 +1713,6 @@ fi
 [ "$SAVEFILE" != "" ] && PSUBDIR=$(dirname "$SAVEFILE"| cut -b2-)  # remove '/' at head
 [ "$DESTDIR" -a "$PSUBDIR" -a ! -d "$DESTDIR/$PSUBDIR" ] && PSUBDIR=""  # may not yet be created
 
-# 13 Nov 2011: except PUPMODE=7 #2.0.12: PUPMODE=7 optional
 case "$PUPMODE" in
 	5)
 		if [ "$SAVEFILE" != "" ]; then SFSMODE="y"
@@ -1731,12 +1720,10 @@ case "$PUPMODE" in
 		else SFSMODE="tmp"
 		fi
 		;;
-	6|12|13) SFSMODE="y";;
+	12|13) SFSMODE="y";;
 	77) SFSMODE="cd";;
 	*) SFSMODE="";;
 esac
-
-[ "$PUPMODE7SUPPORT" = 'true' ] && [ "$PUPMODE" = "7" ] && SFSMODE="y"
 
 if [ "$SFSMODE" = "cd" ]; then
 	PUPHOME="/"	#; DESTDIR="/initrd/pup_rw"
@@ -1909,9 +1896,6 @@ else
 	elif [ "$SFSMODE" = "cd" ]; then
 		WARNSHORT=$WARNEXPERIMENTAL
 		WARNMSG=$(printf "$(gettext "You seem going to save the session back to the live CD. You can place the extra SFS at '%s' if you want the SFS to persist even after the next boot. Note that the RAM should be large enough.")"  "$PUPHOME")'\n'$WARNEXPERIMENTAL
-	elif [ "$PUPMODE" = "6" -o "$PUPMODE" = "7"  ]; then
-		WARNSHORT=$WARNEXPERIMENTAL
-		WARNMSG=$(gettext "Your Puppy is running without a 'pupsave' file but with saving the session to the entire partition.")' '$(gettext "The extra SFS support under this mode may be buggy.")'\n'$WARNEXPERIMENTAL
 	fi
 fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -358,9 +358,6 @@ $(gettext 'Select choice, then click OK button...')"
 } # end of choosesizefunc()
 
 choosestyle() {
- #do not allow save to entire partition if pup installed in a subdirectory...
- #xPSUBDIR="`echo -n "$PUPSFS" | cut -f 3 -d ',' | sed -e 's%/[^/]*$%%'`" #ex: sda3,ext2,/pup220/puppy.sfs will return /pup220
- [ "$SAVEPART" = "$PDEV1" ] && [ -z "$xPSUBDIR" ] && OFFER_PARTITION="y" || OFFER_PARTITION=""
  T_fstitle="$(gettext 'First shutdown: choose saving style')"
  T_fsmenu="$(gettext "You can save the session in a 'folder(directory)' because you chose a Linux partition. Unlike single file, saving in a folder is not restricted to the fixed file size but by the free space on the partition. You can save multiple profiles by different name.")
  
@@ -368,11 +365,7 @@ choosestyle() {
  T_folder="$(gettext 'Save in a folder.') $(gettext '*RECOMMENDED*')"
  T_partition=$(gettext "Save to the entire partition. Only one profile.")
  T_file=$(gettext 'Single file, ext2/3/4 filesystem image in it.')
- if [ "$OFFER_PARTITION" ]; then
-   ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fstitle" --colors --no-cancel --default-item folder --menu "$T_fsmenu" 0 0 0 folder "$T_folder" partition "$T_partition" file "$T_file" 2>/tmp/rc.shutdown_pupsave_style
- else
-   ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fstitle" --colors --no-cancel --default-item folder --menu "$T_fsmenu" 0 0 0 folder "$T_folder" file "$T_file" 2>/tmp/rc.shutdown_pupsave_style
- fi
+ ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fstitle" --colors --no-cancel --default-item folder --menu "$T_fsmenu" 0 0 0 folder "$T_folder" file "$T_file" 2>/tmp/rc.shutdown_pupsave_style
  SAVESTYLE=$(cat /tmp/rc.shutdown_pupsave_style)
  [ "$SAVESTYLE" ]
 }
@@ -789,18 +782,16 @@ case $SAVECHOICE in
        [ -z "$DENSITY" ] && choosefs
        choosesize || exit	###FIXME###
     fi
-    if [ "$SAVESTYLE" != "partition" ]; then
-      choosename
-      NAMEROOT="$NAMEONLY"
-      [ "${SFEXT}" ] && NAMEONLY="$NAMEROOT.${SFEXT}"
-      if [ "$PSAVEDIR" ];then
-        SAVEFILE="${PSAVEDIR}${NAMEONLY}"
-      else
-        SAVEFILE="$PSUBDIR/$NAMEONLY"
-      fi
-      #nameclash || exit	###FIXME###
-      PUPSAVE="$SAVEPART,$SAVEFS,$SAVEFILE"
+    choosename
+    NAMEROOT="$NAMEONLY"
+    [ "${SFEXT}" ] && NAMEONLY="$NAMEROOT.${SFEXT}"
+    if [ "$PSAVEDIR" ];then
+      SAVEFILE="${PSAVEDIR}${NAMEONLY}"
+    else
+      SAVEFILE="$PSUBDIR/$NAMEONLY"
     fi
+    #nameclash || exit	###FIXME###
+    PUPSAVE="$SAVEPART,$SAVEFS,$SAVEFILE"
     case "$SAVESTYLE" in
       folder) save_directory && PUPMODE=128;;
       partition) PUPMODE=32;;

--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -40,12 +40,10 @@ export LANG=C
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@}
 
-case $PUPMODE in
-	7|13) ok=1 ;;
-	*)
-		echo "Wrong PUPMODE ($PUPMODE)!"
-		exit 1 ;;
-esac
+if [ $PUPMODE -ne 13 ] ; then
+	echo "$0: Wrong PUPMODE ($PUPMODE)"
+	exit 1
+fi
 
 SAVEPART="`echo -n "$PUPSAVE" | cut -f 1 -d ','`"
 


### PR DESCRIPTION
This completely removes support for savepartitions. However init can identify savepartitions
and will show a "devastating" info msg (see commit diff)

The fact that savepartitions are only supported in PDEV1 makes them even less appealing.,,

This also shows basically all the core scripts that deal with pupmodes, so gyrog might want to take a look

patch
[remove-support-for-pupmodes-6-7.patch.zip](https://github.com/puppylinux-woof-CE/woof-CE/files/2887690/remove-support-for-pupmodes-6-7.patch.zip)

ref https://github.com/puppylinux-woof-CE/woof-CE/issues/1331#issuecomment-465622873
closes #1331

does anybody object this change?