### PR TITLE
SNS 2.2.1, NW 2.1.1, connectwizard: bugfixes + avoid exec change on exit/X

### DIFF
--- a/woof-code/rootfs-packages/network_wizard/pet.specs
+++ b/woof-code/rootfs-packages/network_wizard/pet.specs
@@ -1,1 +1,1 @@
-network_wizard-2.1|network_wizard|2.1||Network|376K||network_wizard-2.1.pet|+gtkdialog|Dougal's Network Wizard||||
+network_wizard-2.1.1|network_wizard|2.1.1||Network|376K||network_wizard-2.1.1.pet|+gtkdialog|Dougal's Network Wizard||||

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
@@ -75,6 +75,7 @@
 #180923 v2.0:  move network wizard to its package directory.
 #190213 replace functions validip with validip4, dotquad with ip2dec.
 #190217 v2.1: shorten wait after link timeout; remember choice of interface for boot-up; stop interfaces other than that selected, before starting selected interface; separate 'running' test and 'current exec' logic, so exec change avoided if main window aborted (X); refine 'already running' dialog & add to locale files.
+#190223 v2.1.1: Avoid exec change on exiting if no interface buttons used.
 
 # $1: interface
 interface_is_wireless() {
@@ -204,9 +205,7 @@ showMainWindow()
 			10) showLoadModuleWindow ;;
 			17) saveNewModule ;;
 			18) unloadNewModule ;;
-			19) which connectwizard_exec &>/dev/null \
-				  && connectwizard_exec net-setup.sh #190217
-				break ;;
+			19) break ;;
 			13) which connectwizard_exec &>/dev/null \
 				  && connectwizard_exec net-setup.sh #190217
 				local HWADDRESS=$(ifconfig "$INTERFACE" | grep "^$INTERFACE" | tr -s ' ' | cut -d' ' -f5) #190217

--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.2|simple_network_setup|2.2||Network|136K||simple_network_setup-2.2.pet|+gtkdialog|sns as package||||
+simple_network_setup-2.2.1|simple_network_setup|2.2.1||Network|140K||simple_network_setup-2.2.1.pet|+gtkdialog|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -37,6 +37,7 @@
 #180706 Accommodate large network list, by omitting unneeded iwlist lines and limiting search for 'Scan completed'.
 #190209 v2.1.1: increase wait for ethtool link detected, to 6 secs total).
 #190216 v2.2: Correct 'already running' check; correct support of long SSIDs truncated for display; avoid wait after link timeout; move 'current exec' logic, so exec change avoided if main window aborted (X); update 'make default' message.
+#190223 v2.2.1: Avoid exec change on exiting if connect/disconnect and interface buttons not used; add 'note' regarding connection not started by SNS.
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -241,15 +242,24 @@ if [ -s /etc/simple_network_setup/connections ];then
   xCONNECTION="$(echo -n "$ONECONNECTION" | tr \" .)" #170529
   echo "<button><label>${CNT}</label><action>grep -v \"${xCONNECTION}\" /etc/simple_network_setup/connections > /tmp/sns_action1</action><action>mv -f /tmp/sns_action1 /etc/simple_network_setup/connections</action><action type=\"exit\">EXITRESTART></action></button>" >> /tmp/sns_DEL_BTN #170529
  done
+ which connectwizard_exec &>/dev/null \
+  && CONNECTWIZEXEC_XML="<action>$(which connectwizard_exec) sns</action>" \
+  || CONNECTWIZEXEC_XML='' #190223
  if [ "$FLAGINTERNETSTATUS" = "yes" ];then
-  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_no.svg`<label>$(gettext 'Disconnect Now')</label><action>/usr/sbin/networkdisconnect</action><action type=\"exit\">EXITNOW</action></button>"
+  grep -qswv 'sns' /root/.connectwizardrc \
+   && DISCONNECT_EXIT='EXITRESTART' \
+   || DISCONNECT_EXIT='EXITNOW' #190223
+  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_no.svg`<label>$(gettext 'Disconnect Now')</label><action>/usr/sbin/networkdisconnect</action>$CONNECTWIZEXEC_XML<action type=\"exit\">${DISCONNECT_EXIT}</action></button>" #190223
  else
-  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_yes.svg`<label>$(gettext 'Connect Now')</label><action>/usr/sbin/networkdisconnect</action><action>/usr/local/simple_network_setup/rc.network start & </action><action>connect_button_splash</action><action type=\"exit\">EXITNOW</action></button>" #170505
+  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_yes.svg`<label>$(gettext 'Connect Now')</label><action>/usr/sbin/networkdisconnect</action>$CONNECTWIZEXEC_XML<action>/usr/local/simple_network_setup/rc.network start & </action><action>connect_button_splash</action><action type=\"exit\">EXITNOW</action></button>" #170505 190223
  fi
- PROFILE_XML="`/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Connection profiles have previously been created by SNS.')" "$(gettext "The <b>Connect</b> button will try to establish an internet connection by any of the available profiles.")"`
+ grep -qswv 'sns' /root/.connectwizardrc \
+  && DISCONNECT_XML="$(gettext '<b>Note:</b> The current connection was started by another network tool.  To control it with SNS, disconnect now, then re-connect or choose an interface.')" \
+  || DISCONNECT_XML='' #190223
+ PROFILE_XML="`/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Connection profiles have previously been created by SNS.')" "$(gettext "The <b>Connect</b> button will try to establish an internet connection by any of the available profiles.")" "${DISCONNECT_XML}"`
  <hbox border-width=\"7\" spacing=\"10\"><text use-markup=\"true\"><label>\"`cat /tmp/sns_CNT_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_I_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_T_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_D_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_B_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_M_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_S_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_SEC_P`\"</label></text></hbox>
  <hbox><text><label>$(gettext 'Delete:')</label></text>`cat /tmp/sns_DEL_BTN`</hbox>
-"
+" #190223
 fi
 
 if [ "$PROFILE_XML" ]; then
@@ -317,12 +327,7 @@ RETSTRING="`gtkdialog -p SNS_main`" ###main window### #170505
 echo "$RETSTRING"
 EXIT="`echo "$RETSTRING" | grep '^EXIT' | cut -f2 -d'"'`" #'geany
 [ "`echo "$EXIT" | grep 'EXITRESTART'`" != "" ] && exec sns ###restarting sns###
-if [ "`echo "$EXIT" | grep 'Interface'`" = "" ];then #190217...
- [ "`echo "$EXIT" | grep -Ew 'EXITNOW|QUIT'`" != "" ] \
-   && which connectwizard_exec &>/dev/null \
-   && connectwizard_exec sns #Update current exec name. 170329
- exit
-fi
+[ "`echo "$EXIT" | grep 'Interface'`" = "" ] && exit
  
 INTERFACE="`echo -n "$EXIT" | cut -f2 -d '_'`" #ex: wlan1
 
@@ -360,6 +365,9 @@ if [ "$INTERFACE" == "Windows" ];then #100313
  fi
  exec sns
 fi
+
+which connectwizard_exec &>/dev/null \
+ && connectwizard_exec sns #Update current exec name. 170329 190223
 
 ifPATTERN='^'"$INTERFACE"' '
 if [ "`ifconfig | grep "$ifPATTERN"`" != "" ];then

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard_exec
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard_exec
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Set new current network manager/exec
 # Single argument: new network exec name - sns|net-setup.sh|frisbee
-#Exit code: normally 0, but 1 if new exec already running.
+#Exit code: always 0.
 
 NEWEXEC="$1"
 if [ -f /root/.connectwizardrc ];then
@@ -38,8 +38,6 @@ if [ "$NEWEXEC" != "$CURRENT_EXEC" ];then
  esac
  [ -n "$EXECPIDS" ] && kill $EXECPIDS
  echo "$CURRENT_EXEC" > /tmp/.connectwizard_previous_exec
- echo "CURRENT_EXEC=$NEWEXEC" > /root/.connectwizardrc #exit code is 0
-else
- DUPEXECPIDS="$(ps --no-headers -fC "$NEWEXEC" | grep -wv "$$" | grep -wv "$PPID" | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
- [ -z "$DUPEXECPIDS" ] #set exit code - 1 if duplicate
+ echo "CURRENT_EXEC=$NEWEXEC" > /root/.connectwizardrc
 fi
+exit 0

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard_wrapper
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard_wrapper
@@ -23,8 +23,8 @@ if which connectwizard_exec &>/dev/null; then
 		;;
 	  peasywifi)
 		if [ -z "$1" ]; then
-			connectwizard_exec peasywifi \
-			  && exec /usr/local/peasywifi/peasywifi
+			connectwizard_exec peasywifi
+			exec /usr/local/peasywifi/peasywifi
 		else #auto start
 			if grep -qs 'peasywifi' /root/.connectwizardrc; then
 				chmod +x /root/Startup/peasywifi_tray


### PR DESCRIPTION
SNS & network wizard identify themselves as the current network manager only if some action is taken, allowing the user to view the main windows without changing the manager used to reconnect at boot-up.

In NW, working with drivers also avoids setting NW as current.

SNS reports if it detects an active connection started by another network manager, advising disconnecting and reconnecting to put SNS in control.  In that situation, clicking "Disconnect Now" will re-display the main window to allow re-connection.