### PR TITLE
Fix ppm, post install installation status in Gui. See: https://github…

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/downloadpkgs.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/downloadpkgs.sh
@@ -283,12 +283,17 @@ do
    if [ "$PASSEDPARAM" = "DOWNLOADONLY" ];then
     echo "$(gettext 'Verifying'): ${ONEFILE}" > /tmp/petget_proc/petget/install_status
     /usr/local/petget/verifypkg.sh $DLPKG
+    RETVAL=$?
    else
     echo "$(gettext 'Installing'): ${ONEFILE}" > /tmp/petget_proc/petget/install_status
     /usr/local/petget/installpkg.sh $DLPKG
+    RETVAL=$?
+    INSTALLED_PATTERNS_SYS="`cat /root/.packages/layers-installed-packages | cut -f 2 -d '|' | sed -e 's%^%|%' -e 's%$%|%' -e 's%\\-%\\\\-%g'`"
+    echo "$INSTALLED_PATTERNS_SYS" > /tmp/petget_proc/petget_installed_patterns_system
+    cp -f /tmp/petget_proc/petget_installed_patterns_system /tmp/petget_proc/petget_installed_patterns_all
     #...appends pkgname and category to /tmp/petget_proc/petget-installed-pkgs-log if successful.
    fi
-   if [ $? -ne 0 ];then
+   if [ $RETVAL -ne 0 ];then
     LASTPKG=$(tail -n 1 /tmp/petget_proc/pgks_failed_to_install_forced)
     if [ $(echo ${DLPKG} | grep ${LASTPKG}) = "" ]; then
      /usr/lib/gtkdialog/box_ok "$(gettext 'Puppy Package Manager')" error "<b>$(gettext 'Faulty download of') ${DLPKG}</b>"


### PR DESCRIPTION
….com/puppylinux-woof-CE/woof-CE/issues/1763

Closes:
[ppm doesn't update pkg installed status in GUI until GUI is restarted #1763](https://github.com/puppylinux-woof-CE/woof-CE/issues/1763)

Partially Addresses:
[PPM is broken? #1756](https://github.com/puppylinux-woof-CE/woof-CE/issues/1756) 

I tested this in arch32pup, using autoinstall mode. I installed supertuxkart and then which I searched for tux in the search bar, the correct installation status was shown. 

