### PR TITLE
fix error in PREVIEW_DIALOG for ppm in installpreview.sh. Partially a…

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/installpreview.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpreview.sh
@@ -153,13 +153,13 @@ if [ ! -f /tmp/petget_proc/install_quietly ] ; then
  <hbox>
   '${DEPBUTTON}'
   <button>
-   <input file stock=\"gtk-go-down\"></input>
+   <input file stock="gtk-go-down"></input>
    <label>'$(gettext 'Install')' PKG '${ONLYMSG}'</label>
    <action>echo "'${TREE1}'" > /tmp/petget_proc/petget_installpreview_pkgname</action>
    <action type="exit">BUTTON_INSTALL</action>
   </button>
   <button>
-   <input file stock=\"gtk-go-down\"></input>
+   <input file stock="gtk-go-down"></input>
    <label>'$(gettext 'Download-only')'</label>
    <action type="exit">BUTTON_PKGS_DOWNLOADONLY</action>
   </button>


### PR DESCRIPTION
…ddress, "PPM is broken? #1756"

Addresses: 
> "In step by step mode is even worse!. It fails when the package to be installed has dependencies met with a gtkdialog error! " -- mavrothal 
https://github.com/puppylinux-woof-CE/woof-CE/issues/1756

I tested this on arch32pup with the following code:
```
...
while read a_lib; do
  while read packages_db; do
        REPO_TRIAD=$(basename $packages_db)
        REPO_TRIAD=${REPO_TRIAD#Packages-} #todo MAYBE MAKE THIS MORE ROBUST   
    for mode in 1 2; do  
   
      case "$mode" in
      1)
        provides_db="$(echo "$packages_db" | sed 's/^Packages-/^Provides-/')"
        a_lib="$(echo "$a_lib" | sed -r 's/^(.*)([.]so)(.*)$/\1\2/')"
        matches="$(grep -F $a_lib $provides_db)"
        ;;
      2) 
        pre_guess=$a_lib
        while [ 1 -eq 1 ]; do
          guess="$(echo "$pre_guess" | sed 's/[.]so[.]/-/')"
          guess="$(echo "$pre_guess" | sed 's/[.]so//')"
          matches="$(grep -F $guess $packages_db)"
          [ ! -z $matches ] && break 3
          last_pre_guess="$pre_guess"
          pre_guess="$(echo "$pre_guess" | sed -r 's/(.*)(.so)(.*)[.][^.]*/\1\2\3/')"
          [ "$pre_guess" = "$last_pre_guess" ] && break
        done     
        ;;        
      esac
      if [ ! -z "$matches" ]; then
        #pkgs_to_install_s243a is two fields like at: https://github.com/puppylinux-woof-CE/woof-CE/blob/60d94862a3343bf0a062a0fcd0dd73475d6985ba/woof-code/rootfs-skeleton/usr/local/petget/pkg_chooser.sh#L159
        echo "$matches" | cut -d '|' -f1 | \
          sed -n -E '/^[[:space:]]*$/! {s%(.*)%\1|'$REPO_TRIAD'%;p}'  >> /tmp/petget_proc/pkgs_to_install_s243a
        break
      fi 
    done
  done < <(find /var/packages -name 'Packages-*')
done < <(cat /tmp/petget_proc/missinglibs.txt | tr [[:space:]] "\n" ) 

while IFS= read line|| [ -n "$line" ]; 
do     
  export TREE1=$line
  
  #echo $TREE1 > /tmp/petget_proc/forced_install
  do_install #Expects four fields
done < /tmp/petget_proc/pkgs_to_install_s243a
```
https://pastebin.com/HWJ1ADaW
** which is a work in progress to install missing packages. The test script first looks in files of the forum
```
/var/packages/Provides-*
```
, which for some packages contains the name of the libs provided by the package. If this 
isn't available, then the script tries to guess the package name based on the name of the missing lib. 

Some prior discussion on my test script can be found at:
http://murga-linux.com/puppy/viewtopic.php?p=1051756#1051756 

For arch32pup the files of the form Provides-* are generated by the script that I created called "0setup2"
https://pastebin.com/7LSHJzB2

Prior to running my install_missing.sh script, one should first run [check_deps_gui.sh](https://github.com/puppylinux-woof-CE/woof-CE/blob/testing/woof-code/rootfs-packages/check_deps_gui/usr/local/petget/check_deps_gui.sh)

My script should work on other puppies besides arch32pup but it is more focused towards arch32pup. I also recall seeing somewhere in the ppm code a database that is meant to associate a package with missing libs. If I can find that section of code, then I can also look in this database to try and find missing packages. 