### PR TITLE
fix sandbox.sh & sandbox-rw.sh

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/sandbox-rw.sh
+++ b/woof-code/rootfs-skeleton/usr/bin/sandbox-rw.sh
@@ -107,17 +107,21 @@ items=$(
 		}
 		# for (m in mountdev) print m " on " mountdev[m] " type " mounttypes[m]
 		mode=4
-	} else if (mode=4) {
+	} else if (mode==4) {
 		# print the branches and its mappings
-		print $0, mounttypes[$0], "on"
-	}
-  }  
-'
+		if ($0 in mounttypes){
+		  print $0, mounttypes[$0], "on"
+		}
+		else {
+			MNT_PATH=$0
+			sub(/^.*[\/]/,"")
+			print MNT_PATH, $0, "on"
+		}
+	} 
+  }
+' 
 )
 # '
-
-# got a savedir.. breaks the dialog.. that should not happen
-items="$(echo "$items" | grep squashfs)" #only need SFS's
 
 # 3. Ask user to choose the SFS
 dialog --separate-output --backtitle "rw image sandbox" --title "sandbox config" \

--- a/woof-code/rootfs-skeleton/usr/bin/sandbox.sh
+++ b/woof-code/rootfs-skeleton/usr/bin/sandbox.sh
@@ -107,17 +107,21 @@ items=$(
 		}
 		# for (m in mountdev) print m " on " mountdev[m] " type " mounttypes[m]
 		mode=4
-	} else if (mode=4) {
+	} else if (mode==4) {
 		# print the branches and its mappings
-		print $0, mounttypes[$0], "on"
+		if ($0 in mounttypes){
+		  print $0, mounttypes[$0], "on"
+		}
+		else {
+			MNT_PATH=$0
+			sub(/^.*[\/]/,"")
+			print MNT_PATH, $0, "on"
+		}
 	}
   }  
 '
 )
 # '
-
-# got a savedir.. breaks the dialog.. that should not happen
-items="$(echo "$items" | grep squashfs)" #only need SFS's
 
 # 3. Ask user to choose the SFS
 dialog --separate-output --backtitle "tmpfs sandbox" --title "sandbox config" \


### PR DESCRIPTION
Both sandbox.sh and sandbox-rw.sh are broken because:
1. The old script incorrectly assumed a savefolder was a mount point:
2. wdlkmpx, tried to fix this by only allowing sfs files but used the wrong grep expression, which returns nothing. 

This fix uses the base filename for the save folder and consequently mitigates the need for  wdlkmpx previous attempted fix. See discussion:
http://murga-linux.com/puppy/viewtopic.php?p=1047913#1047913

I so far only tested that we can successfully create the sandbox, when running puppy with a save folder. This is an improvement over the previous code but if people want we can do more testing prior to merging. 