### PR TITLE
poweroff: Adding non-acpi support

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/poweroff
+++ b/woof-code/rootfs-skeleton/sbin/poweroff
@@ -11,7 +11,14 @@ done
 
 script=${0##*/}
 
+if [ -d /proc/acpi ] || [ -d /proc/apm ]; then
+ can_shutdown=1
+else
+ can_shutdown=0
+fi
+
 . /etc/rc.d/PUPSTATE
+
 if [ "$PUPMODE" = "5" ] && [ $PPID -eq 1 ] ; then
 	touch /tmp/shutdownconfig_results ; sync  #skip shutdownconfig
 fi
@@ -28,7 +35,18 @@ fi
 /etc/rc.d/rc.shutdown
 
 case $script in
-	poweroff) /bin/busybox poweroff ;;
+	poweroff) 
+	
+	 if [ $can_shutdown -eq 1 ]; then
+	  /bin/busybox poweroff
+	 else
+	  clear > /dev/console
+	  dialog --ok-label "Restart" --msgbox "IT'S NOW SAFE TO TURN OFF YOUR COMPUTER" 5 43
+	  /bin/busybox reboot
+	 fi
+	
+	;;
+	
 	reboot) /bin/busybox reboot ;;
 esac
 


### PR DESCRIPTION
Instead of just a frozen screen if acpi is disabled or not supported, just show a message that it was safe to turn off the computer