### PR TITLE
WIP: fix ppm download button: partially addresses issue #1756 . See https:…

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/installpreview.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpreview.sh
@@ -385,7 +385,8 @@ fi
 
 #now do the actual install...
 PASSEDPRM=""
-if [ -f /tmp/petget_proc/download_only_pet_quietly ]; then
+if [ -f /tmp/petget_proc/download_only_pet_quietly ] ||
+   [ "`echo "$RETPARAMS" | grep '^EXIT' | grep 'BUTTON_PKGS_DOWNLOADONLY'`" != "" ] ; then
   PASSEDPRM="DOWNLOADONLY"
   touch /tmp/petget_proc/manual_pkg_download
 fi


### PR DESCRIPTION
…//github.com/puppylinux-woof-CE/woof-CE/issues/1756#issuecomment-590087808

This partially fixes the broken download button and partially addresses issue #1756 . See:
https://github.com/puppylinux-woof-CE/woof-CE/issues/1756#issuecomment-590087808


I tested it for espeak and it worked. However, on my second test it didn't work for nano, so perhaps there is a flag that isn't getting cleared. 

No rush to merge this commit because it needs further review. 