### PR TITLE
Create update-desktop-database placeholder script

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/update-desktop-database
+++ b/woof-code/rootfs-skeleton/usr/bin/update-desktop-database
@@ -1,0 +1,52 @@
+#!/bin/bash
+#This was a place holder in case the desktop-file-utils is not installed
+#It generates xdg file association database. It works the same as the binary update-desktop-database
+
+process_mime_cache(){
+
+path1="$1"
+
+find "$path1/" -type f -name "*.desktop" | sort > /tmp/desktop-files.tmp
+
+touch "$path1/mimeinfo.cache.new"
+
+while IFS= read -r line
+do
+ bfile="$(basename "$line")"
+ 
+ if [ "$(cat "$line" | grep -E "^MimeType=")" != "" ]; then
+  for xMime in $(cat "$line" | grep -E "^MimeType=" | cut -f 2 -d '=' | tr ';' ' ')
+  do  
+   if [ "$(cat "$path1/mimeinfo.cache.new" | grep -E "^$xMime=")" != "" ]; then
+     if [ "$(cat "$path1/mimeinfo.cache.new" | grep -E "$xMime=" | grep "$bfile")" == "" ]; then
+       mimeval="$(cat "$path1/mimeinfo.cache.new" | grep -E "${xMime}=" | cut -f 2 -d "=")"
+       
+       PTRN="$(echo "$xMime" | sed -e "s#\/#\\\/#g" -e "s#\-#\\\-#g" -e "s#\.#\\\.#g" -e "s#\ #\\\ #g" -e "s#\*#\\\*#g")"
+       sed -i -e "/^$PTRN=/d" "$path1/mimeinfo.cache.new"
+       echo "$xMime=$mimeval;$bfile" >> "$path1/mimeinfo.cache.new"
+     
+     fi
+   else
+    echo "$xMime=$bfile" >> "$path1/mimeinfo.cache.new"
+   fi
+  done
+ fi
+done < /tmp/desktop-files.tmp
+
+rm -f /tmp/desktop-files.tmp
+
+echo "[MIME Cache]" > "$path1/mimeinfo.cache"
+cat "$path1/mimeinfo.cache.new" | sort >> "$path1/mimeinfo.cache"
+
+rm -f "$path1/mimeinfo.cache.new"
+
+}
+
+if [ "$1" == "" ]; then
+	for xdg_path in "$HOME/.local/share/applications" /usr/share/applications /usr/local/share/applications 
+	do
+	 [ -e "$xdg_path" ] && process_mime_cache "$xdg_path"
+	done
+else
+ [ -e "$1" ] && process_mime_cache "$@"
+fi


### PR DESCRIPTION
To ensure the file associations on xdg-compliant file managers works upon installing packages or loading sfs modules even desktop-file-utils was not installed (due to package size concerns). A placeholder script will be used. It works exactly the same as the original update-desktop-database binary executable.