### PR TITLE
Add Java DISTRO_PKGS_SPECS (set to 'no'); fix javaiftest

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/javaiftest
+++ b/woof-code/rootfs-skeleton/usr/sbin/javaiftest
@@ -2,11 +2,7 @@
 #javaiftest - To be run from command line, to see results.
 echo -e "\nEnvironment:"
 echo -e "JAVA_HOME=$JAVA_HOME"
-if [ ! -s /root/.javaifrc ] \
-  || ! grep -qx "JAVAHOME=$JAVA_HOME" /root/.javaifrc \
-  || ! grep -qx "ICEDTEAHOME=$ICEDTEAHOME" /root/.javaifrc; then
-  javaifchange
- fi
+javaifchange
 echo -e "\n.javaifrc:"
 if [ -f /root/.javaifrc ]; then
  cat /root/.javaifrc
@@ -15,7 +11,7 @@ fi
 echo -en "\nwhich java:   "
 if which java 2>/dev/null; then
  echo -n "which javaws: "
- which javaws 2>/dev/null
+ which javaws 2>/dev/null || echo ''
  echo -e "\njava -version:"
  java -version
  if which javaws &>/dev/null \

--- a/woof-distro/x86/debian/buster/DISTRO_PKGS_SPECS-debian-buster
+++ b/woof-distro/x86/debian/buster/DISTRO_PKGS_SPECS-debian-buster
@@ -221,6 +221,7 @@ yes|hotplug2stdout||exe,dev>null,doc>null,nls>null
 yes|htop|htop|exe,dev>null,doc>null,nls>null
 yes|hunspell|hunspell,libhunspell-*,libhunspell-dev|exe,dev,doc>null,nls>null
 yes|hunspell-en-us|hunspell-en-us|exe,dev,doc>null,nls>null
+no|icedtea-netx|icedtea-netx,default-jre,default-jre-headless,librhino-java,libtagsoup-java|exe,dev,doc,nls #java jnlp, needs openjdk-*-jre
 yes|icu|libicu63,libicu-dev|exe,dev,doc>null,nls>null #scribus needs this though it is not listed as a dep. note, it is big, 7MB pkg. crap, better put it into main f.s. NO have manually put this dep into main db. harfbuzz needs icu also.
 yes|id3lib|libid3-3.8.3v5,libid3-3.8.3-dev|exe,dev,doc>null,nls>null
 yes|ijs|libijs-0.35,libijs-dev|exe,dev,doc>null,nls>null
@@ -454,6 +455,7 @@ yes|ntfs-3g|ntfs-3g,libntfs-*,ntfs-3g-dev|exe,dev,doc>null,nls>null #this seems 
 yes|ntpdate|ntpdate|exe,dev,doc,nls #used by psync to sync local time and date from the internet.
 yes|numlockx||exe| #needed by shinobars firstrun.
 yes|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc>null,nls>null #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
+no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected
 yes|openldap|libldap-2.4-2,libldap2-dev|exe,dev,doc>null,nls>null
 yes|opensp|opensp,libosp-dev|exe>dev,dev,doc>null,nls>null|+sgml-base,+sgml-data,+xml-core
 yes|openssh_client|openssh-client|exe,dev,doc>null,nls>null

--- a/woof-distro/x86/ubuntu/upupbb/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86/ubuntu/upupbb/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -255,6 +255,7 @@ yes|hotplug2stdout||exe
 yes|htop||exe
 yes|hunspell-en-us|hunspell-en-us|exe,dev,doc,nls
 yes|hunspell|hunspell,libhunspell-1.6-0,libhunspell-dev|exe,dev,doc,nls
+no|icedtea-netx|icedtea-netx,default-jre,default-jre-headless,librhino-java,libtagsoup-java|exe,dev,doc,nls #java jnlp, needs openjdk-*-jre
 yes|iconfinder||exe
 yes|icu|icu-devtools,libicu60,libicu-dev|exe,dev,doc,nls|
 yes|id3lib|libid3-3.8.3v5,libid3-3.8.3-dev|exe,dev,doc,nls
@@ -516,6 +517,7 @@ yes|ntpdate|ntpdate|exe| #used by psync to sync local time and date from the int
 yes|numactl|libnuma1,libnuma-dev|exe,dev,doc,nls
 yes|numlockx||exe| #needed by shinobars firstrun.
 yes|opencv|libopencv-core3.2,libopencv-imgproc3.2|exe,dev>null,doc,nls| #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
+no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected
 yes|openldap|libldap-2.4-2,libldap2-dev|exe,dev,doc,nls
 no|openslp|libslp1,libslp-dev|exe,dev,doc,nls			# deleted in bionic?
 yes|opensp|opensp,libosp-dev|exe>dev,dev,doc,nls|+sgml-base,+sgml-data,+xml-core

--- a/woof-distro/x86_64/debian/buster64/DISTRO_PKGS_SPECS-debian-buster
+++ b/woof-distro/x86_64/debian/buster64/DISTRO_PKGS_SPECS-debian-buster
@@ -223,6 +223,7 @@ yes|hotplug2stdout||exe,dev>null,doc>null,nls>null
 no|htop|htop|exe,dev>null,doc>null,nls>null
 yes|hunspell|hunspell,libhunspell-*,libhunspell-dev|exe,dev,doc>null,nls>null
 yes|hunspell-en-us|hunspell-en-us|exe,dev,doc>null,nls>null
+no|icedtea-netx|icedtea-netx,default-jre,default-jre-headless,librhino-java,libtagsoup-java|exe,dev,doc,nls #java jnlp, needs openjdk-*-jre
 yes|icu|libicu63,libicu-dev|exe,dev,doc>null,nls>null #scribus needs this though it is not listed as a dep. note, it is big, 7MB pkg. crap, better put it into main f.s. NO have manually put this dep into main db. harfbuzz needs icu also.
 yes|id3lib|libid3-3.8.3v5,libid3-3.8.3-dev|exe,dev,doc>null,nls>null
 yes|ijs|libijs-0.35,libijs-dev|exe,dev,doc>null,nls>null
@@ -455,6 +456,7 @@ yes|ntfs-3g|ntfs-3g,libntfs-*,ntfs-3g-dev|exe,dev,doc>null,nls>null #this seems 
 yes|ntpdate|ntpdate|exe,dev,doc,nls #used by psync to sync local time and date from the internet.
 yes|numlockx||exe| #needed by shinobars firstrun.
 yes|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc>null,nls>null #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
+no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected
 yes|openldap|libldap-2.4-2,libldap2-dev|exe,dev,doc>null,nls>null
 yes|opensp|opensp,libosp-dev|exe>dev,dev,doc>null,nls>null|+sgml-base,+sgml-data,+xml-core
 yes|openssh_client|openssh-client|exe,dev,doc>null,nls>null

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -282,6 +282,7 @@ yes|hotplug2stdout||exe
 yes|htop||exe|pet:tahr
 yes|hunspell|hunspell,libhunspell-*,libhunspell-dev|exe,dev,doc,nls
 yes|hunspell-en-us|hunspell-en-us|exe,dev,doc,nls
+no|icedtea-netx|icedtea-netx,default-jre,default-jre-headless,librhino-java,libtagsoup-java|exe,dev,doc,nls #java jnlp, needs openjdk-*-jre
 no|iconfinder||exe
 yes|icu|icu-devtools,libicu*,libicu-dev|exe,dev,doc,nls|
 yes|id3lib|libid3-3.8.3v5,libid3-3.8.3-dev|exe,dev,doc,nls
@@ -564,6 +565,7 @@ yes|ntpdate||exe| #used by psync to sync local time and date from the internet.
 yes|numactl|libnuma1,libnuma-dev|exe,dev,doc,nls
 yes|numlockx||exe| #needed by shinobars firstrun.
 yes|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc,nls| #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
+no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected
 yes|openldap|libldap-2.4-2,libldap2-dev|exe,dev,doc,nls
 yes|opensp|opensp,libosp-dev|exe>dev,dev,doc,nls|+sgml-base,+sgml-data,+xml-core
 yes|opensp-runtime|libosp5|exe,dev,doc,nls| #needed by libofx and homebank.


### PR DESCRIPTION
Added for Buster and Bionic Pups, not for the Slackos until Slackware provides current LTS versions of openjdk and icedtea (which does not work).  However, the OpenJDK SFS packages work in ScPup(64).