### PR TITLE
kernel-kit/build.sh : strip-unneeded for kmodules

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -1026,7 +1026,15 @@ else
 	KERNEL_MODULES_SFS_NAME="kernel-modules.sfs-${kernel_version}-${package_name_suffix}"
 fi
 
+if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
+ for mods1 in "$(find "$(pwd)/output/${linux_kernel_dir}" -type -f -name "*.ko")"
+  do
+   [ $(file "$mods1" | grep "unstripped") != "" ] && strip --strip-unneeded "$mods1"
+  done
+fi
+
 mksquashfs output/${linux_kernel_dir} output/${KERNEL_MODULES_SFS_NAME} $COMP
+
 [ $? = 0 ] || exit 1
 cd output/
 if [ "$kit_kernel" = "yes" ]; then

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -1033,7 +1033,7 @@ if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")
   done
 fi
 
-mksquashfs output/${linux_kernel_dir} output/${KERNEL_MODULES_SFS_NAME} $COMP
+mksquashfs output/${linux_kernel_dir} output/${KERNEL_MODULES_SFS_NAME} $COMP -b 1M
 
 [ $? = 0 ] || exit 1
 cd output/


### PR DESCRIPTION
This will search for all compile kernel modules and make the kernel modules smaller without being broken. This will activate if strip command exists