### PR TITLE
network_connect: Increase wait for link detection; replace deprecated cmds

### DIFF
--- a/woof-code/rootfs-packages/network_wizard/pet.specs
+++ b/woof-code/rootfs-packages/network_wizard/pet.specs
@@ -1,1 +1,1 @@
-network_wizard-2.1.1|network_wizard|2.1.1||Network|376K||network_wizard-2.1.1.pet|+gtkdialog|Dougal's Network Wizard||||
+network_wizard-2.1.2|network_wizard|2.1.2||Network|376K||network_wizard-2.1.2.pet|+gtkdialog|Dougal's Network Wizard||||

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
@@ -207,7 +207,7 @@ showMainWindow()
 			17) saveNewModule ;;
 			18) unloadNewModule ;;
 			19) break ;;
-			13) which connectwizard_exec &>/dev/null \
+			13) which connectwizard_exec >/dev/null 2>&1 \
 				  && connectwizard_exec net-setup.sh #190217
 				local HWADDRESS=$(ifconfig "$INTERFACE" | grep "^$INTERFACE" | tr -s ' ' | cut -d' ' -f5) #190217
 				ln -snf $HWADDRESS.conf ${NETWORK_INTERFACES_DIR}/selected_conf #190217

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/net-setup.sh
@@ -76,6 +76,7 @@
 #190213 replace functions validip with validip4, dotquad with ip2dec.
 #190217 v2.1: shorten wait after link timeout; remember choice of interface for boot-up; stop interfaces other than that selected, before starting selected interface; separate 'running' test and 'current exec' logic, so exec change avoided if main window aborted (X); refine 'already running' dialog & add to locale files.
 #190223 v2.1.1: Avoid exec change on exiting if no interface buttons used.
+#200412 v2.1.2: Increase wait for ethtool link detected, to 15 secs.
 
 # $1: interface
 interface_is_wireless() {
@@ -206,7 +207,7 @@ showMainWindow()
 			17) saveNewModule ;;
 			18) unloadNewModule ;;
 			19) break ;;
-			13) which connectwizard_exec >/dev/null 2>&1 \
+			13) which connectwizard_exec &>/dev/null \
 				  && connectwizard_exec net-setup.sh #190217
 				local HWADDRESS=$(ifconfig "$INTERFACE" | grep "^$INTERFACE" | tr -s ' ' | cut -d' ' -f5) #190217
 				ln -snf $HWADDRESS.conf ${NETWORK_INTERFACES_DIR}/selected_conf #190217
@@ -1058,12 +1059,13 @@ $ERROR
 
 	echo "X"
 	LINK_DETECTED=no
-	for i in 1 2 3 4 5 ; do
+	TIMEOUT=15 #200412
+	while [ $TIMEOUT -ge 0 ]; do #200412
 		if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
 			LINK_DETECTED="yes"
 			break
 		fi
-		[ $i -lt 5 ] && sleep 1.3 || sleep 0.5 #190217
+		[ $((--TIMEOUT)) -ge 0 ] && sleep 1 || sleep 0.5 #190217 200412
 		echo "X"
 	done
 	if [ "$LINK_DETECTED" = "no" ] ; then

--- a/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
+++ b/woof-code/rootfs-packages/network_wizard/usr/local/network-wizard/rc.network
@@ -61,6 +61,7 @@
 #180923 v2.0: move network wizard to its package directory.
 #190209 v2.0.1: make connectwizardrc usage conditional on presence of connectwizard_exec, for use outside of woofCE pups.
 #190217 v2.1: Correct wait for all ethernet hardware to be detected, preserving 31may12 but respecting predictable interface names; filter iwlist output to reduce file size; remove unused ethtool 'progress' ticks.
+#200412 v2.1.2: Increase wait for ethtool link detected, to 15 secs.
 
 ######### TODO ###########
 #- need to find out about static ip... can we check somehow (arp)? maybe use
@@ -145,12 +146,13 @@ testInterface()
   #INTERFACE="$1"
   echo -n "checking if interface $INTERFACE is alive..."
 	LINK_DETECTED=no
-	for i in 1 2 3 4 5 ; do
+	TIMEOUT=15 #200412
+	while [ $TIMEOUT -ge 0 ]; do #200412
 		if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
 			LINK_DETECTED="yes"
 			break
 		fi
-		[ $i -lt 5 ] && sleep 1.3 #190217
+		[ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190217 200412
 	done
 	if [ "$LINK_DETECTED" = "no" ] ; then
 		return 1

--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.3|simple_network_setup|2.3||Network|140K||simple_network_setup-2.3.pet|+gtkdialog|Barry's simple network manager||||
+simple_network_setup-2.3.1|simple_network_setup|2.3.1||Network|140K||simple_network_setup-2.3.1.pet|+gtkdialog|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -34,6 +34,7 @@
 #190209 v2.1.1: Increase wait for ethtool link detected, to 6 secs total).
 #190210 v2.2: Avoid wait after link timeout.
 #190525 v2.3: Allow for udev list updates; correct module loading & connection checks; add/restore wait for interfaces to configure.
+#200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
 
 #If version is changed, ensure that new VERSION is set in the sns script. #190525
 
@@ -335,12 +336,13 @@ do
  [ $? -ne 0 ] && continue
 
  LINK_DETECTED=no
- for i in 1 2 3 4 5 ; do
+ TIMEOUT=15 #200412
+ while [ $TIMEOUT -ge 0 ]; do #200412
    if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
      LINK_DETECTED="yes"
      break
    fi
-   [ $i -lt 5 ] && sleep 1.5 #190209 190212
+   [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190212 200412
  done
  if [ "$LINK_DETECTED" = "no" ] ; then
    ifconfig $INTERFACE down

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -39,8 +39,9 @@
 #190216 v2.2: Correct 'already running' check; correct support of long SSIDs truncated for display; avoid wait after link timeout; move 'current exec' logic, so exec change avoided if main window aborted (X); update 'make default' message.
 #190223 v2.2.1: Avoid exec change on exiting if connect/disconnect and interface buttons not used; add 'note' regarding connection not started by SNS.
 #190525 v2.3: Add version to main window; re-check SNS running, in case slow to terminate; for interface change, kill current connection.
+#200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
 
-VERSION='2.3'  #UPDATE this with each release!
+VERSION='2.3.1'  #UPDATE this with each release!
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -993,19 +994,20 @@ if [ "$IF_INTTYPE" == "Wired" ];then
  [ $? -eq 0 ] && IFACEUP=true || IFACEUP=false #170402
  if [ $IFACEUP = true ];then #170402
   LINK_DETECTED=no
-  for i in 1 2 3 4 5 ; do
-     if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
-       LINK_DETECTED="yes"
-       break
-     fi
-     [ $i -lt 5 ] && sleep 1.5 #190209 190216
+  TIMEOUT=15 #200412
+  while [ $TIMEOUT -ge 0 ]; do #200412
+   if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
+    LINK_DETECTED="yes"
+    break
+   fi
+   [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190216 200412
   done
   if [ "$LINK_DETECTED" = "no" ] ; then
-     ifconfig $INTERFACE down
-     kill $PIDXX 2>/dev/null
-     /usr/lib/gtkdialog/box_ok "$(gettext 'Simple Network Setup')" error "<b>$(gettext 'There does not seem to be any network connected to') ${INTERFACE}</b>" " " "$(gettext "Is the network cable unplugged? Modem router turned off? If you can fix it, great, otherwise try a different interface.")"
-     exec sns
-     exit
+   ifconfig $INTERFACE down
+   kill $PIDXX 2>/dev/null
+   /usr/lib/gtkdialog/box_ok "$(gettext 'Simple Network Setup')" error "<b>$(gettext 'There does not seem to be any network connected to') ${INTERFACE}</b>" " " "$(gettext "Is the network cable unplugged? Modem router turned off? If you can fix it, great, otherwise try a different interface.")"
+   exec sns
+   exit
   fi
   rm -f /tmp/sns_interface_success #170402
   DHCPCDFIX=""

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.network_eth
@@ -10,6 +10,8 @@
 #180104 check for ethernet bridge hardware if controller not detected; increase wait for detection; move sleep to after test; change report of wait time.
 #180624 add check for predictable network interface device names (e.g. enp0s25).
 #190209 increase wait for ethtool link detected, to 7.5 secs total).
+#200206 replace deprecated ifconfig & iwconfig with busybox ip.
+#200412 increase wait for ethtool link detected, to 15 secs.
 
 export LANG='C'
 
@@ -26,7 +28,7 @@ interface_is_wireless() {
 	fi
 	# k3.2.x: my problematic wireless pci adapter is only recognized by iwconfig..
 	# hmm with 2 pci wireless adapters only iwconfig does the trick
-	if iwconfig ${1} 2>&1 | grep -q 'no wireless' ; then
+	if iw dev ${1} link 2>&1 | grep -q 'Not connected' ; then #200206
 		return 1 #no
 	fi
 	return 0 #yes
@@ -39,7 +41,7 @@ if [ $ethCNT -eq 0 ] ; then
 	ethCNT=$(lspci -nn | grep ' \[0680\]: .* Ethernet ' | wc -l) #180104
 fi
 while [ $ifCNT -lt $ethCNT ];do
- ifCNT=$(ifconfig -a | grep -E '^eth[0-9] |^en[oPps][0-9]|^enx[0-9a-f]' | wc -l) #180624
+ ifCNT=$(ip link show | grep -B 1 'link/ether' | grep -E ': eth[0-9]|: en[oPps][0-9]|: enx[0-9a-f]' | wc -l) #200206
  [ $ifCNT -gt 0 -o $loopCNT -ge 30 ] && break #finding one i/f is enough, other may not have a driver. 180104
  sleep 1 #180104
  loopCNT=$(($loopCNT+1))
@@ -47,26 +49,27 @@ done
 [ $loopCNT -gt 0 ] && echo "rc.network_eth: waited for ethernet interfaces: seconds = ${loopCNT}" >&2 #180104
 
 #code adapted from /usr/local/simple_network_setup/rc.network...
-INTERFACES="`ifconfig -a | grep -F 'Link encap:Ethernet' | cut -f1 -d' ' | tr '\n' ' '`"
+INTERFACES="`ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ':' | tr -d '\n'`" #200206
 for INTERFACE in $INTERFACES #exs: wlan0 eth0
 do
  if interface_is_wireless ${INTERFACE} ; then
    continue #only want wired.
  fi
 
- ifconfig $INTERFACE up
+ ip link set $INTERFACE up #200206
  [ $? -ne 0 ] && continue
 
  LINK_DETECTED=no
- for i in 1 2 3 4 5 ; do
+ TIMEOUT=15 #200412
+ while [ $TIMEOUT -ge 0 ]; do #200412
    if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
      LINK_DETECTED="yes"
      break
    fi
-   sleep 1.5 #190209
+   [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #200412
  done
  if [ "$LINK_DETECTED" = "no" ] ; then
-   ifconfig $INTERFACE down
+   ip link set $INTERFACE down #200206
    continue #no network.
  fi
 
@@ -78,7 +81,7 @@ do
   which sns >/dev/null 2>&1 && echo "$INTERFACE" > /tmp/sns_interface_success
   exit #success.
  else
-  ifconfig $INTERFACE down
+  ip link set $INTERFACE down #200206
   dhcpcd --release $INTERFACE 2>/dev/null
   ip route flush dev $INTERFACE
  fi

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.network_pwf_stop
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.network_pwf_stop
@@ -1,20 +1,23 @@
 #!/bin/sh
 # peasywifi rc.network 'stop' implementation missing from /etc/pwf/rc.network
-set -x; exec >&2 #DEBUG
+#200206 Replace deprecated 'ifconfig' with busybox 'ip'.
+#100415 Refine ip usage.
+
 . /etc/pwf/pwf.conf
-CONNECTEDLINKS=$(ip -o address show | grep 'inet' | cut -f 2 -d ' ')
+CONNECTEDLINKS=$(ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' ' | tr -d : | tr -d '\n') #200415
 if echo $CONNECTEDLINKS | grep -qw "$INTERFACE"; then
-	CURRENTIPS=$(ip addr show | grep $INTERFACE | grep inet | awk '{print $2}') #in case there are several
-	for I in $CURRENTIPS; do ip addr del $I dev $INTERFACE; done
-	ifconfig $INTERFACE down
-	
+	CURRENTIPS=$(ip addr show $INTERFACE | grep -o 'inet [^ ]*' | cut -f 2 -d ' ') #in case there are several 200415
+	for I in $CURRENTIPS; do
+		ip addr del $I dev $INTERFACE
+	done
+	ip link set $INTERFACE down #200206
 	killall wpa_supplicant
 	rm -f /var/run/wpa_supplicant/*
 	killall udhcpc
 else #disconnect other (wired) interfaces
-	ETHLINKS=$(ip -o link show | grep 'link/ether' | cut -f 2 -d ' ' | tr -d :)
+	ETHLINKS=$(ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ' ' | tr -d :)
 	for INTERFACE in $ETHLINKS;do
-		ifconfig $INTERFACE down
+		ip link set $INTERFACE down #200206
 	done
 fi
 killall peasywifi_tray

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard_2nd
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard_2nd
@@ -17,6 +17,7 @@
 #180624 add check for predictable network interface device names (e.g. enp0s25).
 #180919 add peasywifi support.
 #180923 replace specific exec paths with 'which'; move network wizard.
+#200206 replace deprecated 'ifconfig' with busybox 'ip'; replace 180624.
 
 export TEXTDOMAIN=connectwizard_2nd
 export OUTPUT_CHARSET=UTF-8
@@ -126,7 +127,7 @@ if [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'FLAG'`" != "" ];then
  fi #170309 end
  [ $? -gt 2 ] && exit #170510 exec killed
 
- IFSUP="`ifconfig | grep -E '^eth|^wlan|^en[oPpsx]|^wl[oPpsx]'`" #180624
+ IFSUP="`ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' '  | tr -d :`" #200206
  if [ "$IFSUP" != "" ];then
   IFSUP="`echo "$IFSUP" | cut -f 1 -d ' ' | tr '\n' ' '`"
   MSG1="$(gettext 'These interfaces are active:')

--- a/woof-code/rootfs-skeleton/usr/sbin/hostname-set
+++ b/woof-code/rootfs-skeleton/usr/sbin/hostname-set
@@ -11,6 +11,7 @@
 #120505 when hostname changed, also need to restart network connection. ref: http://www.murga-linux.com/puppy/viewtopic.php?t=77743
 #130511 shinobar: reconnect only if local dynamic DNS is available. See my modification near bottom of script.
 #170329 rerwin: for networkdisconnect, disconnect with current exec (instead of default of previous exec). 
+#200206 replace deprecated 'route' with 'ip route'' & ifconfig' with busybox 'ip'.
 
 export TEXTDOMAIN=hostname-set
 export OUTPUT_CHARSET=UTF-8
@@ -65,7 +66,7 @@ RECONNECT=""; M_h3="" #130511 shinobar.
 if [ "$NEW_HOSTNAME" != "$HOSTNAME" ];then
 
  #130511 shinobar: check if network is ready...
- LANG=C route | grep -q 'default[ ].*[ ]0\.0\.0\.0[ ]' && grep -wq 'nameserver' /etc/resolv.conf && NETREADY="y" || NETREADY=""
+ LANG=C ip route | grep -q '^default via' && grep -wq 'nameserver' /etc/resolv.conf && NETREADY="y" || NETREADY="" #200206
  if [ "$NETREADY" ]; then
   #check if there is local Dynamic DNS...
   mv -f /etc/hosts /etc/hosts.bak
@@ -77,7 +78,7 @@ if [ "$NEW_HOSTNAME" != "$HOSTNAME" ];then
   M_h3="$(gettext 'However, it will not take full effect until after X (the desktop) has been restarted -- see the <b>Shutdown</b> entry in the menu.')"
 
   #120505 when hostname changed, also need to restart network connection...
-  IFCONFIG="`ifconfig | grep '^[pwe]' | grep -v 'wmaster'`"
+  IFCONFIG="`ip link show | grep -B 1 -E 'link/ether|link/ppp' | grep -w 'UP' | grep -v 'wmaster'`" #200206
   if [ "$IFCONFIG" ];then
    networkdisconnect --current-exec #170329
    touch /tmp/services/network_default_reconnect_required_flag #/usr/bin/xwin will read this, will call /usr/sbin/network_default_connect

--- a/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
+++ b/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
@@ -18,6 +18,7 @@
 #180919 add peasywifi support.
 #180923 move network wizard.
 #181209 add argument for use by rc.shutdown, for treatment of frisbee.
+#200206 replace deprecated ifconfig & iwconfig with busybox ip & full iw.
 
 CURRENT_EXEC='' #170724
 if [ -f /root/.connectwizardrc ];then #170724
@@ -40,7 +41,7 @@ case "$ARGUMENT" in
 ETHERNETDIR=network_ethernet
 ACTIVE_INTERFACE=""
 [ -f /tmp/sns_interface_success ] && ACTIVE_INTERFACE="`cat /tmp/sns_interface_success`" #SNS
-[ ! "$ACTIVE_INTERFACE" ] && ACTIVE_INTERFACE="`ifconfig | grep '^[a-z]' | grep -v '^lo' | grep -v '^ppp' | grep 'Link encap:Ethernet' | cut -f 1 -d ' ' | head -n 1`"
+[ ! "$ACTIVE_INTERFACE" ] && ACTIVE_INTERFACE="`ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' ' | tr -d : | head -n 1`" #200206
 if [ "$ACTIVE_INTERFACE" ];then
  if [ -d /sys/class/net/${ACTIVE_INTERFACE}/statistics ];then
   RX_BYTES="`cat /sys/class/net/${ACTIVE_INTERFACE}/statistics/rx_bytes`"
@@ -79,10 +80,10 @@ case "$DISCONNECTEXEC" in #170412...
   ;;
 esac #170309
 
-for ONENETIF in `ifconfig | grep '^[^ ].*Ethernet' | cut -f 1 -d ' ' | tr '\n' ' '`; do #170412 end
- ifconfig $ONENETIF down 2> /dev/null
- [ "`iwconfig | grep "^${ONENETIF}" | grep "ESSID"`" != "" ] \
-  && iwconfig $ONENETIF essid off #100309
+for ONENETIF in `ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' ' | tr -d : | tr -d '\n'`; do #200206
+ ip link set $ONENETIF down 2> /dev/null #200206
+ [ "`iw dev ${ONENETIF} info | grep -w "ssid"`" != "" ] \
+  && iw dev $ONENETIF connect off #100309 200206
  dhcpcd --release $ONENETIF 2>/dev/null #100309
 done #180214 end
 


### PR DESCRIPTION
Some users of BionicPup64 report that the wired ethernet interface is not detected in some modern PCs/laptops.  Apparently, the wait for ethtool to detect an interface is insufficient.  They report that FatDog detects those interfaces; FatDog's maximum wait time for the ethernet interface is 15 seconds, compared to 6 seconds in Puppies.

The fix increases the Puppy timeout period to match FatDog's, although the tester needed only 8 seconds.  There seems to be no harm in using 15.

The replacement of the deprecated ifconfig with ip protects against the eventual removal of ifconfig.  Since the Puppies use the busybox version of ip, the replacements avoid using features supported by only the full version.

My strategy is to use 'ip link' wherever the ip address is not needed but to avoid the '-o, -oneline' option which is unsupported for "link" by busybox.  To find the active links, both lines of output are processed.  Note that 'ip -oneline addr' produces different output than the full version -- parsing of its output should handle both output formats, or avoid '-oneline'.

My plan is to replace ifconfig, iwconfig and route in the network managers and then look at other cases.
 