### PR TITLE
Update DISTRO_PKGS_SPECS-slackware64-14.0

### DIFF
--- a/woof-distro/x86_64/slackware64/14.0/DISTRO_PKGS_SPECS-slackware64-14.0
+++ b/woof-distro/x86_64/slackware64/14.0/DISTRO_PKGS_SPECS-slackware64-14.0
@@ -143,7 +143,6 @@ yes|gnome-menus||exe,dev,doc,nls
 yes|gnome-mplayer||exe,dev,doc,nls
 yes|gnumeric||exe,dev,doc,nls
 yes|gnutls|gnutls,nettle,p11-kit|exe,dev,doc,nls
-yes|go-mtpfs||exe
 yes|goffice||exe,dev,doc,nls
 yes|gparted||exe,dev>null,doc,nls
 yes|gperf|gperf|exe,dev,doc,nls


### PR DESCRIPTION
remove go-mtpfs
pupmtp is the successor for handling mtp devices