### PR TITLE
umount: remove empty mountpoint folders on /media

### DIFF
--- a/woof-code/rootfs-skeleton/bin/umount
+++ b/woof-code/rootfs-skeleton/bin/umount
@@ -7,8 +7,17 @@
 if [ -f /usr/local/pup_event/frontend_rox_funcs ] ; then
 	. /usr/local/pup_event/frontend_rox_funcs 2>/dev/null
 	rox_umount "$@"
+	retval=$?
 else
 	umount-FULL -d "$@"
+	retval=$?
 fi
 
-exit $?
+for fld in "$(ls -1 /media/* 2>/dev/null | tr '\n' ' ')"
+do
+ if [ "$(mount | grep "/media/$fld")" == "" ] && [ "$(ls /media/$fld 2>/dev/null)" == "" ]; then
+  rmdir /media/$fld
+ fi
+done
+
+exit $retval


### PR DESCRIPTION
The mountpoint folders created in /media will be removed if it is not used as mountpoint and it was an empty directory