### PR TITLE
xorgwizard: Use xorg-autoconf if available

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
@@ -134,8 +134,12 @@ if [ -f /var/local/xorg_udev ] ; then
 		cp -fv /etc/X11/xorg.conf.udev /etc/X11/xorg.conf
 	fi
 	THE_END=1
-else
-	cp -fv /etc/X11/xorg.conf-auto-pc /etc/X11/xorg.conf
+else	
+	if type xorg-autoconf >/dev/null 2>&1 ; then
+	 xorg-autoconf > /etc/X11/xorg.conf
+	else
+	 cp -fv /etc/X11/xorg.conf-auto-pc /etc/X11/xorg.conf
+	fi
 fi
 
 set_xorg_video_driver


### PR DESCRIPTION
xorg-autoconf is a script that automatically generates xorg.conf with high accuracy and precision which able to configure the video card with proper xorg driver and its parameters

http://www.murga-linux.com/puppy/viewtopic.php?p=1051102