### PR TITLE
SNS: Fix titles for main window & to activate error window.

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.3.1|simple_network_setup|2.3.1||Network|140K||simple_network_setup-2.3.1.pet|+gtkdialog|Barry's simple network manager||||
+simple_network_setup-2.3.2|simple_network_setup|2.3.2||Network|140K||simple_network_setup-2.3.2.pet|+gtkdialog|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -40,8 +40,9 @@
 #190223 v2.2.1: Avoid exec change on exiting if connect/disconnect and interface buttons not used; add 'note' regarding connection not started by SNS.
 #190525 v2.3: Add version to main window; re-check SNS running, in case slow to terminate; for interface change, kill current connection.
 #200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
+#200521 v2.3.2: Correct damage to SNS_error dialog window title syntax; export version.
 
-VERSION='2.3.1'  #UPDATE this with each release!
+export VERSION='2.3.2'  #UPDATE this with each release!
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -1073,7 +1074,7 @@ if [ "$IF_INTTYPE" == "Wired" ];then
   dhcpcd --release $INTERFACE 2>/dev/null
   ip route flush dev $INTERFACE #100703
   export SNS_error='
-  <window ="'$(gettext 'Simple Network Setup')'"title icon-name="gtk-network">
+  <window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network">
   <vbox>
     <frame>
       '"`/usr/lib/gtkdialog/xml_pixmap dialog-error popup`"'
@@ -1098,7 +1099,7 @@ if [ "$IF_INTTYPE" == "Wired" ];then
       </button>
     </hbox>
   </vbox>
-  </window>'
+  </window>' #200521
   RETSTRING="`gtkdialog -p SNS_error --center`"
   [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'BUT_GOBACK'`" != "" ] && exec sns
  fi


### PR DESCRIPTION
The window displayed for error conditions failed to be displayed for several years now.  The version of SNS was intended to be shown in the main window, was not appearing.  This fixes both issues.