### PR TITLE
installpkg.sh: Improve package upgrade/downgrade

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -627,7 +627,15 @@ if [ "$installed_pkg" != "" ]; then
 	  else
 	   #Delete the file which is not a part of upgrade
 	   if [ -e "$xline" ] && [ ! -d "$xline" ]; then
-	    rm -f "$xline"
+	    
+	    if [ -d "/initrd/pup_rw$xline" ] && [ ! -L "/initrd/pup_rw$xline" ]; then
+	     rm -f "/initrd/pup_rw$xline"
+	    fi
+	    
+	    [ -e "/initrd${SAVE_LAYER}${xline}" ] && rm -f "/initrd${SAVE_LAYER}${xline}"
+	    
+	    [ -e "$xline" ] && rm -f "$xline"
+	   
 	   fi
 	  fi
 	 fi

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -593,8 +593,10 @@ xpkgname="$(echo "$DB_ENTRY" | cut -f 2 -d '|')"
 installed_pkg="$(cat /root/.packages/user-installed-packages | grep "|$xpkgname|")"
 
 if [ "$installed_pkg" != "" ]; then
+  #There is an already installed package. Just update the package file list
   installed_files="$(echo "$installed_pkg" | cut -f 1 -d '|')"
   if [ "$installed_files" != "" ]; then
+   #Check if the old package file list exists
     if [ -e /root/.packages/${installed_files}.files ]; then
     
 	#Ask user to retain files which is not a part of upgrade/downgrade
@@ -616,7 +618,9 @@ if [ "$installed_pkg" != "" ]; then
    
 	while IFS= read -r xline
 	do
+	 #Check if the file was a part of the newly installed package
   	 if [ "$(cat /root/.packages/${DLPKG_NAME}.files | grep "$xline")" == "" ]; then
+	  #Not a part of newly installed package. Do action
 	  if [ "$KEEP_OLD" != "" ]; then
 	   #Add the file to new package file list. It will removed upon uninstallation
 	   [ -e "$xline" ] && echo "$xline" >> /root/.packages/${DLPKG_NAME}.files

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -601,14 +601,14 @@ if [ "$installed_pkg" != "" ]; then
     
 	#Ask user to retain files which is not a part of upgrade/downgrade
         if [ "$DISPLAY" ]; then
-	  /usr/lib/gtkdialog/box_yesno "$(gettext 'Puppy Package Manager')" "$(gettext 'A modification of installed package is detected')" "$(gettext 'Keep the files which is not a part of upgrade/downgrade?')"
+	  /usr/lib/gtkdialog/box_yesno "$(gettext 'Puppy Package Manager')" "$(gettext "$installed_pkg was already installed. It will be replaced by $DLPKG_NAME")" "$(gettext 'Keep the files which is not replaced by upgrade/downgrade?')"
 	  if [ $? -eq 0 ]; then
 	   KEEP_OLD="yes"
 	  else
 	   KEEP_OLD=""
 	  fi
 	else
-	  dialog --yesno "$(gettext 'A modification of installed package is detected\nKeep the files which is not a part of upgrade/downgrade?')" 0 0
+	  dialog --yesno "$(gettext "$installed_pkg was already installed. It will be replaced by $DLPKG_NAME\nKeep the files which is not replaced by upgrade/downgrade?")" 0 0
 	  if [ $? -eq 0 ];then
 	   KEEP_OLD="yes"
 	  else


### PR DESCRIPTION
Ask the user to keep the package files which was not a part of upgrading/downgrading installed packages.

For example an installed package-1.0 contains
/usr/bin/app
/usr/bin/file-C

Then the user was installed package-1.1 contains
/usr/bin/app
/usr/bin/file-B

Therefore package-1.0 was replaced by package-1.1
Since /usr/bin/file-C was not a part of package-1.1, The user will give an option to keep /usr/bin/file-C or delete it. 

This commit was fully tested

