### PR TITLE
fix error reporting when verifying downloaded packages

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/verifypkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/verifypkg.sh
@@ -8,16 +8,16 @@ case $DLPKG in
 		pet2tgz tempfileonly.pet
 		RETVAL=$?
 		rm -rf tempfileonly.*
-		exit $RETVAL
 		;;
 	*.deb)
 		dpkg-deb -c "$DLPKG" >/dev/null 2>&1
-		exit $?
+		RETVAL=$?
 		;;
 	*.t[gx]z|*.tar.*)
 		tar --force-local -tf "$DLPKG" >/dev/null 2>&1
-		exit $?
+		RETVAL=$?
 		;;
 esac
-
+[ $RETVAL -ne 0 ] && echo "$DLPKG" >> /tmp/petget_proc/pgks_failed_to_install_forced && rm -f $DLPKG
+exit $RETVAL
 ### END ###


### PR DESCRIPTION
This partially fixes the final error reporting of the failed downloads but only lists the main package as failed and not all failed downloads for the dependencies. Further fixes will be required to list all failed downloads. 

I noticed the error when test arch32pup with the order wrong order in:

tar --force-local -tf "$DLPKG" >/dev/null 2>&1

which [pebee fixed](https://github.com/puppylinux-woof-CE/woof-CE/commit/7f7cb910b5b9565bea3dce24c7237a0032aa0f4b).  

This produced an error like:
```
/usr/local/petget/downloadpkgs.sh: line 293: [: =: unary operator expected
```
related to this line:
https://github.com/puppylinux-woof-CE/woof-CE/blob/7f7cb910b5b9565bea3dce24c7237a0032aa0f4b/woof-code/rootfs-skeleton/usr/local/petget/downloadpkgs.sh#L293 

The fix was to make sure that verifypkg.sh appended the failed package to pgks_failed_to_install_forced

As a side note one could have suppressed this error by quoting the output on the left hand side of the equality comparison. However, if this was done then I might not have found the error. 

Another note is that when one clicks the download only button, the final message will be whether the package failed or didn't fail to install, It really should say whether it failed to download or not, since we don't actually install it. 
