### PR TITLE
Update DISTRO_PKGS_SPECS-ubuntu-trusty

### DIFF
--- a/woof-distro/x86/ubuntu/trusty/DISTRO_PKGS_SPECS-ubuntu-trusty
+++ b/woof-distro/x86/ubuntu/trusty/DISTRO_PKGS_SPECS-ubuntu-trusty
@@ -444,7 +444,6 @@ yes|mpfr|libmpfr4|exe>dev,dev,doc,nls
 yes|ms-sys||exe|
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls| #needed by synaptics_drv.so in xorg.
 yes|mtPaint||exe,dev,doc,nls
-yes|mtp_phone_connect||exe,dev,doc,nls
 yes|mtr||exe|
 yes|multirename||exe|
 yes|nas|libaudio2,libaudio-dev|exe,dev,doc,nls| #needed by mplayer, qupzilla


### PR DESCRIPTION
removed mtp-phone-connect
pupmtp is the successor for handling mtp devices