### PR TITLE
snapmergepuppy: Keep /home folder permission

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -121,7 +121,7 @@ done
 # =============================================================================
 
 #110224 BK revert, leave save of /dev in for now, just take out some subdirs... 110503 added dev/snd
-find . -mount -type d | tail +2 | sed -e 's/\.\///' | grep -v -E '^mnt|^media|^initrd|^proc|^sys|^tmp|^root/tmp|^\.wh\.|/\.wh\.|^dev/\.|^dev/fd|^dev/pts|^dev/shm|^dev/snd|^var/tmp' |
+find . -mount -type d | tail +2 | sed -e 's/\.\///' | grep -v -E '^mnt|^media|^home|^initrd|^proc|^sys|^tmp|^root/tmp|^\.wh\.|/\.wh\.|^dev/\.|^dev/fd|^dev/pts|^dev/shm|^dev/snd|^var/tmp' |
 while read -r N
 do
 	#v4.01 graceful exit if shutdown X (see /usr/X11R7/bin/restartwm,wmreboot,wmpoweroff)...


### PR DESCRIPTION
Just avoid chowning /home folder. This will be problematic when user logged as a non-root account. Its home folder might be unwritable if /home is chowned