### PR TITLE
need /tmp/petget_proc/petget for check_deps_gui.sh

### DIFF
--- a/woof-code/rootfs-packages/check_deps_gui/usr/local/petget/check_deps_gui.sh
+++ b/woof-code/rootfs-packages/check_deps_gui/usr/local/petget/check_deps_gui.sh
@@ -16,7 +16,7 @@
 [ "$(cat /var/local/petget/nt_category 2>/dev/null)" != "true" ] && \
  [ -f /tmp/petget_proc/install_quietly ] && set -x
  #; mkdir -p /tmp/petget_proc/PPM_LOGs ; NAME=$(basename "$0"); exec 1>> /tmp/petget_proc/PPM_LOGs/"$NAME".log 2>&1
-
+mkdir -p /tmp/petget_proc/petget
 export TEXTDOMAIN=petget___check_deps.sh
 export OUTPUT_CHARSET=UTF-8
 

--- a/woof-code/rootfs-skeleton/usr/local/petget/finduserinstalledpkgs.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/finduserinstalledpkgs.sh
@@ -8,6 +8,7 @@
 
 #/root/.packages/usr-installed-packages has the list of installed pkgs...
 touch /root/.packages/user-installed-packages
+mkdir -p /tmp/petget_proc/petget
 cut -f 1,5,10 -d '|' /root/.packages/user-installed-packages > /tmp/petget_proc/petget/installedpkgs.results
 
 #120529 may have app icons displayed in main window...


### PR DESCRIPTION
Fixes issue, "If ppm isn't called before check_deps_gui.sh" then /tmp/petget_proc/petget doesn't exist and the following error is produced:

```
# ./check_deps_gui.sh
/usr/local/petget/finduserinstalledpkgs.sh: line 11: /tmp/petget_proc/petget/installedpkgs.results: No such file or directory
/usr/local/petget/finduserinstalledpkgs.sh: line 14: /tmp/petget_proc/petget/installedpkgs.results.post-noicons: No such file or directory
/usr/local/petget/finduserinstalledpkgs.sh: line 16: /tmp/petget_proc/petget/installedpkgs.results.post: No such file or directory
cp: cannot stat '/tmp/petget_proc/petget/installedpkgs.results.post-noicons': No such file or directory
grep: /tmp/petget_proc/petget/installedpkgs.results: No such file or directory
```