### PR TITLE
xorg-autoconf: Added auto config for synaptics

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -2,7 +2,7 @@
 #written by mistfire
 #automatically generate xorg configuration
 
-MODLIST="$(busybox lsmod 2>/dev/null)"
+MODLIST="$(busybox lsmod)"
 PCILIST="$(busybox lspci 2>/dev/null)"
 XORG_PATHS="/usr/lib/X11 /usr/lib/xorg /usr/lib64/X11 /usr/lib64/xorg"
 
@@ -736,13 +736,32 @@ else
  AUTOADD="false"
 fi
 
+[ "`grep 'Elantech' /proc/bus/input/devices`" ] && TOUCHPAD='Elantech'
+[ "`grep 'Vendor=10e9' /proc/bus/input/devices`" ] && TOUCHPAD='Elantech'
+[ "`grep 'Vendor=04f3' /proc/bus/input/devices`" ] && TOUCHPAD='Elantech'
+
+[ "`grep 'Alps' /proc/bus/input/devices`" ] && TOUCHPAD='Alps'
+[ "`grep 'Vendor=0433' /proc/bus/input/devices`" ] && TOUCHPAD='Alps'
+[ "`grep 'Vendor=044e' /proc/bus/input/devices`" ] && TOUCHPAD='Alps'
+[ "`grep 'Vendor=048c' /proc/bus/input/devices`" ] && TOUCHPAD='Alps'
+
+[ "`grep 'Synaptics' /proc/bus/input/devices`" ] && TOUCHPAD='Synaptics'
+[ "`grep -E 'SYNA*' /proc/bus/input/devices`" ] && TOUCHPAD='Synaptics'
+[ "`grep 'Vendor=06cb' /proc/bus/input/devices`" ] && TOUCHPAD='Synaptics'
+
+if [ "$TOUCHPAD" != "" ] && [ "$AUTOADD" == "false" ];then
+ SYNAPDEV='InputDevice "Synaptics Mouse" "AlwaysCore" #serverlayoutsynaptics'
+ LOADSYNAP='	Load "synaptics" #loadsynaptics'
+else
+ SYNAPDEV='#InputDevice "Synaptics Mouse" "AlwaysCore" #serverlayoutsynaptics'
+ LOADSYNAP='#	Load "synaptics" #loadsynaptics'
+fi
+
 #Setup server layout input devices
 if [ "$MOUSEDRV" != "" ] && [ "$MOUSEDRV" == "mouse" ]; then
  MOUSEDEV='InputDevice    "Mouse0" "CorePointer"'
- SYNAPDEV='#	InputDevice "Synaptics Mouse" "AlwaysCore" #serverlayoutsynaptics'
 else
  MOUSEDEV='#InputDevice    "Mouse0" "CorePointer"'
- SYNAPDEV=''
 fi
 
 if [ "$KBDRV" != "" ] && [ "$KBDRV" == "kbd" ]; then
@@ -788,9 +807,9 @@ EndSection
 
 
 Section "ServerLayout"
-'$SYNAPDEV'
 	Identifier     "X.org Configured"
 	Screen      0  "Screen0" 0 0
+	'$SYNAPDEV'
 	'$MOUSEDEV'
 	'$KBDEV'
 EndSection
@@ -823,8 +842,8 @@ xorg_mods=$(ls "$xorg_mod_path/extensions" 2>/dev/null | grep -vE "\.la" | sed -
 
 if [ "$xorg_mods" != "" ]; then
 
-echo 'Section "Module"
-#	Load "synaptics" #loadsynaptics'
+echo 'Section "Module"'
+echo " $LOADSYNAP"
 	for xmod in $xorg_mods
 	do
 	 echo '	Load  "'$xmod'"'
@@ -881,6 +900,17 @@ EndSection
 '
 
 fi
+
+#Generate touchpad config
+if [ "$TOUCHPAD" != "" ] && [ "$AUTOADD" == "false" ];then
+echo 'Section "InputDevice"
+	Identifier "Synaptics Mouse"
+	Driver "synaptics"
+	Option "SHMConfig" "on"
+EndSection
+'
+fi
+
 
 #Generate Monitor and Modes Section
 echo 'Section "Monitor"

--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -2,7 +2,7 @@
 #written by mistfire
 #automatically generate xorg configuration
 
-MODLIST="$(busybox lsmod)"
+MODLIST="$(busybox lsmod 2>/dev/null)"
 PCILIST="$(busybox lspci 2>/dev/null)"
 XORG_PATHS="/usr/lib/X11 /usr/lib/xorg /usr/lib64/X11 /usr/lib64/xorg"
 


### PR DESCRIPTION
Added auto configuration for synaptics touchpads. This will only work if AutoAdded parameter was detected disabled.