### PR TITLE
sfs_load: fix for detecting gtk immodules

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -370,7 +370,7 @@ has_afterwork() {
 	reset_has_vars
 	if [ -d $MNTPNT/usr/lib${lsuffix} ] ; then
 		HAS_GDK=$(ls $MNTPNT/usr/lib${lsuffix}/gdk-pixbuf-*/*/* 2>/dev/null)
-		HAS_GTKIM=$(ls $MNTPNT/usr/lib${lsuffix}/gtk-*/*/* | grep "gtk.immodules" 2>/dev/null)
+		HAS_GTKIM=$(ls $MNTPNT/usr/lib${lsuffix}/gtk-*/*/* | grep "/immodules" 2>/dev/null)
 		HAS_PANGO=$(ls $MNTPNT/usr/lib${lsuffix}/pango/*/* 2>/dev/null)
 		HAS_GIO=$(find $MNTPNT/usr/lib${lsuffix} -maxdepth 2 -name "gio" 2>/dev/null)
 		if [ -d $MNTPNT/usr/lib${lsuffix}/gconv ] ; then


### PR DESCRIPTION
Just look for immodules folder inside the sfs modules.