### PR TITLE
64-bit deb-based pups: use systemd-udev 

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -9,7 +9,7 @@
 #   /etc/inittab: rc.sysinit is specified as ::sysinit:
 # - also read /etc/inittab.README
 #
-# eudev is enforced - min 151 - 175+ recommended
+# eudev is enforced - min 204+ recommended
 #
 #w004 LANG=C, faster. /bin/ash, even faster.
 #w481 fix crappy depmod, 'out of memory' in first boot 64MB RAM (no swap).
@@ -340,14 +340,21 @@ chmod -R 1777 /dev/shm #SFR .. ditto
 chmod 666 /dev/urandom #and again
 
 rm -f /etc/init.d/udev #just in case
-# UDEV_LOG=2 to prevent non-critical o/p to screen at bootup and shutdown...
+
+# must create /sbin/udevd symlink if system-udevd is used
+if [ ! -e /bin/udevd ] && [ ! -e /sbin/udevd ] ; then
+	if [ -f /lib/systemd/systemd-udevd ] ; then
+		ln -snfv /lib/systemd/systemd-udevd /sbin/udevd
+	fi
+fi
+
 #110502 change 'never' to 'early', fixes device nodes created with correct owner:group...
 if [ "$BOOT_UDEVDCHILDREN" ];then #120709
-   UDEV_LOG=2 udevd --daemon --resolve-names=early --children-max=${BOOT_UDEVDCHILDREN} #BOOT_UDEVDCHILDREN=1 good idea?
+   udevd --daemon --resolve-names=early --children-max=${BOOT_UDEVDCHILDREN} #BOOT_UDEVDCHILDREN=1 good idea?
 else
-   UDEV_LOG=2 udevd --daemon --resolve-names=early
+   udevd --daemon --resolve-names=early
 fi
-sleep 0.1
+sleep 0.3
 
 # kernel polling - https://lwn.net/Articles/423619/
 echo 5000 > /sys/module/block/parameters/events_dfl_poll_msecs

--- a/woof-code/rootfs-skeleton/usr/local/petget/verifypkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/verifypkg.sh
@@ -1,8 +1,4 @@
 #!/bin/sh
-#(c) Copyright Barry Kauler 2009, puppylinux.com
-#2009 Lesser GPL licence v2 (http://www.fsf.org/licensing/licenses/lgpl.html).
-#called from /usr/local/petget/downloadpkgs.sh.
-#passed param is the path and name of the downloaded package.
 
 export LANG=C
 DLPKG="$1"
@@ -14,8 +10,14 @@ case $DLPKG in
 		rm -rf tempfileonly.*
 		exit $RETVAL
 		;;
-	*.deb) dpkg-deb --contents "$DLPKG" >/dev/null 2>&1 ; exit $? ;;
-	*.t[gx]z|*.tar.*) tar -tf "$DLPKG" >/dev/null 2>&1 ; exit $? ;;
+	*.deb)
+		dpkg-deb -c "$DLPKG" >/dev/null 2>&1
+		exit $?
+		;;
+	*.t[gx]z|*.tar.*)
+		tar -tf "$DLPKG" >/dev/null 2>&1
+		exit $?
+		;;
 esac
 
 ### END ###

--- a/woof-distro/x86_64/debian/buster64/DISTRO_PKGS_SPECS-debian-buster
+++ b/woof-distro/x86_64/debian/buster64/DISTRO_PKGS_SPECS-debian-buster
@@ -570,8 +570,7 @@ yes|tidy|libtidy5deb1,libtidy-dev|exe,dev,doc>null,nls>null #needed by abiword.
 yes|time|time|exe,dev>null,doc>null,nls>null
 yes|transmission|transmission-gtk,transmission-common|exe,dev,doc>null,nls>null
 yes|tree|tree|exe,dev,doc>null,nls>null
-yes|udev|udev,libudev1,libudev-dev|exe>null,dev>null,doc>null,nls>null #fake install
-yes|eudev||exe,dev #pet pkg: replaces udev and libudev
+yes|udev|udev,libudev1,libudev-dev|exe,dev,doc,null
 no|uget|uget,aria2,libc-ares2,libc-ares-dev,libaria2,libaria2-0,libaria2-0-dev|exe,dev,doc>null,nls>null
 yes|unclutter|unclutter|exe,dev>null,doc>null,nls>null
 yes|unzip|unzip|exe,dev>null,doc>null,nls>null

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -63,7 +63,6 @@ yes|avahi|libavahi-client3,libavahi-client-dev,libavahi-glib1,libavahi-glib-dev,
 yes|avfs|avfs|exe,dev,doc,nls
 yes|axel|axel|exe,dev>,doc,nls
 yes|babeltrace|libbabeltrace1,libbabeltrace-ctf-dev,libbabeltrace-dev|exe,dev,doc,nls|
-yes|bacon||exe,dev,doc>dev,nls| 
 yes|bash|bash,bash-builtins|exe,dev,doc,nls
 yes|bbe|bbe|exe,dev,doc,nls| #sed-like editor for binary files.
 yes|bc|bc|exe,dev>null,doc,nls
@@ -515,6 +514,7 @@ yes|lsb-base|lsb-base|exe,dev,doc,nls
 yes|lvm2|dmsetup,liblvm2app2.2,liblvm2cmd2.02,liblvm2-dev|exe,dev,doc,nls|
 yes|lxrandr|lxrandr|exe,dev,doc
 yes|lxtask|lxtask|exe,dev,doc
+yes|lxterminal||exe,dev,doc,nls
 yes|lzma|lzma,lzma-dev|exe,dev,doc,nls
 yes|lzo2|liblzo2-2,liblzo2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls
@@ -637,7 +637,6 @@ yes|Pup-SysInfo||exe|
 yes|puppyinputdetect||exe
 yes|puppyphone||exe
 yes|puppyserialdetect||exe
-no|pupx||exe
 no|pure-ftpd||exe
 yes|python|python,python-cairo,python-gobject-2,python-gtk2,python2.7-minimal,python2.7,libpython2.7,libpython2.7-stdlib,libpython2.7-minimal|exe,doc,nls| #121022 moved from devx to main f.s. /usr/include/python2.7 must also go into main f.s. so take out ,dev. see also libpython2.7 needed by gdb in devx. 130404 added libs.
 no|python3|python3,python3.6,python3-minimal,python3.6-minimal,libpython3.6,libpython3.6-minimal,libpython3.6-stdlib|exe,doc,nls|
@@ -714,8 +713,7 @@ yes|time|time|exe,dev>null,doc,nls
 yes|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls| #needs gtk3, libappindicator
 yes|tree|tree|exe,dev,doc,nls
 yes|ucf|ucf|exe,dev,doc,nls|
-yes|udev|udev,libudev1,libudev-dev|exe>null,dev>null,doc>null,nls>null #fake install
-yes|eudev||exe,dev,doc,nls| #note, requires kmod and a kernel with devtmpfs enabled.
+yes|udev|udev,libudev1,libudev-dev|exe,dev,doc,nls
 yes|uextract||exe,dev,doc,nls|
 yes|uget|uget|exe
 yes|unclutter|unclutter|exe,dev>null,doc,nls

--- a/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PKGS_SPECS-ubuntu-trusty
+++ b/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PKGS_SPECS-ubuntu-trusty
@@ -71,6 +71,7 @@ yes|caps||exe,dev,doc,nls #needed by zigberts pequalizer, refer t=31206&start=12
 yes|cdparanoia|cdparanoia,libcdparanoia0,libcdparanoia-dev|exe,dev,doc,nls
 yes|cdrkit|genisoimage,wodim,icedax|exe,dev,doc,nls
 yes|cdrtools||exe,dev,doc,nls
+yes|cgmanager|libcgmanager0,libnih-dbus1,libnih1|exe,dev,doc,nls # udev?
 yes|cgtkcalc||exe,dev>null,doc,nls
 yes|chntpw|chntpw|exe,dev,doc,nls
 yes|cifs-utils|cifs-utils|exe,dev,doc,nls
@@ -128,7 +129,6 @@ yes|elfutils|libelf1,libelf-dev|exe,dev,doc,nls| #note, libelf is a different pk
 yes|enchant|libenchant1c2a,libenchant-dev|exe,dev,doc,nls
 yes|esound|esound-common,libesd0,libesd0-dev|exe,dev,nls,doc
 yes|ethtool|ethtool|exe,dev>null,doc,nls
-yes|eudev||exe,dev,doc,nls #note, requires kmod and a kernel with devtmpfs enabled.
 yes|exiv2|exiv2,libexiv2-12,libexiv2-dev|exe,dev,doc,nls
 yes|expat|libexpat1,libexpat1-dev|exe,dev,doc,nls
 yes|f2fs-tools||exe,dev,doc,nls
@@ -427,6 +427,7 @@ yes|llvm|libllvm3.4|exe,dev,doc,nls| #needed by libgl1-mesa-dri, but huge 7MB de
 yes|lsb-base|lsb-base|exe,dev,doc,nls
 yes|lxrandr|lxrandr|exe,dev,doc
 yes|lxtask|lxtask|exe,dev,doc
+yes|lxterminal||exe,dev,doc,nls
 yes|lzma|lzma,lzma-dev|exe,dev,doc,nls
 yes|lzo2|liblzo2-2,liblzo2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls
@@ -615,7 +616,7 @@ yes|time|time|exe,dev>null,doc,nls
 yes|transmission||exe,dev,doc,nls #gtk2
 yes|tree|tree|exe,dev,doc,nls
 yes|tslib|libts-0.0-0,libts-bin,libts-dev|exe,dev,doc,nls
-yes|udev|udev,libudev1,libudev-dev|exe>null,dev>null,doc>null,nls>null #fake install
+yes|udev|udev,libudev1,libudev-dev|exe,dev,doc,nls
 yes|uextract||exe,dev,doc,nls
 yes|uget||exe
 yes|unclutter|unclutter|exe,dev>null,doc,nls
@@ -660,7 +661,7 @@ yes|xml-core|xml-core|exe>dev,dev,doc,nls
 yes|xorg_base_new|libglapi-mesa,libx11-xcb1,libx11-xcb-dev,xfonts-utils,libxmu-headers,mesa-common-dev,libgl1-mesa-dri,xinit,x11-xkb-utils,x11-xserver-utils,x11-utils,x11-apps,fontconfig,libdrm2,libdrm-dev,libdrm-intel1,libdrm-nouveau2,libdrm-radeon1,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl1-mesa-glx,libgl1-mesa-dev,libglu1-mesa,libglu1-mesa-dev,libice6,libice-dev,libsm6,libsm-dev,libspice-server1,libspice-server-dev,libx11-6,libx11-dev,libx11-data,libxau6,libxau-dev,libxaw7,libxaw7-dev,libxcomposite1,libxcomposite-dev,libxcursor1,libxcursor-dev,libxdamage1,libxdamage-dev,libxdmcp6,libxdmcp-dev,libxext6,libxext-dev,libxfixes3,libxfixes-dev,libxfont1,libxfont-dev,libxft2,libxft-dev,libxi6,libxi-dev,libxinerama1,libxinerama-dev,libxkbfile1,libxkbfile-dev,libxmu6,libxmu-dev,libxmuu1,libxmuu-dev,libxpm4,libxpm-dev,libxrandr2,libxrandr-dev,libxrender1,libxrender-dev,libxres1,libxres-dev,libxss1,libxss-dev,libxt6,libxt-dev,libxtst6,libxtst-dev,libxv1,libxv-dev,libxxf86dga1,libxxf86dga-dev,libxxf86vm1,libxxf86vm-dev,xkb-data,xinput,xbitmaps|exe,dev,doc,nls
 yes|xorg_dri|libgl1-mesa-dri,mesa-utils|exe,dev,doc,nls|
 yes|xsane||exe
-yes|xserver_xorg|xserver-xorg-dev,xserver-common,xserver-xorg,xserver-xorg-core,xserver-xorg-video-*,xserver-xorg-input-kbd,xserver-xorg-input-mouse,xserver-xorg-input-synaptics,xserver-xorg-input-evdev,xserver-xorg-input-wacom,-xserver-xorg-video-*-dbg,-xserver-xorg-video-dummy,-xserver-xorg-video-glint,-xserver-xorg-video-ivtv,-xserver-xorg-video-nsc,-xserver-xorg-video-tga,-xserver-xorg-video-vga,-xserver-xorg-video-vmware,-xserver-xorg-video-fbdev|exe,dev,doc,nls| #for precise pangolin
++yes|xserver_xorg|xserver-xorg-dev,xserver-common,xserver-xorg,xserver-xorg-core,xserver-xorg-input-acecad,xserver-xorg-input-aiptek,xserver-xorg-input-all,xserver-xorg-input-elographics,xserver-xorg-input-evdev,xserver-xorg-input-evdev-dev,xserver-xorg-input-joystick,xserver-xorg-input-joystick-dev,xserver-xorg-input-kbd,xserver-xorg-input-mouse,xserver-xorg-input-mtrack,xserver-xorg-input-multitouch,xserver-xorg-input-mutouch,xserver-xorg-input-synaptics,xserver-xorg-input-synaptics-dev,xserver-xorg-input-vmmouse,xserver-xorg-input-void,xserver-xorg-input-wacom,xserver-xorg-video-all,xserver-xorg-video-ati,xserver-xorg-video-cirrus,xserver-xorg-video-dummy,xserver-xorg-video-fbdev,xserver-xorg-video-glamoregl,xserver-xorg-video-intel,xserver-xorg-video-mach64,xserver-xorg-video-mga,xserver-xorg-video-modesetting,xserver-xorg-video-neomagic,xserver-xorg-video-nouveau,xserver-xorg-video-openchrome,xserver-xorg-video-qxl,xserver-xorg-video-r128,xserver-xorg-video-radeon,xserver-xorg-video-s3,xserver-xorg-video-savage,xserver-xorg-video-siliconmotion,xserver-xorg-video-sis,xserver-xorg-video-sisusb,xserver-xorg-video-tdfx,xserver-xorg-video-trident,xserver-xorg-video-vesa,xserver-xorg-video-vmware|exe,dev,doc,nls
 yes|xsoldier||exe
 yes|xtrans|xtrans-dev|exe>dev,dev,doc,nls
 yes|xvidcore|libxvidcore4,libxvidcore-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PKGS_SPECS-ubuntu-xenial
+++ b/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PKGS_SPECS-ubuntu-xenial
@@ -467,6 +467,7 @@ yes|lsb-base|lsb-base|exe,dev,doc,nls
 yes|lvm2|dmsetup,liblvm2app2.2,liblvm2cmd2.02,liblvm2-dev|exe,dev,doc,nls|
 yes|lxrandr|lxrandr|exe,dev,doc
 yes|lxtask|lxtask|exe,dev,doc
+yes|lxterminal||exe,dev,doc,nls
 yes|lzma|lzma,lzma-dev|exe,dev,doc,nls
 yes|lzo2|liblzo2-2,liblzo2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls
@@ -654,8 +655,7 @@ yes|time|time|exe,dev>null,doc,nls
 yes|transmission|transmission-common,transmission-gtk|exe,dev,doc,nls| #needs gtk3, libappindicator
 yes|tree|tree|exe,dev,doc,nls
 yes|ucf|ucf|exe,dev,doc,nls|
-yes|udev|udev,libudev1,libudev-dev|exe>null,dev>null,doc>null,nls>null #fake install
-yes|eudev||exe,dev,doc,nls| #note, requires kmod and a kernel with devtmpfs enabled.
+yes|udev|udev,libudev1,libudev-dev|exe,dev,doc,nls
 yes|uget||exe
 yes|unclutter|unclutter|exe,dev>null,doc,nls
 yes|unrar||exe,dev,doc,nls


### PR DESCRIPTION
essential fixes for dpup buster64, tahrpup64, xenialpup64, bionicpup64

- tahrpup64: also fix xorg / include lxterminal l (common64) .. urxvt doesn't run
- xenialpup64: also include lxterminal (common64) .. urxvt doesn't run
- bionicpup64: also include lxterminall (common64)
- dpupbuster64 is missing many apps.

64-bit builds boot to desktop with working audio and ethernet,,, a desktop that may not be that friendly without the w shortcuts & keybindings.

there's more stuff to fix, some apps are broken due to missing libs and incompatible old .pets.