### PR TITLE
z_update_system_cache.sh: Added update gconv

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/z_update_system_cache.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/z_update_system_cache.sh
@@ -29,7 +29,7 @@ do
 	  /usr/bin/update-mime-database $usrfld/share/mime 2>/dev/null
 	fi
 	
-	if [ -e "$usrfld/share/mime/packages" ] && [ "$(ls -1 "$usrfld/share/mime/packages")" == "" ]; then
+	if [ -e "$usrfld/share/mime/packages" ] && [ "$(ls -1 "$usrfld/share/mime/packages" 2>/dev/null)" == "" ]; then
 	 rm -rf $usrfld/share/mime/*
 	fi
   fi

--- a/woof-code/rootfs-skeleton/usr/local/petget/z_update_system_cache.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/z_update_system_cache.sh
@@ -49,6 +49,10 @@ do
 
 done
 
+if [ "$(grep -q -m 1 '/gconv/' $PKGFILES)" != "" ]; then
+  iconvconfig 2>/dev/null
+fi
+
 if [ "$(grep -q -m 1 '/usr/lib/gdk-pixbuf' $PKGFILES)" != "" ] || [ "$(grep -q -m 1 '/usr/local/lib/gdk-pixbuf' $PKGFILES)" != "" ]; then
 	if [ -e /usr/bin/update-gdk-pixbuf-loaders ] ; then
 	 update-gdk-pixbuf-loaders


### PR DESCRIPTION
Added update gconv modules cache file if the packages contains gconv modules (part of glibc library).
sfs_load has already have update gconv but missing on PPM