### PR TITLE
xorg-autoconf: Properly decode bus id

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -4,7 +4,7 @@
 
 XORG_PATHS="/usr/lib/xorg /usr/lib64/xorg /usr/lib/X11 /usr/lib64/X11"
 
-MODLIST="$(busybox lsmod)"
+MODLIST="$(busybox lsmod 2>/dev/null)"
 PCILIST="$(busybox lspci 2>/dev/null)"
 [ "$MODLIST" == "" ] && MODLIST="$(lsmod 2>/dev/null)" 
 [ "$PCILIST" == "" ] && PCILIST="$(lspci -nD 2>/dev/null | sed "s#^0000:##g")"
@@ -42,6 +42,20 @@ if [ "$XORG_MODULE_PATH" == "" ] || [ ! -e "$XORG_MODULE_PATH" ]; then
   fi
  done
 fi
+
+decode_busid(){
+
+XPID="$1"
+
+RID="$(echo "$XPID" | sed -e "s#\.#:#g")"
+
+R1=$(echo $((0x$(echo $RID | cut -f 1 -d ':'))))
+R2=$(echo $((0x$(echo $RID | cut -f 2 -d ':'))))
+R3=$(echo $((0x$(echo $RID | cut -f 3 -d ':'))))
+
+echo "$R1:$R2:$R3"
+	
+}
 
 write_evdev_conf(){
 	
@@ -189,7 +203,8 @@ probe_intel(){
 
  devid="$(echo "$1" | cut -f 2 -d ':')"
  cnum="$2"
- bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+ xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+ bid="$(decode_busid "$xbid")"
 
  accel=""
 
@@ -296,7 +311,8 @@ probe_amd(){
 
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 
 accel=""
 
@@ -421,7 +437,8 @@ probe_s3(){
 
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 
 case $devid in
 8c03|8c02|8c01|8c00|8a10|8a01|883d|5631)
@@ -466,7 +483,8 @@ probe_3dfx(){
 
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 
 case $devid in
 0001|0002)
@@ -508,7 +526,8 @@ probe_xgi(){
 
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 
 case $devid in
 0047)
@@ -550,7 +569,8 @@ probe_nvidia(){
 
  devid="$(echo "$1" | cut -f 2 -d ':')"
  cnum="$2"
- bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+ xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+ bid="$(decode_busid "$xbid")"
 
  drvfound=""	
 
@@ -601,7 +621,8 @@ probe_via(){
 
  devid="$(echo "$1" | cut -f 2 -d ':')"
  cnum="$2"
- bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+ xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+ bid="$(decode_busid "$xbid")"
 
  drvfound=""	
 
@@ -642,7 +663,8 @@ write_nodrv(){
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
 drvname="$3"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 		
 echo 'Section "Device"
 	Identifier  "Card'$cnum'"
@@ -758,7 +780,8 @@ write_fallback(){
 
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 
 if [ -e /sys/firmware/efi ]; then
  drvname="fbdev"
@@ -784,7 +807,8 @@ write_generic(){
 devid="$(echo "$1" | cut -f 2 -d ':')"
 cnum="$2"
 drvname="$3"
-bid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ' | sed -e "s#^0##g" -e "s#:0#:#g" -e "s#\.#:#g")"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
 
 drvfound=""
 

--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -337,10 +337,10 @@ case $devid in
 4742|4744|4749|474d|474e|474f|4750|4752|4753|4756|4757|4759|475a)
  drv="r128"
 ;;
-4c46|4c47|4c49|4c4d|4c50|4c52|4d46|5050|5052)
+4c45|4c46|4c47|4c49|4c4d|4c50|4c52|4d46|5050|5052|504*)
  drv="r128"
 ;;
-5046|5245|5246|524b|524c|5346|534d|5446|5452)
+5046|5245|5246|524b|524c|5346|534d|5446|5452|4d4c|524*|534*|544*|545*)
  drv="r128"
 ;;
 4354|4358|4554|4654|4754|4755|4758|4c42|4c54|5354|5654|5655|5656)
@@ -575,7 +575,7 @@ probe_nvidia(){
  drvfound=""	
 
  case $devid in
- 0018|0019)
+ 0008|0009|0018|0019|002*)
   if [ "$(echo "$MODLIST" | awk '{ print $1 }' | grep -E "^nvidia")" != "" ]; then
    drv="nvidia"
   else
@@ -841,6 +841,139 @@ EndSection
 '	
 	
 }
+
+probe_vmware(){
+
+ devid="$(echo "$1" | cut -f 2 -d ':')"
+ cnum="$2"
+ xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+ bid="$(decode_busid "$xbid")"
+
+ drv=""
+ drvfound=""	
+ 
+if [ -e $XORG_MODULE_PATH/drivers/vmware_drv.so ]; then
+ drv="vmware"
+ drvfound="1"
+fi
+
+if [ "$drvfound" == "" ]; then
+  if [ "$(echo "$MODLIST" | awk '{ print $1 }' | grep -E "^vmwgfx")" != "" ]; then
+   drv="modesetting"
+   drvfound="1"
+  fi
+fi
+
+if [ "$drvfound" == "" ]; then
+ if [ -e /sys/firmware/efi ]; then
+  drv="fbdev"
+ else
+  if [ "$(ls /dev/fb* 2>/dev/null)" != "" ]; then
+   drv="fbdev"
+  else
+   drv="vesa"
+  fi
+ fi
+fi
+		
+echo 'Section "Device"
+	Identifier  "Card'$cnum'"
+	Driver      "'$drv'" #card'$cnum'driver
+	BusID       "'$bid'" #card'$cnum'busid
+EndSection
+'
+
+}
+
+probe_trident(){
+
+devid="$(echo "$1" | cut -f 2 -d ':')"
+cnum="$2"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
+
+case $devid in
+9420|9430)
+ drv="tvga8900"
+;;
+*)
+ drv="trident"
+;;
+esac
+
+drvfound=""
+
+[ -e $XORG_MODULE_PATH/drivers/${drv}_drv.so ] && drvfound="1"
+
+if [ "$drvfound" == "" ]; then
+ if [ -e /sys/firmware/efi ]; then
+  drv="fbdev"
+ else
+  if [ "$(ls /dev/fb* 2>/dev/null)" != "" ]; then
+   drv="fbdev"
+   accel=""
+  else
+   drv="vesa"
+   accel=""
+  fi
+ fi
+fi
+
+echo 'Section "Device"
+	Identifier  "Card'$cnum'"
+	Driver      "'$drv'" #card'$cnum'driver
+	BusID       "'$bid'" #card'$cnum'busid
+EndSection
+'
+	
+}
+
+probe_diamond(){
+
+devid="$(echo "$1" | cut -f 2 -d ':')"
+cnum="$2"
+xbid="$(echo "$PCILIST" | grep "$1" | cut -f 1 -d ' ')"
+bid="$(decode_busid "$xbid")"
+
+case $devid in
+00a0|00a8)
+ drv="cirrus"
+;;
+0550|1092)
+ drv="nv"
+;;
+*)
+ drv="diamond"
+;;
+esac
+
+drvfound=""
+
+[ -e $XORG_MODULE_PATH/drivers/${drv}_drv.so ] && drvfound="1"
+
+if [ "$drvfound" == "" ]; then
+ if [ -e /sys/firmware/efi ]; then
+  drv="fbdev"
+ else
+  if [ "$(ls /dev/fb* 2>/dev/null)" != "" ]; then
+   drv="fbdev"
+   accel=""
+  else
+   drv="vesa"
+   accel=""
+  fi
+ fi
+fi
+
+echo 'Section "Device"
+	Identifier  "Card'$cnum'"
+	Driver      "'$drv'" #card'$cnum'driver
+	BusID       "'$bid'" #card'$cnum'busid
+EndSection
+'
+	
+}
+
 
 #Look for available input drivers
 if [ ! -e $XORG_MODULE_PATH/input/kbd_drv.so ]; then
@@ -1165,30 +1298,35 @@ do
 		121a) probe_3dfx "${vid}:${dvid}" "$cnum" ;;
 		18ca) probe_xgi "${vid}:${dvid}" "$cnum" ;;
 		10de) probe_nvidia "${vid}:${dvid}" "$cnum" ;;
+		1023) probe_trident "${vid}:${dvid}" "$cnum" ;;
+		1092) probe_diamond "${vid}:${dvid}" "$cnum" ;;
 		1002|1022) probe_amd "${vid}:${dvid}" "$cnum" ;;		
 		1412|1106) probe_via "${vid}:${dvid}" "$cnum" ;;
+		15ad|fffe) probe_vmware "${vid}:${dvid}" "$cnum" ;;
 		1013) write_generic "${vid}:${dvid}" "$cnum" cirrus ;;
 		1039) write_generic "${vid}:${dvid}" "$cnum" sis ;;
 		15ad) write_generic "${vid}:${dvid}" "$cnum" vmware ;;
 		102b) write_generic "${vid}:${dvid}" "$cnum" mga ;;
 		10c8) write_generic "${vid}:${dvid}" "$cnum" neomagic ;;
 		100c) write_generic "${vid}:${dvid}" "$cnum" tseng ;;
-		1023) write_generic "${vid}:${dvid}" "$cnum" trident ;;
 		1a03) write_generic "${vid}:${dvid}" "$cnum" ast ;;
 		1142) write_generic "${vid}:${dvid}" "$cnum" apm ;;
 		edd8) write_generic "${vid}:${dvid}" "$cnum" ark ;;
 		102c) write_generic "${vid}:${dvid}" "$cnum" chips ;;
-		105d) write_generic "${vid}:${dvid}" "$cnum" chips ;;
+		105d) write_generic "${vid}:${dvid}" "$cnum" i128 ;;
 		126f) write_generic "${vid}:${dvid}" "$cnum" siliconmotion ;;
 		1011) write_generic "${vid}:${dvid}" "$cnum" tga ;;
-		1023) write_generic "${vid}:${dvid}" "$cnum" trident ;;
 		1078) write_generic "${vid}:${dvid}" "$cnum" cyrix ;;
 		10a9) write_generic "${vid}:${dvid}" "$cnum" newport ;;
 		100b) write_generic "${vid}:${dvid}" "$cnum" nsc ;;
 		1163) write_generic "${vid}:${dvid}" "$cnum" rendition ;;
 		80ee) write_generic "${vid}:${dvid}" "$cnum" vboxvideo ;;
-		1115|104c) write_generic "${vid}:${dvid}" "$cnum" glint ;;		
-		15ad|fffe) write_generic "${vid}:${dvid}" "$cnum" vmware ;;
+		10e0) write_generic "${vid}:${dvid}" "$cnum" imstt ;;
+		104e) write_generic "${vid}:${dvid}" "$cnum" oak ;;
+		003d) write_generic "${vid}:${dvid}" "$cnum" i740 ;;
+		10b4) write_generic "${vid}:${dvid}" "$cnum" s3virge ;;
+		1023|1179) write_generic "${vid}:${dvid}" "$cnum" trident ;;
+		1115|104c|3d3d) write_generic "${vid}:${dvid}" "$cnum" glint ;;		
 		*) write_fallback "${vid}:${dvid}" "$cnum";;
 	esac
 


### PR DESCRIPTION
Xorg bus id in xorg.conf was full decimal instead of hexadecimal. PCI ID in hexadecimal will be converted to decimal counterpart