### PR TITLE
woof-distro raspbian: Add bootmenu.txt

### DIFF
--- a/woof-distro/arm/raspbian/stretch/rootfs-skeleton/boot/bootmenu.txt
+++ b/woof-distro/arm/raspbian/stretch/rootfs-skeleton/boot/bootmenu.txt
@@ -1,0 +1,12 @@
+
+LABEL raspup
+	PMEDIA usbflash
+
+LABEL "raspup pfix-ram"
+	PFIX ram
+
+LABEL search
+	SEARCH_DRIVE all
+
+LABEL "ram disk shell"
+	PFIX rdsh


### PR DESCRIPTION
I ran into the “savefile massacre” bug when I was developing the init bootmenu script and never finished writing documentation for it.

On my SD card I put a copy of the DISTRO_SPECS file, the devx, puppy sfs and savefile in a directory named raspup-7.1 and use the following in my bootmenu.txt

```
LABEL raspup-7.1
	PMEDIA usbflash
	DISTRO_SPECS mmcblk0p1:/raspup-7.1/DISTRO_SPECS
	PUPSFS mmcblk0p1:/raspup-7.1/puppy_raspup_7.1.sfs
	PSAVE mmcblk0p1:/raspup-7.1/raspupsave.2fs

LABEL "raspup-7.1 pfix-ram"
	DISTRO_SPECS mmcblk0p1:/raspup-7.1/DISTRO_SPECS
	PFIX ram

LABEL search
	SEARCH_DRIVE all

LABEL "ram disk shell"
	PFIX rdsh
```

The boot loader/firmware has to be in the root of the SD card, as well as the kernels and kernel module sfs files.  But it is possible to choose between multiple Raspup installations in different directories or possibly on a USB stick.

Running in RAM probably only works on the Pis with 1GiB of RAM, but if you make a cut down cli only build it should fit on a Pi1.

I modeled the syntax on the syslinux config file syntax, and made keywords for the parameters that the puppy init script used.  The idea was to get the functionality that would otherwise be provided by grub or syslinux for Raspberry Pis.