### PR TITLE
88-puppy-autodetect.rules: Add MTP detection

### DIFF
--- a/woof-code/rootfs-skeleton/etc/udev/rules.d/88-puppy-autodetect.rules
+++ b/woof-code/rootfs-skeleton/etc/udev/rules.d/88-puppy-autodetect.rules
@@ -10,3 +10,7 @@
 #ACTION=="add", SUBSYSTEM=="usb", ATTR{bInterfaceClass}=="06", RUN+="/usr/sbin/pupautodetect camera"
 #or together like this:
 ACTION=="add", SUBSYSTEM=="usb", ENV{INTERFACE}=="6/1/*", RUN+="/usr/sbin/pupautodetect camera"
+
+###MTP Device###
+#mtp device plugged in via usb...
+ACTION=="add", SUBSYSTEM=="usb", ENV{ID_MTP_DEVICE}=="1", RUN+="/usr/sbin/pupautodetect android-device"

--- a/woof-code/rootfs-skeleton/etc/udev/rules.d/88-puppy-autodetect.rules
+++ b/woof-code/rootfs-skeleton/etc/udev/rules.d/88-puppy-autodetect.rules
@@ -13,4 +13,4 @@ ACTION=="add", SUBSYSTEM=="usb", ENV{INTERFACE}=="6/1/*", RUN+="/usr/sbin/pupaut
 
 ###MTP Device###
 #mtp device plugged in via usb...
-ACTION=="add", SUBSYSTEM=="usb", ENV{ID_MTP_DEVICE}=="1", RUN+="/usr/sbin/pupautodetect android-device"
+ACTION=="add", SUBSYSTEM=="usb", ENV{INTERFACE}=="255/255/*", RUN+="/usr/sbin/pupautodetect android-device"


### PR DESCRIPTION
 Based from udevadm info --query=all --path=[usb path from udevadm monitor] INTERFACE value of MTP lies at 255/255/*