### PR TITLE
rc.shutdown: unload ndiswrapper module

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -122,6 +122,10 @@ done
 
 killall udevd > /dev/null 2>&1
 
+if [ -e /etc/ndiswrapper ]; then
+ rmmod ndiswrapper
+fi
+
 #first time booted puppy, there may not have been any persistent storage...
 if [ $PUPMODE -eq 5 ];then
  # shutdownconfig creates /tmp/shutdownconfig_results


### PR DESCRIPTION
Just unload the ndiswrapper module on shutdown in order to prevent accessing windows driver files when unmounting the drives or savefile 