### PR TITLE
dbus_FIXUPHACK: Fix file permissions

### DIFF
--- a/woof-code/packages-templates/dbus_FIXUPHACK
+++ b/woof-code/packages-templates/dbus_FIXUPHACK
@@ -22,3 +22,7 @@ esac
 if [ -f etc/init.d/dbus ] ; then
 	sed -i '/set -e/d' etc/init.d/dbus
 fi
+
+find ./ -name "dbus-daemon-launch-helper" -type f -exec chown root:messagebus "{}" \;
+find ./ -name "dbus-daemon-launch-helper" -type f -exec chmod u+s "{}" \;
+find ./ -name "pkexec" -type f -exec chmod u+s "{}" \;


### PR DESCRIPTION
Add suid for dbus-daemon-launch-helper and pkexec 
dbus-daemon-launch-helper doesn't work properly if the group was not set to messagebus