### PR TITLE
mount: contain ntfs error logs in a folder

### DIFF
--- a/woof-code/rootfs-skeleton/bin/mount
+++ b/woof-code/rootfs-skeleton/bin/mount
@@ -83,6 +83,9 @@ elif [ "$LUKS_FLAG" = "yes" ] ; then
   exec mount.crypto_LUKS "$@" #mount.crypto_LUKS has specific rox code
 
 elif [ "$NTFS_FLAG" = "yes" ];then
+
+  [ ! -d /tmp/ntfs-errors ] && mkdir -p /tmp/ntfs-errors
+
   case "$@" in
     *"-o "*) #don't override -o
       ntfs-3g "${@}" || busybox mount "${@}"
@@ -93,15 +96,15 @@ elif [ "$NTFS_FLAG" = "yes" ];then
       CMDPRMS="`echo -n "$*" | tr '\t' ' ' | tr -s ' ' | tr ' ' '\n' | grep '^/' | tr '\n' ' '`"
       #kirk advised these options so Rox will not complain about file
       #permissions when copy a file to a ntfs partition...
-      [ -f /tmp/ntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfsmnterr${MYPID}.txt
-      ntfs-3g $CMDPRMS -o ${USER_OTPS}silent 2>/tmp/ntfsmnterr${MYPID}.txt
+      [ -f /tmp/ntfs-errors/ntfs-errorsntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
+      ntfs-3g $CMDPRMS -o ${USER_OTPS}silent 2>/tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
       RETVAL=$?
       #v2.16 ntfs-3g v1.417, part. scheduled for check, failed with value 10...
       #v4.00 ntfs-3g v1.2412 does not have 4,10, has 15 for dirty f.s., 14 hiberneted...
       case $RETVAL in 4|10|15) #14 = must mount read-only
-        ntfs-3g $CMDPRMS -o ${USER_OTPS}force,silent 2>/tmp/ntfsmnterr${MYPID}.txt
+        ntfs-3g $CMDPRMS -o ${USER_OTPS}force,silent 2>/tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
         RETVAL=$?
-        ERRMSG1="`cat /tmp/ntfsmnterr${MYPID}.txt`"
+        ERRMSG1="`cat /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt`"
         echo "$ERRMSG1"
         if [ $RETVAL -eq 0 ];then
          echo "WARNING: NTFS f.s. mounted read/write but corrupted."
@@ -113,7 +116,7 @@ It is mounted read/write, but advice is only write
 to it in emergency situation. Recommendation is
 boot Windows and fix the filesystem first!!!" &
         fi
-       [ ! -s /tmp/ntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfsmnterr${MYPID}.txt
+       [ ! -s /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
        ;;
       esac
  
@@ -124,7 +127,7 @@ boot Windows and fix the filesystem first!!!" &
        #mount read-only...
        busybox mount -r -t ntfs $CMDPRMS
        RETVAL=$?
-       ERRMSG1="`cat /tmp/ntfsmnterr${MYPID}.txt`"
+       ERRMSG1="`cat /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt`"
        echo "$ERRMSG1"
        if [ $RETVAL -eq 0 ];then
         echo "WARNING: NTFS f.s. mounted read-only."

--- a/woof-code/rootfs-skeleton/bin/mount
+++ b/woof-code/rootfs-skeleton/bin/mount
@@ -96,7 +96,7 @@ elif [ "$NTFS_FLAG" = "yes" ];then
       CMDPRMS="`echo -n "$*" | tr '\t' ' ' | tr -s ' ' | tr ' ' '\n' | grep '^/' | tr '\n' ' '`"
       #kirk advised these options so Rox will not complain about file
       #permissions when copy a file to a ntfs partition...
-      [ -f /tmp/ntfs-errors/ntfs-errorsntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
+      [ -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
       ntfs-3g $CMDPRMS -o ${USER_OTPS}silent 2>/tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
       RETVAL=$?
       #v2.16 ntfs-3g v1.417, part. scheduled for check, failed with value 10...


### PR DESCRIPTION
Rather than dump ntfs error messages on /tmp just put it in a folder for easy troubleshooting