### PR TITLE
shutdownconfig - gtkdialog progressbar trigger x11 race condition

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -670,11 +670,16 @@ if [ $DISPLAY ];then
     </hbox>
     </vbox></window>"
     
-  eval "$(gtkdialog -p XY_DIALOG --center)"
-  case "$EXIT" in
-    abort) SAVECHOICE=255     ;;
-    *)     SAVECHOICE="$EXIT" ;;
-  esac
+  doagain=10
+  while [ $doagain -gt 0 ]
+  do
+   eval "$(gtkdialog -p XY_DIALOG --center)"
+   case "$EXIT" in
+     "")    doagain=$(( $doagain - 1 ))   ;; #progressbar crash
+     abort) SAVECHOICE=255; doagain=0     ;;
+     *)     SAVECHOICE="$EXIT"; doagain=0 ;;
+   esac
+  done
 
 else
   T_display="`eval_gettext \"Select \Zb\\\${T_save}\ZB (just press ENTER key) to be provided with the available save options, or select \Zb\\\${T_no}\ZB (TAB then ENTER) to exit without saving.\"`"


### PR DESCRIPTION
Testing with fossapup64 has shown that gtkdialog progressbar can trigger a known x11 race condition on some hardware.
https://gitlab.freedesktop.org/xorg/lib/libx11/-/merge_requests/34
The error is:
[xcb] Unknown sequence number while processing reply
[xcb] Most likely this is a multi-threaded client and XInitThreads has not been called
[xcb] Aborting, sorry about that.
gtkdialog: ../../src/xcb_io.c:641: _XReply: Assertion `!xcb_xlib_threads_sequence_lost' failed.

The error only occurs once on the first invocation in a session, but reappears if the desktop manager is restarted.
The error can be suppressed by setting maxcpus=1 as a kernel switch
The error goes away if xorgwizard is used to change the video driver from modesetting to nouveau.

The code changes are not a fix to the underlying problem but some defensive code to ignore the error when it is produced. In most hardware the error will not be seen.

progressbar is used in other places besides shutdownconfig and maybe the same code should be applied to all occurrences....but shutdownconfig is the most important