### PR TITLE
init: unmount stray tmpfs mountpoints

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/init
+++ b/woof-code/rootfs-skeleton/sbin/init
@@ -19,7 +19,13 @@ INITEXE='/bin/busybox init'
 [ -f /etc/rc.d/PUPSTATE ] && . /etc/rc.d/PUPSTATE
 [ "$PUPMODE" = "" ] && PUPMODE=2
 
+unmount_stray_tmpfs(){
+ umount -l /tmp 2>/dev/null
+ umount -l /var/run 2>/dev/null
+}
+
 if [ $PUPMODE -ne 2 ] ; then
+    unmount_stray_tmpfs
 	exec ${INITEXE} #not a full hd install.
 fi
 
@@ -38,6 +44,7 @@ print_distro_version() {
 
 if [ "$1" = "initrd_full_install" ] ; then
 	print_distro_version
+	unmount_stray_tmpfs 
 	exec ${INITEXE}
 fi
 
@@ -48,6 +55,7 @@ fi
 # tmpfs: exec switch_root /pup_new /sbin/init ramdisk_done
 if [ "$1" = "ramdisk_done" ] ; then
 	# pdev1 is mounted rw, proc is unmounted.
+	unmount_stray_tmpfs
 	exec ${INITEXE} >/dev/null 2>&1
 fi
 

--- a/woof-code/rootfs-skeleton/sbin/init
+++ b/woof-code/rootfs-skeleton/sbin/init
@@ -22,6 +22,8 @@ INITEXE='/bin/busybox init'
 unmount_stray_tmpfs(){
  umount -l /tmp 2>/dev/null
  umount -l /var/run 2>/dev/null
+ rm -rf /tmp/* 2>/dev/null
+ find "/var/run/" -type f -name "*.pid" -delete 2>/dev/null
 }
 
 if [ $PUPMODE -ne 2 ] ; then


### PR DESCRIPTION
Lazy unmount /tmp and /var/run and clean them before the init start to avoid any problems when the system was initialized.

This was very helpful if the system was improperly shutdown or the system lost power