### PR TITLE
more robust free space checking for sandboxes. See: http://www.murga-…

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/functions_x
+++ b/woof-code/rootfs-skeleton/etc/rc.d/functions_x
@@ -76,7 +76,7 @@ fx_personal_storage_free_mb() {
 			SIZEFREEM=${F4} ; break ;;
 		esac
 	done <<EOF
-$(df -m)
+$(df -a)
 EOF
 	echo "$SIZEFREEM"
 }


### PR DESCRIPTION
…linux.com/puppy/viewtopic.php?p=1051204#1051204

If you run puppylinux in a chroot system (e.g. my [psandbox script](https://gitlab.com/s243a/psandbox)), then this isn't an issue at first since PUPMODE=2. However, if you then boot the created save file as your actual system then /etc/rc.d/PUPSTATE might be left over and it might have a PUPMODE different than "2". In my case it was 12, when testing arch32pup. This broke puppies package manager when I tried to reload the puppy in a sandbox since the PUPSTATE was left over (from my real boot) with PUPMODE=12. 

For further discussion see:
[More Robust Free Space Checking for ppm @ http://www.murga-linux.com/](http://www.murga-linux.com/puppy/viewtopic.php?p=1051204#1051204)

This changed fixed the ppm (puppy package manager) in chroot system. 