### PR TITLE
Create sync-rox-icons

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/sync-rox-icons
+++ b/woof-code/rootfs-skeleton/usr/bin/sync-rox-icons
@@ -1,0 +1,32 @@
+#!/bin/sh
+#This script syncs the rox mimetype icons with mimetypes on /usr/share/icons/hicolor
+
+for roxconfig in /usr/local/apps/ROX-Filer/ROX /usr/share/rox/ROX /usr/libexec/ROX-Filer/ROX /usr/lib/ROX-Filer/ROX /usr/share/ROX-Filer/ROX /usr/local/share/ROX-Filer/ROX /usr/local/libexec/ROX-Filer/ROX /usr/local/lib/ROX-Filer/ROX
+do
+ if [ -e $roxconfig/MIME ]; then
+  echo "syncing $roxconfig/MIME ..."
+  for mime1 in application audio video text image
+  do
+     iconsrc="/usr/share/icons/hicolor/48x48/mimetypes"
+     mimeicons="$(ls -1 /usr/share/icons/hicolor/48x48/mimetypes/${mime1}* 2>/dev/null)"  
+     
+     if [ "$mimeicons" == "" ]; then
+      iconsrc="/usr/share/icons/hicolor/24x24/mimetypes"
+      mimeicons="$(ls -1 /usr/share/icons/hicolor/24x24/mimetypes/${mime1}* 2>/dev/null)"
+     fi
+     
+     if [ "$mime1" != "image" ]; then
+      if [ "$mimeicons" != "" ]; then
+       rm -f "$roxconfig/MIME/${mime1}*"
+       for icon1 in $mimeicons
+       do
+        bname="$(basename $icon1)"
+        rm -f $roxconfig/MIME/$bname
+        ln -s "$iconsrc/$bname" $roxconfig/MIME/$bname
+       done
+      fi
+     fi
+     
+   done
+  fi
+done


### PR DESCRIPTION
This script syncs the rox mimetype icons with mimetypes on /usr/share/icons/hicolor
An attempt to make rox-filer xdg-desktop compliant