### PR TITLE
xorg-autoconf: lsmod fix

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -2,10 +2,11 @@
 #written by mistfire
 #automatically generate xorg configuration
 
-MODLIST="$(busybox lsmod)"
+MODLIST="$(busybox lsmod 2>/dev/null)"
 PCILIST="$(busybox lspci 2>/dev/null)"
 XORG_PATHS="/usr/lib/X11 /usr/lib/xorg /usr/lib64/X11 /usr/lib64/xorg"
 
+[ "$MODLIST" == "" ] && MODLIST="$(lsmod 2>/dev/null)"
 [ "$PCILIST" == "" ] && PCILIST="$(lspci -nD | sed "s#^0000:##g")" 
 
 probe_intel(){


### PR DESCRIPTION
Use binary version of lsmod if there is no lsmod applet on busybox