### PR TITLE
filemnt: Move image file mountpoint from /mnt to /media

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -137,7 +137,6 @@ if [ "$MNTEDLOOP" = "" ];then #not mounted on $MOUNTPOINT
          ;;
       img|hfv|vfd|dsk)
         mount -o loop "$imgFile" "$MntPt"
-        Err=$?
         ;;   
       *) 
          mount -t $Type -o loop,rw "$imgFile" "$MOUNTPOINT"

--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -35,9 +35,13 @@ if [ "$MNTEDLOOP" = "" ];then #not mounted on $MOUNTPOINT
     2fs) Type='ext2'     ; check_luks=yes ;;
     3fs) Type='ext3'     ; check_luks=yes ;;
     4fs) Type='ext4'     ; check_luks=yes ;;
-    sfs) Type='squashfs' ;;
+    sfs|lzm|xzm|sb|squashfs) Type='squashfs' ;;
     iso) Type='iso'      ;;
     wim) Type='wim'      ;;
+    img) Type='img'		 ;;
+    vfd) Type='vfd'		 ;;
+    hfv) Type='hfv'		 ;;
+    dsk) Type='dsk'		 ;;
     *) Type=$(blkid "$imgFile" | grep -o ' TYPE=.*' | cut -f 2 -d '"') ;;
   esac
   if [ "$Type" = "" ] ; then
@@ -131,6 +135,10 @@ if [ "$MNTEDLOOP" = "" ];then #not mounted on $MOUNTPOINT
          wimmountrw "$imgFile" "$MOUNTPOINT" || \
            wimmount "$imgFile" "$MOUNTPOINT"
          ;;
+      img|hfv|vfd|dsk)
+        mount -o loop "$imgFile" "$MntPt"
+        Err=$?
+        ;;   
       *) 
          mount -t $Type -o loop,rw "$imgFile" "$MOUNTPOINT"
          ;;

--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -12,7 +12,7 @@ imgFile="$1"
 imgFileBASE=${imgFile##*/} ## imgFileBASE="`basename "$imgFile"`" #BK
 [ "$(dirname "$imgFile")" = "." ] && imgFile=$(pwd)/${imgFileBASE}
 
-[ -e /media ] && mkdir /media
+[ ! -e /media ] && mkdir /media
 
 # may need to replace with /mnt/home...
 HOMELINK="`readlink /mnt/home`"

--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -12,6 +12,8 @@ imgFile="$1"
 imgFileBASE=${imgFile##*/} ## imgFileBASE="`basename "$imgFile"`" #BK
 [ "$(dirname "$imgFile")" = "." ] && imgFile=$(pwd)/${imgFileBASE}
 
+[ -e /media ] && mkdir /media
+
 # may need to replace with /mnt/home...
 HOMELINK="`readlink /mnt/home`"
 case $HOMELINK in *initrd*)
@@ -19,8 +21,8 @@ case $HOMELINK in *initrd*)
   #ex: /initrd/mnt/dev_save/kernel_src-3.0.7-patched.sfs becomes /mnt/home/kernel_src-3.0.7-patched.sfs
 esac
 
-#ex: /mnt/home/kernel_src-3.0.7-patched.sfs becomes /mnt/+mnt+home+kernel_src-3.0.7-patched.sfs
-MOUNTPOINT='/mnt/'"`echo "$imgFile" |sed "s#^\.##g" |sed "s#/#+#g" | tr ' ' '_'`" # SFR, added 'tr'
+#ex: /mnt/home/kernel_src-3.0.7-patched.sfs becomes /media/+mnt+home+kernel_src-3.0.7-patched.sfs
+MOUNTPOINT='/media/'"`echo "$imgFile" |sed "s#^\.##g" |sed "s#/#+#g" | tr ' ' '_'`" # SFR, added 'tr'
 # BK is it already mounted?
 MNTEDLOOP="$(cat /proc/mounts | grep -F " $MOUNTPOINT " | cut -f 1 -d ' ')"
 [ ! -z $MNTEDLOOP ] && MNTEDLOOP=$(echo "$MNTEDLOOP" | sed 's|/dev/loop/|/dev/loop|') 


### PR DESCRIPTION
Moving mounted image from /mnt to /media will shows the mounted disk image on file managers like Thunar and PCManFM for easy unmounting. Also pup-volume-monitor supports detection of mountpoints in /media.