### PR TITLE
pup_event_frontend_d: perform post-wine task

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/pup_event/pup_event_frontend_d
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/pup_event_frontend_d
@@ -34,6 +34,14 @@ do
 	if [ -f /tmp/frontend_startup_lock ] ; then
 		continue
 	fi
+	
+	if [ $MINUTE -eq 10 ] ; then
+	  if [ "$(which wine)" != "" ] && [ "$(pidof wineserver)" == "" ]; then
+	    if [ "$(pidof xdg-wine)" == "" ]; then
+	      exec xdg-wine
+	    fi
+	   fi
+	 fi
 
 	MINUTE=$(( $MINUTE + 10 ));
 	if [ $MINUTE -eq 60 ] ; then


### PR DESCRIPTION
If wine is installed it will run xdg-wine every ten seconds however if no wine program was running