### PR TITLE
Remove whiteout files for mounted underdog

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -156,6 +156,30 @@ echo -n "$DATESAVE" > /var/local/shutdown_date_saved
 #the top aufs layer, meaning that there is no intermediary tmpfs in ram for working
 #files, hence everything is saved directly, ditto for PUPMODE=2 a full h.d. install.
 #hence need to do some explicit wiping here...
+
+if [ "$(mount | grep "/pup_ud")" != "" ]; then
+
+    if [ -e /initrd/pup_ud/etc/xdg/autostart ]; then
+	  for dfile in $(ls -1 /initrd/pup_ud/etc/xdg/autostart 2>/dev/null)
+	  do
+	   [ -e /initrd/pup_rw/etc/xdg/autostart/.wh.$dfile ] && rm -f /initrd/pup_rw/etc/xdg/autostart/.wh.$dfile
+	  done
+    fi
+    
+    if [ -e /initrd/pup_ud/etc/init.d ]; then
+      
+      rm -f /initrd/pup_rw/etc/init.d/.wh.rcS 2>/dev/null
+      rm -f /initrd/pup_rw/etc/init.d/.wh.rCS 2>/dev/null
+      rm -f /initrd/pup_rw/etc/init.d/.wh.rc 2>/dev/null
+      
+	  for dfile in $(ls -1 /initrd/pup_ud/etc/init.d 2>/dev/null)
+	  do
+	    [ -e /initrd/pup_rw/etc/init.d/.wh.$dfile ] && rm -f /initrd/pup_rw/etc/init.d/.wh.$dfile
+	  done
+    fi
+    
+fi
+
 cat /var/log/messages* > /var/log/previous.messages
 rm -f /var/log/messages*
 rm -f /var/lock/LCK*


### PR DESCRIPTION
Remove whiteout files that hides underdog init scripts upon shutdown to avoid troubles