### PR TITLE
Update DISTRO_PKGS_SPECS-ubuntu-bionic

### DIFF
--- a/woof-distro/x86/ubuntu/upupbb/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86/ubuntu/upupbb/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -200,7 +200,6 @@ yes|gnome-mplayer||exe,dev,doc,nls
 yes|gnome-vfs|libgnomevfs2-0,libgnomevfs2-dev,libgnomevfs2-common|exe,dev,doc,nls
 yes|gnumeric||exe,dev,doc,nls| #gtk2
 yes|gnutls|gnutls-bin,libgnutls30,libgnutls28-dev,libopts25,libopts25-dev,libgnutls-openssl27,libgnutls-dane0,libunbound2,libgnutlsxx28|exe,dev,doc,nls
-yes|go-mtpfs|go-mtpfs|exe,dev,doc,nls|
 yes|gobject-introspection|gir1.2-freedesktop,libgirepository1.0-dev|exe,dev,doc,nls
 yes|goffice||exe,dev,doc,nls| #gtk2
 yes|gparted|gparted|exe,dev>null,doc,nls
@@ -492,7 +491,6 @@ yes|MPlayer||exe,dev,doc,nls
 yes|ms-sys||exe
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls| #needed by synaptics_drv.so in xorg.
 yes|mtPaint||exe,dev,doc,nls|
-yes|mtp_phone_connect||exe,dev,doc,nls|
 yes|mtr||exe
 yes|multirename||exe
 yes|nas|libaudio2,libaudio-dev|exe,dev,doc,nls| #needed by mplayer, qupzilla


### PR DESCRIPTION
remove go-mtpfs and mtp-phone-connect
pupmtp is the successor for handling mtp devices