### PR TITLE
group: sync messagebus id with its id on passwd

### DIFF
--- a/woof-code/rootfs-skeleton/etc/group
+++ b/woof-code/rootfs-skeleton/etc/group
@@ -7,8 +7,7 @@ nobody:x:65534:
 guest:x:501:
 spot:x:502:spot
 bin::2:root,bin,daemon
-503:x:503:messagebus
-messagebus:x:504:messagebus
+messagebus:x:503:messagebus
 ftp:x:1000:
 dip:x:30:
 uucp::10:


### PR DESCRIPTION
Mismatch id of messagebus between passwd and group file can cause troubles on dbus activation and polkit