### PR TITLE
slacko: use slackware version in pupsave

### DIFF
--- a/initrd-progs/0initrd/sbin/isoboot
+++ b/initrd-progs/0initrd/sbin/isoboot
@@ -21,14 +21,15 @@
 # - a savefolder is used
 
 #===================
-#    grub4dos  
+#  grub4dos  - https://github.com/chenall/grub4dos/releases
 #===================
-#title Start pup.iso
-#  find --set-root --ignore-floppies /ISO/pup.iso
-#  map /ISO/pup.iso (0xff)
+#title Start /ISO/pup.iso
+#  set iso=/ISO/pup.iso
+#  find --set-root --ignore-floppies %iso%
+#  map %iso% (0xff) || map --mem %iso% (0xff)
 #  map --hook
 #  root (0xff)
-#  kernel (0xff)/vmlinuz find_iso=/ISO/pup.iso
+#  kernel (0xff)/vmlinuz find_iso=%iso%
 #  initrd (0xff)/initrd.gz
 
 #===================

--- a/woof-distro/x86/slackware/14.0/DISTRO_SPECS
+++ b/woof-distro/x86/slackware/14.0/DISTRO_SPECS
@@ -1,11 +1,11 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Slacko Puppy'
 #version number of this distribution:
-DISTRO_VERSION=5.8.10
+DISTRO_VERSION=5.8.12
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='slackware'
 #Prefix for some filenames: exs: slackosave.2fs, slacko-5.7.1.sfs
-DISTRO_FILE_PREFIX='slacko'
+DISTRO_FILE_PREFIX='slacko140-32'
 #The version of the distro whose binary packages were used to build this distro:
 DISTRO_COMPAT_VERSION='14.0'
 #-

--- a/woof-distro/x86/slackware/14.1/DISTRO_SPECS
+++ b/woof-distro/x86/slackware/14.1/DISTRO_SPECS
@@ -1,11 +1,11 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Slacko Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.4
+DISTRO_VERSION=6.5
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='slackware'
 #Prefix for some filenames: exs: slackosave.2fs, slacko-6.3.2.sfs
-DISTRO_FILE_PREFIX='slacko'
+DISTRO_FILE_PREFIX='slacko141-32'
 #The version of the distro whose binary packages were used to build this distro:
 DISTRO_COMPAT_VERSION='14.1'
 #the kernel pet package used:

--- a/woof-distro/x86/slackware/14.2/DISTRO_SPECS
+++ b/woof-distro/x86/slackware/14.2/DISTRO_SPECS
@@ -1,11 +1,11 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Slacko Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.9.9.9
+DISTRO_VERSION=7.0rc
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='slackware'
 #Prefix for some filenames: exs: slackosave.2fs, slacko-6.9.9.9.sfs
-DISTRO_FILE_PREFIX='slacko'
+DISTRO_FILE_PREFIX='slacko142-32'
 #The version of the distro whose binary packages were used to build this distro:
 DISTRO_COMPAT_VERSION='14.2'
 #the kernel pet package used:

--- a/woof-distro/x86_64/slackware64/14.0/DISTRO_SPECS
+++ b/woof-distro/x86_64/slackware64/14.0/DISTRO_SPECS
@@ -1,11 +1,11 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Slacko64 Puppy'
 #version number of this distribution:
-DISTRO_VERSION=5.8.10
+DISTRO_VERSION=5.8.12
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='slackware64'
 #Prefix for some filenames: exs: slacko64save.2fs, slacko64-5.8.8.sfs
-DISTRO_FILE_PREFIX='slacko64'
+DISTRO_FILE_PREFIX='slacko140-64'
 #The version of the distro whose binary packages were used to build this distro:
 DISTRO_COMPAT_VERSION='14.0'
 #the kernel pet package used:

--- a/woof-distro/x86_64/slackware64/14.1/DISTRO_SPECS
+++ b/woof-distro/x86_64/slackware64/14.1/DISTRO_SPECS
@@ -1,11 +1,11 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Slacko64 Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.4
+DISTRO_VERSION=6.5
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='slackware64'
 #Prefix for some filenames: exs: slacko64save.2fs, slacko64-6.3.2.sfs
-DISTRO_FILE_PREFIX='slacko64'
+DISTRO_FILE_PREFIX='slacko141-64'
 #The version of the distro whose binary packages were used to build this distro:
 DISTRO_COMPAT_VERSION='14.1'
 #the kernel pet package used:

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_SPECS
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_SPECS
@@ -1,11 +1,11 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Slacko64 Puppy'
 #version number of this distribution:
-DISTRO_VERSION=6.9.9.9
+DISTRO_VERSION=7.0rc
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='slackware64'
 #Prefix for some filenames: exs: slacko64save.2fs, slacko64-6.9.9.9.sfs
-DISTRO_FILE_PREFIX='slacko64'
+DISTRO_FILE_PREFIX='slacko142-64'
 #The version of the distro whose binary packages were used to build this distro:
 DISTRO_COMPAT_VERSION='14.2'
 #the kernel pet package used:


### PR DESCRIPTION
It's possible to create pupsaves from Live CDs.

It's also possible to boot directly from ISOs [and create pupsaves] with special grub4dos/grub2 menu entries, so it's easy to test default stuff in real hardware.

(example menu entry can be found in this commit
or in initrd-progs/0initrd/sbin/isoboot)

The pupsaves are always located in HDD/SSD/Flash/etc drvs.

But there's a problem with slacko: pupsave collision.

New pupsaves:

- slacko 5.8.12  : slacko140_32 [save[.4fs]]
- slacko64 5.8.12: slacko140_64 [save[.4fs]]

- slacko 6.5  : slacko141_32 [save[.4fs]]
- slacko64 6.5: slacko141_64 [save[.4fs]]

- slacko 7.0rc  : slacko142_32 [save[.4fs]]
- slacko64 7.0rc: slacko142_64 [save[.4fs]]