### PR TITLE
woof-distro x86: use 'common32/64' gnome-mplayer

### DIFF
--- a/woof-distro/x86/debian/Packages-puppy-stretch-official
+++ b/woof-distro/x86/debian/Packages-puppy-stretch-official
@@ -11,7 +11,6 @@ freememapplet-2.8.6-i686_stretch|freememapplet|2.8.6-i686_stretch||BuildingBlock
 gmeasures-0.7-i686_stretch|gmeasures|0.7-i686_stretch||Business|100||gmeasures-0.7-i686_stretch.pet|+gtk+2|convert measurements from imperial to metric and back|debian|stretch||
 gnome-menus-2.14.3-i686_stretch|gnome-menus|2.14.3-i686_stretch||BuildingBlock|288||gnome-menus-2.14.3-i686_stretch.pet||gnome-menus controls the heirarchy of the menu system|debian|stretch||
 gnome-menus_DEV-2.14.3-i686_stretch|gnome-menus_DEV|2.14.3-i686_stretch||BuildingBlock|520||gnome-menus_DEV-2.14.3-i686_stretch.pet|+gnome-menus|gnome-menus development|debian|stretch||
-gnome-mplayer-1.1w-i686_stretch|gnome-mplayer|1.1w-i686_stretch||BuildingBlock|560||gnome-mplayer-1.1w-i686_stretch.pet||No description provided|debian|stretch||
 gtkhash-1.1-i686_stretch|gtkhash|1.1-i686_stretch||Utility|244||gtkhash-1.1-i686_stretch.pet|+gtk+2|a utility for computing checksums|debian|stretch||
 hardinfo-5.2-i18n-i686_stretch|hardinfo|5.2-i18n-i686_stretch||System|852||hardinfo-5.2-i18n-i686_stretch.pet|+gtk+2|System Profiler and Benchmark|debian|stretch||
 hicolor-icon-theme_winthose-1.1|hicolor-icon-theme_winthose|1.1||BuildingBlock|8852K||hicolor-icon-theme_winthose-1.1.pet||No description provided||||

--- a/woof-distro/x86/slackware/14.1/DISTRO_PKGS_SPECS-slackware-14.1
+++ b/woof-distro/x86/slackware/14.1/DISTRO_PKGS_SPECS-slackware-14.1
@@ -120,7 +120,6 @@ yes|gdb|gdb|exe>dev,dev,doc,nls
 yes|gdbm|gdbm|exe,dev,doc,nls
 yes|gdk-pixbuf2|gdk-pixbuf2|exe,dev,doc,nls
 yes|geany||exe,dev>null,doc,nls
-yes|gecko-mediaplayer||exe,dev>null,doc,nls
 yes|get_libreoffice||exe
 yes|getcurpos||exe
 yes|getflash||exe
@@ -136,7 +135,6 @@ yes|glibc_locales|glibc|exe,dev,doc,nls>exe| #slackware glibc-i18n- does not hav
 yes|glibmm_static||exe,dev>dev
 yes|gmeasures||exe,dev>null,doc,nls
 yes|gmp|gmp|exe,dev,doc,nls
-yes|gmtk||exe,dev,doc,nls
 yes|gnome-menus||exe,dev,doc,nls
 yes|gnome-mplayer||exe,dev,doc,nls
 yes|gnumeric||exe,dev,doc,nls

--- a/woof-distro/x86/slackware/14.1/Packages-puppy-slacko14.1-official
+++ b/woof-distro/x86/slackware/14.1/Packages-puppy-slacko14.1-official
@@ -95,9 +95,6 @@ geany-plugins-1.25-i686_slk600|geany-plugins|1.25-i686_slk600||BuildingBlock|252
 geany-plugins_DEV-1.25-i686_slk600|geany-plugins_DEV|1.25-i686_slk600||BuildingBlock|148||geany-plugins_DEV-1.25-i686_slk600.pet|+geany-plugins|geany-plugins development|slackware|14.1||
 geany-plugins_DOC-1.25-i686_slk600|geany-plugins_DOC|1.25-i686_slk600||BuildingBlock|1920||geany-plugins_DOC-1.25-i686_slk600.pet|+geany-plugins|geany-plugins documentation||||
 geany-plugins_NLS-1.25-i686_slk600|geany-plugins_NLS|1.25-i686_slk600||BuildingBlock|1340||geany-plugins_NLS-1.25-i686_slk600.pet|+geany-plugins|geany-plugins locales||||
-gecko-mediaplayer-1.0.9b-i686_slk600|gecko-mediaplayer|1.0.9b-i686_slk600||Multimedia|684||gecko-mediaplayer-1.0.9b-i686_slk600.pet|+gmtk,+gtk+2,+gnome-mplayer,+mplayer|A Firefox plugin to play media off the net using gnome-mplayer|slackware|14.1||
-gecko-mediaplayer_DOC-1.0.9b-i686_slk600|gecko-mediaplayer_DOC|1.0.9b-i686_slk600||Multimedia|84||gecko-mediaplayer_DOC-1.0.9b-i686_slk600.pet|+gecko-mediaplayer|gecko-mediaplayer documentation||||
-gecko-mediaplayer_NLS-1.0.9b-i686_slk600|gecko-mediaplayer_NLS|1.0.9b-i686_slk600||Multimedia|148||gecko-mediaplayer_NLS-1.0.9b-i686_slk600.pet|+gecko-mediaplayer|gecko-mediaplayer locales||||
 ghostscript-9.05-s14|ghostscript|9.05-s14||BuildingBlock|13310K||ghostscript-9.05-s14.pet||Ghostscript|slackware|14.0||
 gifsicle-1.87-i686_slk600|gifsicle|1.87-i686_slk600||BuildingBlock|332||gifsicle-1.87-i686_slk600.pet||command-line tool for creating, editing, and getting information about GIF images and animations|slackware|14.1||
 gifsicle_DOC-1.87-i686_slk600|gifsicle_DOC|1.87-i686_slk600||BuildingBlock|64||gifsicle_DOC-1.87-i686_slk600.pet|+gifsicle|gifsicle documentation||||
@@ -109,10 +106,6 @@ glibmm_static_DOC-2.28.2-i686_slk600|glibmm_static_DOC|2.28.2-i686_slk600||Build
 glibmm_static_NLS-2.28.2-i686_slk600|glibmm_static_NLS|2.28.2-i686_slk600||BuildingBlock|28||glibmm_static_NLS-2.28.2-i686_slk600.pet|+glibmm_static|glibmm_static locales||||
 gmeasures-0.7-i686_slk600|gmeasures|0.7-i686_slk600||Business|108||gmeasures-0.7-i686_slk600.pet|+gtk+2|convert measurements from imperial to metric and back|slackware|14.1||
 gmeasures_DOC-0.7-i686_slk600|gmeasures_DOC|0.7-i686_slk600||Business|60||gmeasures_DOC-0.7-i686_slk600.pet|+gmeasures|gmeasures documentation||||
-gmtk-1.0.9b-i686_slk600|gmtk|1.0.9b-i686_slk600||BuildingBlock|172||gmtk-1.0.9b-i686_slk600.pet|+gtk+2|gnome-mplayer toolkit library|slackware|14.1||
-gmtk_DEV-1.0.9b-i686_slk600|gmtk_DEV|1.0.9b-i686_slk600||BuildingBlock|628||gmtk_DEV-1.0.9b-i686_slk600.pet|+gmtk|gmtk development|slackware|14.1||
-gmtk_DOC-1.0.9b-i686_slk600|gmtk_DOC|1.0.9b-i686_slk600||BuildingBlock|68||gmtk_DOC-1.0.9b-i686_slk600.pet|+gmtk|gmtk documentation||||
-gmtk_NLS-1.0.9b-i686_slk600|gmtk_NLS|1.0.9b-i686_slk600||BuildingBlock|520||gmtk_NLS-1.0.9b-i686_slk600.pet|+gmtk|gmtk locales||||
 gnome_games_Lite-2.26.1-i486-Spup|gnome_games_Lite|2.26.1-i486-Spup||Fun|15092K||gnome_games_Lite-2.26.1-i486-Spup.pet|+gtk+2|A great collection of fun games|slackware|14.0||
 gnome-icon-theme-2.25.92-i686_slk600|gnome-icon-theme|2.25.92-i686_slk600||Desktop|19204||gnome-icon-theme-2.25.92-i686_slk600.pet||Icon theme for gnome apps||||
 gnome-icon-theme_DEV-2.25.92-i686_slk600|gnome-icon-theme_DEV|2.25.92-i686_slk600||Desktop|20||gnome-icon-theme_DEV-2.25.92-i686_slk600.pet|+gnome-icon-theme|gnome-icon-theme development||||
@@ -121,9 +114,6 @@ gnome-icon-theme_NLS-2.25.92-i686_slk600|gnome-icon-theme_NLS|2.25.92-i686_slk60
 gnome-menus-2.14.3-i686_slk600|gnome-menus|2.14.3-i686_slk600||BuildingBlock|144||gnome-menus-2.14.3-i686_slk600.pet||gnome-menus controls the heirarchy of the menu system|slackware|14.1||
 gnome-menus_DEV-2.14.3-i686_slk600|gnome-menus_DEV|2.14.3-i686_slk600||BuildingBlock|520||gnome-menus_DEV-2.14.3-i686_slk600.pet|+gnome-menus|gnome-menus development|slackware|14.1||
 gnome-menus_NLS-2.14.3-i686_slk600|gnome-menus_NLS|2.14.3-i686_slk600||BuildingBlock|856||gnome-menus_NLS-2.14.3-i686_slk600.pet|+gnome-menus|gnome-menus locales||||
-gnome-mplayer-1.0.9b-i686|gnome-mplayer|1.0.9b-i686||Multimedia|592||gnome-mplayer-1.0.9b-i686.pet|+gmtk,+gtk+2,+mplayer|A light weight graphical front end to MPlayer|slackware|14.1||
-gnome-mplayer_DOC-1.0.9b-i686|gnome-mplayer_DOC|1.0.9b-i686||Multimedia|208||gnome-mplayer_DOC-1.0.9b-i686.pet|+gnome-mplayer|gnome-mplayer documentation||||
-gnome-mplayer_NLS-1.0.9b-i686|gnome-mplayer_NLS|1.0.9b-i686||Multimedia|1260||gnome-mplayer_NLS-1.0.9b-i686.pet|+gnome-mplayer|gnome-mplayer locales||||
 gnumeric-1.10.17-i686_slk600|gnumeric|1.10.17-i686_slk600||Business|9628||gnumeric-1.10.17-i686_slk600.pet|+goffice,+gtk+2,+glib2|A light weight spread sheet application|slackware|14.1||
 gnumeric_DEV-1.10.17-i686_slk600|gnumeric_DEV|1.10.17-i686_slk600||Business|1056||gnumeric_DEV-1.10.17-i686_slk600.pet|+gnumeric|gnumeric development|slackware|14.1||
 gnumeric_DOC-1.10.17-i686_slk600|gnumeric_DOC|1.10.17-i686_slk600||Business|9784||gnumeric_DOC-1.10.17-i686_slk600.pet|+gnumeric|gnumeric documentation||||

--- a/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
+++ b/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
@@ -125,7 +125,6 @@ yes|gdbm|gdbm|exe,dev,doc,nls
 yes|gdk-pixbuf2|gdk-pixbuf2|exe,dev,doc,nls
 yes|gdmap||exe,dev>null,doc,nls
 yes|geany||exe,dev,doc,nls
-yes|gecko-mediaplayer||exe,dev>null,doc,nls
 yes|get_browser||exe
 yes|get_libreoffice||exe
 yes|getcurpos||exe,dev
@@ -141,7 +140,6 @@ yes|glibc_locales|glibc,glibc-zoneinfo,glibc-i18n|exe,dev,doc,nls>exe| #slackwar
 yes|glibmm|glibmm|exe,dev,doc,nls
 yes|gmeasures||exe,dev>null,doc,nls
 yes|gmp|gmp|exe,dev,doc,nls
-yes|gmtk||exe,dev,doc,nls
 yes|gnome-icon-theme||exe>dev,dev,doc,nls| #too bloated for main fs so send to devx, needed to compile some progs
 yes|gnome-menus||exe,dev,doc,nls
 yes|gnome-mplayer||exe,dev,doc,nls

--- a/woof-distro/x86/slackware/14.2/Packages-puppy-slacko14.2-official
+++ b/woof-distro/x86/slackware/14.2/Packages-puppy-slacko14.2-official
@@ -84,20 +84,12 @@ geany-plugins-1.27-i686_s700|geany-plugins|1.27-i686_s700||BuildingBlock|2088||g
 geany-plugins_DEV-1.27-i686_s700|geany-plugins_DEV|1.27-i686_s700||BuildingBlock|160||geany-plugins_DEV-1.27-i686_s700.pet|+geany-plugins|geany-plugins development|slackware|14.2||
 geany-plugins_DOC-1.27-i686_s700|geany-plugins_DOC|1.27-i686_s700||BuildingBlock|2144||geany-plugins_DOC-1.27-i686_s700.pet|+geany-plugins|geany-plugins documentation||||
 geany-plugins_NLS-1.27-i686_s700|geany-plugins_NLS|1.27-i686_s700||BuildingBlock|1372||geany-plugins_NLS-1.27-i686_s700.pet|+geany-plugins|geany-plugins locales||||
-gecko-mediaplayer-1.0.9b-i686_s700|gecko-mediaplayer|1.0.9b-i686_s700||Multimedia|616||gecko-mediaplayer-1.0.9b-i686_s700.pet|+gmtk,+gtk+2,+gnome-mplayer,+mplayer|A Firefox plugin to play media off the net using gnome-mplayer|slackware|14.2||
-gecko-mediaplayer_DEV-1.0.9b-i686_s700|gecko-mediaplayer_DEV|1.0.9b-i686_s700||Multimedia|20||gecko-mediaplayer_DEV-1.0.9b-i686_s700.pet|+gecko-mediaplayer|gecko-mediaplayer development||||
-gecko-mediaplayer_DOC-1.0.9b-i686_s700|gecko-mediaplayer_DOC|1.0.9b-i686_s700||Multimedia|84||gecko-mediaplayer_DOC-1.0.9b-i686_s700.pet|+gecko-mediaplayer|gecko-mediaplayer documentation||||
-gecko-mediaplayer_NLS-1.0.9b-i686_s700|gecko-mediaplayer_NLS|1.0.9b-i686_s700||Multimedia|148||gecko-mediaplayer_NLS-1.0.9b-i686_s700.pet|+gecko-mediaplayer|gecko-mediaplayer locales||||
 gifsicle-1.88-i686_s700|gifsicle|1.88-i686_s700||BuildingBlock|336||gifsicle-1.88-i686_s700.pet|BuildingBlock|command-line tool for creating, editing, and getting information about GIF images and animations|slackware|14.2||
 gifsicle_DEV-1.88-i686_s700|gifsicle_DEV|1.88-i686_s700||BuildingBlock|20||gifsicle_DEV-1.88-i686_s700.pet|+gifsicle|gifsicle development||||
 gifsicle_DOC-1.88-i686_s700|gifsicle_DOC|1.88-i686_s700||BuildingBlock|64||gifsicle_DOC-1.88-i686_s700.pet|+gifsicle|gifsicle documentation||||
 gmeasures-0.7-i686_s700|gmeasures|0.7-i686_s700||Business|88||gmeasures-0.7-i686_s700.pet|+gtk+2|convert measurements from imperial to metric and back|slackware|14.2||
 gmeasures_DEV-0.7-i686_s700|gmeasures_DEV|0.7-i686_s700||Business|20||gmeasures_DEV-0.7-i686_s700.pet|+gmeasures|gmeasures development||||
 gmeasures_DOC-0.7-i686_s700|gmeasures_DOC|0.7-i686_s700||Business|60||gmeasures_DOC-0.7-i686_s700.pet|+gmeasures|gmeasures documentation||||
-gmtk-1.0.9b-i686_s700|gmtk|1.0.9b-i686_s700||BuildingBlock|152||gmtk-1.0.9b-i686_s700.pet|+gtk+2|gnome-mplayer toolkit library|slackware|14.2||
-gmtk_DEV-1.0.9b-i686_s700|gmtk_DEV|1.0.9b-i686_s700||BuildingBlock|624||gmtk_DEV-1.0.9b-i686_s700.pet|+gmtk|gmtk development|slackware|14.2||
-gmtk_DOC-1.0.9b-i686_s700|gmtk_DOC|1.0.9b-i686_s700||BuildingBlock|68||gmtk_DOC-1.0.9b-i686_s700.pet|+gmtk|gmtk documentation||||
-gmtk_NLS-1.0.9b-i686_s700|gmtk_NLS|1.0.9b-i686_s700||BuildingBlock|520||gmtk_NLS-1.0.9b-i686_s700.pet|+gmtk|gmtk locales||||
 gnome-icon-theme-2.25.92-i686_s700|gnome-icon-theme|2.25.92-i686_s700||Desktop|19204||gnome-icon-theme-2.25.92-i686_s700.pet||Icon theme for gnome apps||||
 gnome-icon-theme_DEV-2.25.92-i686_s700|gnome-icon-theme_DEV|2.25.92-i686_s700||Desktop|20||gnome-icon-theme_DEV-2.25.92-i686_s700.pet|+gnome-icon-theme|gnome-icon-theme development||||
 gnome-icon-theme_DOC-2.25.92-i686_s700|gnome-icon-theme_DOC|2.25.92-i686_s700||Desktop|988||gnome-icon-theme_DOC-2.25.92-i686_s700.pet|+gnome-icon-theme|gnome-icon-theme documentation||||
@@ -105,10 +97,6 @@ gnome-icon-theme_NLS-2.25.92-i686_s700|gnome-icon-theme_NLS|2.25.92-i686_s700||D
 gnome-menus-2.14.3-i686_s700|gnome-menus|2.14.3-i686_s700||BuildingBlock|288||gnome-menus-2.14.3-i686_s700.pet||gnome-menus controls the heirarchy of the menu system|slackware|14.2||
 gnome-menus_DEV-2.14.3-i686_s700|gnome-menus_DEV|2.14.3-i686_s700||BuildingBlock|460||gnome-menus_DEV-2.14.3-i686_s700.pet|+gnome-menus|gnome-menus development|slackware|14.2||
 gnome-menus_NLS-2.14.3-i686_s700|gnome-menus_NLS|2.14.3-i686_s700||BuildingBlock|856||gnome-menus_NLS-2.14.3-i686_s700.pet|+gnome-menus|gnome-menus locales||||
-gnome-mplayer-1.0.9-i686_s700|gnome-mplayer|1.0.9-i686_s700||Multimedia|652||gnome-mplayer-1.0.9-i686_s700.pet|+gmtk,+gtk+2,+mplayer|A light weight graphical front end to MPlayer|slackware|14.2||
-gnome-mplayer_DEV-1.0.9-i686_s700|gnome-mplayer_DEV|1.0.9-i686_s700||Multimedia|20||gnome-mplayer_DEV-1.0.9-i686_s700.pet|+gnome-mplayer|gnome-mplayer development|slackware|14.2||
-gnome-mplayer_DOC-1.0.9-i686_s700|gnome-mplayer_DOC|1.0.9-i686_s700||Multimedia|208||gnome-mplayer_DOC-1.0.9-i686_s700.pet|+gnome-mplayer|gnome-mplayer documentation||||
-gnome-mplayer_NLS-1.0.9-i686_s700|gnome-mplayer_NLS|1.0.9-i686_s700||Multimedia|1260||gnome-mplayer_NLS-1.0.9-i686_s700.pet|+gnome-mplayer|gnome-mplayer locales||||
 gnumeric-1.10.17-i686_s701|gnumeric|1.10.17-i686_s701||Business|10172K||gnumeric-1.10.17-i686_s701.pet|+goffice,+gtk+2,+glib2|Calculation, Analysis, and Visualization of Information|slackware|14.2||
 gnumeric_DEV-1.10.17-i686_s701|gnumeric_DEV|1.10.17-i686_s701||Business|1068||gnumeric_DEV-1.10.17-i686_s701.pet|+gnumeric|gnumeric development|slackware|14.2||
 gnumeric_DOC-1.10.17-i686_s701|gnumeric_DOC|1.10.17-i686_s701||Business|9784||gnumeric_DOC-1.10.17-i686_s701.pet|+gnumeric|gnumeric documentation||||

--- a/woof-distro/x86/ubuntu/Packages-puppy-tahr-official
+++ b/woof-distro/x86/ubuntu/Packages-puppy-tahr-official
@@ -65,7 +65,6 @@ gnet-2.0.8|gnet|2.0.8||Network|901K||gnet-2.0.8.pet|+bash,+binutils,+bzip2,+core
 gnet_DEV-2.0.8|gnet_DEV|2.0.8||Network|901K||gnet_DEV-2.0.8.pet|+bash,+binutils,+bzip2,+coreutils,+diffutils,+findutils,+gawk,+gcc,+glib,+glibc,+grep,+make,+mktemp,+pkgconfig,+sed,+sysfiles,+tar|A network library|t2|april|||
 gnome-menus-2.14.3-up|gnome-menus|2.14.3-up||BuildingBlock|132K||gnome-menus-2.14.3-up.pet||needed by xdg_puppy, note later versions gnome-menus do not work properly|ubuntu|precise||
 gnome-menus_DEV-2.14.3-up|gnome-menus_DEV|2.14.3-up||BuildingBlock|408K||gnome-menus_DEV-2.14.3-up.pet|+gnome-menus|needed by xdg_puppy|ubuntu|precise||
-gnome-mplayer-1.0.8-i686|gnome-mplayer|1.0.8-i686||Multimedia|1820K||gnome-mplayer-1.0.8-i686.pet||Play your media||||
 gnumeric-1.10.17-i486-precise|gnumeric|1.10.17-i486-precise||Business;spreadsheet|9676K||gnumeric-1.10.17-i486-precise.pet|+gtk+|Gnumeric spreadsheet editor|ubuntu|precise||
 gnumeric_NLS-1.10.17-i486-precise|gnumeric_NLS|1.10.17-i486-precise||Business;spreadsheet|11836K||gnumeric_NLS-1.10.17-i486-precise.pet|+gnumeric|spreadsheet editor||||
 goffice-0.8.16-w5c|goffice|0.8.16-w5c||BuildingBlock|2400K||goffice-0.8.16-w5c.pet|+gtk+|A library of documentcentric objects and utilities|puppy|wary5||

--- a/woof-distro/x86/ubuntu/upupbb/Packages-puppy-upupbb-extra
+++ b/woof-distro/x86/ubuntu/upupbb/Packages-puppy-upupbb-extra
@@ -5,10 +5,6 @@ ffmpeg-3.4.2-i686_ub1803|ffmpeg|3.4-i686_ub1803||BuildingBlock|12980||ffmpeg-3.4
 ffmpeg_DEV-3.4.2-i686_ub1803|ffmpeg_DEV|3.4-i686_ub1803||BuildingBlock|17168||ffmpeg_DEV-3.4.2-i686_ub1803.pet|+ffmpeg|ffmpeg development||||
 ffmpeg_DOC-3.4.2-i686_ub1803|ffmpeg_DOC|3.4-i686_ub1803||BuildingBlock|10372||ffmpeg_DOC-3.4.2-i686_ub1803.pet|+ffmpeg|ffmpeg documentation||||
 ghostscript-9.21|ghostscript|9.21|1|BuildingBlock|61290K|extras|ghostscript-9.21-i586-1.txz||Postscript and PDF interpreter||||
-gnome-mplayer-1.0.9-i686_s700|gnome-mplayer|1.0.9-i686_s700||Multimedia|652||gnome-mplayer-1.0.9-i686_s700.pet|+gmtk,+gtk+2,+mplayer|A light weight graphical front end to MPlayer||||
-gnome-mplayer_DEV-1.0.9-i686_s700|gnome-mplayer_DEV|1.0.9-i686_s700||Multimedia|20||gnome-mplayer_DEV-1.0.9-i686_s700.pet|+gnome-mplayer|gnome-mplayer development||||
-gnome-mplayer_DOC-1.0.9-i686_s700|gnome-mplayer_DOC|1.0.9-i686_s700||Multimedia|208||gnome-mplayer_DOC-1.0.9-i686_s700.pet|+gnome-mplayer|gnome-mplayer documentation||||
-gnome-mplayer_NLS-1.0.9-i686_s700|gnome-mplayer_NLS|1.0.9-i686_s700||Multimedia|1260||gnome-mplayer_NLS-1.0.9-i686_s700.pet|+gnome-mplayer|gnome-mplayer locales||||
 goffice-0.8.17|goffice|0.8.17||BuildingBlock|3420K||goffice-0.8.17.pet||no description provided||||
 initscripts_2.88dsf|initscripts|2.88dsf|59.3ubuntu2|System|169K|extras|initscripts_2.88dsf-59.3ubuntu2_i386.deb|+mount&ge2.11x-1,+debianutils&ge4,+lsb-base&ge3.2-14,+sysvinit-utils&ge2.88dsf-50,+sysv-rc,+coreutils&ge5.93|scripts for initializing and shutting down the system||||
 jwm-2.3.7-i686|jwm|2.3.7-i686||Desktop|268||jwm-2.3.7-i686.pet|+cairo,+rsvg,+libpng,+libjpeg,+xpm,+fribidi|Joes Window Manager for X||||

--- a/woof-distro/x86_64/slackware64/14.1/DISTRO_PKGS_SPECS-slackware64-14.1
+++ b/woof-distro/x86_64/slackware64/14.1/DISTRO_PKGS_SPECS-slackware64-14.1
@@ -121,7 +121,6 @@ yes|gdb|gdb|exe>dev,dev,doc,nls
 yes|gdbm|gdbm|exe,dev,doc,nls
 yes|gdk-pixbuf2|gdk-pixbuf2|exe,dev,doc,nls
 yes|geany||exe,dev>null,doc,nls
-yes|gecko-mediaplayer||exe,dev>null,doc,nls
 yes|get_libreoffice||exe
 yes|getcurpos||exe
 yes|getflash||exe
@@ -137,7 +136,6 @@ yes|glibc_locales|glibc|exe,dev,doc,nls>exe| #slackware glibc-i18n- does not hav
 yes|glibmm_static||exe,dev>dev
 yes|gmeasures||exe,dev>null,doc,nls
 yes|gmp|gmp|exe,dev,doc,nls
-yes|gmtk||exe,dev,doc,nls
 yes|gnome-menus||exe,dev,doc,nls
 yes|gnome-mplayer||exe,dev,doc,nls
 yes|gnumeric||exe,dev,doc,nls

--- a/woof-distro/x86_64/slackware64/14.1/Packages-puppy-slacko6414.1-official
+++ b/woof-distro/x86_64/slackware64/14.1/Packages-puppy-slacko6414.1-official
@@ -63,25 +63,15 @@ geany-plugins-1.25-x86_64|geany-plugins|1.25-x86_64||BuildingBlock|2952||geany-p
 geany-plugins_DEV-1.25-x86_64|geany-plugins_DEV|1.25-x86_64||BuildingBlock|152||geany-plugins_DEV-1.25-x86_64.pet|+geany-plugins|geany-plugins development|slackware64|14.1||
 geany-plugins_DOC-1.25-x86_64|geany-plugins_DOC|1.25-x86_64||BuildingBlock|1988||geany-plugins_DOC-1.25-x86_64.pet|+geany-plugins|geany-plugins documentation||||
 geany-plugins_NLS-1.25-x86_64|geany-plugins_NLS|1.25-x86_64||BuildingBlock|1340||geany-plugins_NLS-1.25-x86_64.pet|+geany-plugins|geany-plugins locales||||
-gecko-mediaplayer-1.0.9b-x86_64|gecko-mediaplayer|1.0.9b-x86_64||Multimedia|696||gecko-mediaplayer-1.0.9b-x86_64.pet|+gmtk,+gtk+2,+gnome-mplayer,+mplayer|A Firefox plugin to play media off the net using gnome-mplayer|slackware64|14.1||
-gecko-mediaplayer_DOC-1.0.9b-x86_64|gecko-mediaplayer_DOC|1.0.9b-x86_64||Multimedia|84||gecko-mediaplayer_DOC-1.0.9b-x86_64.pet|+gecko-mediaplayer|gecko-mediaplayer documentation||||
-gecko-mediaplayer_NLS-1.0.9b-x86_64|gecko-mediaplayer_NLS|1.0.9b-x86_64||Multimedia|148||gecko-mediaplayer_NLS-1.0.9b-x86_64.pet|+gecko-mediaplayer|gecko-mediaplayer locales||||
 glibmm_static-2.28.2-x86_64|glibmm_static|2.28.2-x86_64||BuildingBlock|940||glibmm_static-2.28.2-x86_64.pet|+mm-common|C++ bindings for glib2||||
 glibmm_static_DEV-2.28.2-x86_64|glibmm_static_DEV|2.28.2-x86_64||BuildingBlock|23552||glibmm_static_DEV-2.28.2-x86_64.pet|+glibmm_static|glibmm_static development|slackware64|14.1||
 glibmm_static_DOC-2.28.2-x86_64|glibmm_static_DOC|2.28.2-x86_64||BuildingBlock|20644||glibmm_static_DOC-2.28.2-x86_64.pet|+glibmm_static|glibmm_static documentation||||
 glibmm_static_NLS-2.28.2-x86_64|glibmm_static_NLS|2.28.2-x86_64||BuildingBlock|28||glibmm_static_NLS-2.28.2-x86_64.pet|+glibmm_static|glibmm_static locales||||
 gmeasures-0.7-x86_64|gmeasures|0.7-x86_64||Business|120||gmeasures-0.7-x86_64.pet|+gtk+2|convert measurements from imperial to metric and back|slackware64|14.1||
 gmeasures_DOC-0.7-x86_64|gmeasures_DOC|0.7-x86_64||Business|60||gmeasures_DOC-0.7-x86_64.pet|+gmeasures|gmeasures documentation||||
-gmtk-1.0.9b-x86_64|gmtk|1.0.9b-x86_64||BuildingBlock|176||gmtk-1.0.9b-x86_64.pet|+gtk+2|gnome-mplayer toolkit library|slackware64|14.1||
-gmtk_DEV-1.0.9b-x86_64|gmtk_DEV|1.0.9b-x86_64||BuildingBlock|904||gmtk_DEV-1.0.9b-x86_64.pet|+gmtk|gmtk development|slackware64|14.1||
-gmtk_DOC-1.0.9b-x86_64|gmtk_DOC|1.0.9b-x86_64||BuildingBlock|68||gmtk_DOC-1.0.9b-x86_64.pet|+gmtk|gmtk documentation||||
-gmtk_NLS-1.0.9b-x86_64|gmtk_NLS|1.0.9b-x86_64||BuildingBlock|520||gmtk_NLS-1.0.9b-x86_64.pet|+gmtk|gmtk locales||||
 gnome-menus-2.14.3-x86_64|gnome-menus|2.14.3-x86_64||BuildingBlock|140||gnome-menus-2.14.3-x86_64.pet||gnome-menus controls the heirarchy of the menu system|slackware64|14.1||
 gnome-menus_DEV-2.14.3-x86_64|gnome-menus_DEV|2.14.3-x86_64||BuildingBlock|908||gnome-menus_DEV-2.14.3-x86_64.pet|+gnome-menus|gnome-menus development|slackware64|14.1||
 gnome-menus_NLS-2.14.3-x86_64|gnome-menus_NLS|2.14.3-x86_64||BuildingBlock|856||gnome-menus_NLS-2.14.3-x86_64.pet|+gnome-menus|gnome-menus locales||||
-gnome-mplayer-1.0.9b-x86_64|gnome-mplayer|1.0.9b-x86_64||Multimedia|564||gnome-mplayer-1.0.9b-x86_64.pet|+gmtk,+gtk+2,+mplayer|A light weight graphical front end to MPlayer|slackware64|14.1||
-gnome-mplayer_DOC-1.0.9b-x86_64|gnome-mplayer_DOC|1.0.9b-x86_64||Multimedia|208||gnome-mplayer_DOC-1.0.9b-x86_64.pet|+gnome-mplayer|gnome-mplayer documentation||||
-gnome-mplayer_NLS-1.0.9b-x86_64|gnome-mplayer_NLS|1.0.9b-x86_64||Multimedia|1260||gnome-mplayer_NLS-1.0.9b-x86_64.pet|+gnome-mplayer|gnome-mplayer locales||||
 gnumeric-1.10.17-x86_64|gnumeric|1.10.17-x86_64||Business|10156||gnumeric-1.10.17-x86_64.pet|+goffice,+gtk+2,+glib2|A light weight spread sheet application|slackware64|14.1||
 gnumeric_DEV-1.10.17-x86_64|gnumeric_DEV|1.10.17-x86_64||Business|1056||gnumeric_DEV-1.10.17-x86_64.pet|+gnumeric|gnumeric development|slackware64|14.1||
 gnumeric_DOC-1.10.17-x86_64|gnumeric_DOC|1.10.17-x86_64||Business|9784||gnumeric_DOC-1.10.17-x86_64.pet|+gnumeric|gnumeric documentation||||

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
@@ -125,7 +125,6 @@ yes|gdbm|gdbm|exe,dev,doc,nls
 yes|gdk-pixbuf2|gdk-pixbuf2|exe,dev,doc,nls
 yes|gdmap||exe,dev>null,doc,nls
 yes|geany||exe,dev,doc,nls
-yes|gecko-mediaplayer||exe,dev>null,doc,nls
 yes|get_libreoffice||exe
 yes|get_browser||exe
 yes|getcurpos||exe,dev
@@ -141,7 +140,6 @@ yes|glibc_locales|glibc,glibc-zoneinfo,glibc-i18n|exe,dev,doc,nls>exe| #slackwar
 yes|glibmm|glibmm|exe,dev,doc,nls
 yes|gmeasures||exe,dev>null,doc,nls
 yes|gmp|gmp|exe,dev,doc,nls
-yes|gmtk||exe,dev,doc,nls
 yes|gnome-icon-theme||exe>dev,dev,doc,nls| #too bloated for main fs so send to devx, needed to compile some progs
 yes|gnome-menus||exe,dev,doc,nls
 yes|gnome-mplayer||exe,dev,doc,nls

--- a/woof-distro/x86_64/slackware64/14.2/Packages-puppy-slacko6414.2-official
+++ b/woof-distro/x86_64/slackware64/14.2/Packages-puppy-slacko6414.2-official
@@ -84,17 +84,9 @@ geany-plugins-1.27-x86_64_s700|geany-plugins|1.27-x86_64_s700||BuildingBlock|209
 geany-plugins_DEV-1.27-x86_64_s700|geany-plugins_DEV|1.27-x86_64_s700||BuildingBlock|160||geany-plugins_DEV-1.27-x86_64_s700.pet|+geany-plugins|geany-plugins development|slackware64|14.2||
 geany-plugins_DOC-1.27-x86_64_s700|geany-plugins_DOC|1.27-x86_64_s700||BuildingBlock|2144||geany-plugins_DOC-1.27-x86_64_s700.pet|+geany-plugins|geany-plugins documentation||||
 geany-plugins_NLS-1.27-x86_64_s700|geany-plugins_NLS|1.27-x86_64_s700||BuildingBlock|1372||geany-plugins_NLS-1.27-x86_64_s700.pet|+geany-plugins|geany-plugins locales||||
-gecko-mediaplayer-1.0.9b-x86_64_s700|gecko-mediaplayer|1.0.9b-x86_64_s700||Multimedia|584||gecko-mediaplayer-1.0.9b-x86_64_s700.pet|+gmtk,+gtk+2,+gnome-mplayer,+mplayer|A Firefox plugin to play media off the net using gnome-mplayer|slackware64|14.2||
-gecko-mediaplayer_DEV-1.0.9b-x86_64_s700|gecko-mediaplayer_DEV|1.0.9b-x86_64_s700||Multimedia|20||gecko-mediaplayer_DEV-1.0.9b-x86_64_s700.pet|+gecko-mediaplayer|gecko-mediaplayer development|slackware64|14.2||
-gecko-mediaplayer_DOC-1.0.9b-x86_64_s700|gecko-mediaplayer_DOC|1.0.9b-x86_64_s700||Multimedia|84||gecko-mediaplayer_DOC-1.0.9b-x86_64_s700.pet|+gecko-mediaplayer|gecko-mediaplayer documentation||||
-gecko-mediaplayer_NLS-1.0.9b-x86_64_s700|gecko-mediaplayer_NLS|1.0.9b-x86_64_s700||Multimedia|148||gecko-mediaplayer_NLS-1.0.9b-x86_64_s700.pet|+gecko-mediaplayer|gecko-mediaplayer locales||||
 gmeasures-0.7-x86_64_s700|gmeasures|0.7-x86_64_s700||Business|100||gmeasures-0.7-x86_64_s700.pet|+gtk+2|convert measurements from imperial to metric and back|slackware64|14.2||
 gmeasures_DEV-0.7-x86_64_s700|gmeasures_DEV|0.7-x86_64_s700||Business|20||gmeasures_DEV-0.7-x86_64_s700.pet|+gmeasures|gmeasures development|slackware64|14.2||
 gmeasures_DOC-0.7-x86_64_s700|gmeasures_DOC|0.7-x86_64_s700||Business|60||gmeasures_DOC-0.7-x86_64_s700.pet|+gmeasures|gmeasures documentation||||
-gmtk-1.0.9b-x86_64_s700|gmtk|1.0.9b-x86_64_s700||BuildingBlock|140||gmtk-1.0.9b-x86_64_s700.pet|+gtk+2|gnome-mplayer toolkit library|slackware64|14.2||
-gmtk_DEV-1.0.9b-x86_64_s700|gmtk_DEV|1.0.9b-x86_64_s700||BuildingBlock|916||gmtk_DEV-1.0.9b-x86_64_s700.pet|+gmtk|gmtk development|slackware64|14.2||
-gmtk_DOC-1.0.9b-x86_64_s700|gmtk_DOC|1.0.9b-x86_64_s700||BuildingBlock|68||gmtk_DOC-1.0.9b-x86_64_s700.pet|+gmtk|gmtk documentation||||
-gmtk_NLS-1.0.9b-x86_64_s700|gmtk_NLS|1.0.9b-x86_64_s700||BuildingBlock|520||gmtk_NLS-1.0.9b-x86_64_s700.pet|+gmtk|gmtk locales||||
 gnome-icon-theme-2.25.92-x86_64_s700|gnome-icon-theme|2.25.92-x86_64_s700||Desktop|19204||gnome-icon-theme-2.25.92-x86_64_s700.pet||Icon theme for gnome apps||||
 gnome-icon-theme_DEV-2.25.92-x86_64_s700|gnome-icon-theme_DEV|2.25.92-x86_64_s700||Desktop|20||gnome-icon-theme_DEV-2.25.92-x86_64_s700.pet|+gnome-icon-theme|gnome-icon-theme development|slackware64|14.2||
 gnome-icon-theme_DOC-2.25.92-x86_64_s700|gnome-icon-theme_DOC|2.25.92-x86_64_s700||Desktop|988||gnome-icon-theme_DOC-2.25.92-x86_64_s700.pet|+gnome-icon-theme|gnome-icon-theme documentation||||
@@ -102,10 +94,6 @@ gnome-icon-theme_NLS-2.25.92-x86_64_s700|gnome-icon-theme_NLS|2.25.92-x86_64_s70
 gnome-menus-2.14.3-x86_64_s700|gnome-menus|2.14.3-x86_64_s700||BuildingBlock|280||gnome-menus-2.14.3-x86_64_s700.pet||gnome-menus controls the heirarchy of the menu system|slackware64|14.2||
 gnome-menus_DEV-2.14.3-x86_64_s700|gnome-menus_DEV|2.14.3-x86_64_s700||BuildingBlock|748||gnome-menus_DEV-2.14.3-x86_64_s700.pet|+gnome-menus|gnome-menus development|slackware64|14.2||
 gnome-menus_NLS-2.14.3-x86_64_s700|gnome-menus_NLS|2.14.3-x86_64_s700||BuildingBlock|856||gnome-menus_NLS-2.14.3-x86_64_s700.pet|+gnome-menus|gnome-menus locales||||
-gnome-mplayer-1.0.9-x86_64_s700|gnome-mplayer|1.0.9-x86_64_s700||Multimedia|580||gnome-mplayer-1.0.9-x86_64_s700.pet|+gmtk,+gtk+2,+mplayer|A light weight graphical front end to MPlayer|slackware64|14.2||
-gnome-mplayer_DEV-1.0.9-x86_64_s700|gnome-mplayer_DEV|1.0.9-x86_64_s700||Multimedia|20||gnome-mplayer_DEV-1.0.9-x86_64_s700.pet|+gnome-mplayer|gnome-mplayer development|slackware64|14.2||
-gnome-mplayer_DOC-1.0.9-x86_64_s700|gnome-mplayer_DOC|1.0.9-x86_64_s700||Multimedia|208||gnome-mplayer_DOC-1.0.9-x86_64_s700.pet|+gnome-mplayer|gnome-mplayer documentation||||
-gnome-mplayer_NLS-1.0.9-x86_64_s700|gnome-mplayer_NLS|1.0.9-x86_64_s700||Multimedia|1260||gnome-mplayer_NLS-1.0.9-x86_64_s700.pet|+gnome-mplayer|gnome-mplayer locales||||
 gnumeric-1.10.17-x86_64_s701|gnumeric|1.10.17-x86_64_s701||Business|10204||gnumeric-1.10.17-x86_64_s701.pet|+goffice,+gtk+2,+glib2|A light weight spread sheet application|slackware64|14.2||
 gnumeric_DEV-1.10.17-x86_64_s701|gnumeric_DEV|1.10.17-x86_64_s701||Business|1068||gnumeric_DEV-1.10.17-x86_64_s701.pet|+gnumeric|gnumeric development|slackware64|14.2||
 gnumeric_DOC-1.10.17-x86_64_s701|gnumeric_DOC|1.10.17-x86_64_s701||Business|9784||gnumeric_DOC-1.10.17-x86_64_s701.pet|+gnumeric|gnumeric documentation||||

--- a/woof-distro/x86_64/ubuntu/bionic64/Packages-puppy-bionic64-official
+++ b/woof-distro/x86_64/ubuntu/bionic64/Packages-puppy-bionic64-official
@@ -80,10 +80,6 @@ gmeasures-0.7-x86_64_bionic|gmeasures|0.7-x86_64_bionic||Business|112||gmeasures
 gmeasures_DEV-0.7-x86_64_bionic|gmeasures_DEV|0.7-x86_64_bionic||Business|20||gmeasures_DEV-0.7-x86_64_bionic.pet|+gmeasures|gmeasures development|ubuntu|bionic||
 gmeasures_DOC-0.7-x86_64_bionic|gmeasures_DOC|0.7-x86_64_bionic||Business|60||gmeasures_DOC-0.7-x86_64_bionic.pet|+gmeasures|gmeasures documentation||||
 gmic-2.4.1-x86_64_bionic|gmic|2.4.1-x86_64_bionic||BuildingBlock|26820K||gmic-2.4.1-x86_64_bionic.pet||no description provided|ubuntu|bionic||
-gmtk-1.0.9b-x86_64_bionic|gmtk|1.0.9b-x86_64_bionic||BuildingBlock|124||gmtk-1.0.9b-x86_64_bionic.pet|+gtk+2|gnome-mplayer toolkit library|ubuntu|bionic||
-gmtk_DEV-1.0.9b-x86_64_bionic|gmtk_DEV|1.0.9b-x86_64_bionic||BuildingBlock|992||gmtk_DEV-1.0.9b-x86_64_bionic.pet|+gmtk|gmtk development|ubuntu|bionic||
-gmtk_DOC-1.0.9b-x86_64_bionic|gmtk_DOC|1.0.9b-x86_64_bionic||BuildingBlock|48||gmtk_DOC-1.0.9b-x86_64_bionic.pet|+gmtk|gmtk documentation||||
-gmtk_NLS-1.0.9b-x86_64_bionic|gmtk_NLS|1.0.9b-x86_64_bionic||BuildingBlock|168||gmtk_NLS-1.0.9b-x86_64_bionic.pet|+gmtk|gmtk locales||||
 gnome-icon-theme-2.25.92-x86_64_bionic|gnome-icon-theme|2.25.92-x86_64_bionic||Desktop|20096||gnome-icon-theme-2.25.92-x86_64_bionic.pet||Icon theme for gnome apps||||
 gnome-icon-theme_DEV-2.25.92-x86_64_bionic|gnome-icon-theme_DEV|2.25.92-x86_64_bionic||Desktop|20||gnome-icon-theme_DEV-2.25.92-x86_64_bionic.pet|+gnome-icon-theme|gnome-icon-theme development|ubuntu|bionic||
 gnome-icon-theme_NLS-2.25.92-x86_64_bionic|gnome-icon-theme_NLS|2.25.92-x86_64_bionic||Desktop|712||gnome-icon-theme_NLS-2.25.92-x86_64_bionic.pet|+gnome-icon-theme|gnome-icon-theme locales||||


### PR DESCRIPTION
gnome-mplayer development came to a halt in 2015. Debian and derivatives removed it.

The reason is that gnome-mplayer became unmantainable and significantly buggy around that time (woofce was also facing similar issues).. too much bloat and too much legacy code.

Some people used to say that the last properly working version was probably 1.0.8 or 1.0.7

I have had problems compiling and using gnome-mplayer in recent distro versions. It would sometimes hang/crash, issues with dvd's, issues with seeking XX:XX times and many glib warnings and errors in the console

I have attempted to make it more usable and stable in my fork
- updated the build system
- removed ancient gtk and glib code (gtk 2.24+, glib 2.32+)
- removed some mostly unused dependencies in puppy (thousands of code lines)
- does not require apps.gnome-mplayer.preferences.gschema.xml / apps.gecko-mediaplayer.preferences.gschema.xml
- integrated gmtk (it has gnome-player specific code, and can't be used by any other app)
- deleted gecko-mediaplayer stuff (unsupported since firefox 52, palemoon 28 = firefox 52) 

more details here https://github.com/wdlkmpx/gnome-mplayer/commits/master

Now gnome-mplayer is more stable.. for me..

Packages for testing...
www.01micko.com/wdlkmpx/tmp/gnome-mplayer-1.1.2w-i686_common32.pet
www.01micko.com/wdlkmpx/tmp/gnome-mplayer_NLS-1.1.2w-i686_common32.pet

www.01micko.com/wdlkmpx/tmp/gnome-mplayer-1.1.2w-x86_64_common64.pet
www.01micko.com/wdlkmpx/tmp/gnome-mplayer_NLS-1.1.2w-x86_64_common64.pet

This also removes all references to `gmtk` and `gecko-mediaplayer` pet packages...