### PR TITLE
Update new 'puppy' URLs for deb based distros

### DIFF
--- a/woof-distro/x86/debian/sid/repo-url
+++ b/woof-distro/x86/debian/sid/repo-url
@@ -5,7 +5,7 @@ http://ftp.au.debian.org/debian/|$VERSION|main|Packages.xz
 
 ### puppy repo 
 DEFAULT_REPOS="$DEFAULT_REPOS \
-http://lightofdawn.org/puppy-extra|puppy|main|Packages.gz \
+http://distro.ibiblio.org/puppylinux/next/puppy-extra|puppy|main|Packages.gz \
 "
 
 ### # enable if you want to include at apt database in sfs

--- a/woof-distro/x86/devuan/ascii/repo-url
+++ b/woof-distro/x86/devuan/ascii/repo-url
@@ -5,7 +5,7 @@ http://deb.devuan.org/merged/|$VERSION|main|Packages.xz
 
 ### puppy repo 
 DEFAULT_REPOS="$DEFAULT_REPOS \
-http://lightofdawn.org/puppy-extra|puppy|main|Packages.gz \
+http://distro.ibiblio.org/puppylinux/next/puppy-extra|puppy|main|Packages.gz \
 "
 
 ### # enable if you want to include at apt database in sfs

--- a/woof-distro/x86/ubuntu/trusty/repo-url
+++ b/woof-distro/x86/ubuntu/trusty/repo-url
@@ -5,7 +5,7 @@ http://archive.ubuntu.com/ubuntu|$VERSION|main:universe|Packages.bz2 \
 
 ### puppy repo 
 DEFAULT_REPOS="$DEFAULT_REPOS \
-http://lightofdawn.org/puppy-extra|puppy|main|Packages.gz \
+http://distro.ibiblio.org/puppylinux/next/puppy-extra|puppy|main|Packages.gz \
 "
 
 ### disable if you don't want to use latest updates 


### PR DESCRIPTION
Uploaded appropriate packages to https://distro.ibiblio.org/puppylinux/next/ and tested all `i386` builds and debian `amd64` build. All boot to working desktop in qemu.