### PR TITLE
Create glib-memory-alloc

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile.d/glib-memory-alloc
+++ b/woof-code/rootfs-skeleton/etc/profile.d/glib-memory-alloc
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+export G_SLICE="always_malloc"


### PR DESCRIPTION
Some gtk+ apps look for G_SLICE environment variable values. Otherwise the app depend on these variable will not run