### PR TITLE
Improve underdog: hide some underdog init scripts and autostarts

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1066,9 +1066,32 @@ if [ "$UNDERDOG" ];then #boot parameter
  ensure_mounted "$UNDERDOG" "/pup_ud"
  if [ "$ONE_MP" ];then
   mount -o remount,append:${ONE_MP}=rr /pup_new
-  #if [ $? -eq 0 ];then
-   #do any necessary underdog fiddles
-  #fi
+  if [ $? -eq 0 ];then
+       #Hide /etc/xdg/autostart files let puppy run on top
+    if [ -e /pup_ud/etc/xdg/autostart ]; then
+      [ ! -e /pup_rw/etc/xdg/autostart ] && mkdir -p /pup_rw/etc/xdg/autostart
+	  for dfile in $(ls -1 /pup_ud/etc/xdg/autostart 2>/dev/null)
+	  do
+	   [ ! -e /pup_rw/etc/xdg/autostart/$dfile ] && touch /pup_rw/etc/xdg/autostart/.wh.$dfile
+	  done
+    fi
+    
+    #Hide /etc/init.d files let puppy run on top
+    if [ -e /pup_ud/etc/init.d ]; then
+      [ ! -e /pup_rw/etc/init.d ] && mkdir -p /pup_rw/etc/init.d
+      
+      touch /pup_rw/etc/init.d/.wh.rcS 2>/dev/null
+      touch /pup_rw/etc/init.d/.wh.rCS 2>/dev/null
+      touch /pup_rw/etc/init.d/.wh.rc 2>/dev/null
+      
+	  for dfile in $(ls -1 /pup_ud/etc/init.d 2>/dev/null)
+	  do
+	   if [ "$(echo "$dfile" | grep -E "httpd|lighttpd|nginx|mysql|postgresql|ziproxy|tinc|tinyproxy|tlp|transmission|VBoxService|wicd|vrrpd|privoxy|postfix|postgrey|vrrpd|smartd|squid|atd|apache|hiawatha|rsync|tazpanel|ftpd|timidity|lm-sensor|sane|thermald|cherokee|clamd|freeradius|nagios|x11vnc|vnstatd|unfsd|pptpd|pcscd|p910nd|vmtoolsd|ofono|nscd|ndo2db|nrpe|motion|miniupnpd|dnsmasq|dhid|cyrus|couchdb|chilli|connman|gpm|hostapd|hylafax|compcache|netdata|ntop|openldap|openssh|perdition|xrdp|ypserv|daemon")" == "" ]; then
+	    [ ! -e /pup_rw/etc/init.d/$dfile ] && touch /pup_rw/etc/init.d/.wh.$dfile
+	   fi
+	  done
+    fi
+  fi
  fi
 fi
 


### PR DESCRIPTION
Need to hide some init scripts due to puppy's rc.services nature that executes scripts in init.d with executable permissions. Also some autostarts which was not compatible with puppy