### PR TITLE
WIP: in ld.so.conf add: include /etc/ld.so.conf.d/*.conf

### DIFF
--- a/woof-code/rootfs-skeleton/etc/ld.so.conf
+++ b/woof-code/rootfs-skeleton/etc/ld.so.conf
@@ -6,3 +6,4 @@
 /opt/mozilla.org/lib
 /opt/samba/lib
 /root/my-applications/lib
+include /etc/ld.so.conf.d/*.conf


### PR DESCRIPTION
This line is typically added to ld.so.conf in debian distributions. WIthout this line Arch32Pup cannot find the firefox libs because there is no post install script in the firefox package to symbolically link the somewhere in the library search path (i.e. LD_LIBRARY_PATH). 

See:
http://murga-linux.com/puppy/viewtopic.php?p=1052454#1052454