### PR TITLE
rc.services: delete non-running pid files first

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.services
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.services
@@ -5,6 +5,20 @@
 #this sleep benefits all slow peripherals.
 sleep 6
 
+#Delete pidfiles which is not active
+for pidfile in $(find /var/run -type f -name "*.pid")
+do
+ xrunning=0
+ pidnums=$(cat $pidfile 2>/dev/null | tr '\n' ' ')
+ if [ "$pidnums" != "" ]; then
+  for $pid in $pidnums
+  do
+   [ -e /proc/$pid ] && xrunning=$(expr $xrunning + 1)
+  done
+ fi
+ [ $xrunning -eq 0 ] && rm -f $pidfile
+done
+
 for service_script in /etc/init.d/*
 do
  [ -x $service_script ] && $service_script start


### PR DESCRIPTION
Remove pid files which contains pid numbers that is not running at all. In order to start the services accurately. Those pid files does not remove if improper shutdown occured