### PR TITLE
init: Add switch init option

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/init
+++ b/woof-code/rootfs-skeleton/sbin/init
@@ -38,7 +38,6 @@ openrc)
  [ -f /usr/sbin/openrc-init ] && INITEXE='/usr/sbin/openrc-init'
 ;;
 systemd)
- exec 1>/dev/console 2>&1
  [ -f /lib/systemd/systemd ] && INITEXE='/lib/systemd/systemd'
  [ -f /bin/systemd ] && INITEXE='/bin/systemd'
  [ -f /sbin/systemd ] && INITEXE='/sbin/systemd'

--- a/woof-code/rootfs-skeleton/sbin/init
+++ b/woof-code/rootfs-skeleton/sbin/init
@@ -14,7 +14,39 @@ if [ "$DISPLAY" ] || [ "$XDG_CONFIG_HOME" ] ; then
 	exit
 fi
 
+INITTYPE="$(cat /proc/cmdline | tr ' ' '\n' | grep -E "^init=" | cut -f 2 -d '=')"
+
 INITEXE='/bin/busybox init'
+
+case $INITTYPE in
+minit)
+ [ -f /bin/minit ] && INITEXE='/bin/minit'
+ [ -f /sbin/minit ] && INITEXE='/sbin/minit'
+ [ -f /usr/bin/minit ] && INITEXE='/usr/bin/minit'
+ [ -f /usr/sbin/minit ] && INITEXE='/usr/sbin/minit'
+;;
+runit)
+ [ -f /bin/runit ] && INITEXE='/bin/runit'
+ [ -f /sbin/runit ] && INITEXE='/sbin/runit'
+ [ -f /usr/bin/runit ] && INITEXE='/usr/bin/runit'
+ [ -f /usr/sbin/runit ] && INITEXE='/usr/sbin/runit'
+;;
+openrc)
+ [ -f /bin/openrc-init ] && INITEXE='/bin/openrc-init'
+ [ -f /sbin/openrc-init ] && INITEXE='/sbin/openrc-init'
+ [ -f /usr/bin/openrc-init ] && INITEXE='/usr/bin/openrc-init'
+ [ -f /usr/sbin/openrc-init ] && INITEXE='/usr/sbin/openrc-init'
+;;
+systemd)
+ exec 1>/dev/console 2>&1
+ [ -f /lib/systemd/systemd ] && INITEXE='/lib/systemd/systemd'
+ [ -f /bin/systemd ] && INITEXE='/bin/systemd'
+ [ -f /sbin/systemd ] && INITEXE='/sbin/systemd'
+ [ -f /usr/bin/systemd ] && INITEXE='/usr/bin/systemd'
+ [ -f /usr/sbin/systemd ] && INITEXE='/usr/sbin/systemd'
+ [ -f /usr/lib/systemd/systemd ] && INITEXE='/usr/lib/systemd/systemd'
+;;
+esac
 
 [ -f /etc/rc.d/PUPSTATE ] && . /etc/rc.d/PUPSTATE
 [ "$PUPMODE" = "" ] && PUPMODE=2


### PR DESCRIPTION
Add option to switch init system by putting init=[systemd|runit|minit|openrc|sysvinit] on boot parameter otherwise it use busybox init by default