### PR TITLE
3builddistro-Z: Make output sfs files smaller

### DIFF
--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -41,6 +41,32 @@ PKGLISTS_COMPAT="`echo "$PKG_DOCS_DISTRO_COMPAT" | tr ' ' '\n' | cut -f 3 -d '|'
 
 export WKGDIR="`pwd`"
 
+strip_binary_files(){
+
+sPATH="$1"
+
+EXCLUDE_EXT="\.log\$|\.txt\$|\.xml\$|\.jpg\$|\.png\$|\.svg\$|\.list\$|\.rules\$|\.ttf\$|\.wav\$|\.gz\$|\.xz$|\.lzma\$|\.sh\$|\.img\$|\.iso\$|\.conf\$|\.cfg\$|\.mo\$|\.schema\$|\.desktop\$|\.cache\$|\.info\$|\.ppd\$|\.cpio\$|\.old\$|\.bak\$|\.css\$|\.html\$|\.htm\$|\.bac\$|\.js\$|\.gif\$|\.swf\|\.new\$|\.ini\$|\.cnf\$|\.wav\$|\.mp3\$|README\$|INSTALL\$|\.ui\$|\.zip\$|COPYING\$|\.directory\$|\.menu\$|\.pdf\$|\.doc\$|\.xls\$|\.ppt\$|\.mov\$|\.mpg\$|\.avi\$|\.policy\$|\.inc\$|\.xpm\$|\.cgi\$|receipt\$|modifiers\$|sudoers\$|\.mounts\$|\.schemas\$|\.dsk\$|\.tdb\$|\.nanorc\$|\.rc\$|\.c\$|\.cpp\$|\.h\$|\.service\$"
+
+echo "Searching files to strip..."
+for so1 in `find "$sPATH" -type f | grep -E "bin|sbin|etc|lib|usr|opt|var" | grep -vE "$EXCLUDE_EXT"`
+do
+ flinfo="$(file "$so1")"
+ if [ ! -L "$so1" ]; then
+  if [ "$(echo "$flinfo" | grep "shared object" | grep "not stripped")" != "" ]; then
+   echo "Stripping $(basename "$so1") ..."
+   strip --strip-unneeded "$so1"
+  elif [ "$(echo "$flinfo" | grep -E "ELF.*executable" | grep "not stripped")" != "" ]; then
+   echo "Stripping $(basename "$so1") ..."
+   strip --strip-unneeded "$so1"
+  else
+   echo "File skipped: $(basename "$so1")"
+  fi
+ fi
+done
+
+}
+
+
 if [ "$BUILD_ZIP" = "yes" ]; then
 	SDFLAG="zip"
 elif [ "$DISTRO_TARGETARCH" = "arm" ]; then
@@ -1250,11 +1276,16 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 	../support/rootfs-hacks.sh rootfs-complete
 	#-----------------------------------------
 	#build the rootfs-complete sfs...
+	
+	if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
+	 strip_binary_files "$(pwd)/rootfs-complete"
+	fi
+	
 	echo
 	echo "Now building the main f.s., ${PUPPYSFS}..."
 	sync
 	rm -f build/${PUPPYSFS} 2>/dev/null
-	mksquashfs rootfs-complete build/${PUPPYSFS} ${SFSCOMP} #100911 110713
+	mksquashfs rootfs-complete build/${PUPPYSFS} ${SFSCOMP} -b 1M #100911 110713
 	sync
 	###########
 	if [ -d adrv -o -d fdrv -o -d ydrv ];then
@@ -1271,8 +1302,13 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 			echo
 			echo "Now building the $SYS_SFS f.s., $TYPE_SYS_SFS ..."
 			sync
+			
+			if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
+	                  strip_binary_files "$(pwd)/$SYS_SFS"
+			fi
+	
 			rm -f build/${TYPE_SYS_SFS} 2>/dev/null
-			mksquashfs $SYS_SFS build/${TYPE_SYS_SFS} ${SFSCOMP} #170330
+			mksquashfs $SYS_SFS build/${TYPE_SYS_SFS} ${SFSCOMP} -b 1M #170330
 			sync
 		done
 		###########	
@@ -1379,9 +1415,13 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 	do
 		rm -rf sandbox3/devx/${i}
 	done
+	
+	if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
+	  strip_binary_files "$(pwd)/sandbox3/devx"
+	fi
 
 	echo "Now creating ${DEVXSFS} ..."
-	mksquashfs sandbox3/devx ./sandbox3/${DEVXSFS} ${SFSCOMP} #100911 110713
+	mksquashfs sandbox3/devx ./sandbox3/${DEVXSFS} ${SFSCOMP} -b 1M #100911 110713
 	sync
 	chmod 644 ./sandbox3/${DEVXSFS}
 	echo "...done"

--- a/woof-code/3builddistro-Z
+++ b/woof-code/3builddistro-Z
@@ -41,32 +41,6 @@ PKGLISTS_COMPAT="`echo "$PKG_DOCS_DISTRO_COMPAT" | tr ' ' '\n' | cut -f 3 -d '|'
 
 export WKGDIR="`pwd`"
 
-strip_binary_files(){
-
-sPATH="$1"
-
-EXCLUDE_EXT="\.log\$|\.txt\$|\.xml\$|\.jpg\$|\.png\$|\.svg\$|\.list\$|\.rules\$|\.ttf\$|\.wav\$|\.gz\$|\.xz$|\.lzma\$|\.sh\$|\.img\$|\.iso\$|\.conf\$|\.cfg\$|\.mo\$|\.schema\$|\.desktop\$|\.cache\$|\.info\$|\.ppd\$|\.cpio\$|\.old\$|\.bak\$|\.css\$|\.html\$|\.htm\$|\.bac\$|\.js\$|\.gif\$|\.swf\|\.new\$|\.ini\$|\.cnf\$|\.wav\$|\.mp3\$|README\$|INSTALL\$|\.ui\$|\.zip\$|COPYING\$|\.directory\$|\.menu\$|\.pdf\$|\.doc\$|\.xls\$|\.ppt\$|\.mov\$|\.mpg\$|\.avi\$|\.policy\$|\.inc\$|\.xpm\$|\.cgi\$|receipt\$|modifiers\$|sudoers\$|\.mounts\$|\.schemas\$|\.dsk\$|\.tdb\$|\.nanorc\$|\.rc\$|\.c\$|\.cpp\$|\.h\$|\.service\$"
-
-echo "Searching files to strip..."
-for so1 in `find "$sPATH" -type f | grep -E "bin|sbin|etc|lib|usr|opt|var" | grep -vE "$EXCLUDE_EXT"`
-do
- flinfo="$(file "$so1")"
- if [ ! -L "$so1" ]; then
-  if [ "$(echo "$flinfo" | grep "shared object" | grep "not stripped")" != "" ]; then
-   echo "Stripping $(basename "$so1") ..."
-   strip --strip-unneeded "$so1"
-  elif [ "$(echo "$flinfo" | grep -E "ELF.*executable" | grep "not stripped")" != "" ]; then
-   echo "Stripping $(basename "$so1") ..."
-   strip --strip-unneeded "$so1"
-  else
-   echo "File skipped: $(basename "$so1")"
-  fi
- fi
-done
-
-}
-
-
 if [ "$BUILD_ZIP" = "yes" ]; then
 	SDFLAG="zip"
 elif [ "$DISTRO_TARGETARCH" = "arm" ]; then
@@ -1277,10 +1251,6 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 	#-----------------------------------------
 	#build the rootfs-complete sfs...
 	
-	if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
-	 strip_binary_files "$(pwd)/rootfs-complete"
-	fi
-	
 	echo
 	echo "Now building the main f.s., ${PUPPYSFS}..."
 	sync
@@ -1303,10 +1273,6 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 			echo "Now building the $SYS_SFS f.s., $TYPE_SYS_SFS ..."
 			sync
 			
-			if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
-	                  strip_binary_files "$(pwd)/$SYS_SFS"
-			fi
-	
 			rm -f build/${TYPE_SYS_SFS} 2>/dev/null
 			mksquashfs $SYS_SFS build/${TYPE_SYS_SFS} ${SFSCOMP} -b 1M #170330
 			sync
@@ -1416,10 +1382,6 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 		rm -rf sandbox3/devx/${i}
 	done
 	
-	if [ "$(which strip)" != "" ] && [ "$(strip --help | grep "\-\-strip\-unneeded")" != "" ]; then
-	  strip_binary_files "$(pwd)/sandbox3/devx"
-	fi
-
 	echo "Now creating ${DEVXSFS} ..."
 	mksquashfs sandbox3/devx ./sandbox3/${DEVXSFS} ${SFSCOMP} -b 1M #100911 110713
 	sync


### PR DESCRIPTION
This was achieve by stripping library files and executable files which was not stripped and set mksquashfs at 1M block size