### PR TITLE
profile: move qt library, variable, and binary setup to /etc/profile.d/qt-libs

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile
+++ b/woof-code/rootfs-skeleton/etc/profile
@@ -10,13 +10,6 @@ else
 fi
 export PATH LD_LIBRARY_PATH
 
-if [ -d /opt/qt4 ];then
-	LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/opt/qt4/lib"
-	[ -d /opt/qt4/bin ] && PATH="$PATH:/opt/qt4/bin" #if devx sfs.
-	export QT4DIR="/opt/qt4"
-	[ -d /opt/qt4/include ] && export CPLUS_INCLUDE_PATH="/opt/qt4/include" #devx
-fi
-export QT_XFT=true
 export GDK_USE_XFT=1 #for gtk...
 export OOO_FORCE_DESKTOP="gnome" #Open Office, force ue of GTK...
 


### PR DESCRIPTION
Code for qt library path and variable setup was moved at /etc/profile.d/qt-libs