### PR TITLE
xwin: Improved support for uefi mode

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -75,16 +75,30 @@ if [ -f /tmp/xwin_xorgwizard_cli ] ; then
 # normal operation
 elif [ -f /etc/X11/xorg.conf ];then
 	USING_DRIVER=$(grep '#card0driver' /etc/X11/xorg.conf | grep -v '#.*Driver')
-	SPECVESA="`find /usr/lib /usr/X11R7/lib /usr/lib64 -noleaf -mount -type f -name vesa_drv.so 2>/dev/null | grep -v 'backup' | grep -m1 'vesa_drv.so'`" #1201031 bug fix.
+	
+	if [ -e /sys/firmware/efi ]; then
+	 #booted from uefi
+	 SPECDRV="`find /usr/lib /usr/X11R7/lib /usr/lib64 -noleaf -mount -type f -name fbdev_drv.so 2>/dev/null | grep -v 'backup' | grep -m1 'vesa_drv.so'`" #1201031 bug fix.
+	else
+	 #booted from bios
+	 SPECDRV="`find /usr/lib /usr/X11R7/lib /usr/lib64 -noleaf -mount -type f -name vesa_drv.so 2>/dev/null | grep -v 'backup' | grep -m1 'vesa_drv.so'`" #1201031 bug fix.
+	fi
+	
 	if [ "$USING_DRIVER" ] ; then #find location of video chip drivers...
 		#get current driver...
-		DRVRSPATH="`dirname $SPECVESA`"
+		DRVRSPATH="`dirname $SPECDRV`"
 		#one driver is mtx_drv.o hmmm, okay do it this way (pakt)...
 		CURRENT_DRIVER="`grep '#card0driver' /etc/X11/xorg.conf | cut -f 2 -d '"'`"
 		if [ "$CURRENT_DRIVER" ];then
 			ls -1 $DRVRSPATH/* | grep $CURRENT_DRIVER >/dev/null
 			#driver file not found, comment out
-			[ $? -ne 0 ] && sed -i 's|.*#card0driver|#	Driver      "vesa" #card0driver|' /etc/X11/xorg.conf
+			if [ $? -ne 0 ]; then
+			  if [ -e /sys/firmware/efi ]; then
+			   sed -i 's|.*#card0driver|#	Driver      "fbdev" #card0driver|' /etc/X11/xorg.conf			 
+			  else
+			   sed -i 's|.*#card0driver|#	Driver      "vesa" #card0driver|' /etc/X11/xorg.conf
+		          fi
+			fi
 		fi
 	fi
 else


### PR DESCRIPTION
When puppy boots from UEFI. Use fbdev as fallback driver instead of vesa. VESA only works on bios only due to 10H interrupt which was not present on UEFI