### PR TITLE
remove "fallback if binary is missing" message

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/gcolor2
+++ b/woof-code/rootfs-skeleton/usr/bin/gcolor2
@@ -42,7 +42,7 @@ export -f edit_conf
 #===========================================================
 
 while [ 1 ] ;do
-	colorval=$(yad --color --title="gcolor2 script (fallback if binary is missing)" \
+	colorval=$(yad --color --title="gcolor2 script" \
 	--window-icon=/usr/share/pixmaps/puppy/graphics.svg \
 	--init-color="$(< $valfile)"  --geometry="$(< $geofile)" \
 	--always-print-result --gtk-palette --expand-palette \


### PR DESCRIPTION
When I opened gcolor2 in the menu, I saw in the title "fallback if binary is missing". I think this might confuse the user and make them think "oh no, my binary is missing and I need to find it again" when the script is now the main gcolor2. The script seems to be working just as good as the original app so I think this message in brackets can be removed, or at least changed to something other than what it was before. Do you agree? :D