### PR TITLE
shutdownconfig: Improved shutdownconfig dialog

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -748,8 +748,37 @@ T_ms="`eval_gettext \"You can save the session and all of the settings and perso
 If unsure, it is recommended that you do save the session, so all your personal settings and files will be automatically loaded at next boot.\"`"
 if [ $DISPLAY ];then
   T_display="`eval_gettext \"Click the \Zb\\\${T_save}\ZB button to be provided with the available save options, or click \Zb\\\${T_no}\ZB to exit immediately without saving anything.\"`" #111012 fix.
-  yesno="$T_ms \n\n$T_display \n\n$T_orwait240"
-  pupdialog --background '#FFFF80' --colors --title "$T_canceltitle" --backtitle "$T_title" --timeout $TIMELIMIT --countdown "$T_countdown" --no-label "$T_no" --yes-label "$T_save" --yesno "$yesno" 0 0 #120512
+   
+    STEP=6
+    
+    export XY_DIALOG="<window title=\"$T_title\" icon-name=\"gtk-save\" resizable=\"false\"><vbox>
+    <text use-markup=\"true\"><label>\"$T_ms\"</label></text>
+    <text use-markup=\"true\"><label>\"$T_canceltitle\"</label></text>
+    <progressbar><input>for i in \$(seq 0 10 100); do echo \$i; sleep $STEP; done;echo 100</input>
+      <label>$(gettext 'Shutdown in 60 seconds.')</label>
+      <action type=\"exit\">20</action>
+    </progressbar>
+    <hbox>
+     <button>
+     <input file icon=\"gtk-yes\"></input>
+     <label>$T_save</label><action>EXIT:0</action>
+     </button>
+     <button>
+      <input file icon=\"gtk-no\"></input>
+     <label>$T_no</label><action>EXIT:20</action>
+     </button>
+    </hbox>
+    </vbox></window>"
+    
+   eval $(gtkdialog -p XY_DIALOG --center) 
+   
+   if [ "$EXIT" == "abort" ] && [ $EXIT != "" ]; then
+   SAVECHOICE=255
+   else 
+   SAVECHOICE=$EXIT
+   fi
+
+
 else
   T_display="`eval_gettext \"Select \Zb\\\${T_save}\ZB (just press ENTER key) to be provided with the available save options, or select \Zb\\\${T_no}\ZB (TAB then ENTER) to exit without saving.\"`"
   yesno="$T_ms \n\n$T_display \n\n$T_orwait240"


### PR DESCRIPTION
Instead of flashy countdown timer shown, just a progress bar that indicates countdown
based from shinobar's shutdown save session interface