### PR TITLE
networkdisconnect: Correct disconnection for SNS-managed interfaces

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
+++ b/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
@@ -19,6 +19,7 @@
 #180923 move network wizard.
 #181209 add argument for use by rc.shutdown, for treatment of frisbee.
 #200206 replace deprecated ifconfig & iwconfig with busybox ip & full iw.
+#200425 add invocation of SNS rc.network; pause before checking for other links (timing issue). 
 
 CURRENT_EXEC='' #170724
 if [ -f /root/.connectwizardrc ];then #170724
@@ -66,8 +67,11 @@ case "$DISCONNECTEXEC" in #170412...
   sleep 0.1
   if [ -n "$(ps --no-headers -fC udhcpc,wpa_supplicant)" ];then
     # 'stop' option ignored in peasywifi rc.network - workaround:
-    /etc/rc.d/rc.network_peasywifi_stop
+    /etc/rc.d/rc.network_pwf_stop
   fi
+  ;;
+ sns) #200425...
+  /usr/local/simple_network_setup/rc.network stop
   ;;
  net-setup.sh)
   /usr/local/network-wizard/rc.network stop #180923
@@ -80,6 +84,7 @@ case "$DISCONNECTEXEC" in #170412...
   ;;
 esac #170309
 
+sleep 0.1 #200425
 for ONENETIF in `ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' ' | tr -d : | tr -d '\n'`; do #200206
  ip link set $ONENETIF down 2> /dev/null #200206
  [ "`iw dev ${ONENETIF} info | grep -w "ssid"`" != "" ] \


### PR DESCRIPTION
When using simple_network_setup already connected to a network and clicking on "Disconnect", the connection disconnects as expected.  But starting SNS again and clicking "Reconnect" fails to reconnect -- but not always.  The failure is due to dhcpcd still running!

Single-core PCs will see the problem but multi-core PCs may not.  The generic logic used to terminate an SNS connection is executed only if the specific link is "up".  In the multi-core PC, the link shows as "down" after the test is made; a 0.1-second sleep before the test lets the test find it "down", so skips killing dhcpcd.

To correct this, networkdisconnect invokes the SNS rc.network "stop" option, similar to the support for the other network managers.  The sleep is inserted in case any other links are up that are not managed by the current network manager.

Also, the incorrectly specified name of the peasywifi "stop" workaround script is corrected.