### PR TITLE
Create psynclient.desktop

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/applications/psynclient.desktop
+++ b/woof-code/rootfs-skeleton/usr/share/applications/psynclient.desktop
@@ -1,6 +1,10 @@
 [Desktop Entry]
 Encoding=UTF-8
+Name=pSynclient Touchpad Setup
+Icon=/usr/share/pixmaps/puppy/touchpad.svg
+Comment=Configure your synaptics touchpad
+Exec=psynclient
+Terminal=false
 Type=Application
-NoDisplay=true
-Name=psynclient
-Exec=psynclient -l
+Categories=X-Desktop;System
+GenericName=psynclient

--- a/woof-code/rootfs-skeleton/usr/share/applications/psynclient.desktop
+++ b/woof-code/rootfs-skeleton/usr/share/applications/psynclient.desktop
@@ -1,0 +1,6 @@
+[Desktop Entry]
+Encoding=UTF-8
+Type=Application
+NoDisplay=true
+Name=psynclient
+Exec=psynclient -l


### PR DESCRIPTION
psynclient is a gui frontend of synclient for configuring synaptic touchpads. It works the same as flsynclient but it has advanced options, extremely lightweight, and architecture independent.