### PR TITLE
Upgrade frisbee & pgprs: restore mobile log display, internationalize, refine code

### DIFF
--- a/woof-code/rootfs-packages/frisbee/etc/gprs.conf
+++ b/woof-code/rootfs-packages/frisbee/etc/gprs.conf
@@ -1,9 +1,5 @@
-# /etc/ppp/gprs.conf - constants for pgprs and frisbee (gprs)
+# /etc/gprs.conf - constants for pgprs and frisbee (gprs)
 # State data is retained in /root/.config/gprs.conf.
-
-# Lock file descriptor numbers controlling access by pgprs and frosbee:
-GPRS_SETUP_LOCK_FD=111
-GPRS_CONNECT_LOCK_FD=112
 
 # Access numbers:
 GPRS_ACCESS_NUMBERS='*99# #777 *99***1# *99***2# *99***3# *99***4#'

--- a/woof-code/rootfs-packages/frisbee/etc/init.d/frisbee.sh
+++ b/woof-code/rootfs-packages/frisbee/etc/init.d/frisbee.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091 # Skip sourced checks.
 ### BEGIN DEBIAN INIT INFO
 # Provides:          frisbee wpa_supplicant & dhcpcd up/down
 # Required-Start:    
@@ -18,10 +19,15 @@
 #160212 rcrsn51: Remove unnecessary 'stop' case because it impacts shutdown by disconnecting networks before samba terminates -- dhcpcd and wpa_supplicant are terminated as part of shutdown.
 #170612 verify wifi country of regulation matches user specified country.
 #180203 repeat iwconfig for slow-loading wifi modules (kernels 4+).
+#200829 v2.0 resolve shellcheck warnings; remove unused/ineffective code.
 
 grep -q '^frisbee_mode=1' /etc/frisbee/frisbee.conf || exit
 
-[ -d /usr/local/frisbee ] && . /usr/local/frisbee/func || . /usr/lib/frisbee/func
+if [ -d /usr/local/frisbee ]; then
+	. /usr/local/frisbee/connect-func
+else
+	. /usr/lib/frisbee/connect-func
+fi
 
 [ -f /etc/default/frisbee ] && . /etc/default/frisbee #140531
 
@@ -30,103 +36,94 @@ if [ -h /etc/resolv.conf ] ; then  #pppoe creates a symlink
 	touch /etc/resolv.conf
 fi
 
-start_wpa_supplicant() #140826...
-{
-	#Requires WIFI_IF, WIFACES
+start_wpa_supplicant() { #140826...
 	#20140118 npierce: ensure wpa inactive or association/authentication complete...
 	if grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf; then #140303
-		export INTERFACE=$WIFI_IF
-		WPAPAT="wpa_supplicant .*\-i *$WIFI_IF "
-		[ "$(busybox ps | grep "$WPAPAT" | grep -v ' grep ')" = "" ] \
-		 && start_wpa #in foreground
+	    export INTERFACE=$1
+	    if ! pgrep -a 'wpa_supplicant' | grep -qw "\-i$INTERFACE"; then
+	        start_wpa #in foreground
+	        sleep 1
+	    fi
 
-		COUNT=33
-		while [ $(( COUNT-- )) -gt 0 ];do
-			wpa_cli -i $INTERFACE status 2> /dev/null \
-			 | grep -qE 'wpa_state=COMPLETED|wpa_state=INACTIVE' && break
-			sleep 1
-		done
-		[ $COUNT -lt 0 ] \
-		 && echo "$0: wpa scan on $INTERFACE found no wireless networks" \
-		 && return 1
+	    COUNT=33
+	    until wpa_cli -i "$INTERFACE" status 2> /dev/null | \
+	      grep -qE 'wpa_state=COMPLETED|wpa_state=INACTIVE'; do
+	        [ $(( --COUNT )) -le 0 ] && break
+	        sleep 1
+	    done
+	    [ $COUNT -le 0 ] \
+	      && echo "$0: wpa scan on $INTERFACE found no wireless networks" \
+	      && return 1
 	fi
 	return 0 #20140118 end
 }
 
 case "$1" in
 	start|'')
-		[ -d /tmp/.frisbee ] || mkdir /tmp/.frisbee
-		
-		if grep -q '^announce_state_changes=1' /etc/frisbee/frisbee.conf; then
-			[ ! -f /etc/dhcpcd_state_notify ] && touch /etc/dhcpcd_state_notify
-		elif grep -q '^announce_state_changes=0' /etc/frisbee/frisbee.conf; then
-			[ -f /etc/dhcpcd_state_notify ] && rm -f /etc/dhcpcd_state_notify
-		fi
+	    [ -d /tmp/.frisbee ] || mkdir /tmp/.frisbee
+	    
+	    if grep -q '^announce_state_changes=1' /etc/frisbee/frisbee.conf; then
+	        [ ! -f /etc/dhcpcd_state_notify ] && touch /etc/dhcpcd_state_notify
+	    elif grep -q '^announce_state_changes=0' /etc/frisbee/frisbee.conf; then
+	        [ -f /etc/dhcpcd_state_notify ] && rm -f /etc/dhcpcd_state_notify
+	    fi
 
-		[ -x /usr/sbin/connectwizard_crd ] && connectwizard_crd >&2 #170612
+	    [ -x /usr/sbin/connectwizard_crd ] && connectwizard_crd >&2 #170612
 
-		WAITCNT=0; WAITMAX=10 #180203...
-		while true; do
-			WIFACES="$(get_ifs_wireless)" || [ $WAITCNT -ge $WAITMAX ] && break
-			sleep 1
-			WAITCNT=$(expr $WAITCNT + 1)
-		done
-		[ $WAITCNT -gt 0 ] && echo "frisbee.sh: waited for ethernet interfaces: seconds = ${WAITCNT}" >&2 #180203 end
+	    WAITCNT=0; WAITMAX=30 #180203...
+	    until WIFACES="$(get_ifs_wireless)" || [ $WAITCNT -ge $WAITMAX ]; do
+	        sleep 1
+	        (( WAITCNT++ ))
+	    done
+	    [ "$WAITCNT" -gt 0 ] \
+	      && echo "frisbee.sh: waited for ethernet interfaces: seconds = ${WAITCNT}" >&2 #180203 end
 
-#		WIFACES="$(get_ifs_wireless)" #140824...
-		if [ "$WIFACES" ];then
-			[ -d /tmp/.network_tray ] \
-			 && touch /tmp/.network_tray/use_wireless_control_menu_labels \
-			 || touch /tmp/.network_tray-use_wireless_control_menu_labels
-		else
-			[ -d /tmp/.network_tray ] \
-			 && rm -f /tmp/.network_tray/use_wireless_control_menu_labels \
-			 || rm -f /tmp/.network_tray-use_wireless_control_menu_labels
-		fi #140224 end
+	    if [ "$WIFACES" ];then #140824...
+	        if [ -d /tmp/.network_tray ]; then
+	            touch /tmp/.network_tray/use_wireless_control_menu_labels
+	        else
+	            touch /tmp/.network_tray-use_wireless_control_menu_labels
+	        fi
+	    else
+	        if [ -d /tmp/.network_tray ]; then
+	            rm -f /tmp/.network_tray/use_wireless_control_menu_labels
+	        else
+	            rm -f /tmp/.network_tray-use_wireless_control_menu_labels
+	        fi
+	    fi #140224 end
 
-		USERIF=$(cat /etc/frisbee/userif 2>/dev/null) #140824...
+	    USERIF=$(cat /etc/frisbee/userif 2>/dev/null) #140824...
 
-		WIFI_IF=""
-		if [ "$USERIF" ] && echo -n "$WIFACES" | grep -q -w "$USERIF"; then
-			WIFI_IF="$USERIF"
-			echo -n "$WIFI_IF" > /etc/frisbee/interface #140303
-			rm -f /etc/frisbee/userif
-		else
-			WIFI_IF="$(cat /etc/frisbee/interface 2>/dev/null)"
-			if [ -z "$WIFI_IF" ] \
-			 || [ "$(echo -n "$WIFACES" | grep -q -w "$WIFI_IF")" = "" ]; then
-				WIFI_IF="$(echo -n "$WIFACES" | head  -n 1)" #140303
-				echo -n "$WIFI_IF" > /etc/frisbee/interface #140303
-			fi
-		fi
+	    WIFI_IF=""
+	    if [ "$USERIF" ] && echo -n "$WIFACES" | grep -q -w "$USERIF"; then
+	        WIFI_IF="$USERIF"
+	        echo -n "$WIFI_IF" > /etc/frisbee/interface #140303
+	        rm -f /etc/frisbee/userif
+	    else
+	        WIFI_IF="$(cat /etc/frisbee/interface 2>/dev/null)"
+	        if [ -z "$WIFI_IF" ] \
+	          || [ "$(echo -n "$WIFACES" | grep -q -w "$WIFI_IF")" = "" ]; then
+	            WIFI_IF="$(echo -n "$WIFACES" | head  -n 1)" #140303
+	            echo -n "$WIFI_IF" > /etc/frisbee/interface #140303
+	        fi
+	    fi
 
-		if [ "$WIFI_IF" ];then #140824 end
-
-			INTMODULE=$(readlink /sys/class/net/$WIFI_IF/device/driver/module)
-			INTMODULE=${INTMODULE##*/}
-			case "$INTMODULE" in
-				hostap*) DRIVER="hostap" ;;
-				rt61|rt73) DRIVER="ralink" ;;
-				*) DRIVER="wext" ;;
-			esac
-			[ -d /etc/acpi ] && echo "$INTMODULE" > /etc/acpi/wifi-driver
-
-			[ "$WIFACES" ] && start_wpa_supplicant #140826
-
-		fi
-		start_dhcp&
-		;;
+	    [ -n "$WIFI_IF" ] && [ -n "$WIFACES" ] \
+	      && start_wpa_supplicant "$WIFI_IF" #140824 end, 140826
+	    start_dhcp&
+	    ;;
 
 #160212...
-#		stop)
-#		wpa_cli terminate 2>/dev/null
-#		dhcpcd -k 150410
-#		;;
+#       stop)
+#       wpa_cli terminate 2>/dev/null
+#       dhcpcd -k 150410
+#       ;;
 
 	restart)
-		WIFI_IF=`cat /etc/frisbee/interface 2>/dev/null` #140826...
-		WIFACES="$(get_ifs_wireless)"
-		[ "$WIFI_IF" -a "$WIFACES" ] && start_wpa_supplicant
-		reset_dhcp
-		;;
+	    WIFI_IF=$(cat /etc/frisbee/interface 2>/dev/null) #140826...
+	    WIFACES="$(get_ifs_wireless)"
+	    [ -n "$WIFI_IF" ] && [ -n "$WIFACES" ] \
+	      && start_wpa_supplicant "$WIFI_IF"
+	    reset_dhcp
+	    ;;
 esac

--- a/woof-code/rootfs-packages/frisbee/etc/ppp/chatscripts/gprs-connect-chat
+++ b/woof-code/rootfs-packages/frisbee/etc/ppp/chatscripts/gprs-connect-chat
@@ -48,7 +48,7 @@
 	ABORT		'\nERROR\r'
 	''			\rAT
 	TIMEOUT		12
-	SAY			"\ndefining PDP context...\n"
+	SAY			"\nDefining PDP context...\n"
 	OK			@/etc/ppp/chatscripts/gprs-cpin_command
 	OK			@/etc/ppp/chatscripts/gprs-cgdcont_command
 #	OK			AT+CGQREQ=1,0,0,0,0,0
@@ -56,9 +56,9 @@
 	OK			ATH
 	OK			ATE1
 	OK			AT+CSQ
-	+CSQ       	ATDT\T
+	+CSQ		ATD\T
 	TIMEOUT		22
-	SAY			"\nwaiting for connect...\n"
+	SAY			"\nWaiting for connect...\n"
 	CONNECT		""
 	SAY			"\nConnected."
 	SAY			"\nIf the following ppp negotiations fail,\n"

--- a/woof-code/rootfs-packages/frisbee/pet.specs
+++ b/woof-code/rootfs-packages/frisbee/pet.specs
@@ -1,1 +1,1 @@
-frisbee-1.4.9|frisbee|1.4.9||Network|264K||frisbee-1.4.9.pet|+gtkdialog&ge0.8.4|Frisbee network manager||||
+frisbee-2.0|frisbee|2.0||Network|276K||frisbee-2.0.pet|+gtkdialog&ge0.8.4|Frisbee network manager||||

--- a/woof-code/rootfs-packages/frisbee/pinstall.sh
+++ b/woof-code/rootfs-packages/frisbee/pinstall.sh
@@ -80,7 +80,7 @@ if [ "$(pwd)" = "/" ];then
  fi
 
  # Allow installer to make frisbee the default network manager.
- if Xdialog  --title "Frisbee" --default-no --timeout 60 --ok-label "Yes, set as default" --cancel-label "No" --left --yesno "$(gettext "Frisbee is installed as one of the Connect Wizard network manager options.")\n\n$(gettext "Do you want frisbee to be the default network manager at the next boot-up or\nat the initial boot of a distro package?")" 0 0;then
+ if Xdialog  --title "$(gettext 'Frisbee')" --default-no --timeout 60 --ok-label "$(gettext 'Yes, set as default')" --cancel-label "$(gettext 'No')" --left --wrap --yesno "$(gettext 'Frisbee is installed as one of the Connect Wizard network manager options.')\n\n$(gettext 'Do you want frisbee to be the default network manager?')" 0 60;then
   echo -e '#!/bin/sh\nexec frisbee' > usr/local/bin/defaultconnect
   sed -i -e '/^frisbee_mode=/ s/=.*/=1/' \
   -e '/^wireless_enabled=/ s/=.*/=1/' \
@@ -112,13 +112,15 @@ if [ "$(pwd)" = "/" ];then
    root/.packages/frisbee-1.*.files
  fi
 
+#Remove old gprs.conf, to use new one. 200607
+rm -f etc/ppp/gprs.conf
+
  #Remove old gprs.conf, to generate new one.
- rm -f etc/gprs.conf
- rm -f root/.config/gprs.conf
+rm -f root/.config/gprs.conf
 
  #Remove replaced options file, if not used by pgprs.
  [ -f usr/sbin/pgprs ] && rm -f etc/ppp/options.gprs
 fi
 
-#Replace placeholder with /usr/local/bin link to moved script.
+#v2.0 Replace placeholder with /usr/local/bin link to moved script.
 ln -snf /usr/local/frisbee/frisbee usr/local/bin/

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/connect-func
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/connect-func
@@ -1,0 +1,117 @@
+#!/bin/bash
+# shellcheck disable=SC1091,SC2005,SC2162 # Skip sourced checks; useless echos add newline; allow read without -r.
+#Shebang above triggers geany color highlighting.
+#200829 (v2.0) Moved functions from func; resolve shellcheck warnings.
+
+function connect {
+	prof=$(wpa_cli -i "$INTERFACE" list_networks|tail -n 1|cut -d " " -f 1)
+	if [[ $prof == "network" ]] ; then
+	    return 1
+	fi
+	if wpa_cli -i "$INTERFACE" status|grep -q COMPLETED ; then
+	    #dhcpcd -n 
+	    dhcpcd -n "$INTERFACE" #180210
+	    return 0
+	fi
+	ip link set "$INTERFACE" up #200829
+	if ! ps -C wpa_supplicant >/dev/null; then #200829
+	    start_wpa
+	fi
+	if ! pgrep -x dhcpcd >/dev/null; then #200829
+	    start_dhcp
+	else #180210
+	    dhcpcd -n "$INTERFACE" #180210
+	fi
+	wpa_cli -i "$INTERFACE" reconnect 
+	#dhcpcd -n 
+	
+	sleep 2
+	return 0
+}
+export -f connect
+
+#############################################
+
+
+function disconnect {
+	[ "$INTERFACE" = "none" ] && return
+	wpa_cli -i "$INTERFACE" disconnect 2>/dev/null
+	sleep 1 
+	wpa_cli -i "$INTERFACE" disconnect 2>/dev/null
+	pgrep -x wait_disconnect >/dev/null && killall wait_disconnect #140607 200829
+	dhcpcd -k "$INTERFACE"
+}
+export -f disconnect
+
+#############################################
+
+function wait_disconnect {
+# shellcheck disable=SC2034 # parameter intentionally not used.
+	for i in 1 2 3 ; do
+	    sleep 10
+	    wpa_cli -i "$INTERFACE" status | grep DISCONNECTED && return #140607
+	done
+
+	dhcpcd -k "$INTERFACE" 
+}
+export -f wait_disconnect
+
+#############################################
+
+function get_ifs_wireless { #140819...
+	#returns true/0 if interfaces present
+	WIFACES=$(iw dev 2>&1 | grep -o 'Interface [^ ]*' | cut -f 2 -d ' ')
+	echo "$WIFACES"
+	[ "$WIFACES" ]
+	return $?
+}
+export -f get_ifs_wireless
+
+#############################################
+
+function start_wpa {
+	rfkill unblock wlan 2>/dev/null #140221
+	ip link set "$INTERFACE" up #200829
+	if grep -q '^wireless_autostart=1' /etc/frisbee/frisbee.conf ; then
+	    WPACFGFILE="/etc/frisbee/wpa_supplicant.conf"
+	    rm -f /tmp/wpa_supplicant.conf
+	else
+	    WPACFGFILE="/tmp/wpa_supplicant.conf"
+	    [ -f $WPACFGFILE ] \
+	      || sed -e '/^network=/,/}/d' /etc/frisbee/wpa_supplicant.conf > $WPACFGFILE
+	fi
+	if grep -q '^wpa_log_mode=1' /etc/frisbee/frisbee.conf ; then
+	    setsid wpa_supplicant -B -d -Dnl80211,wext -i"$INTERFACE" -c"$WPACFGFILE" > /tmp/wpa_supplicant.log #200829
+	else
+	    setsid wpa_supplicant -B -Dnl80211,wext -i"$INTERFACE" -c"$WPACFGFILE" > /tmp/wpa_supplicant.log #200829
+	fi
+	wpa_cli -i "$INTERFACE" scan >/dev/null
+}
+export -f start_wpa
+
+#############################################
+
+function start_dhcp {
+	ZOPTION="" #140824...
+	WIFI_IF="$(cat /etc/frisbee/interface 2> /dev/null)"
+	if [ "$WIFI_IF" ];then
+	    OTHERWIFI="$(get_ifs_wireless | grep -vw "$WIFI_IF" | tr '\n' , | sed 's/,$//')"
+	    [ "$OTHERWIFI" ] && ZOPTION="-Z $OTHERWIFI"
+	fi
+# shellcheck disable=SC2086 # ZOPTION may be null; quotes result in '' inserted.
+	setsid dhcpcd -b -d $ZOPTION -f /etc/frisbee/dhcpcd.conf #140824 end
+	sleep 2
+}
+export -f start_dhcp
+
+#############################################
+
+function reset_dhcp {
+	dhcpcd -k
+	killall -9 dhcpcd
+	killall wpa_cli 2>/dev/null
+	start_dhcp
+}
+export -f reset_dhcp
+
+#############################################

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee
@@ -1,142 +1,140 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=SC1091 # Skip sourced checks.
 # frisbee - [--setup], --deactivate, --connect, --disconnect, --test_active, --help
 # Exit state is false if (1) not in frisbee mode or (2) no wireless interface
 #160201 New common frisbee interface -- old script renamed to frisbee-main, moved to frisbee directory.
 #170412 1.4.3 Stop network connections other than by this script; add mode-disable logic unrelated to frisbee.
-#set -x; exec &>/tmp/debug.log #send feedback and trace to debug.log
+#200829 2.0 Upgrade frisbee-gprs-connect;  remove lock usage for conflict detection; use ps-FULL; move etc gprs.conf; connect/disconnect gprs if wifi/ethernet i/f unavailable; resolve shellcheck warnings; add --activate option.
 
-export VERSION='1.4.9'  #UPDATE this with each release!
+export VERSION='2.0'  #UPDATE this with each release!
 
 export TEXTDOMAIN=frisbee
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
-[ -d /usr/lib/frisbee ] \
- && export FRISBEEFUNCDIR="/usr/lib/frisbee" \
- || export FRISBEEFUNCDIR="/usr/local/frisbee" #accomodate debian dogs
+if [ -d /usr/lib/frisbee ];then
+	export FRISBEEFUNCDIR="/usr/lib/frisbee"
+else
+	export FRISBEEFUNCDIR="/usr/local/frisbee" #accomodate debian dogs
+fi
 
 [ -f /root/.config/gprs.conf ] \
- || echo -e "GPRSDEV=\nGPRSAPN=\nGPRSNBR=\nGPRSPIN=\nGPRSUSER=\nGPRSPAPONLY=" > /root/.config/gprs.conf
+  || echo -e "GPRSDEV=\nGPRSAPN=\nGPRSNBR=\nGPRSPIN=\nGPRSUSER=\nGPRSPAPONLY=" > /root/.config/gprs.conf
 . /root/.config/gprs.conf
-mkdir -p /var/lock/gprs
-ICONLIB=/usr/local/lib/X11/pixmaps
-
-#Lock management - for unblocked locking only.
-eval $(grep '^GPRS_SETUP_LOCK_FD=' /etc/ppp/gprs.conf)
-[ "$GPRS_SETUP_LOCK_FD" ] || exit 1 
-eval exec "$GPRS_SETUP_LOCK_FD>/var/lock/gprs/setup"
-eval $(grep '^GPRS_CONNECT_LOCK_FD=' /etc/ppp/gprs.conf)
-[ "$GPRS_CONNECT_LOCK_FD" ] || exit 1 
-eval exec "$GPRS_CONNECT_LOCK_FD>/var/lock/gprs/connect"
+export ICONLIB=/usr/local/lib/X11/pixmaps
 
 fix_config_file() {
 	grep -q '^pppoe_' /etc/frisbee/frisbee.conf \
-	 || echo -e "pppoe_select=0\npppoe_paponly=0" >> /etc/frisbee/frisbee.conf
+	  || echo -e "pppoe_select=0\npppoe_paponly=0" >> /etc/frisbee/frisbee.conf
 	grep -q '^terminal' /etc/frisbee/frisbee.conf \
-	 || echo -e "terminal=rxvt" >> /etc/frisbee/frisbee.conf #140607
+	  || echo -e "terminal=rxvt" >> /etc/frisbee/frisbee.conf #140607
 	grep -q '^editor' /etc/frisbee/frisbee.conf \
-	 || echo -e "editor=defaulttexteditor" >> /etc/frisbee/frisbee.conf #140607
+	  || echo -e "editor=defaulttexteditor" >> /etc/frisbee/frisbee.conf #140607
+}
+
+function interface_is_available { #200829...
+	local IF
+	IF="$(cat /etc/frisbee/interface 2>/dev/null)"
+	if [ -n "$IF" ] \
+	  && ip link show "$IF" >/dev/null 2>&1 \
+	  && ! grep '^denyinterfaces' /etc/frisbee/dhcpcd.conf | grep -qw "$IF"; then
+	    if iw dev 2>&1 | grep -o 'Interface [^ ]*' | cut -f 2 -d ' ' | grep -qw "$IF"; then
+	        grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf && return 0
+	    else
+	        return 0
+	    fi
+	fi
+	return 1
 }
 
 # Determine option, Interpreting legacy interface calls via links.
-case $(basename $0) in
- frisbee) OPTION="$1"; OPTION="${OPTION:=--setup}" ;;
- connect) OPTION="--connect" ;;
- disconnect) OPTION="--disconnect" ;;
- frisbee_mode_disable) OPTION="--deactivate" ;;
+case $(basename "$0") in
+	frisbee) OPTION="$1"; OPTION="${OPTION:=--setup}" ;;
+	connect) OPTION="--connect" ;;
+	disconnect) OPTION="--disconnect" ;;
+	frisbee_mode_disable) OPTION="--deactivate" ;;
 esac
 
 while [ "$OPTION" ]; do
 	OPT=$OPTION; OPTION=''
 	case $OPT in
 	  --setup)
-		if flock --exclusive --nonblock $GPRS_SETUP_LOCK_FD; then
-			[ -x /usr/sbin/connectwizard_exec ] \
-			 && connectwizard_exec frisbee #170412
-			[ $(wc -l </etc/frisbee/frisbee.conf) -lt 10 ] && fix_config_file
-			/usr/local/frisbee/frisbee-main
-			flock --unlock $GPRS_SETUP_LOCK_FD
-		else
-			if [ -n "$(busybox pidof frisbee-main)" ]; then
-				Xdialog --center --wmclass "frisbee" --title "Frisbee" --icon $ICONLIB/error.xpm --msgbox "\n$(gettext 'Frisbee cannot start now because it is already active.')\n$(gettext 'Please use the active Frisbee session.')\n" 0 70
-			elif [ -n "$(busybox pidof pgprs-setup)" ]; then
-				Xdialog --center --wmclass "frisbee" --title "Frisbee" --icon $ICONLIB/error.xpm --ok-label "OK" --cancel-label $(gettext 'Retry') --yesno "\n$(gettext 'Frisbee cannot start now because the PGPRS wireless modem controller is active.')\n$(gettext 'If you terminate PGPRS, you can Retry Frisbee.')\n" 0 70
-				[ $? -eq 1 ] && OPTION='--setup'
-			else #stale lock - delete, recreate and retry
-				rm -f /var/lock/gprs/setup
-				eval exec "$GPRS_SETUP_LOCK_FD>/var/lock/gprs/setup"
-				logger "frisbee: $(gettext 'Stale "setup" lock detected and replaced')"
-				OPTION='--setup'
-			fi
-		fi
-		;;
+	    if pgrep -x frisbee | grep -qwv "$$"; then #200829
+	        if ps -C frisbee-main >/dev/null 2>&1; then #200829
+	            Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee')" --icon $ICONLIB/error.xpm --msgbox "\n$(gettext 'Frisbee cannot start now because it is already active.')\n$(gettext 'Please use the active Frisbee session.')\n" 0 70
+	        elif ps -C frisbee-gprs-connect >/dev/null; then
+	            Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee')" --icon $ICONLIB/error.xpm --msgbox "\n$(gettext 'Frisbee cannot start now because its connection window is active.')\n$(gettext 'Please use the active Frisbee connection window.')\n" 0 70
+	        fi
+	    else
+	        [ -x /usr/sbin/connectwizard_exec ] \
+	          && connectwizard_exec frisbee #170412
+	        [ "$(wc -l </etc/frisbee/frisbee.conf)" -lt 10 ] && fix_config_file
+	        /usr/local/frisbee/frisbee-main
+	    fi
+	    ;;
+	  --activate) #200829...
+	    /usr/local/frisbee/frisbee-mode-enable
+	    ;;
 	  --deactivate)
-		/usr/local/frisbee/frisbee-mode-disable
-		if grep -q '^dhcpcd_state_notify=1' /etc/frisbee/frisbee.conf;then #170412...
-			[ -f /etc/dhcpcd_state_notify ] || touch /etc/dhcpcd_state_notify
-		else
-			rm -f /etc/dhcpcd_state_notify
-		fi
-		if [ -d /tmp/.network_tray ];then
-			rm -f /tmp/.network_tray/use_wireless_control_menu_labels
-		else
-			rm -f /tmp/.network_tray-use_wireless_control_menu_labels #140209
-		fi #170412 end
-		;;
+	    /usr/local/frisbee/frisbee-mode-disable
+	    if grep -q '^dhcpcd_state_notify=1' /etc/frisbee/frisbee.conf; then #170412...
+	        [ -f /etc/dhcpcd_state_notify ] || touch /etc/dhcpcd_state_notify
+	    else
+	        rm -f /etc/dhcpcd_state_notify
+	    fi
+	    if [ -d /tmp/.network_tray ];then
+	        rm -f /tmp/.network_tray/use_wireless_control_menu_labels
+	    else
+	        rm -f /tmp/.network_tray-use_wireless_control_menu_labels #140209
+	    fi #170412 end
+	    ;;
 	  --connect)
-		if [ -s /etc/frisbee/interface ];then
-			/usr/local/frisbee/frisbee-wifi-connect
-		fi
-		;;
+	    if grep -qs '^frisbee_mode=1' /etc/frisbee/frisbee.conf; then #200829...
+	        if interface_is_available; then 
+	            /usr/local/frisbee/frisbee-wifi-connect
+	        else
+	            echo -n "$GPRSDEV" | grep  -qv '^--' && OPTION="--connect-gprs"
+	        fi
+	    fi
+	    ;;
 	  --disconnect)
-		if [ -s /etc/frisbee/interface ];then
-			if grep -qs '^frisbee_mode=1' /etc/frisbee/frisbee.conf;then #170412
-				/usr/local/frisbee/frisbee-wifi-disconnect
-			fi #170412
-		fi
-		;;
+	    if grep -qs '^frisbee_mode=1' /etc/frisbee/frisbee.conf;then #170412
+	        if interface_is_available; then #200829...
+	            /usr/local/frisbee/frisbee-wifi-disconnect
+	        else
+	            echo -n "$GPRSDEV" | grep  -qv '^--' && OPTION="--disconnect-gprs"
+	        fi
+	    fi #170412
+	    ;;
 	  --connect-gprs)
-		if [ "${GPRSDEV:0:4}" != "/dev" ]; then
-			Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(gettext 'Cannot connect - No modem interface (/dev/...) specified.')" 0 0
-		elif [ -z "$GPRSAPN" ];then
-			Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(gettext 'Cannot connect - No Access Point Name (APN) specified.')" 0 0
-		elif [ -z "$GPRSNBR" ];then
-			Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(gettext 'Cannot connect - No Access Number specified.')" 0 0
-		elif [ -f /var/run/ppp-gprs.pid ];then
-			ACTIVEDEV="$(busybox ps | grep "^ *$(cat /var/run/ppp-gprs.pid)" | grep 'pppd' | grep -v 'grep' | grep -o '/dev/[a-z][^ ]*')"
-			if [ "$ACTIVEDEV" ];then
-				Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(eval_gettext "Cannot connect with mobile device \\\$GPRSDEV.")\n$(eval_gettext "Mobile device \$ACTIVEDEV is currently connected.")" 0 0
-			fi
-		elif flock --exclusive --nonblock $GPRS_CONNECT_LOCK_FD; then
-			/usr/local/frisbee/frisbee-gprs-connect
-			flock --unlock $GPRS_CONNECT_LOCK_FD
-		else #connection active
-			if [ -n "$(busybox pidof pgprs-connect)" -o -n "$(busybox pidof frisbee-gprs-connect)" ]; then
-				Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connect')" --icon $ICONLIB/info.xpm --msgbox "\n$(eval_gettext "Modem device '\$GPRSDEV' connection window is active.")\n\n$(gettext 'Please go to the active GPRS Connection Log window.')\n" 0 70
-			else #stale lock - delete, recreate and retry
-				rm -f /var/lock/gprs/connect
-				eval exec "$GPRS_CONNECT_LOCK_FD>/var/lock/gprs/connect"
-				logger "frisbee: $(gettext 'Stale "connect" lock detected and replaced')"
-				OPTION='--connect'
-			fi
-		fi
-		;;
+	    if [ "${GPRSDEV:0:4}" != "/dev" ];then
+	        Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(gettext 'Cannot connect - No modem interface (/dev/...) specified.')" 0 0
+	    elif [ -z "$GPRSAPN" ];then
+	        Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(gettext 'Cannot connect - No Access Point Name (APN) specified.')" 0 0
+	    elif [ -z "$GPRSNBR" ];then
+	        Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "$(gettext 'Cannot connect - No Access Number specified.')" 0 0
+	    elif ps -C frisbee-gprs-connect >/dev/null; then #200829
+	        Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS Connect')" --icon $ICONLIB/info.xpm --msgbox "\n$(eval_gettext "Modem device '\$GPRSDEV' connection window is active.")\n\n$(gettext 'Please go to the active GPRS Connection Log window.')\n" 0 70
+	    else
+	        /usr/local/frisbee/frisbee-gprs-connect
+	    fi
+	    ;;
 	  --disconnect-gprs)
-		if [ -s /var/run/ppp-gprs.pid ];then
-			/usr/local/frisbee/frisbee-gprs-disconnect
-		else
-			Xdialog --center --wmclass "frisbee"  --title "Frisbee GPRS"  --msgbox "GPRS connection inactive." 0 0
-		fi
-		;;
+	    if [ -s /var/run/ppp-gprs.pid ];then
+	        /usr/local/frisbee/frisbee-gprs-disconnect
+	    else
+	        Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS')"  --msgbox "GPRS connection inactive." 0 0
+	    fi
+	    ;;
 	  --test_active) # Return current state of frisbee mode (=true).
-		grep -qs '^frisbee_mode=1' /etc/frisbee/frisbee.conf
-		exit #exit status = result of grep
-		;;
+	    grep -qs '^frisbee_mode=1' /etc/frisbee/frisbee.conf
+	    exit #exit status = result of grep
+	    ;;
 	  --version)
-		echo "$VERSION"
-		;;
+	    echo "$VERSION"
+	    ;;
 	  *)
-		echo "$(gettext 'Usage: frisbee [option]')
+	    echo "$(gettext 'Usage: frisbee [option]')
 
 $(gettext 'Manage ethernet and wireless (wifi, GPRS/3G) network connections')
 
@@ -151,7 +149,7 @@ $(gettext 'Options'):
  --version         $(gettext 'Display frisbee version')
  --help            $(gettext 'Display this text')
  "
-		;;
+	    ;;
 	esac
 done
 exit 0

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-gprs-connect
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-gprs-connect
@@ -1,91 +1,127 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=SC1091 # Skip sourced checks.
+#200829 (v2.0) Correct display of connect log to work around Xdialog regression; correct not-connected logic; make pppd detach after connection; specify busybox microcom because full version interprets -t as "work in telnet mode" instead of timeout; add version to window title; replace pidof with pgrep; resolve shellcheck warnings; reactivate after networkdisconnect.
 
 export TEXTDOMAIN=frisbee
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
-function connect_func () {
+CONNECTLOG=/tmp/.gprs_connect.log #200829
+
+function connect_func {
 	export TEXTDOMAIN=frisbee
 	export OUTPUT_CHARSET=UTF-8
 	. gettext.sh
-	ps aux | grep -q 'wvdial isp[12]' \
-	 || rm -f /tmp/.network_tray-use_analog_dialup_icons 2>/dev/null #130505
-	echo -e "$(eval_gettext "Attempting connection through \$GPRSDEV to APN \$GPRSAPN...\n")" #130812
-	if [ ! -x /usr/sbin/resolvconf ];then #160116...
-	 if [ -x /usr/sbin/networkdisconnect ];then #but not ppp interface.
-	  /usr/sbin/networkdisconnect
-	 else 
-	  [ -n "$(busybox pidof wpa_supplicant)" ] \
-	   && wpa_cli terminate #kills any running wpa_supplicant
-	  dhcpcd -k
-	 fi
+	pgrep -f 'wvdial isp[12]' >/dev/null \
+	  || rm -f /tmp/.network_tray-use_analog_dialup_icons 2>/dev/null #130505
+	echo -e "$(eval_gettext "Attempting connection through \$GPRSDEV to APN \$GPRSAPN...")\n" >> $CONNECTLOG #130812 200829
+	if [ ! -x /usr/sbin/resolvconf ]; then #160116...
+	    if [ -x /usr/sbin/networkdisconnect ]; then #but not ppp interface.
+	        /usr/sbin/networkdisconnect
+	    else 
+	        ps -C wpa_supplicant >/dev/null \
+	          && wpa_cli terminate #kills any running wpa_supplicant #200829
+	        dhcpcd -k
+	    fi
+	    frisbee --activate #200829
 	fi
 	[ -e /dev/ppp ] || mknod /dev/ppp c 108 0
 	# Start PPP daemon...
 	# For sanity, keep a lock on the serial line (lock).
 	logger "frisbee: $(eval_gettext "Starting PPP daemon for \$GPRSDEV")"
-	/usr/sbin/pppd $GPRSDEV \
-	 call gprs-generated \
-	 connect "chat -v -T $GPRSNBR -f /etc/ppp/chatscripts/gprs-connect-chat" \
-	 disconnect "chat -v -s -S -f /etc/ppp/chatscripts/gprs-disconnect-chat" \
-	 linkname gprs \
-	 nodetach \
-	 lock
+	/usr/sbin/pppd "$GPRSDEV" \
+	  call gprs-generated \
+	  connect "chat -v -T $GPRSNBR -f /etc/ppp/chatscripts/gprs-connect-chat" \
+	  disconnect "chat -v -s -S -f /etc/ppp/chatscripts/gprs-disconnect-chat" \
+	  linkname gprs \
+	  updetach \
+	  lock \
+	  >> $CONNECTLOG 2>&1 #200829
 	local STATUS=$?
-	echo "$(eval_gettext "Exit status is \$STATUS")" #130812
-	echo "$(gettext 'DISCONNECTED')"
+# shellcheck disable=SC2005 # echo needed for newline.
+	echo "$(eval_gettext "Exit status is \$STATUS")" >> $CONNECTLOG #130812 200829
 	logger "frisbee: $(eval_gettext "pppd exit status for \$GPRSDEV is \$STATUS")"
+	if [ -s /var/run/ppp-gprs.pid ]; then #200829...
+# shellcheck disable=SC2005 # echo needed for newline.
+	    echo "$(gettext 'CONNECTED')" >> $CONNECTLOG
+	else
+# shellcheck disable=SC2005 # echo needed for newline.
+	    echo "$(gettext 'NOT CONNECTED')" >> $CONNECTLOG
+	fi
+	sleep 2 #Let connection_dialog_func show the entire log before stopping the feed.
+	TAILPID="$(pgrep -f "tail -f $CONNECTLOG")"
+	[ -n "$TAILPID" ] && kill "$TAILPID"
 	exit $STATUS
 }
 export -f connect_func
 
-function connection_dialog_func () {
-	local DISCSTOP="$(gettext 'DISCONNECT')"
-	Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connection Log')" --backtitle "$(eval_gettext "NOTICE: If log shows a failure to connect, click '\$DISCSTOP' to exit.")" --ok-label "$DISCSTOP or stop trying" --cancel-label "$(gettext 'CLOSE window but stay online')" --fixed-font --tailbox /tmp/.gprs_connect.log 25 82
-	local STATUS=$?
-	if [ $STATUS -eq 0 -a -s /var/run/ppp-gprs.pid ];then
-		frisbee-gprs-disconnect
+function connection_dialog_func {
+	local READLOG='cat' #200829...
+	local TAIL_PATH
+	TAIL_PATH="$(which tail)"
+	if [ -n "$CONNECT_PID" ] && [ -n "$TAIL_PATH" ]; then
+	    if [ -L "$TAIL_PATH" ]; then #busybox tail, cannot follow (-f)
+	        gtkdialog-splash -timeout 10 -placement center -bg orange -text "$(eval_gettext "Attempting connection to APN \$GPRSAPN.")  $(gettext 'Please wait.')" &
+	        sleep 10
+	    else
+	        READLOG="tail -f"
+	    fi
+	fi
+	$READLOG $CONNECTLOG | \
+	  Xdialog --center --wmclass frisbee --title "$(eval_gettext "Frisbee \$VERSION - GPRS Connection Log")" --backtitle "$(gettext 'NOTICE: If log shows a failure to connect, click DISCONNECT to exit.')" --ok-label "$(gettext 'DISCONNECT or stop trying')" --cancel-label "$(gettext 'CLOSE window but stay online')" --logbox - 25 82
+	local STATUS=$? #0 = disconnect/stop, 1 = close but stay connected, 255 = abort
+	if [ $STATUS -eq 0 ] && [ -s /var/run/ppp-gprs.pid ]; then #200829 end
+	    frisbee-gprs-disconnect
 	fi
 	return $STATUS
 }
 
 . /root/.config/gprs.conf
 
-if [ -s /var/run/ppp-gprs.pid ];then
+if [ -s /var/run/ppp-gprs.pid ]; then
+	GPRS_PPPD_PID="$(grep -ow '[0-9]*' /var/run/ppp-gprs.pid)" #200829...
+	#Kill connection if not for current device.
+	if pgrep -ax 'pppd' | grep -w "^$GPRS_PPPD_PID" | grep -qv "$GPRSDEV"; then
+	    kill "$GPRS_PPPD_PID"
+	    rm -f /var/run/ppp-gprs.pid
+	fi
+	CONNECT_PID='' #200829
 	connection_dialog_func
-	exit $? #0 = disonnect/stop, 1 = close but stay connected, 255 = abort
+	exit $? #0 = disconnect/stop, 1 = close but stay connected, 255 = abort
 else
 	echo "#Generated by frisbee-gprs-connect" > /etc/ppp/peers/gprs-generated
 	echo "call gprs-editable" >> /etc/ppp/peers/gprs-generated
-	if [ "$GPRSUSER" ];then
-		echo -e "auth\nuser $GPRSUSER" >> /etc/ppp/peers/gprs-generated
-		[ "$GPRSPAPONLY" = "true" ] \
-		 && echo "require-pap" >> /etc/ppp/peers/gprs-generated
+	if [ "$GPRSUSER" ]; then
+	    echo -e "auth\nuser $GPRSUSER" >> /etc/ppp/peers/gprs-generated
+	    [ "$GPRSPAPONLY" = "true" ] \
+	     && echo "require-pap" >> /etc/ppp/peers/gprs-generated
 	else
-		echo "noauth" >> /etc/ppp/peers/gprs-generated
+	    echo "noauth" >> /etc/ppp/peers/gprs-generated
 	fi
 
 	[ "$GPRSPIN" ] \
-	 && SAVEVAL="AT+CPIN=\"$GPRSPIN\"" \
-	 || SAVEVAL="AT"
-	[ "$SAVEVAL" != "$(cat /etc/ppp/chatscripts/gprs-cpin_command 2>/dev/null | grep -v ^\')" ] \
-	 && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cpin_command
+	  && SAVEVAL="AT+CPIN=\"$GPRSPIN\"" \
+	  || SAVEVAL="AT"
+	[ "$SAVEVAL" != "$(grep -v "^'" /etc/ppp/chatscripts/gprs-cpin_command 2>/dev/null)" ] \
+	  && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cpin_command
 	SAVEVAL="AT+CGDCONT=1,\"IP\",\"$GPRSAPN\""
-	[ "$SAVEVAL" != "$(cat /etc/ppp/chatscripts/gprs-cgdcont_command 2>/dev/null | grep -v ^\')" ] \
-	 && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cgdcont_command
+	[ "$SAVEVAL" != "$(grep -v "^'" /etc/ppp/chatscripts/gprs-cgdcont_command 2>/dev/null)" ] \
+	  && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cgdcont_command
 
-	if [ -c $GPRSDEV ] \
-	 && echo ATZ | microcom -t 200 $GPRSDEV 2>/dev/null | grep -q 'ATZ'; then #160104
-		echo -n > /tmp/.gprs_connect.log
-		connect_func 2>&1 > /tmp/.gprs_connect.log &
-		if [ $? -eq 0 ];then
-			connection_dialog_func #160116
-			exit $? #0 = disonnect/stop, 1 = close but stay connected, 255 = abort
-		else
-			Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connection Log')" --backtitle "\n$(gettext 'The attempt to connect was unsuccessful:')\n" --no-ok --cancel-label $(gettext 'Close') --fixed-font --tailbox /tmp/.gprs_connect.log 25 82
-		fi
+	if [ -c "$GPRSDEV" ] \
+	  && echo ATZ | busybox microcom -t 200 "$GPRSDEV" 2>/dev/null | grep -q 'ATZ'; then #160104
+	    echo -n > $CONNECTLOG
+	    connect_func & #200829
+# shellcheck disable=SC2181 # status test necessary due to '&' above.
+	    if [ $? -eq 0 ]; then
+	        CONNECT_PID=$! #200829
+	        connection_dialog_func #160116
+	        exit $? #0 = disconnect/stop, 1 = close but stay connected, 255 = abort
+	    else
+	        Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS Connection Log')" --backtitle "\n$(gettext 'The attempt to connect was unsuccessful:')\n" --no-ok --cancel-label "$(gettext 'Close')" --fixed-font --logbox $CONNECTLOG 25 82
+	    fi
 	else
-		Xdialog --center --wmclass "frisbee" --title "Frisbee $(gettext 'GPRS Connect')" --icon $ICONLIB/error.xpm --msgbox "\n$(gettext 'Cannot connect.')\n\n$(eval_gettext "Modem device '\$GPRSDEV' is not accessable.")\n$(gettext 'It might not be plugged in.')\n" 10 60
+	    Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS Connect')" --icon "$ICONLIB/error.xpm" --msgbox "\n$(gettext 'Cannot connect.')\n\n$(eval_gettext "Modem device '\$GPRSDEV' is not accessable.")\n$(gettext 'It might not be plugged in.')\n" 10 60
 	fi
 fi
 exit 0

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-gprs-disconnect
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-gprs-disconnect
@@ -1,17 +1,19 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=SC1091 # Skip sourced checks.
+#200829 (v2.0) Resolve shellcheck warnings.
 
 export TEXTDOMAIN=frisbee
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
-PPPDPID=$(cat /var/run/ppp-gprs.pid)
-if [ "$PPPDPID" ];then
-	CONNECTEDDEV="$(busybox ps | grep "^ *$PPPDPID" | grep 'pppd' | grep -v 'grep' | grep -o '/dev/[a-z][^ ]*')"
-#echo "frisbee-gprs-disconnect - PPPDPID: $PPPDPID  CONNECTEDDEV: $CONNECTEDDEV  " >> /tmp/debug.log  #DEBUG
-	if [ "$CONNECTEDDEV" ];then
-		kill $PPPDPID
-		rm -f /var/run/ppp-gprs.pid
-		gtkdialog-splash -timeout 15 -placement center -bg orange -text "$(eval_gettext "Mobile device \\\$CONNECTEDDEV disconnected")"
+PPPD_PID=$(cat /var/run/ppp-gprs.pid)
+if [ -n "$PPPD_PID" ];then
+	CONNECTED_DEVICE="$(pgrep -ax 'pppd' | grep -w "^$PPPD_PID" | grep -o '/dev/[a-z][^ ]*')" #200829
+	if [ -n "$CONNECTED_DEVICE" ];then
+	    kill "$PPPD_PID"
+	    sleep 0.1 #200829
+	    rm -f /var/run/ppp-gprs.pid
+	    gtkdialog-splash -timeout 15 -placement center -bg orange -text "$(eval_gettext "Mobile device \$CONNECTED_DEVICE disconnected")"
 	fi
 fi
 exit 0

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-main
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-main
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1090,SC1091 # Skip sourced checks.
 #Frisbee Copyright Jemimah Ruhala 2012 jemimah@gmx.com
 #Localization - argolance - January 2013
 #140607 Add --version option; add terminal emulator selection to frisbee.conf
@@ -15,9 +16,13 @@
 #160201 Restructure components with new common frisbee interface; integrate mobile and pgprs use of gprs.conf; rename this script and move to frisbee directory; add locks to avoid duplicate instances and conflicts with pgprs.
 #170413 Prepend FRISBEE_ to dialog names to find them for killing.
 #170623 Refresh network list every 30 seconds instead of 15.
+#200829 (v2.0) Move etc gprs.conf; update mobile save and connect functions; correct mobile number list input; add internationalization exports, for momanager; resolve shellcheck warnings; connect-related functions moved to connect-func.
 
+export TEXTDOMAIN=frisbee #200829
+export OUTPUT_CHARSET=UTF-8 #200829
 . gettext.sh
-. $FRISBEEFUNCDIR/func
+. "$FRISBEEFUNCDIR/connect-func" #200829
+. "$FRISBEEFUNCDIR/func"
 . /root/.config/gprs.conf
 
 rm -f /tmp/.frisbee/* 2>/dev/null
@@ -38,7 +43,7 @@ else
 	PPPOEMBLSELSENS=sensitive=\"false\"
 	PPPOEMBLSELTIP="$(gettext "Disabled due to absence of Roaring Penguin PPPoE package.")" #140602 end
 	grep -q '^pppoe_select=1' /etc/frisbee/frisbee.conf \
-	 && sed -i -e '/^pppoe_select=/ s/=.*/=0/' /etc/frisbee/frisbee.conf
+	  && sed -i -e '/^pppoe_select=/ s/=.*/=0/' /etc/frisbee/frisbee.conf
 fi
 if grep -q '^pppoe_select=1' /etc/frisbee/frisbee.conf;then
 	PPPOEFRMSENS="true"
@@ -51,8 +56,8 @@ fi
 #Ensure pppoe device file present...
 if [ ! -s /tmp/.frisbee/pppoedevlist ];then
 	grep -q -s "^ETH='*." /etc/ppp/pppoe.conf \
-	 && echo -n "$(sed -n -e "s/^ETH='*\([^' ]*\).*/\1/p" /etc/ppp/pppoe.conf 2>/dev/null)" > /tmp/.frisbee/pppoedevlist \
-	 || echo "--$(gettext 'None detected')--" > /tmp/.frisbee/pppoedevlist
+	  && echo -n "$(sed -n -e "s/^ETH='*\([^' ]*\).*/\1/p" /etc/ppp/pppoe.conf 2>/dev/null)" > /tmp/.frisbee/pppoedevlist \
+	  || echo "--$(gettext 'None detected')--" > /tmp/.frisbee/pppoedevlist
 fi
 
 #Ensure pppoe firewall selection list present...
@@ -85,88 +90,88 @@ fi
 #Pre-set telephone network user passwords, because variables apparently initialized randomly - user not initially set when password needs it...
 PPPOEPSWD="$(read_password_from_secret "$(sed -n -e "s/^USER='*\([^' ]*\).*/\1/p" /etc/ppp/pppoe.conf 2>/dev/null)")"
 [ "$PPPOEPSWD" ] && PPPOEPSWDDFLT="<default>$PPPOEPSWD</default>"
-GPRSPSWD="$(read_password_from_secret $GPRSUSER)"
+GPRSPSWD="$(read_password_from_secret "$GPRSUSER")"
 [ "$GPRSPSWD" ] && GPRSPSWDDFLT="<default>$GPRSPSWD</default>"
 
 #Create the mobile access number list.
-eval "$(grep 'GPRS_ACCESS_NUMBERS=' /etc/ppp/gprs.conf)"
+eval "$(grep 'GPRS_ACCESS_NUMBERS=' /etc/gprs.conf)" #200829
 echo "$GPRS_ACCESS_NUMBERS" | tr ' ' '\n' > /tmp/.frisbee/mobilenbrlist
 
 export CLEAR_AND_DISABLE_STATIC_IP_FIELDS="
-        <action>clear:IP</action>
-        <action>disable:IP</action>
-        <action>disable:IPLAB</action>
-        <action>clear:SUBNET</action>
-        <action>disable:SUBNET</action>
-        <action>disable:SUBNETLAB</action>
-        <action>clear:GATEWAY</action>
-        <action>disable:GATEWAY</action>
-        <action>disable:GATEWAYLAB</action>
-        <action>clear:DNS1</action>
-        <action>disable:DNS1</action>
-        <action>disable:DNS1LAB</action>
-        <action>clear:DNS2</action>
-        <action>disable:DNS2</action>
-        <action>disable:DNS2LAB</action>
+	<action>clear:IP</action>
+	<action>disable:IP</action>
+	<action>disable:IPLAB</action>
+	<action>clear:SUBNET</action>
+	<action>disable:SUBNET</action>
+	<action>disable:SUBNETLAB</action>
+	<action>clear:GATEWAY</action>
+	<action>disable:GATEWAY</action>
+	<action>disable:GATEWAYLAB</action>
+	<action>clear:DNS1</action>
+	<action>disable:DNS1</action>
+	<action>disable:DNS1LAB</action>
+	<action>clear:DNS2</action>
+	<action>disable:DNS2</action>
+	<action>disable:DNS2LAB</action>
 "
 
 export CLEAR_AND_DISABLE_WPA_FIELDS="
-	    <action>clear:ENCKEY</action>
-	    <action>disable:ENCKEY</action>
-	    <action>disable:ENCKEYLAB</action>
-	    <action>clear:IDENT</action>
-	    <action>disable:IDENT</action>
-	    <action>disable:IDENTLAB</action>
-	    <action>clear:SSID</action>
-	    <action>disable:SSID</action>
-	    <action>clear:PRIORITY</action>
-	    <action>disable:PRIORITY</action>
-	    <action>disable:PRIORITYLAB</action>
-	    <action>clear:BSSID</action>
-	    <action>disable:BSSID</action>
-	    <action>clear:AUTH</action>
-	    <action>disable:AUTH</action>
-	    <action>clear:PROTO</action>
-	    <action>disable:PROTO</action>
-	    <action>clear:AUTHALG</action>
-	    <action>disable:AUTHALG</action>
-	    <action>clear:ENC</action>
-	    <action>disable:ENC</action>
-	    <action>clear:ENABLED</action>
-	    <action>disable:ENABLED</action>
+	<action>clear:ENCKEY</action>
+	<action>disable:ENCKEY</action>
+	<action>disable:ENCKEYLAB</action>
+	<action>clear:IDENT</action>
+	<action>disable:IDENT</action>
+	<action>disable:IDENTLAB</action>
+	<action>clear:SSID</action>
+	<action>disable:SSID</action>
+	<action>clear:PRIORITY</action>
+	<action>disable:PRIORITY</action>
+	<action>disable:PRIORITYLAB</action>
+	<action>clear:BSSID</action>
+	<action>disable:BSSID</action>
+	<action>clear:AUTH</action>
+	<action>disable:AUTH</action>
+	<action>clear:PROTO</action>
+	<action>disable:PROTO</action>
+	<action>clear:AUTHALG</action>
+	<action>disable:AUTHALG</action>
+	<action>clear:ENC</action>
+	<action>disable:ENC</action>
+	<action>clear:ENABLED</action>
+	<action>disable:ENABLED</action>
 "
 
 export SET_STATE_OF_STATIC_IP_FIELDS="
-        <action>if true clear:IP</action>
-        <action>if true disable:IP</action>
-        <action>if true disable:IPLAB</action>
-        <action>if true clear:SUBNET</action>
-        <action>if true disable:SUBNET</action>
-        <action>if true disable:SUBNETLAB</action>
-        <action>if true clear:GATEWAY</action>
-        <action>if true disable:GATEWAY</action>
-        <action>if true disable:GATEWAYLAB</action>
-        <action>if true clear:DNS1</action>
-        <action>if true disable:DNS1</action>
-        <action>if true disable:DNS1LAB</action>
-        <action>if true clear:DNS2</action>
-        <action>if true disable:DNS2</action>
-        <action>if true disable:DNS2LAB</action>
-        <action>if false refresh:IP</action>
-        <action>if false enable:IP</action>
-        <action>if false enable:IPLAB</action>
-        <action>if false refresh:SUBNET</action>
-        <action>if false enable:SUBNET</action>
-        <action>if false enable:SUBNETLAB</action>
-        <action>if false refresh:GATEWAY</action>
-        <action>if false enable:GATEWAY</action>
-        <action>if false enable:GATEWAYLAB</action>
-        <action>if false refresh:DNS1</action>
-        <action>if false enable:DNS1</action>
-        <action>if false enable:DNS1LAB</action>
-        <action>if false refresh:DNS2</action>
-        <action>if false enable:DNS2</action>
-        <action>if false enable:DNS2LAB</action>
+	<action>if true clear:IP</action>
+	<action>if true disable:IP</action>
+	<action>if true disable:IPLAB</action>
+	<action>if true clear:SUBNET</action>
+	<action>if true disable:SUBNET</action>
+	<action>if true disable:SUBNETLAB</action>
+	<action>if true clear:GATEWAY</action>
+	<action>if true disable:GATEWAY</action>
+	<action>if true disable:GATEWAYLAB</action>
+	<action>if true clear:DNS1</action>
+	<action>if true disable:DNS1</action>
+	<action>if true disable:DNS1LAB</action>
+	<action>if true clear:DNS2</action>
+	<action>if true disable:DNS2</action>
+	<action>if true disable:DNS2LAB</action>
+	<action>if false refresh:IP</action>
+	<action>if false enable:IP</action>
+	<action>if false enable:IPLAB</action>
+	<action>if false refresh:SUBNET</action>
+	<action>if false enable:SUBNET</action>
+	<action>if false enable:SUBNETLAB</action>
+	<action>if false refresh:GATEWAY</action>
+	<action>if false enable:GATEWAY</action>
+	<action>if false enable:GATEWAYLAB</action>
+	<action>if false refresh:DNS1</action>
+	<action>if false enable:DNS1</action>
+	<action>if false enable:DNS1LAB</action>
+	<action>if false refresh:DNS2</action>
+	<action>if false enable:DNS2</action>
+	<action>if false enable:DNS2LAB</action>
 "
 
 
@@ -175,357 +180,365 @@ function profile_editor {
 	export OUTPUT_CHARSET=UTF-8
 	. gettext.sh
 
-	export FRISBEE_PROFEDIT="
-	<window title=\"Frisbee $VERSION - $(gettext 'Manage Saved Network Profiles')\"image-name=\"/usr/share/pixmaps/frisbee.png\" window-position=\"1\">
+# shellcheck disable=SC2089 # Backslashes & quotes OK.
+	FRISBEE_PROFEDIT="
+	<window title=\"$(eval_gettext "Frisbee \$VERSION - Manage Saved Network Profiles")\" image-name=\"/usr/share/pixmaps/frisbee.png\" window-position=\"1\">
 	<vbox>
-	    <frame $(gettext 'Select a Profile to Edit or Delete')>
-	     <table>
-              <width>600</width>
-              <height>100</height>
-	      <label>$(gettext 'ID   | SSID                               |BSSID                 |Flags')</label>
-	      <variable>ID</variable>
-	      <input>get_ssids</input>
-	      <action>echo \$ID > /tmp/.frisbee/id</action>
-	      <action>clear:ENCKEY</action>
-	      <action>refresh:ENCKEY</action>
-	      <action>enable:ENCKEY</action>
-	      <action>enable:ENCKEYLAB</action>
-	      <action>clear:IDENT</action>
-	      <action>refresh:IDENT</action>
-	      <action>enable:IDENT</action>
-	      <action>enable:IDENTLAB</action>
-	      <action>refresh:SSID</action>
-	      <action>enable:SSID</action>
-	      <action>clear:PRIORITY</action>
-	      <action>refresh:PRIORITY</action>
-	      <action>enable:PRIORITY</action>
-	      <action>enable:PRIORITYLAB</action>
-	      <action>clear:BSSID</action>
-	      <action>refresh:BSSID</action>
-	      <action>enable:BSSID</action>
-	      <action>refresh:AUTH</action>
-	      <action>enable:AUTH</action>
-	      <action>refresh:AUTHALG</action>
-	      <action>enable:AUTHALG</action>
-	      <action>refresh:PROTO</action>
-	      <action>enable:PROTO</action>
-	      <action>refresh:ENC</action>
-	      <action>enable:ENC</action>
-	      <action>refresh:ENCKEY</action>
-	      <action>enable:ENCKEY</action>
-	      <action>refresh:ENABLED</action>
-	      <action>enable:ENABLED</action>
-          <action>enable:DHCPFRM</action>
-	      <action>refresh:AUTODHCP</action>
-          <action>enable:AUTODHCP</action>
-          <action>refresh:IP</action>
-          <action>enable:IP</action>
-          <action>enable:IPLAB</action>
-          <action>refresh:SUBNET</action>
-          <action>enable:SUBNET</action>
-          <action>enable:SUBNETLAB</action>
-          <action>refresh:GATEWAY</action>
-          <action>enable:GATEWAY</action>
-          <action>enable:GATEWAYLAB</action>
-          <action>refresh:DNS1</action>
-          <action>enable:DNS1</action>
-          <action>enable:DNS1LAB</action>
-          <action>refresh:DNS2</action>
-          <action>enable:DNS2</action>
-          <action>enable:DNS2LAB</action>
-          <action condition=\"command_is_true(test \$ID && echo true)\">enable:SAVEPROFBTN</action>
-          <action condition=\"command_is_true(test \$ID && echo true)\">enable:DELETEPROFBTN</action>
-          <action function=\"break\" condition=\"command_is_true(test \$ID -a \$AUTODHCP = false && echo true)\">true</action>
-          $CLEAR_AND_DISABLE_STATIC_IP_FIELDS    
-          <action function=\"break\" condition=\"command_is_true(test \$ID && echo true)\">true</action>
-          <action condition=\"command_is_true(test \$ID || echo true)\">disable:AUTODHCP</action>
-          <action condition=\"command_is_true(test \$ID || echo true)\">disable:DHCPFRM</action>
-	      $CLEAR_AND_DISABLE_WPA_FIELDS
-          <action condition=\"command_is_true(test \$ID || echo true)\">disable:SAVEPROFBTN</action>
-          <action condition=\"command_is_true(test \$ID || echo true)\">disable:DELETEPROFBTN</action>
-	     </table>
-	     <hbox>
-	      <vbox>
-	       <hbox>
-	         <text tooltip-text=\"$(gettext 'To change the SSID, you must delete the profile and add it again')\">
-             <sensitive>false</sensitive>
-	         <variable>SSID</variable>
-	         <input>echo -n SSID:\ ; get_ssid</input> 
-	        </text>
-	      <text tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
-           <sensitive>false</sensitive>
-	       <variable>AUTH</variable>
-	       <input>echo -n Auth-type:\ ;get_auth \"\$ID\"</input> 
-	      </text>
-	      <text  tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
-           <sensitive>false</sensitive>
-	       <variable>PROTO</variable>
-	       <input>echo -n Proto:\ ; get_proto \"\$ID\"</input>
-	      </text>
-	      <text  tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
-           <sensitive>false</sensitive>
-	       <variable>AUTHALG</variable>
-	       <input>echo -n Auth-Alg:\ ; get_auth_alg \"\$ID\"</input>
-	      </text>
+	 <frame $(gettext 'Select a Profile to Edit or Delete')>
+	  <table>
+	       <width>600</width>
+	       <height>100</height>
+	   <label>$(gettext 'ID   | SSID                               |BSSID                 |Flags')</label>
+	   <variable>ID</variable>
+	   <input>get_ssids</input>
+	   <action>echo \$ID > /tmp/.frisbee/id</action>
+	   <action>clear:ENCKEY</action>
+	   <action>refresh:ENCKEY</action>
+	   <action>enable:ENCKEY</action>
+	   <action>enable:ENCKEYLAB</action>
+	   <action>clear:IDENT</action>
+	   <action>refresh:IDENT</action>
+	   <action>enable:IDENT</action>
+	   <action>enable:IDENTLAB</action>
+	   <action>refresh:SSID</action>
+	   <action>enable:SSID</action>
+	   <action>clear:PRIORITY</action>
+	   <action>refresh:PRIORITY</action>
+	   <action>enable:PRIORITY</action>
+	   <action>enable:PRIORITYLAB</action>
+	   <action>clear:BSSID</action>
+	   <action>refresh:BSSID</action>
+	   <action>enable:BSSID</action>
+	   <action>refresh:AUTH</action>
+	   <action>enable:AUTH</action>
+	   <action>refresh:AUTHALG</action>
+	   <action>enable:AUTHALG</action>
+	   <action>refresh:PROTO</action>
+	   <action>enable:PROTO</action>
+	   <action>refresh:ENC</action>
+	   <action>enable:ENC</action>
+	   <action>refresh:ENCKEY</action>
+	   <action>enable:ENCKEY</action>
+	   <action>refresh:ENABLED</action>
+	   <action>enable:ENABLED</action>
+	   <action>enable:DHCPFRM</action>
+	   <action>refresh:AUTODHCP</action>
+	   <action>enable:AUTODHCP</action>
+	   <action>refresh:IP</action>
+	   <action>enable:IP</action>
+	   <action>enable:IPLAB</action>
+	   <action>refresh:SUBNET</action>
+	   <action>enable:SUBNET</action>
+	   <action>enable:SUBNETLAB</action>
+	   <action>refresh:GATEWAY</action>
+	   <action>enable:GATEWAY</action>
+	   <action>enable:GATEWAYLAB</action>
+	   <action>refresh:DNS1</action>
+	   <action>enable:DNS1</action>
+	   <action>enable:DNS1LAB</action>
+	   <action>refresh:DNS2</action>
+	   <action>enable:DNS2</action>
+	   <action>enable:DNS2LAB</action>
+	   <action condition=\"command_is_true(test \$ID && echo true)\">enable:SAVEPROFBTN</action>
+	   <action condition=\"command_is_true(test \$ID && echo true)\">enable:DELETEPROFBTN</action>
+	   <action function=\"break\" condition=\"command_is_true(test \$ID -a \$AUTODHCP = false && echo true)\">true</action>
+	   $CLEAR_AND_DISABLE_STATIC_IP_FIELDS    
+	   <action function=\"break\" condition=\"command_is_true(test \$ID && echo true)\">true</action>
+	   <action condition=\"command_is_true(test \$ID || echo true)\">disable:AUTODHCP</action>
+	   <action condition=\"command_is_true(test \$ID || echo true)\">disable:DHCPFRM</action>
+	   $CLEAR_AND_DISABLE_WPA_FIELDS
+	   <action condition=\"command_is_true(test \$ID || echo true)\">disable:SAVEPROFBTN</action>
+	   <action condition=\"command_is_true(test \$ID || echo true)\">disable:DELETEPROFBTN</action>
+	  </table>
+	  <hbox>
+	   <vbox>
+	    <hbox>
+	     <text tooltip-text=\"$(gettext 'To change the SSID, you must delete the profile and add it again')\">
+	      <sensitive>false</sensitive>
+	      <variable>SSID</variable>
+	      <input>echo -n SSID:\ ; get_ssid</input> 
+	     </text>
+	     <text tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
+	      <sensitive>false</sensitive>
+	      <variable>AUTH</variable>
+	      <input>echo -n Auth-type:\ ;get_auth \"\$ID\"</input> 
+	     </text>
 	     <text  tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
-           <sensitive>false</sensitive>
-	       <variable>ENC</variable>
-	       <input>echo -n Encryption:\ ; get_enc \"\$ID\"</input>
-	      </text>
-	       </hbox>
-	     <hbox>
+	      <sensitive>false</sensitive>
+	      <variable>PROTO</variable>
+	      <input>echo -n Proto:\ ; get_proto \"\$ID\"</input>
+	     </text>
+	     <text  tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
+	      <sensitive>false</sensitive>
+	      <variable>AUTHALG</variable>
+	      <input>echo -n Auth-Alg:\ ; get_auth_alg \"\$ID\"</input>
+	     </text>
+	     <text  tooltip-text=\"$(gettext 'If you need to change this, delete the profile and add the network again; encryption settings are automatically detected')\">
+	      <sensitive>false</sensitive>
+	      <variable>ENC</variable>
+	      <input>echo -n Encryption:\ ; get_enc \"\$ID\"</input>
+	     </text>
+	    </hbox>
+	    <hbox>
 	     <checkbox tooltip-text=\"$(gettext 'Wpa_supplicant will not try to connect to a network that is disabled')\">
 	      <label>\"$(gettext 'Network Enabled')\"</label>
-          <sensitive>false</sensitive>
+	      <sensitive>false</sensitive>
 	      <variable>ENABLED</variable>
 	      <input>get_enabled \"\$ID\"</input>
 	     </checkbox>
-	      <hbox>
-	       <text>
-            <sensitive>false</sensitive>
-            <variable>PRIORITYLAB</variable>
-            <label>\"$(gettext 'Priority')\"</label>
-	       </text>
-	       <entry tooltip-text=\"$(gettext 'Wpa_supplicant will prefer to connect to the network with the largest number in the Priority field')\">
-            <sensitive>false</sensitive>
-	        <variable>PRIORITY</variable>
-	        <input>get_priority \"\$ID\"</input> 
-	       </entry>
-	       </hbox>
-	       </hbox>
-	       <hbox>
-	        <text>
-            <sensitive>false</sensitive>
-            <variable>IDENTLAB</variable>
-	         <label>\"$(gettext 'Identity')\"</label>
-	        </text>
-	        <entry tooltip-text=\"$(gettext 'Enter your EAP authorisation identifier, if required.')\">
-             <sensitive>false</sensitive>
-	         <variable>IDENT</variable>
-	         <input>echo</input> 
-	         <input>get_identity \"\$ID\"</input> 
-	        </entry>
-	        <text>
-            <sensitive>false</sensitive>
-            <variable>ENCKEYLAB</variable>
-	         <label>\"$(gettext 'Key or Password')\"</label>
-	        </text>
-	        <entry tooltip-text=\"$(gettext 'Enter your ASCII or HEX key or password here; for best results with WEP, use the HEX key')\">
-             <sensitive>false</sensitive>
-	         <visible>password</visible>
-	         <variable>ENCKEY</variable>
-	         <input>echo</input> 
-	         <input>get_key \"\$ID\"</input> 
-	        </entry>
-	       </hbox>
-	     </vbox>
-	   </hbox>
-	  </frame>
-	  <frame $(gettext 'DHCP Settings')>
-	   <hbox>
-     <vbox>
-        <checkbox tooltip-text=\"$(gettext 'Request IP address and routing information from a DHCP server')\">
-        <label>$(gettext 'Auto DHCP')</label>
-        <sensitive>false</sensitive>
-        <variable>AUTODHCP</variable>
-        <input>get_dhcp_auto_wireless \"\$(get_ssid)\"</input>
-        $SET_STATE_OF_STATIC_IP_FIELDS
-       </checkbox>
-      <hbox>
-       <text>
-       <sensitive>false</sensitive>
-       <variable>IPLAB</variable><label>$(gettext 'Static IP Address')</label></text>
-       <entry tooltip-text=\"$(gettext 'Enter static IP address')\">
-        <sensitive>false</sensitive>
-        <variable>IP</variable>
-        <input>get_static_ip_wireless \"\$(get_ssid)\"</input>
-       </entry>
-      </hbox>
-      <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>SUBNETLAB</variable>
-        <label>\"$(gettext 'Subnet Mask')\"</label>
-       </text>
-       <entry tooltip-text=\"$(gettext 'Enter subnet mask')\">
-        <sensitive>false</sensitive>
-        <variable>SUBNET</variable>
-        <input>get_mask_wireless \"\$(get_ssid)\"</input>
-       </entry>
-      </hbox>
-      </vbox>
-      <vbox>
-       <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>GATEWAYLAB</variable><label>$(gettext 'Gateway')</label></text>
-        <entry tooltip-text=\"$(gettext 'Enter gateway IP address')\">
-         <sensitive>false</sensitive>
-         <variable>GATEWAY</variable> 
-         <input>get_gateway_wireless \"\$(get_ssid)\"</input>
-        </entry>
-       </hbox>
-      <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>DNS1LAB</variable><label>$(gettext 'DNS Server 1')</label>
-       </text>
-       <entry tooltip-text=\"$(gettext 'Enter the IP address for the DNS server')\">
-        <sensitive>false</sensitive>
-        <variable>DNS1</variable>
-        <input>get_dns1_wireless \"\$(get_ssid)\"</input>
-       </entry>
-      </hbox>
-      <hbox>
-         <text>
-          <sensitive>false</sensitive>
-          <variable>DNS2LAB</variable><label>$(gettext 'DNS Server 2')</label>
-         </text>
-	 <entry tooltip-text=\"$(gettext 'Enter IP address for backup DNS server; this field is optional')\">
-          <sensitive>false</sensitive>
-          <variable>DNS2</variable>
-          <input>get_dns2_wireless \"\$(get_ssid)\"</input>
-         </entry>
-        </hbox>
-       </vbox>
-      </hbox>
-      <sensitive>false</sensitive>
-      <variable>DHCPFRM</variable>
-      </frame>
-	  <hbox space-expand=\"true\">
-	   <button tooltip-text=\"$(gettext 'Select a profile, make changes, then click this button to save the changes')\">
-	    <input file stock=\"gtk-save\"></input>
-	    <label>$(gettext 'Save Profile')</label>
-        <sensitive>false</sensitive>
-        <variable>SAVEPROFBTN</variable>
-        <action>disable:SAVEPROFBTN</action>
-        <action>disable:DELETEPROFBTN</action>
-	    <action>update_dhcp_wireless \"\$(get_ssid)|\$AUTODHCP|\$IP|\$SUBNET|\$GATEWAY|\$DNS1|\$DNS2\" && update_profile \"\$ID|\$SSID|\$BSSID|\$ENCKEY|\$PRIORITY|\$ENABLED|\$AUTH|\$ENC|\$IDENT\"</action>
-	    <action>clear:ID</action>
-	    <action>refresh:ID</action>
-	    $CLEAR_AND_DISABLE_WPA_FIELDS
-        <action>disable:DHCPFRM</action>
-        <action>clear:AUTODHCP</action>
-        <action>disable:AUTODHCP</action>
-        $CLEAR_AND_DISABLE_STATIC_IP_FIELDS   
-	   </button>
-	   <button tooltip-text=\"$(gettext 'Delete the selected profile')\" >
-	    <input file stock=\"gtk-delete\"></input>
-	    <label>$(gettext 'Delete Profile')</label>
-        <sensitive>false</sensitive>
-        <variable>DELETEPROFBTN</variable>
-        <action>disable:SAVEPROFBTN</action>
-        <action>disable:DELETEPROFBTN</action>
-	    <action>delete_profile \"\$ID\"</action>
-	    <action>clear:ID</action>
-	    <action>refresh:ID</action>
-	    $CLEAR_AND_DISABLE_WPA_FIELDS
-        <action>disable:DHCPFRM</action>
-        <action>clear:AUTODHCP</action>
-        <action>disable:AUTODHCP</action>
-        $CLEAR_AND_DISABLE_STATIC_IP_FIELDS   
-	   </button>
+	     <hbox>
+	      <text>
+	       <sensitive>false</sensitive>
+	       <variable>PRIORITYLAB</variable>
+	       <label>\"$(gettext 'Priority')\"</label>
+	      </text>
+	      <entry tooltip-text=\"$(gettext 'Wpa_supplicant will prefer to connect to the network with the largest number in the Priority field')\">
+	       <sensitive>false</sensitive>
+	       <variable>PRIORITY</variable>
+	       <input>get_priority \"\$ID\"</input> 
+	      </entry>
+	     </hbox>
+	    </hbox>
+	    <hbox>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>IDENTLAB</variable>
+	      <label>\"$(gettext 'Identity')\"</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter your EAP authorisation identifier, if required.')\">
+	      <sensitive>false</sensitive>
+	      <variable>IDENT</variable>
+	      <input>echo</input> 
+	      <input>get_identity \"\$ID\"</input> 
+	     </entry>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>ENCKEYLAB</variable>
+	      <label>\"$(gettext 'Key or Password')\"</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter your ASCII or HEX key or password here; for best results with WEP, use the HEX key')\">
+	      <sensitive>false</sensitive>
+	      <visible>password</visible>
+	      <variable>ENCKEY</variable>
+	      <input>echo</input> 
+	      <input>get_key \"\$ID\"</input> 
+	     </entry>
+	    </hbox>
+	   </vbox>
 	  </hbox>
-	 </vbox>
-	 </window>"
-	
-		 
-   rm -f /tmp/.frisbee/id
-   gtkdialog --program=FRISBEE_PROFEDIT --center
+	 </frame>
+	 <frame $(gettext 'DHCP Settings')>
+	  <hbox>
+	   <vbox>
+	    <checkbox tooltip-text=\"$(gettext 'Request IP address and routing information from a DHCP server')\">
+	     <label>$(gettext 'Auto DHCP')</label>
+	     <sensitive>false</sensitive>
+	     <variable>AUTODHCP</variable>
+	     <input>get_dhcp_auto_wireless \"\$(get_ssid)\"</input>
+	     $SET_STATE_OF_STATIC_IP_FIELDS
+	    </checkbox>
+	    <hbox>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>IPLAB</variable>
+	      <label>$(gettext 'Static IP Address')</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter static IP address')\">
+	      <sensitive>false</sensitive>
+	      <variable>IP</variable>
+	      <input>get_static_ip_wireless \"\$(get_ssid)\"</input>
+	     </entry>
+	    </hbox>
+	    <hbox>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>SUBNETLAB</variable>
+	      <label>\"$(gettext 'Subnet Mask')\"</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter subnet mask')\">
+	      <sensitive>false</sensitive>
+	      <variable>SUBNET</variable>
+	      <input>get_mask_wireless \"\$(get_ssid)\"</input>
+	     </entry>
+	    </hbox>
+	   </vbox>
+	   <vbox>
+	    <hbox>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>GATEWAYLAB</variable><label>$(gettext 'Gateway')</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter gateway IP address')\">
+	      <sensitive>false</sensitive>
+	      <variable>GATEWAY</variable> 
+	      <input>get_gateway_wireless \"\$(get_ssid)\"</input>
+	     </entry>
+	    </hbox>
+	    <hbox>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>DNS1LAB</variable><label>$(gettext 'DNS Server 1')</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter the IP address for the DNS server')\">
+	      <sensitive>false</sensitive>
+	      <variable>DNS1</variable>
+	      <input>get_dns1_wireless \"\$(get_ssid)\"</input>
+	     </entry>
+	    </hbox>
+	    <hbox>
+	     <text>
+	      <sensitive>false</sensitive>
+	      <variable>DNS2LAB</variable><label>$(gettext 'DNS Server 2')</label>
+	     </text>
+	     <entry tooltip-text=\"$(gettext 'Enter IP address for backup DNS server; this field is optional')\">
+	      <sensitive>false</sensitive>
+	      <variable>DNS2</variable>
+	      <input>get_dns2_wireless \"\$(get_ssid)\"</input>
+	     </entry>
+	    </hbox>
+	   </vbox>
+	  </hbox>
+	  <sensitive>false</sensitive>
+	  <variable>DHCPFRM</variable>
+	 </frame>
+	 <hbox space-expand=\"true\">
+	  <button tooltip-text=\"$(gettext 'Select a profile, make changes, then click this button to save the changes')\">
+	   <input file stock=\"gtk-save\"></input>
+	   <label>$(gettext 'Save Profile')</label>
+	   <sensitive>false</sensitive>
+	   <variable>SAVEPROFBTN</variable>
+	   <action>disable:SAVEPROFBTN</action>
+	   <action>disable:DELETEPROFBTN</action>
+	   <action>update_dhcp_wireless \"\$(get_ssid)|\$AUTODHCP|\$IP|\$SUBNET|\$GATEWAY|\$DNS1|\$DNS2\" && update_profile \"\$ID|\$SSID|\$BSSID|\$ENCKEY|\$PRIORITY|\$ENABLED|\$AUTH|\$ENC|\$IDENT\"</action>
+	   <action>clear:ID</action>
+	   <action>refresh:ID</action>
+	   $CLEAR_AND_DISABLE_WPA_FIELDS
+	   <action>disable:DHCPFRM</action>
+	   <action>clear:AUTODHCP</action>
+	   <action>disable:AUTODHCP</action>
+	   $CLEAR_AND_DISABLE_STATIC_IP_FIELDS   
+	  </button>
+	  <button tooltip-text=\"$(gettext 'Delete the selected profile')\" >
+	   <input file stock=\"gtk-delete\"></input>
+	   <label>$(gettext 'Delete Profile')</label>
+	   <sensitive>false</sensitive>
+	   <variable>DELETEPROFBTN</variable>
+	   <action>disable:SAVEPROFBTN</action>
+	   <action>disable:DELETEPROFBTN</action>
+	   <action>delete_profile \"\$ID\"</action>
+	   <action>clear:ID</action>
+	   <action>refresh:ID</action>
+	   $CLEAR_AND_DISABLE_WPA_FIELDS
+	   <action>disable:DHCPFRM</action>
+	   <action>clear:AUTODHCP</action>
+	   <action>disable:AUTODHCP</action>
+	   $CLEAR_AND_DISABLE_STATIC_IP_FIELDS   
+	  </button>
+	 </hbox>
+	</vbox>
+	</window>"
+# shellcheck disable=SC2090 # Backslashes & quotes OK.
+	export FRISBEE_PROFEDIT
+
+	rm -f /tmp/.frisbee/id
+	gtkdialog --program=FRISBEE_PROFEDIT --center
 }
 export -f profile_editor
 
 function diag {
-		export TEXTDOMAIN=frisbee
-		export OUTPUT_CHARSET=UTF-8
-		. gettext.sh
-		#140602 pre-set button for diagnostic data (pdiag) option...
-		if [ "$(which pdiag 2>/dev/null)" ];then
-			DIAGGENSENS=sensitive=\"true\"
-			DIAGGENTIP="$(gettext 'Generate an archive file containing diagnostic logs and data.')"
-		else
-			DIAGGENSENS=sensitive=\"false\"
-			DIAGGENTIP="$(gettext "Disabled due to absence of 'pdiag' package that creates diagnostic archive file.")"
-		fi
-		TERMEMLTR=$(grep '^terminal=' /etc/frisbee/frisbee.conf | sed 's/.*=\([^ 	#]*\).*/\1/') #140607
-		[ "$TERMEMLTR" ] && [ "$(which $TERMEMLTR 2>/dev/null)" ] || TERMEMLTR=rxvt #140607
-		get_status
-		export FRISBEE_DIAGNOSTICS="
-		<window title=\"Frisbee $VERSION - $(gettext 'Wireless Diagnostic Tools')\" image-name=\"/usr/share/pixmaps/frisbee.png\" window-position=\"1\">
-		   <vbox> 
+	export TEXTDOMAIN=frisbee
+	export OUTPUT_CHARSET=UTF-8
+	. gettext.sh
+	#140602 pre-set button for diagnostic data (pdiag) option...
+	if [ "$(which pdiag 2>/dev/null)" ];then
+	    DIAGGENSENS=sensitive=\"true\"
+	    DIAGGENTIP="$(gettext 'Generate an archive file containing diagnostic logs and data.')"
+	else
+	    DIAGGENSENS=sensitive=\"false\"
+	    DIAGGENTIP="$(gettext "Disabled due to absence of 'pdiag' package that creates diagnostic archive file.")"
+	fi
+	TERMEMLTR=$(grep '^terminal=' /etc/frisbee/frisbee.conf | sed 's/.*=\([^ 	#]*\).*/\1/') #140607
+	[ "$TERMEMLTR" ] && [ "$(which "$TERMEMLTR" 2>/dev/null)" ] || TERMEMLTR=rxvt #140607
+	get_status
+# shellcheck disable=SC2089 # Backslashes & quotes OK.
+	FRISBEE_DIAGNOSTICS="
+	<window title=\"$(eval_gettext "Frisbee \$VERSION - Wireless Diagnostic Tools")\" image-name=\"/usr/share/pixmaps/frisbee.png\" window-position=\"1\">
+	<vbox> 
 
-	    <frame `eval_gettext \"Status of \\\$INTERFACE\"`>
-	     <edit editable=\"false\">
-	      <variable>STATUS</variable>
-	      <input file>/tmp/.frisbee/status</input>
-	      <height>200</height>
-	      <width>600</width>
-	     </edit>
-		 <hbox space-expand=\"true\">
-		  <checkbox tooltip-text=\"$(gettext 'Log wpa_supplicant activities; restart networks to activate - creates large /tmp/wpa_supplicant.log file')\">
-		   <variable>ENDEBUG</variable>
-		   <input>grep -q '^wpa_log_mode=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
-		   <label>$(gettext 'Enable Debug Logging')</label>
-		   <action>if true grep -q '^wpa_log_mode=1' /etc/frisbee/frisbee.conf || sed -i -e '/^wpa_log_mode=/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
-		   <action>if false grep -q '^wpa_log_mode=0' /etc/frisbee/frisbee.conf || sed -i -e '/^wpa_log_mode=/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
-		  </checkbox>
-          <button>
-           <label>$(gettext 'Refresh')</label>
-            <input file stock=\"gtk-refresh\"></input>
-            <action>get_status</action>
-             <action>refresh:STATUS</action>    
-          </button>
-		 </hbox>
-	    </frame>
-	    <hbox> 
-	    <frame $(gettext 'WPA_Supplicant Tools')>
-	    <vbox> 
- 	   <hbox space-expand=\"true\">
-	      <button tooltip-text=\"$(gettext 'View the wpa_supplicant log file')\">
+	 <frame $(eval_gettext "Status of \$INTERFACE")>
+	  <edit editable=\"false\">
+	   <variable>STATUS</variable>
+	   <input file>/tmp/.frisbee/status</input>
+	   <height>200</height>
+	   <width>600</width>
+	  </edit>
+	  <hbox space-expand=\"true\">
+	   <checkbox tooltip-text=\"$(gettext 'Log wpa_supplicant activities; restart networks to activate - creates large /tmp/wpa_supplicant.log file')\">
+	    <variable>ENDEBUG</variable>
+	    <input>grep -q '^wpa_log_mode=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
+	    <label>$(gettext 'Enable Debug Logging')</label>
+	    <action>if true grep -q '^wpa_log_mode=1' /etc/frisbee/frisbee.conf || sed -i -e '/^wpa_log_mode=/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
+	    <action>if false grep -q '^wpa_log_mode=0' /etc/frisbee/frisbee.conf || sed -i -e '/^wpa_log_mode=/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
+	   </checkbox>
+	   <button>
+	    <label>$(gettext 'Refresh')</label>
+	    <input file stock=\"gtk-refresh\"></input>
+	    <action>get_status</action>
+	    <action>refresh:STATUS</action>    
+	   </button>
+	  </hbox>
+	 </frame>
+	 <hbox> 
+	  <frame $(gettext 'WPA_Supplicant Tools')>
+	  <vbox> 
+	   <hbox space-expand=\"true\">
+	    <button tooltip-text=\"$(gettext 'View the wpa_supplicant log file')\">
 	     <input file stock=\"gtk-find\"></input>
 	     <label>$(gettext 'View Log')</label>
-	     <action>Xdialog --wmclass \"frisbee\" --title \"Frisbee - $(gettext 'Wpa_Supplicant Log')\" --no-cancel --ok-label \"Close\"  --textbox /tmp/wpa_supplicant.log 30 100& </action>
+	     <action>Xdialog --wmclass frisbee --title \"$(gettext 'Frisbee - Wpa_Supplicant Log')\" --no-cancel --ok-label \"Close\"  --textbox /tmp/wpa_supplicant.log 30 100& </action>
 	    </button>
- 	   </hbox>
- 	   <hbox space-expand=\"true\">
+	   </hbox>
+	   <hbox space-expand=\"true\">
 	    <button tooltip-text=\"$(gettext 'Edit the wpa_supplicant configuration file')\"> 
 	     <input file stock=\"gtk-edit\"></input>
 	     <label>$(gettext 'Edit Configuration')</label>
 	     <action>wpaconf_edit</action>
 	    </button>
- 	   </hbox>
- 	   <hbox space-expand=\"true\">
-	     <button tooltip-text=\"$(gettext 'Control Wi-Fi Protected Access by command line interface commands to wpa_supplicant')\">
+	   </hbox>
+	   <hbox space-expand=\"true\">
+	    <button tooltip-text=\"$(gettext 'Control Wi-Fi Protected Access by command line interface commands to wpa_supplicant')\">
 	     <input file stock=\"gtk-execute\"></input>
 	     <label>$(gettext 'Control WPA Functions')</label>
 	     <action>$TERMEMLTR -e wpa_cli -i \$INTERFACE&</action>
 	    </button>
- 	   </hbox>
-	    </vbox> 
-	    </frame>
-	    <frame $(gettext 'Other Actions')>
-	    <vbox> 
- 	   <hbox space-expand=\"true\">
+	   </hbox>
+	  </vbox> 
+	  </frame>
+	  <frame $(gettext 'Other Actions')>
+	  <vbox> 
+	   <hbox space-expand=\"true\">
 	    <button tooltip-text=\"$(gettext 'Set ap_scan parameter')\">
 	     <input file stock=\"gtk-preferences\"></input>
 	     <label>$(gettext 'Set AP scan mode')</label>
 	     <action>set_ap_scan</action>
 	    </button>
- 	   </hbox>
- 	   <hbox space-expand=\"true\">
-	     <button $DIAGGENSENS tooltip-text=\"$DIAGGENTIP\">
+	   </hbox>
+	   <hbox space-expand=\"true\">
+	    <button $DIAGGENSENS tooltip-text=\"$DIAGGENTIP\">
 	     <input file stock=\"gtk-execute\"></input>
 	     <label>$(gettext 'Generate Diagnostic Data')</label>
 	     <action>pdiag --wpa&</action>
 	    </button>
- 	   </hbox>
-	    </vbox> 
-	   </frame>
 	   </hbox>
-	    
-	  </vbox>
-	  </window>
+	  </vbox> 
+	  </frame>
+	 </hbox>
+
+	</vbox>
+	</window>
 	" #140816
+# shellcheck disable=SC2090 # Backslashes & quotes OK.
+	export FRISBEE_DIAGNOSTICS
 	gtkdialog --program=FRISBEE_DIAGNOSTICS --center
 }
 export -f diag
@@ -536,22 +549,23 @@ export -f diag
 while true; do #140819
 	###Get the wireless device, i.e. ath0, wlan0, ra0, etc...
 	WIRELESSEN=sensitive=\"true\"
-	export INTERFACE=`cat /etc/frisbee/interface 2>/dev/null`
+	INTERFACE="$(cat /etc/frisbee/interface 2>/dev/null)"
+	export INTERFACE
 	if [[ -z $INTERFACE ]] || [[ -z "$(get_ifs_wireless)" ]] ; then #140819
-		[[ -z $INTERFACE ]] && INTERFACE=none #140303
-		WIRELESSEN=sensitive=\"false\"
+	    [[ -z $INTERFACE ]] && INTERFACE=none #140303
+	    WIRELESSEN=sensitive=\"false\"
 	fi
 
 	#pre-set buttons for wifi option...
 	if grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf;then
-		ENABLEWIRELESS=sensitive=\"true\"
+	    ENABLEWIRELESS=sensitive=\"true\"
 	else
-		ENABLEWIRELESS=sensitive=\"false\"
+	    ENABLEWIRELESS=sensitive=\"false\"
 	fi
 
 	grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf \
-	 && if_connected \
-	 && wpa_cli -i $INTERFACE scan >/dev/null &
+	  && if_connected \
+	  && wpa_cli -i $INTERFACE scan >/dev/null &
 	get_log
 	
 	#Ensure list files present.
@@ -561,603 +575,603 @@ while true; do #140819
 
 	WIRELESS_TAB="
    <vbox>
-    <hbox>
-     <hbox space-expand=\"true\">
-      <checkbox tooltip-text=\"$(gettext 'Enable wireless networking')\">
-       <variable>ENWIRE</variable>
-       <input>grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
-       <label>$(gettext 'Enable Wireless')</label>
-       <action>if true enable:ENAUTO</action>
-       <action>if false disable:ENAUTO</action>
-       <action>if true enable:TABLE</action>
-       <action>if false disable:TABLE</action>
-       <action condition=\"command_is_true(test \$TABLE && echo true)\">if true enable:CONNECTBUTTON</action>
-       <action>if false disable:CONNECTBUTTON</action>
-       <action>if true enable:REFRESHBUTTON</action>
-       <action>if false disable:REFRESHBUTTON</action>
-       <action>if true enable:CURSTAT</action>
-       <action>if false disable:CURSTAT</action>
-       <action>if true enable:CURIP</action>
-       <action>if false disable:CURIP</action>
-       <action>refresh:CURSTAT</action>
-       <action>refresh:CURIP</action>
-       <action>if true grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf || sed -i -e '/^wireless_enabled=/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
-       <action>if false grep -q '^wireless_enabled=0' /etc/frisbee/frisbee.conf || sed -i -e '/^wireless_enabled=/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
-       <action>if true if_connected || ( get_ifs_wireless > /dev/null && connect && wpa_cli -i \$INTERFACE scan )</action>
-       <action>if false if_connected && disconnect</action>
-       <action>if false get_ifs_wireless > /dev/null || echo -n '' > /etc/frisbee/interface</action>
-      </checkbox>
-      <checkbox $ENABLEWIRELESS tooltip-text=\"$(gettext 'Connect last-used, available wireless network automatically when Puppy starts; must be checked to retain any saved network profiles (because the configuration file is only temporary, for current session)')\">
-       <variable>ENAUTO</variable>
-       <input>grep -q '^wireless_autostart=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
-       <label>$(gettext 'Connect WiFi Automatically')</label>
-       <action>if true sed -i -e '/^wireless_autostart=[^1]/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
-       <action>if false sed -i -e '/^wireless_autostart=[^0]/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
-       <action>reset_wpa&</action>
-       <action>reset_dhcp&</action>
-      </checkbox>
-     </hbox>
-     <button tooltip-text=\"$(gettext 'Select an interface, if you have multiple wireless cards')\"> <input file stock=\"gtk-preferences\"></input>
-      <label>$(gettext 'Change Interface')</label>
-      <action>change_if_wireless</action>
-      <action function=\"exit\" condition=\"command_is_true([ -s /etc/frisbee/userif ] && echo -n true)\">RESTART</action>
-     </button>
-     <button tooltip-text=\"$(gettext 'Diagnose wireless problems')\"> <input file stock=\"gtk-execute\"></input>
-      <label>$(gettext 'Diagnostics')</label>
-      <action>get_status</action>
-      <action>diag&</action>
-     </button>
-    </hbox>
-    <vbox $WIRELESSEN>
-    <frame `eval_gettext \"Scan results for \\\$INTERFACE\"`>
-     <table $ENABLEWIRELESS>
-      <width>700</width>
-      <height>180</height>
-      <variable>TABLE</variable>
-      <label>$(gettext 'BSSID                  |Freq  |Strength|SSID              |Encryption')</label>
-      <input>get_scan_results</input>
-      <action condition=\"command_is_true(test \$TABLE && echo true)\">enable:CONNECTBUTTON</action>
-      <action condition=\"command_is_true(test \$TABLE || echo true)\">disable:CONNECTBUTTON</action>
-     </table>
-     <hbox space-expand=\"true\">
-      <text $ENABLEWIRELESS tooltip-text=\"$(gettext 'Connection status')\">
-      <variable>CURSTAT</variable>
-      <input>current_status</input>
-      </text>
-      <text $ENABLEWIRELESS tooltip-text=\"$(gettext 'Connection status')\">
-       <variable>CURIP</variable>
-       <input>current_ip</input>
-      </text>
-      <button tooltip-text=\"$(gettext 'Connect to selected network')\">
-       <input file stock=\"gtk-connect\"></input>
-       <label>$(gettext 'Connect')</label>
-       <sensitive>false</sensitive>
-       <variable>CONNECTBUTTON</variable>
-       <action>add_profile \"\$TABLE\"</action>
-       <action>clear:TABLE</action>
-       <action>refresh:TABLE</action>
-       <action>refresh:CURSTAT</action>
-       <action>refresh:CURIP</action>
-      </button>
-      <button $ENABLEWIRELESS tooltip-text=\"$(gettext 'Update the network list and resume periodic scanning for networks')\">
-       <label>$(gettext 'Refresh')</label>
-       <input file stock=\"gtk-refresh\"></input>
-       <variable>REFRESHBUTTON</variable>
-       <action>clear:TABLE</action>
-       <action>refresh:TABLE</action>
-       <action>disable:CONNECTBUTTON</action>
-       <action>refresh:CURSTAT</action>
-       <action>refresh:CURIP</action>
-      </button>
-     </hbox>
-    </frame>
-     <hbox space-expand=\"true\">
-      <button tooltip-text=\"$(gettext 'Edit or delete saved network profiles')\"> <input file stock=\"gtk-preferences\"></input>
-       <label>$(gettext 'Manage Saved Networks')</label>
-       <action>profile_editor&</action>
-      </button>
-      <button tooltip-text=\"$(gettext 'Restart the wpa_supplicant daemon')\">
-       <input file stock=\"gtk-redo\"></input> 
-       <label>$(gettext 'Restart Networks')</label>
-       <action>gtkdialog-splash -placement center -timeout 3 -bg orange -text  \"$(gettext 'Resetting network processes')\"&</action>
-       <action>grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf && reset_wpa&</action>
-       <action>reset_dhcp&</action>
-       <action>clear:IF</action>    
-       <action>refresh:IF</action> 
-       <action>clear:AUTODHCP</action>
-       <action>disable:AUTODHCP</action>
-       $CLEAR_AND_DISABLE_STATIC_IP_FIELDS   
-      </button>
-     </hbox>
-    </vbox>
-    <hbox><timer interval=\"30\" visible=\"false\">
-        <action>refresh:CURSTAT</action>
-        <action>refresh:CURIP</action>
-        <action function=\"break\" condition=\"command_is_true(test \$TABLE && echo true)\">true</action>
-        <action>disable:CONNECTBUTTON</action>
-        <action>clear:TABLE</action>
-        <action>refresh:TABLE</action>
-    </timer></hbox>
+	<hbox>
+	 <hbox space-expand=\"true\">
+	  <checkbox tooltip-text=\"$(gettext 'Enable wireless networking')\">
+	   <variable>ENWIRE</variable>
+	   <input>grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
+	   <label>$(gettext 'Enable Wireless')</label>
+	   <action>if true enable:ENAUTO</action>
+	   <action>if false disable:ENAUTO</action>
+	   <action>if true enable:TABLE</action>
+	   <action>if false disable:TABLE</action>
+	   <action condition=\"command_is_true(test \$TABLE && echo true)\">if true enable:CONNECTBUTTON</action>
+	   <action>if false disable:CONNECTBUTTON</action>
+	   <action>if true enable:REFRESHBUTTON</action>
+	   <action>if false disable:REFRESHBUTTON</action>
+	   <action>if true enable:CURSTAT</action>
+	   <action>if false disable:CURSTAT</action>
+	   <action>if true enable:CURIP</action>
+	   <action>if false disable:CURIP</action>
+	   <action>refresh:CURSTAT</action>
+	   <action>refresh:CURIP</action>
+	   <action>if true grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf || sed -i -e '/^wireless_enabled=/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
+	   <action>if false grep -q '^wireless_enabled=0' /etc/frisbee/frisbee.conf || sed -i -e '/^wireless_enabled=/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
+	   <action>if true if_connected || ( get_ifs_wireless > /dev/null && connect && wpa_cli -i \$INTERFACE scan )</action>
+	   <action>if false if_connected && disconnect</action>
+	   <action>if false get_ifs_wireless > /dev/null || echo -n '' > /etc/frisbee/interface</action>
+	  </checkbox>
+	  <checkbox $ENABLEWIRELESS tooltip-text=\"$(gettext 'Connect last-used, available wireless network automatically when Puppy starts; must be checked to retain any saved network profiles (because the configuration file is only temporary, for current session)')\">
+	   <variable>ENAUTO</variable>
+	   <input>grep -q '^wireless_autostart=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
+	   <label>$(gettext 'Connect WiFi Automatically')</label>
+	   <action>if true sed -i -e '/^wireless_autostart=[^1]/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
+	   <action>if false sed -i -e '/^wireless_autostart=[^0]/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
+	   <action>reset_wpa&</action>
+	   <action>reset_dhcp&</action>
+	  </checkbox>
+	 </hbox>
+	 <button tooltip-text=\"$(gettext 'Select an interface, if you have multiple wireless cards')\"> <input file stock=\"gtk-preferences\"></input>
+	  <label>$(gettext 'Change Interface')</label>
+	  <action>change_if_wireless</action>
+	  <action function=\"exit\" condition=\"command_is_true([ -s /etc/frisbee/userif ] && echo -n true)\">RESTART</action>
+	 </button>
+	 <button tooltip-text=\"$(gettext 'Diagnose wireless problems')\"> <input file stock=\"gtk-execute\"></input>
+	  <label>$(gettext 'Diagnostics')</label>
+	  <action>get_status</action>
+	  <action>diag&</action>
+	 </button>
+	</hbox>
+	<vbox $WIRELESSEN>
+	<frame $(eval_gettext "Scan results for \$INTERFACE")>
+	 <table $ENABLEWIRELESS>
+	  <width>700</width>
+	  <height>180</height>
+	  <variable>TABLE</variable>
+	  <label>$(gettext 'BSSID                  |Freq  |Strength|SSID              |Encryption')</label>
+	  <input>get_scan_results</input>
+	  <action condition=\"command_is_true(test \$TABLE && echo true)\">enable:CONNECTBUTTON</action>
+	  <action condition=\"command_is_true(test \$TABLE || echo true)\">disable:CONNECTBUTTON</action>
+	 </table>
+	 <hbox space-expand=\"true\">
+	  <text $ENABLEWIRELESS tooltip-text=\"$(gettext 'Connection status')\">
+	  <variable>CURSTAT</variable>
+	  <input>current_status</input>
+	  </text>
+	  <text $ENABLEWIRELESS tooltip-text=\"$(gettext 'Connection status')\">
+	   <variable>CURIP</variable>
+	   <input>current_ip</input>
+	  </text>
+	  <button tooltip-text=\"$(gettext 'Connect to selected network')\">
+	   <input file stock=\"gtk-connect\"></input>
+	   <label>$(gettext 'Connect')</label>
+	   <sensitive>false</sensitive>
+	   <variable>CONNECTBUTTON</variable>
+	   <action>add_profile \"\$TABLE\"</action>
+	   <action>clear:TABLE</action>
+	   <action>refresh:TABLE</action>
+	   <action>refresh:CURSTAT</action>
+	   <action>refresh:CURIP</action>
+	  </button>
+	  <button $ENABLEWIRELESS tooltip-text=\"$(gettext 'Update the network list and resume periodic scanning for networks')\">
+	   <label>$(gettext 'Refresh')</label>
+	   <input file stock=\"gtk-refresh\"></input>
+	   <variable>REFRESHBUTTON</variable>
+	   <action>clear:TABLE</action>
+	   <action>refresh:TABLE</action>
+	   <action>disable:CONNECTBUTTON</action>
+	   <action>refresh:CURSTAT</action>
+	   <action>refresh:CURIP</action>
+	  </button>
+	 </hbox>
+	</frame>
+	 <hbox space-expand=\"true\">
+	  <button tooltip-text=\"$(gettext 'Edit or delete saved network profiles')\"> <input file stock=\"gtk-preferences\"></input>
+	   <label>$(gettext 'Manage Saved Networks')</label>
+	   <action>profile_editor&</action>
+	  </button>
+	  <button tooltip-text=\"$(gettext 'Restart the wpa_supplicant daemon')\">
+	   <input file stock=\"gtk-redo\"></input> 
+	   <label>$(gettext 'Restart Networks')</label>
+	   <action>gtkdialog-splash -placement center -timeout 3 -bg orange -text  \"$(gettext 'Resetting network processes')\"&</action>
+	   <action>grep -q '^wireless_enabled=1' /etc/frisbee/frisbee.conf && reset_wpa&</action>
+	   <action>reset_dhcp&</action>
+	   <action>clear:IF</action>    
+	   <action>refresh:IF</action> 
+	   <action>clear:AUTODHCP</action>
+	   <action>disable:AUTODHCP</action>
+	   $CLEAR_AND_DISABLE_STATIC_IP_FIELDS   
+	  </button>
+	 </hbox>
+	</vbox>
+	<hbox><timer interval=\"30\" visible=\"false\">
+	    <action>refresh:CURSTAT</action>
+	    <action>refresh:CURIP</action>
+	    <action function=\"break\" condition=\"command_is_true(test \$TABLE && echo true)\">true</action>
+	    <action>disable:CONNECTBUTTON</action>
+	    <action>clear:TABLE</action>
+	    <action>refresh:TABLE</action>
+	</timer></hbox>
    </vbox>"
 	#End of WIRELESS_TAB
 
 NETWORKS_TAB="   
    <vbox>
    <frame>
-    <table>
-     <label>$(gettext 'Interface   | Type                                        |Action')</label>
-     <variable>IF</variable>
-     <input>get_interfaces</input>
-     <action>refresh:IGNORE</action>
-     <action>enable:IGNORE</action>
-     <action condition=\"command_is_true(test \$IGNORE = false && echo true)\">refresh:AUTODHCP</action>
-     <action condition=\"command_is_true(test \$IGNORE = false && echo true)\">enable:AUTODHCP</action>
-     <action condition=\"command_is_false(test \$IGNORE = false || echo false)\">disable:AUTODHCP</action>
-     <action condition=\"command_is_true(test \$IF && echo true)\">enable:SAVEBUTTON</action>
-     <action condition=\"command_is_true(test \$IF || echo true)\">disable:SAVEBUTTON</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:IP</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:IP</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:IPLAB</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:SUBNET</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:SUBNET</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:SUBNETLAB</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:GATEWAY</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:GATEWAY</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:GATEWAYLAB</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:DNS1</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS1</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS1LAB</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:DNS2</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS2</action>
-     <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS2LAB</action>
-     <action function=\"break\" condition=\"command_is_true(test \$IF && echo true)\" condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">true</action>
-     $CLEAR_AND_DISABLE_STATIC_IP_FIELDS    
-     <action condition=\"command_is_true(test \$IF || echo true)\">disable:AUTODHCP</action>
-     <action condition=\"command_is_true(test \$IF || echo true)\">disable:IGNORE</action>
-    </table>
-    <hbox>
-     <vbox>
-      <hbox>
-       <checkbox tooltip-text=\"$(gettext 'Tell dhcpcd to ignore this interface')\">
-        <label>$(gettext 'Ignore')</label>
-        <sensitive>false</sensitive>
-        <variable>IGNORE</variable>
-        <input>get_dhcp_ignored \"\$IF\"</input>
-        <action function=\"break\" condition=\"command_is_false(test \$IF || echo false)\">true</action>
-        <action>if true clear:AUTODHCP</action>
-        <action>if true disable:AUTODHCP</action>
-        <action>if false enable:AUTODHCP</action>
-        $SET_STATE_OF_STATIC_IP_FIELDS
-       </checkbox>
-       </hbox>
-      <hbox>
-       <text>
-       <sensitive>false</sensitive>
-       <variable>IPLAB</variable><label>$(gettext 'Static IP Address')</label></text>
-       <entry tooltip-text=\"$(gettext 'Enter static IP address')\">
-        <sensitive>false</sensitive>
-        <variable>IP</variable>
-        <input>get_static_ip \"\$IF\"</input>
-       </entry>
-      </hbox>
-      <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>SUBNETLAB</variable>
-        <label>$(gettext 'Subnet Mask')</label>
-       </text>
-       <entry tooltip-text=\"$(gettext 'Enter subnet mask')\">
-        <sensitive>false</sensitive>
-        <variable>SUBNET</variable>
-        <input>get_mask \"\$IF\"</input>
-       </entry>
-      </hbox>
-      <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>GATEWAYLAB</variable><label>$(gettext 'Gateway')</label></text>
-        <entry tooltip-text=\"$(gettext 'Enter gateway IP address')\">
-         <sensitive>false</sensitive>
-         <variable>GATEWAY</variable> 
-         <input>get_gateway \"\$IF\"</input>
-        </entry>
-       </hbox>
-      </vbox>
-      <vbox>
-             <checkbox tooltip-text=\"$(gettext 'Request IP address and routing information from a DHCP server')\">
-        <label>$(gettext 'Auto DHCP')</label>
-        <sensitive>false</sensitive>
-        <variable>AUTODHCP</variable>
-        <input>get_dhcp_auto \"\$IF\"</input>
-        <action function=\"break\" condition=\"command_is_false(test \$IF || echo false)\">true</action>
-        $SET_STATE_OF_STATIC_IP_FIELDS
-       </checkbox>
-      <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>DNS1LAB</variable><label>$(gettext 'DNS Server 1')</label>
-       </text>
-       <entry tooltip-text=\"$(gettext 'Enter the IP address for the DNS server')\">
-        <sensitive>false</sensitive>
-        <variable>DNS1</variable>
-        <input>get_dns1 \"\$IF\"</input>
-       </entry>
-      </hbox>
-      <hbox>
-       <text>
-        <sensitive>false</sensitive>
-        <variable>DNS2LAB</variable><label>$(gettext 'DNS Server 2')</label>
-       </text>
+	<table>
+	 <label>$(gettext 'Interface   | Type                                        |Action')</label>
+	 <variable>IF</variable>
+	 <input>get_interfaces</input>
+	 <action>refresh:IGNORE</action>
+	 <action>enable:IGNORE</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false && echo true)\">refresh:AUTODHCP</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false && echo true)\">enable:AUTODHCP</action>
+	 <action condition=\"command_is_false(test \$IGNORE = false || echo false)\">disable:AUTODHCP</action>
+	 <action condition=\"command_is_true(test \$IF && echo true)\">enable:SAVEBUTTON</action>
+	 <action condition=\"command_is_true(test \$IF || echo true)\">disable:SAVEBUTTON</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:IP</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:IP</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:IPLAB</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:SUBNET</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:SUBNET</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:SUBNETLAB</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:GATEWAY</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:GATEWAY</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:GATEWAYLAB</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:DNS1</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS1</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS1LAB</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">refresh:DNS2</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS2</action>
+	 <action condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">enable:DNS2LAB</action>
+	 <action function=\"break\" condition=\"command_is_true(test \$IF && echo true)\" condition=\"command_is_true(test \$IGNORE = false -a \$AUTODHCP = false && echo true)\">true</action>
+	 $CLEAR_AND_DISABLE_STATIC_IP_FIELDS    
+	 <action condition=\"command_is_true(test \$IF || echo true)\">disable:AUTODHCP</action>
+	 <action condition=\"command_is_true(test \$IF || echo true)\">disable:IGNORE</action>
+	</table>
+	<hbox>
+	 <vbox>
+	  <hbox>
+	   <checkbox tooltip-text=\"$(gettext 'Tell dhcpcd to ignore this interface')\">
+	    <label>$(gettext 'Ignore')</label>
+	    <sensitive>false</sensitive>
+	    <variable>IGNORE</variable>
+	    <input>get_dhcp_ignored \"\$IF\"</input>
+	    <action function=\"break\" condition=\"command_is_false(test \$IF || echo false)\">true</action>
+	    <action>if true clear:AUTODHCP</action>
+	    <action>if true disable:AUTODHCP</action>
+	    <action>if false enable:AUTODHCP</action>
+	    $SET_STATE_OF_STATIC_IP_FIELDS
+	   </checkbox>
+	   </hbox>
+	  <hbox>
+	   <text>
+	   <sensitive>false</sensitive>
+	   <variable>IPLAB</variable><label>$(gettext 'Static IP Address')</label></text>
+	   <entry tooltip-text=\"$(gettext 'Enter static IP address')\">
+	    <sensitive>false</sensitive>
+	    <variable>IP</variable>
+	    <input>get_static_ip \"\$IF\"</input>
+	   </entry>
+	  </hbox>
+	  <hbox>
+	   <text>
+	    <sensitive>false</sensitive>
+	    <variable>SUBNETLAB</variable>
+	    <label>$(gettext 'Subnet Mask')</label>
+	   </text>
+	   <entry tooltip-text=\"$(gettext 'Enter subnet mask')\">
+	    <sensitive>false</sensitive>
+	    <variable>SUBNET</variable>
+	    <input>get_mask \"\$IF\"</input>
+	   </entry>
+	  </hbox>
+	  <hbox>
+	   <text>
+	    <sensitive>false</sensitive>
+	    <variable>GATEWAYLAB</variable><label>$(gettext 'Gateway')</label></text>
+	    <entry tooltip-text=\"$(gettext 'Enter gateway IP address')\">
+	     <sensitive>false</sensitive>
+	     <variable>GATEWAY</variable> 
+	     <input>get_gateway \"\$IF\"</input>
+	    </entry>
+	   </hbox>
+	  </vbox>
+	  <vbox>
+	         <checkbox tooltip-text=\"$(gettext 'Request IP address and routing information from a DHCP server')\">
+	    <label>$(gettext 'Auto DHCP')</label>
+	    <sensitive>false</sensitive>
+	    <variable>AUTODHCP</variable>
+	    <input>get_dhcp_auto \"\$IF\"</input>
+	    <action function=\"break\" condition=\"command_is_false(test \$IF || echo false)\">true</action>
+	    $SET_STATE_OF_STATIC_IP_FIELDS
+	   </checkbox>
+	  <hbox>
+	   <text>
+	    <sensitive>false</sensitive>
+	    <variable>DNS1LAB</variable><label>$(gettext 'DNS Server 1')</label>
+	   </text>
+	   <entry tooltip-text=\"$(gettext 'Enter the IP address for the DNS server')\">
+	    <sensitive>false</sensitive>
+	    <variable>DNS1</variable>
+	    <input>get_dns1 \"\$IF\"</input>
+	   </entry>
+	  </hbox>
+	  <hbox>
+	   <text>
+	    <sensitive>false</sensitive>
+	    <variable>DNS2LAB</variable><label>$(gettext 'DNS Server 2')</label>
+	   </text>
 	   <entry tooltip-text=\"$(gettext 'Enter IP address for backup DNS server; this field is optional')\">
-        <sensitive>false</sensitive>
-        <variable>DNS2</variable>
-        <input>get_dns2 \"\$IF\"</input>
-       </entry>
-      </hbox>
-      <hbox space-expand=\"true\">
-       <button tooltip-text=\"$(gettext 'Save interface settings; dhcpcd will restart')\">
-        <input file stock=\"gtk-save\"></input>
-        <label>$(gettext 'Save')</label>
-        <sensitive>false</sensitive>
-        <variable>SAVEBUTTON</variable>
-        <action>update_dhcp \"\$IF|\$IGNORE|\$AUTODHCP|\$IP|\$SUBNET|\$GATEWAY|\$DNS1|\$DNS2\"</action>
-        <action>clear:IF</action>
-        <action>refresh:IF</action>
-        <action>clear:IGNORE</action>
-        <action>disable:IGNORE</action>
-        <action>clear:AUTODHCP</action>
-        <action>disable:AUTODHCP</action>
-        $CLEAR_AND_DISABLE_STATIC_IP_FIELDS
-        <action>disable:SAVEBUTTON</action>
-       </button>
-       <button tooltip-text=\"$(gettext 'Update the network interface list, usually after inserting or removing a USB wireless or ethernet device. ')\">
-        <input file stock=\"gtk-refresh\"></input>
-        <label>$(gettext 'Refresh')</label>
-        <action>clear:IF</action>    
-        <action>refresh:IF</action>
-        <action>clear:IGNORE</action>
-        <action>disable:IGNORE</action>
-        <action>clear:AUTODHCP</action>
-        <action>disable:AUTODHCP</action>
-        $CLEAR_AND_DISABLE_STATIC_IP_FIELDS    
-        <action>disable:SAVEBUTTON</action>
-       </button>
-      </hbox>
-     </vbox>
-    </hbox>
-    </frame>
-    <hbox space-expand=\"true\">
-     <button tooltip-text=\"$(gettext 'View network information')\"> <input file stock=\"gtk-execute\"></input>
-      <label>$(gettext 'Network Status')</label>
-      <action>ipinfo&</action>
-     </button>
-     <button tooltip-text=\"$(gettext 'View the dhcpcd log file')\">
-      <input file stock=\"gtk-find\"></input>
-      <label>$(gettext 'View DHCP Log')</label>
-      <action> [ -f /var/log/messages ] && grep dhcpcd /var/log/messages > /tmp/dhcpcd.log</action>
-      <action> [ -f /var/log/everything/current ] && grep dhcpcd /var/log/everything/current > /tmp/dhcpcd.log</action>
-      <action>Xdialog --wmclass \"frisbee\" --title \"Frisbee - $(gettext 'DHCP Log')\" --no-cancel --ok-label \"Close\"  --textbox /tmp/dhcpcd.log 30 100& </action>
-     </button>
-    </hbox>
-    <hbox space-expand=\"true\">
-     <button tooltip-text=\"$(gettext 'Edit the dhcpcd configuration file')\"> 
+	    <sensitive>false</sensitive>
+	    <variable>DNS2</variable>
+	    <input>get_dns2 \"\$IF\"</input>
+	   </entry>
+	  </hbox>
+	  <hbox space-expand=\"true\">
+	   <button tooltip-text=\"$(gettext 'Save interface settings; dhcpcd will restart')\">
+	    <input file stock=\"gtk-save\"></input>
+	    <label>$(gettext 'Save')</label>
+	    <sensitive>false</sensitive>
+	    <variable>SAVEBUTTON</variable>
+	    <action>update_dhcp \"\$IF|\$IGNORE|\$AUTODHCP|\$IP|\$SUBNET|\$GATEWAY|\$DNS1|\$DNS2\"</action>
+	    <action>clear:IF</action>
+	    <action>refresh:IF</action>
+	    <action>clear:IGNORE</action>
+	    <action>disable:IGNORE</action>
+	    <action>clear:AUTODHCP</action>
+	    <action>disable:AUTODHCP</action>
+	    $CLEAR_AND_DISABLE_STATIC_IP_FIELDS
+	    <action>disable:SAVEBUTTON</action>
+	   </button>
+	   <button tooltip-text=\"$(gettext 'Update the network interface list, usually after inserting or removing a USB wireless or ethernet device. ')\">
+	    <input file stock=\"gtk-refresh\"></input>
+	    <label>$(gettext 'Refresh')</label>
+	    <action>clear:IF</action>    
+	    <action>refresh:IF</action>
+	    <action>clear:IGNORE</action>
+	    <action>disable:IGNORE</action>
+	    <action>clear:AUTODHCP</action>
+	    <action>disable:AUTODHCP</action>
+	    $CLEAR_AND_DISABLE_STATIC_IP_FIELDS    
+	    <action>disable:SAVEBUTTON</action>
+	   </button>
+	  </hbox>
+	 </vbox>
+	</hbox>
+	</frame>
+	<hbox space-expand=\"true\">
+	 <button tooltip-text=\"$(gettext 'View network information')\"> <input file stock=\"gtk-execute\"></input>
+	  <label>$(gettext 'Network Status')</label>
+	  <action>ipinfo&</action>
+	 </button>
+	 <button tooltip-text=\"$(gettext 'View the dhcpcd log file')\">
+	  <input file stock=\"gtk-find\"></input>
+	  <label>$(gettext 'View DHCP Log')</label>
+	  <action> [ -f /var/log/messages ] && grep dhcpcd /var/log/messages > /tmp/dhcpcd.log</action>
+	  <action> [ -f /var/log/everything/current ] && grep dhcpcd /var/log/everything/current > /tmp/dhcpcd.log</action>
+	  <action>Xdialog --wmclass frisbee --title \"$(gettext 'Frisbee - DHCP Log')\" --no-cancel --ok-label \"Close\"  --textbox /tmp/dhcpcd.log 30 100& </action>
+	 </button>
+	</hbox>
+	<hbox space-expand=\"true\">
+	 <button tooltip-text=\"$(gettext 'Edit the dhcpcd configuration file')\"> 
 	  <input file stock=\"gtk-edit\"></input>
 	  <label>$(gettext 'Edit dhcpcd.conf')</label>
 	  <action>dhcpconf_edit</action>
 	 </button>
-     <button tooltip-text=\"$(gettext 'Restart the dhcpcd daemon')\">
-      <input file stock=\"gtk-redo\"></input> 
-      <label>$(gettext 'Restart DHCP')</label>
-      <action>gtkdialog-splash -placement center -timeout 3 -bg orange -text  \"$(gettext 'Resetting DHCP processes')\"&</action>
-      <action>reset_dhcp&</action>
-     </button>
-    </hbox>
+	 <button tooltip-text=\"$(gettext 'Restart the dhcpcd daemon')\">
+	  <input file stock=\"gtk-redo\"></input> 
+	  <label>$(gettext 'Restart DHCP')</label>
+	  <action>gtkdialog-splash -placement center -timeout 3 -bg orange -text  \"$(gettext 'Resetting DHCP processes')\"&</action>
+	  <action>reset_dhcp&</action>
+	 </button>
+	</hbox>
    </vbox>"
 	#End of NETWORKS_TAB
 
 	TELEPHONE_TAB="
    <vbox>
-    <hbox space-expand=\"true\">
-     <radiobutton $PPPOEMBLSELSENS tooltip-text=\"$PPPOEMBLSELTIP\">
-      <label>"$(gettext 'Configure PPPoE for DSL')"</label>
-      <variable>PPPOESEL</variable>
-      <input>grep -q '^pppoe_select=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
-      <action>if true grep -q '^pppoe_select=1' /etc/frisbee/frisbee.conf || sed -i -e '/^pppoe_select=/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
-      <action>if true refresh:PPPOEPSWD</action>
-      <action>if true refresh:PPPOEFRM</action>
-      <action>if true enable:PPPOEFRM</action>
-      <action>if false refresh:PPPOEUIDREQD</action>
-      <action>if false save_pppoe_configuration</action>
-      <action>if false disable:PPPOEFRM</action>
-      <action>if true disable:SAVEBTN</action>
-     </radiobutton>
-     <radiobutton tooltip-text=\"$(gettext 'Click this button to set up a mobile wireless connection and enter the specifics below.')\">
-      <label>"$(gettext 'Configure mobile wireless')"</label>
-      <variable>MBLSEL</variable>
-      <input>grep -q '^pppoe_select=0' /etc/frisbee/frisbee.conf && echo true || echo false</input>
-      <action>if true grep -q '^pppoe_select=0' /etc/frisbee/frisbee.conf || sed -i -e '/^pppoe_select=/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
-      <action>if true refresh:GPRSPSWD</action>
-      <action>if true refresh:MBLFRM</action>
-      <action>if true enable:MBLFRM</action>
-      <action>if false refresh:MBLUIDREQD</action>
-      <action>if false save_mobile_configuration</action>
-      <action>if false disable:MBLFRM</action>
-      <action>if true disable:SAVEBTN</action>
-     </radiobutton>
-    </hbox>
-    <hbox space-expand=\"true\">
-     <vbox>
-      <frame $(gettext 'PPPoE for Digital Subscriber Line (DSL)')>
-       <vbox>
-        <hbox space-expand=\"true\">
-         <text tooltip-text=\"$(gettext 'Select ethernet interface for PPPoE')\">
-         <label>$(gettext 'Ethernet Interface:')</label>
-         </text>
-         <comboboxtext>
-         <variable>PPPOEDEV</variable>
-         <input file>/tmp/.frisbee/pppoedevlist</input>
-         <action>enable:SAVEBTN</action>
-         </comboboxtext>
-        </hbox>
-        <hbox space-expand=\"true\" space-fill=\"true\">
-         <checkbox tooltip-text=\"$(gettext 'If you want the link to come up on demand (instead of being up continuously), check this box.  The link is brought down after 5 minutes idle.')\">
-          <variable>PPPOEDEMAND</variable>
-          <input>read_telephone_value pppoedemand</input>
-          <label>$(gettext 'Connect on demand')</label>
-          <action>enable:SAVEBTN</action>
-         </checkbox>
-        </hbox>
-        <hbox space-expand=\"true\" space-fill=\"true\">
-         <checkbox tooltip-text=\"$(gettext 'To specify Domain Name Server IP addresses or to prevent obtaining the DNS IP address, check this box and enter 1 or 2 IP addresses or leave blank to make no change to current setting.')\">
-          <variable>PPPOEDNS</variable>
-          <input>read_telephone_value pppoedns</input>
-          <label>$(gettext 'Set/keep DNS1[ 2]:')</label>
-          <action>if true refresh:PPPOEDNSVALUE</action>
-          <action>if true show:PPPOEDNSVALUE</action>
-          <action>if false hide:PPPOEDNSVALUE</action>
-          <action>enable:SAVEBTN</action>
-         </checkbox>
-         <entry $SHOWPPPOEDNSVALUE>
-          <variable>PPPOEDNSVALUE</variable>
-          <input>read_telephone_value pppoednsvalue</input>
-          <action>enable:SAVEBTN</action>
-         </entry>
-        </hbox>
-        <hbox space-expand=\"true\">
-         <text tooltip-text=\"$(gettext 'Select firewall configuration for PPPoE.  Choose Standalone for a basic stand-alone web-surfing workstation, Masquerade for a machine acting as an Internet gateway or None')\">
-         <label>$(gettext 'Firewall Configuration:')</label>
-         </text>
-         <comboboxtext>
-          <variable>PPPOEFIREWALL</variable>
-          <input file>/tmp/.frisbee/pppoefirewalllist</input>
-          <action>enable:SAVEBTN</action>
-         </comboboxtext>
-        </hbox>
-        <hbox space-expand=\"true\" space-fill=\"true\">
-         <checkbox tooltip-text=\"$(gettext 'If internet service provider requires a user name and password, check this box and enter them below.  Unchecking the box will clear them without changing the saved copies.')\">
-          <variable>PPPOEUIDREQD</variable>
-          <input>read_telephone_value pppoeuidreq</input>
-          <label>$(gettext 'Authenticate')</label>
-          <action>if true refresh:PPPOEUSER</action>
-          <action>if true show:PPPOEUSER</action>
-          <action>if true refresh:PPPOEPSWD</action>
-          <action>if true show:PPPOEPSWD</action>
-          <action>if true refresh:PPPOEPAPONLY</action>
-          <action>if true show:PPPOEPAPONLY</action>
-          <action>if true refresh:PPPOEUSERBOX</action>
-          <action>if true show:PPPOEUSERBOX</action>
-          <action>if true refresh:PPPOEPSWDBOX</action>
-          <action>if true show:PPPOEPSWDBOX</action>
-          <action>if false clear:PPPOEUSER</action>
-          <action>if false clear:PPPOEPSWD</action>
-          <action>if false hide:PPPOEUSERBOX</action>
-          <action>if false hide:PPPOEPSWDBOX</action>
-          <action>if false hide:PPPOEPAPONLY</action>
-          <action>if false enable:SAVEBTN</action>
-         </checkbox>
-         <checkbox $SHOWPPPOEUID tooltip-text=\"$(gettext 'If internet service provider requires PAP authenticatiion, check this box.')\">
-          <variable>PPPOEPAPONLY</variable>
-          <input>read_telephone_value pppoepaponly</input>
-          <label>$(gettext 'PAP auth only')</label>
-          <action>enable:SAVEBTN</action>
-         </checkbox>
-        </hbox>
-        <hbox $SHOWPPPOEUID space-expand=\"true\">
-         <text>
-         <label>$(gettext 'Username:')</label>
-         </text>
-         <entry>
-         <variable>PPPOEUSER</variable>
-         <input>read_telephone_value pppoeuser</input>
-         <action>clear:PPPOEPSWD</action>
-         <action>refresh:PPPOEPSWD</action>
-         <action>enable:SAVEBTN</action>
-         </entry>
-         <variable>PPPOEUSERBOX</variable>
-        </hbox>
-        <hbox $SHOWPPPOEUID space-expand=\"true\">
-         <text tooltip-text=\"$(gettext "If you change this password, be aware that it will be saved by only the 'Save' and 'Connect' buttons and will be ignored if you change the 'Configure...' button.")\">
-         <label>$(gettext 'Password:')</label>
-         </text>
-         <entry>
-         <visible>password</visible>
-         <variable>PPPOEPSWD</variable>
-         $PPPOEPSWDDFLT
-         <input>read_telephone_value pppoepswd</input>
-         <action>enable:SAVEBTN</action>
-         </entry>
-         <variable>PPPOEPSWDBOX</variable>
-        </hbox>
-       </vbox>
-      <variable>PPPOEFRM</variable>
-      <sensitive>$PPPOEFRMSENS</sensitive>
-      </frame>
-     </vbox>
+	<hbox space-expand=\"true\">
+	 <radiobutton $PPPOEMBLSELSENS tooltip-text=\"$PPPOEMBLSELTIP\">
+	  <label>\"$(gettext 'Configure PPPoE for DSL')\"</label>
+	  <variable>PPPOESEL</variable>
+	  <input>grep -q '^pppoe_select=1' /etc/frisbee/frisbee.conf && echo true || echo false</input>
+	  <action>if true grep -q '^pppoe_select=1' /etc/frisbee/frisbee.conf || sed -i -e '/^pppoe_select=/ s/=.*/=1/' /etc/frisbee/frisbee.conf</action>
+	  <action>if true refresh:PPPOEPSWD</action>
+	  <action>if true refresh:PPPOEFRM</action>
+	  <action>if true enable:PPPOEFRM</action>
+	  <action>if false refresh:PPPOEUIDREQD</action>
+	  <action>if false save_pppoe_configuration</action>
+	  <action>if false disable:PPPOEFRM</action>
+	  <action>if true disable:SAVEBTN</action>
+	 </radiobutton>
+	 <radiobutton tooltip-text=\"$(gettext 'Click this button to set up a mobile wireless connection and enter the specifics below.')\">
+	  <label>\"$(gettext 'Configure mobile wireless')\"</label>
+	  <variable>MBLSEL</variable>
+	  <input>grep -q '^pppoe_select=0' /etc/frisbee/frisbee.conf && echo true || echo false</input>
+	  <action>if true grep -q '^pppoe_select=0' /etc/frisbee/frisbee.conf || sed -i -e '/^pppoe_select=/ s/=.*/=0/' /etc/frisbee/frisbee.conf</action>
+	  <action>if true refresh:GPRSPSWD</action>
+	  <action>if true refresh:MBLFRM</action>
+	  <action>if true enable:MBLFRM</action>
+	  <action>if false refresh:MBLUIDREQD</action>
+	  <action>if false save_mobile_configuration</action>
+	  <action>if false disable:MBLFRM</action>
+	  <action>if true disable:SAVEBTN</action>
+	 </radiobutton>
+	</hbox>
+	<hbox space-expand=\"true\">
+	 <vbox>
+	  <frame $(gettext 'PPPoE for Digital Subscriber Line (DSL)')>
+	   <vbox>
+	    <hbox space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext 'Select ethernet interface for PPPoE')\">
+	     <label>$(gettext 'Ethernet Interface:')</label>
+	     </text>
+	     <comboboxtext>
+	     <variable>PPPOEDEV</variable>
+	     <input file>/tmp/.frisbee/pppoedevlist</input>
+	     <action>enable:SAVEBTN</action>
+	     </comboboxtext>
+	    </hbox>
+	    <hbox space-expand=\"true\" space-fill=\"true\">
+	     <checkbox tooltip-text=\"$(gettext 'If you want the link to come up on demand (instead of being up continuously), check this box.  The link is brought down after 5 minutes idle.')\">
+	      <variable>PPPOEDEMAND</variable>
+	      <input>read_telephone_value pppoedemand</input>
+	      <label>$(gettext 'Connect on demand')</label>
+	      <action>enable:SAVEBTN</action>
+	     </checkbox>
+	    </hbox>
+	    <hbox space-expand=\"true\" space-fill=\"true\">
+	     <checkbox tooltip-text=\"$(gettext 'To specify Domain Name Server IP addresses or to prevent obtaining the DNS IP address, check this box and enter 1 or 2 IP addresses or leave blank to make no change to current setting.')\">
+	      <variable>PPPOEDNS</variable>
+	      <input>read_telephone_value pppoedns</input>
+	      <label>$(gettext 'Set/keep DNS1[ 2]:')</label>
+	      <action>if true refresh:PPPOEDNSVALUE</action>
+	      <action>if true show:PPPOEDNSVALUE</action>
+	      <action>if false hide:PPPOEDNSVALUE</action>
+	      <action>enable:SAVEBTN</action>
+	     </checkbox>
+	     <entry $SHOWPPPOEDNSVALUE>
+	      <variable>PPPOEDNSVALUE</variable>
+	      <input>read_telephone_value pppoednsvalue</input>
+	      <action>enable:SAVEBTN</action>
+	     </entry>
+	    </hbox>
+	    <hbox space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext 'Select firewall configuration for PPPoE.  Choose Standalone for a basic stand-alone web-surfing workstation, Masquerade for a machine acting as an Internet gateway or None')\">
+	     <label>$(gettext 'Firewall Configuration:')</label>
+	     </text>
+	     <comboboxtext>
+	      <variable>PPPOEFIREWALL</variable>
+	      <input file>/tmp/.frisbee/pppoefirewalllist</input>
+	      <action>enable:SAVEBTN</action>
+	     </comboboxtext>
+	    </hbox>
+	    <hbox space-expand=\"true\" space-fill=\"true\">
+	     <checkbox tooltip-text=\"$(gettext 'If internet service provider requires a user name and password, check this box and enter them below.  Unchecking the box will clear them without changing the saved copies.')\">
+	      <variable>PPPOEUIDREQD</variable>
+	      <input>read_telephone_value pppoeuidreq</input>
+	      <label>$(gettext 'Authenticate')</label>
+	      <action>if true refresh:PPPOEUSER</action>
+	      <action>if true show:PPPOEUSER</action>
+	      <action>if true refresh:PPPOEPSWD</action>
+	      <action>if true show:PPPOEPSWD</action>
+	      <action>if true refresh:PPPOEPAPONLY</action>
+	      <action>if true show:PPPOEPAPONLY</action>
+	      <action>if true refresh:PPPOEUSERBOX</action>
+	      <action>if true show:PPPOEUSERBOX</action>
+	      <action>if true refresh:PPPOEPSWDBOX</action>
+	      <action>if true show:PPPOEPSWDBOX</action>
+	      <action>if false clear:PPPOEUSER</action>
+	      <action>if false clear:PPPOEPSWD</action>
+	      <action>if false hide:PPPOEUSERBOX</action>
+	      <action>if false hide:PPPOEPSWDBOX</action>
+	      <action>if false hide:PPPOEPAPONLY</action>
+	      <action>if false enable:SAVEBTN</action>
+	     </checkbox>
+	     <checkbox $SHOWPPPOEUID tooltip-text=\"$(gettext 'If internet service provider requires PAP authenticatiion, check this box.')\">
+	      <variable>PPPOEPAPONLY</variable>
+	      <input>read_telephone_value pppoepaponly</input>
+	      <label>$(gettext 'PAP auth only')</label>
+	      <action>enable:SAVEBTN</action>
+	     </checkbox>
+	    </hbox>
+	    <hbox $SHOWPPPOEUID space-expand=\"true\">
+	     <text>
+	     <label>$(gettext 'Username:')</label>
+	     </text>
+	     <entry>
+	     <variable>PPPOEUSER</variable>
+	     <input>read_telephone_value pppoeuser</input>
+	     <action>clear:PPPOEPSWD</action>
+	     <action>refresh:PPPOEPSWD</action>
+	     <action>enable:SAVEBTN</action>
+	     </entry>
+	     <variable>PPPOEUSERBOX</variable>
+	    </hbox>
+	    <hbox $SHOWPPPOEUID space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext "If you change this password, be aware that it will be saved by only the 'Save' and 'Connect' buttons and will be ignored if you change the 'Configure...' button.")\">
+	     <label>$(gettext 'Password:')</label>
+	     </text>
+	     <entry>
+	     <visible>password</visible>
+	     <variable>PPPOEPSWD</variable>
+	     $PPPOEPSWDDFLT
+	     <input>read_telephone_value pppoepswd</input>
+	     <action>enable:SAVEBTN</action>
+	     </entry>
+	     <variable>PPPOEPSWDBOX</variable>
+	    </hbox>
+	   </vbox>
+	  <variable>PPPOEFRM</variable>
+	  <sensitive>$PPPOEFRMSENS</sensitive>
+	  </frame>
+	 </vbox>
 
-     <vbox>
-      <frame $(gettext 'Mobile Wireless (GPRS/3G/GSM)')>
-       <vbox>
-        <hbox space-expand=\"true\">
-         <text tooltip-text=\"$(gettext "If no device detected, plug in a USB device and click the 'Refresh' button")\">
-         <label>$(gettext 'Modem Interface:')</label>
-         </text>
-         <comboboxtext>
-         <variable>GPRSDEV</variable>
-         <input>build_mobile_device_list</input>
-         <default>$(read_telephone_value device || echo =--Error--)</default>
-         <input file>/tmp/.frisbee/mobiledevlist</input>
-         <action>enable:SAVEBTN</action>
-         </comboboxtext>
-        </hbox>
-        <hbox space-expand=\"true\">
-         <text tooltip-text=\"$(gettext "Access Point Name for Internet Service Provider's data service")\">
-         <label>APN:</label>
-         </text>
-         <entry>
-         <input>read_telephone_value apn</input>
-         <variable>GPRSAPN</variable>
-         <action>enable:SAVEBTN</action>
-         </entry>
-        </hbox>
-        <hbox space-expand=\"true\">
-         <text tooltip-text=\"$(gettext "Dialup access number for Internet Service Provider's data service, such as *99#, *99***1#, #777")\">
-         <label>$(gettext 'Access Number:')</label>
-         </text>
-         <comboboxtext>
-          <variable>GPRSNBR</variable>
-          <default>\"$(read_telephone_value number)\"</default>
-          <input file>/tmp/.frisbee/mobilenbrlist</input>
-          <action>enable:SAVEBTN</action>
-         </comboboxtext>
-        </hbox>
-        <hbox space-expand=\"true\">
-         <text tooltip-text=\"$(gettext "A four-digit Personal Identification Number (PIN) associated with the phone/modem's SIM card")\">
-         <label>$(gettext 'SIM PIN:')</label>
-         </text>
-         <entry>
-         <input>read_telephone_value pin</input>
-         <variable>GPRSPIN</variable>
-         <action>enable:SAVEBTN</action>
-         </entry>
-        </hbox>
-        <hbox space-expand=\"true\" space-fill=\"true\">
-         <checkbox tooltip-text=\"$(gettext 'If internet service provider requires a user name and password, check this box and enter them below.  Unchecking the box will clear them without changing the saved copies.')\">
-          <variable>MBLUIDREQD</variable>
-          <input>read_telephone_value uidreq</input>
-          <label>$(gettext 'Authenticate')</label>
-          <action>if true refresh:GPRSUSER</action>
-          <action>if true show:GPRSUSER</action>
-          <action>if true refresh:GPRSPSWD</action>
-          <action>if true show:GPRSPSWD</action>
-          <action>if true refresh:GPRSPAPONLY</action>
-          <action>if true show:GPRSPAPONLY</action>
-          <action>if true refresh:MBLUSERBOX</action>
-          <action>if true show:MBLUSERBOX</action>
-          <action>if true refresh:MBLPSWDBOX</action>
-          <action>if true show:MBLPSWDBOX</action>
-          <action>if false clear:GPRSUSER</action>
-          <action>if false clear:GPRSPSWD</action>
-          <action>if false hide:MBLUSERBOX</action>
-          <action>if false hide:MBLPSWDBOX</action>
-          <action>if false hide:GPRSPAPONLY</action>
-          <action>if false enable:SAVEBTN</action>
-         </checkbox>
-         <checkbox $SHOWMBLUID tooltip-text=\"$(gettext 'If internet service provider requires PAP authenticatiion, check this box.')\">
-          <variable>GPRSPAPONLY</variable>
-          <input>read_telephone_value gprspaponly</input>
-          <label>$(gettext 'PAP auth only')</label>
-          <action>enable:SAVEBTN</action>
-         </checkbox>
-        </hbox>
-        <hbox $SHOWMBLUID space-expand=\"true\">
-         <text>
-         <label>$(gettext 'Username:')</label>
-         </text>
-         <entry>
-         <variable>GPRSUSER</variable>
-         <input>read_telephone_value gprsuser</input>
-         <action>clear:GPRSPSWD</action>
-         <action>refresh:GPRSPSWD</action>
-         <action>enable:SAVEBTN</action>
-         </entry>
-         <variable>MBLUSERBOX</variable>
-        </hbox>
-        <hbox $SHOWMBLUID space-expand=\"true\">
-         <text tooltip-text=\"$(gettext "If you change this password, be aware that it will be saved by only the 'Save' and 'Connect' buttons and will be ignored if you change the 'Configure...' button.")\">
-         <label>$(gettext 'Password:')</label>
-         </text>
-         <entry>
-         <visible>password</visible>
-         <variable>GPRSPSWD</variable>
-         $GPRSPSWDDFLT
-         <input>read_telephone_value gprspswd</input>
-         <action>enable:SAVEBTN</action>
-         </entry>
-         <variable>MBLPSWDBOX</variable>
-        </hbox>
-       </vbox>
-      <variable>MBLFRM</variable>
-      <sensitive>$MBLFRMSENS</sensitive>
-      </frame>
-     </vbox>
-    </hbox>
-      <hbox space-expand=\"true\">
-       <button tooltip-text=\"$(gettext 'Update the interface device selection list, usually after inserting or removing a USB wireless modem or ethernet device. ')\">
-       <input file stock=\"gtk-refresh\"></input>
-       <label>$(gettext 'Refresh')</label>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">build_pppoe_interface_list</action>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">clear:PPPOEDEV</action>    
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">refresh:PPPOEDEV</action>    
-       <action condition=\"sensitive_is_true(MBLFRM)\">clear:GPRSDEV</action>    
-       <action condition=\"sensitive_is_true(MBLFRM)\">refresh:GPRSDEV</action>    
-       </button>
-       <button tooltip-text=\"$(gettext 'Save the configuration values. ')\">
-       <input file stock=\"gtk-save\"></input>
-       <label>$(gettext 'Save')</label>
-       <sensitive>false</sensitive>
-       <variable>SAVEBTN</variable>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_configuration</action>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_password</action>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">refresh:PPPOEUIDREQD</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">save_mobile_configuration</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">save_mobile_password</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">refresh:MBLUIDREQD</action>
-       <action>disable:SAVEBTN</action>
-       </button>
-       <button tooltip-text=\"$(gettext 'View status')\">
-       <input file stock=\"gtk-info\"></input>
-       <label>$(gettext 'Status')</label>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">Xdialog --wmclass \"frisbee\"  --title \"Frisbee PPPoE\"  --msgbox \"\$(pppoe-status)\" 0 0 &</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">mobile_status</action>
-       <action>disable:SAVEBTN</action>
-       </button>
-       <button tooltip-text=\"$(gettext 'Connect now')\">
-       <input file stock=\"gtk-connect\"></input>
-       <label>$(gettext 'Connect')</label>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_configuration</action>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_password</action>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">refresh:PPPOEUIDREQD</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">save_mobile_configuration</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">save_mobile_password</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">refresh:MBLUIDREQD</action>
-       <action>disable:SAVEBTN</action>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">connect_pppoe</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">frisbee --connect-gprs &</action>
-       </button>
-       <button tooltip-text=\"$(gettext 'Disconnect now')\">
-       <input file stock=\"gtk-disconnect\"></input>
-       <label>$(gettext 'Disconnect')</label>
-       <action condition=\"sensitive_is_true(PPPOEFRM)\">disconnect_pppoe</action>
-       <action condition=\"sensitive_is_true(MBLFRM)\">frisbee --disconnect-gprs</action>
-       </button>
-      </hbox>
-   </vbox>"
+	 <vbox>
+	  <frame $(gettext 'Mobile Wireless (GPRS/3G/GSM)')>
+	   <vbox>
+	    <hbox space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext "If no device detected, plug in a USB device and click the 'Refresh' button")\">
+	     <label>$(gettext 'Modem Interface:')</label>
+	     </text>
+	     <comboboxtext>
+	     <variable>GPRSDEV</variable>
+	     <input>build_mobile_device_list</input>
+	     <default>$(read_telephone_value device || echo '--Error--')</default>
+	     <input file>/tmp/.frisbee/mobiledevlist</input>
+	     <action>enable:SAVEBTN</action>
+	     </comboboxtext>
+	    </hbox>
+	    <hbox space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext "Access Point Name for Internet Service Provider's data service")\">
+	     <label>$(gettext 'APN:')</label>
+	     </text>
+	     <entry>
+	     <input>read_telephone_value apn</input>
+	     <variable>GPRSAPN</variable>
+	     <action>enable:SAVEBTN</action>
+	     </entry>
+	    </hbox>
+	    <hbox space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext "Dialup access number for Internet Service Provider's data service, such as *99#, *99***1#, #777")\">
+	     <label>$(gettext 'Access Number:')</label>
+	     </text>
+	     <comboboxtext>
+	      <variable>GPRSNBR</variable>
+	      <input>grep '^GPRS_ACCESS_NUMBERS=' /etc/gprs.conf | grep -o '=.*' | tr -d = | tr -d \' | tr ' ' '\n' > /tmp/.frisbee/mobilenbrlist</input>
+	      <default>\"$(read_telephone_value number)\"</default>
+	      <input file>/tmp/.frisbee/mobilenbrlist</input>
+	      <action>enable:SAVEBTN</action>
+	     </comboboxtext>
+	    </hbox>
+	    <hbox space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext "A four-digit Personal Identification Number (PIN) associated with the phone/modem's SIM card")\">
+	     <label>$(gettext 'SIM PIN:')</label>
+	     </text>
+	     <entry>
+	     <input>read_telephone_value pin</input>
+	     <variable>GPRSPIN</variable>
+	     <action>enable:SAVEBTN</action>
+	     </entry>
+	    </hbox>
+	    <hbox space-expand=\"true\" space-fill=\"true\">
+	     <checkbox tooltip-text=\"$(gettext 'If internet service provider requires a user name and password, check this box and enter them below.  Unchecking the box will clear them without changing the saved copies.')\">
+	      <variable>MBLUIDREQD</variable>
+	      <input>read_telephone_value uidreq</input>
+	      <label>$(gettext 'Authenticate')</label>
+	      <action>if true refresh:GPRSUSER</action>
+	      <action>if true show:GPRSUSER</action>
+	      <action>if true refresh:GPRSPSWD</action>
+	      <action>if true show:GPRSPSWD</action>
+	      <action>if true refresh:GPRSPAPONLY</action>
+	      <action>if true show:GPRSPAPONLY</action>
+	      <action>if true refresh:MBLUSERBOX</action>
+	      <action>if true show:MBLUSERBOX</action>
+	      <action>if true refresh:MBLPSWDBOX</action>
+	      <action>if true show:MBLPSWDBOX</action>
+	      <action>if false clear:GPRSUSER</action>
+	      <action>if false clear:GPRSPSWD</action>
+	      <action>if false hide:MBLUSERBOX</action>
+	      <action>if false hide:MBLPSWDBOX</action>
+	      <action>if false hide:GPRSPAPONLY</action>
+	      <action>if false enable:SAVEBTN</action>
+	     </checkbox>
+	     <checkbox $SHOWMBLUID tooltip-text=\"$(gettext 'If internet service provider requires PAP authenticatiion, check this box.')\">
+	      <variable>GPRSPAPONLY</variable>
+	      <input>read_telephone_value gprspaponly</input>
+	      <label>$(gettext 'PAP auth only')</label>
+	      <action>enable:SAVEBTN</action>
+	     </checkbox>
+	    </hbox>
+	    <hbox $SHOWMBLUID space-expand=\"true\">
+	     <text>
+	     <label>$(gettext 'Username:')</label>
+	     </text>
+	     <entry>
+	     <variable>GPRSUSER</variable>
+	     <input>read_telephone_value gprsuser</input>
+	     <action>clear:GPRSPSWD</action>
+	     <action>refresh:GPRSPSWD</action>
+	     <action>enable:SAVEBTN</action>
+	     </entry>
+	     <variable>MBLUSERBOX</variable>
+	    </hbox>
+	    <hbox $SHOWMBLUID space-expand=\"true\">
+	     <text tooltip-text=\"$(gettext "If you change this password, be aware that it will be saved by only the 'Save' and 'Connect' buttons and will be ignored if you change the 'Configure...' button.")\">
+	     <label>$(gettext 'Password:')</label>
+	     </text>
+	     <entry>
+	     <visible>password</visible>
+	     <variable>GPRSPSWD</variable>
+	     $GPRSPSWDDFLT
+	     <input>read_telephone_value gprspswd</input>
+	     <action>enable:SAVEBTN</action>
+	     </entry>
+	     <variable>MBLPSWDBOX</variable>
+	    </hbox>
+	   </vbox>
+	  <variable>MBLFRM</variable>
+	  <sensitive>$MBLFRMSENS</sensitive>
+	  </frame>
+	 </vbox>
+	</hbox>
+	  <hbox space-expand=\"true\">
+	   <button tooltip-text=\"$(gettext 'Update the interface device selection list, usually after inserting or removing a USB wireless modem or ethernet device. ')\">
+	   <input file stock=\"gtk-refresh\"></input>
+	   <label>$(gettext 'Refresh')</label>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">build_pppoe_interface_list</action>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">clear:PPPOEDEV</action>    
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">refresh:PPPOEDEV</action>    
+	   <action condition=\"sensitive_is_true(MBLFRM)\">clear:GPRSDEV</action>    
+	   <action condition=\"sensitive_is_true(MBLFRM)\">refresh:GPRSDEV</action>    
+	   </button>
+	   <button tooltip-text=\"$(gettext 'Save the configuration values. ')\">
+	   <input file stock=\"gtk-save\"></input>
+	   <label>$(gettext 'Save')</label>
+	   <sensitive>false</sensitive>
+	   <variable>SAVEBTN</variable>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_configuration</action>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_password</action>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">refresh:PPPOEUIDREQD</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">save_mobile_configuration</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">refresh:MBLUIDREQD</action>
+	   <action>disable:SAVEBTN</action>
+	   </button>
+	   <button tooltip-text=\"$(gettext 'View status')\">
+	   <input file stock=\"gtk-info\"></input>
+	   <label>$(gettext 'Status')</label>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">Xdialog --wmclass frisbee  --title \"$(gettext 'Frisbee PPPoE')\"  --msgbox \"\$(pppoe-status)\" 0 0 &</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">mobile_status</action>
+	   <action>disable:SAVEBTN</action>
+	   </button>
+	   <button tooltip-text=\"$(gettext 'Connect now')\">
+	   <input file stock=\"gtk-connect\"></input>
+	   <label>$(gettext 'Connect')</label>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_configuration</action>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">save_pppoe_password</action>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">refresh:PPPOEUIDREQD</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">save_mobile_configuration</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">refresh:MBLUIDREQD</action>
+	   <action>disable:SAVEBTN</action>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">connect_pppoe</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">connect_mobile</action>
+	   </button>
+	   <button tooltip-text=\"$(gettext 'Disconnect now')\">
+	   <input file stock=\"gtk-disconnect\"></input>
+	   <label>$(gettext 'Disconnect')</label>
+	   <action condition=\"sensitive_is_true(PPPOEFRM)\">disconnect_pppoe</action>
+	   <action condition=\"sensitive_is_true(MBLFRM)\">frisbee --disconnect-gprs</action>
+	   </button>
+	  </hbox>
+   </vbox>" #200829
 	#("#geany) End of TELEPHONE_TAB
 
-	export FRISBEE_MAIN_DIALOG="
-<window title=\"Frisbee $VERSION - $(gettext 'Configure Networks')\" image-name=\"/usr/share/pixmaps/frisbee.png\" window-position=\"1\">
+# shellcheck disable=SC2089 # Backslashes & quotes OK.
+	FRISBEE_MAIN_DIALOG="
+<window title=\"$(eval_gettext "Frisbee \$VERSION - Configure Networks")\" image-name=\"/usr/share/pixmaps/frisbee.png\" window-position=\"1\">
  <vbox>
-  <notebook labels=\"$(gettext 'Wireless Networks|Network Interfaces|Telephone Networks')\">
+  <notebook labels=\"$(gettext 'Wireless Networks')|$(gettext 'Network Interfaces')|$(gettext 'Telephone Networks')\">
 
 $WIRELESS_TAB
 $NETWORKS_TAB
@@ -1189,12 +1203,14 @@ $TELEPHONE_TAB
 </window>
 "
 	#("#geany) End of MAIN_DIALOG
+# shellcheck disable=SC2090 # Backslashes & quotes OK.
+	export FRISBEE_MAIN_DIALOG
 
 	EXIT=$(gtkdialog --program=FRISBEE_MAIN_DIALOG --center | grep ^EXIT | cut -f 2 -d = | grep -v 'Exit on' | tail -n 1 | tr -d \")
 	rm -f /tmp/.frisbee/* 2>/dev/null
 
 	[[ "$EXIT" != "RESTART" ]] && break #140819...
-	
+
 	gtkdialog-splash -placement center -bg orange -text "$(gettext 'Stopping network devices')" &
 	SPLASHPID=$!
 	/etc/init.d/frisbee.sh stop

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-mode-enable
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-mode-enable
@@ -2,15 +2,15 @@
 if ! grep -q '^frisbee_mode=1' /etc/frisbee/frisbee.conf;then
 	sed -i -e '/^frisbee_mode=/ s/=.*/=1/' /etc/frisbee/frisbee.conf #set frisbee mode in effect
 	if [ -f /etc/dhcpcd_state_notify ];then
-		grep -q '^dhcpcd_state_notify=1' /etc/frisbee/frisbee.conf \
-		 || sed -i -e '/^dhcpcd_state_notify=/ s/=.*/=1/' /etc/frisbee/frisbee.conf #on before frisbee mode
-		grep -q '^announce_state_changes=1' /etc/frisbee/frisbee.conf \
-		 || rm -f /etc/dhcpcd_state_notify
+	    grep -q '^dhcpcd_state_notify=1' /etc/frisbee/frisbee.conf \
+	      || sed -i -e '/^dhcpcd_state_notify=/ s/=.*/=1/' /etc/frisbee/frisbee.conf #on before frisbee mode
+	    grep -q '^announce_state_changes=1' /etc/frisbee/frisbee.conf \
+	      || rm -f /etc/dhcpcd_state_notify
 	else
-		grep -q '^dhcpcd_state_notify=0' /etc/frisbee/frisbee.conf \
-		 || sed -i -e '/^dhcpcd_state_notify=/ s/=.*/=0/' /etc/frisbee/frisbee.conf #off before frisbee mode
-		grep -q '^announce_state_changes=1' /etc/frisbee/frisbee.conf \
-		 && touch /etc/dhcpcd_state_notify
+	    grep -q '^dhcpcd_state_notify=0' /etc/frisbee/frisbee.conf \
+	      || sed -i -e '/^dhcpcd_state_notify=/ s/=.*/=0/' /etc/frisbee/frisbee.conf #off before frisbee mode
+	    grep -q '^announce_state_changes=1' /etc/frisbee/frisbee.conf \
+	      && touch /etc/dhcpcd_state_notify
 	fi
 fi
 

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-wifi-connect
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-wifi-connect
@@ -1,5 +1,7 @@
 #!/bin/bash
-INTERFACE=`cat /etc/frisbee/interface`
-. $FRISBEEFUNCDIR/func
+# shellcheck disable=SC1090 # Skip sourced checks.
+# shellcheck disable=SC2034 # Variable used by sourced file.
+INTERFACE="$(cat /etc/frisbee/interface)"
+. "$FRISBEEFUNCDIR/connect-func"
 connect
 #reset_dhcp&

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-wifi-disconnect
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/frisbee-wifi-disconnect
@@ -1,12 +1,15 @@
 #!/bin/bash
+# shellcheck disable=SC1090 # Skip sourced checks.
 #180210 disconnect other ethernet interfaces if wifi already disconnected.
-INTERFACE=`cat /etc/frisbee/interface`
-. $FRISBEEFUNCDIR/func
-INTERFACES=$(ifconfig | sed -n -e '/Ethernet/ N' -e '/^[^ ].*inet addr/ s/ .*// p')
-if echo $INTERFACES | grep -qw "$INTERFACE"; then
- disconnect
+#200829 (v2.0) Replace deprecated ifconfig.
+
+INTERFACE=$(cat /etc/frisbee/interface)
+. "$FRISBEEFUNCDIR/connect-func"
+INTERFACES=$(ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ':' | tr -d '\n') #200829
+if echo "$INTERFACES" | grep -qw "$INTERFACE"; then
+	disconnect
 else #disconnect other (wired) interfaces
- for INTERFACE in $INTERFACES;do
-  dhcpcd -k $INTERFACE 
- done
+	for INTERFACE in $INTERFACES;do
+	    dhcpcd -k "$INTERFACE" 
+	done
 fi

--- a/woof-code/rootfs-packages/frisbee/usr/local/frisbee/func
+++ b/woof-code/rootfs-packages/frisbee/usr/local/frisbee/func
@@ -1,4 +1,6 @@
-#!/bin/sh  #Triggers geany color highlighting
+#!/bin/bash
+# shellcheck disable=SC1091,SC2005,SC2162 # Skip sourced checks; useless echos add newline; allow read without -r.
+#Shebang above triggers geany color highlighting, informs shellcheck.
 #Commands read and executed by frisbee components only.
 #Localization - argolance - January 2013
 #130822 Support EAP-PEAP & EAP-TTLC identity & password
@@ -14,20 +16,24 @@
 #170621 display networks in order of signal quality.
 #180313 prevent error messages from appearing as Xdialog user input/selection.
 #180721 Replace modem-stats with corrected use of microcom.
+#200829 (v2.0) Test for nonexistant hardware with setserial, to avoid broken pipes; move etc gprs.conf; add conflict checks to mobile save and connect; replace deprecated ifconfig & iwconfig; add quotes to GPRSDEV in /root/.config/gprs.conf; replace pidof with pgrep or ps -C; add internationalization exports, for momanager; add nl80211 wpa driver; resolve shellcheck warnings; moved connect-related functions to connect-func.
+
+export TEXTDOMAIN=frisbee #for momanager translation 200829...
+export OUTPUT_CHARSET=UTF-8
 
 #############################################
 
 function max_priority {
 	#set -x
 	MAX_PRIORITY=0
-	wpa_cli -i $INTERFACE list_networks |head | while read LINE ; do
-		[[ $LINE =~ ^network* ]] && continue
-        ID=$(echo "$LINE" |cut -f1)
-		PRIORITY=`wpa_cli -i $INTERFACE get_network $ID priority`
-		if [[ $PRIORITY -gt $MAX_PRIORITY ]] ; then #140929
-			MAX_PRIORITY=$PRIORITY #140929
-			echo $MAX_PRIORITY
-		fi
+	wpa_cli -i "$INTERFACE" list_networks |head | while read LINE ; do
+	    [[ $LINE =~ ^network* ]] && continue
+	    ID=$(echo "$LINE" |cut -f1)
+	    PRIORITY=$(wpa_cli -i "$INTERFACE" get_network "$ID" priority)
+	    if [[ $PRIORITY -gt $MAX_PRIORITY ]] ; then #140929
+	        MAX_PRIORITY=$PRIORITY #140929
+	        echo "$MAX_PRIORITY"
+	    fi
 	done |tail -n 1
 }
 
@@ -36,17 +42,17 @@ export -f max_priority
 #############################################
 
 function check_profile_exists {
-    #set -x
+	#set -x
 	SSID=$1
 	ID=-1
-	wpa_cli -i $INTERFACE list_networks | while read LINE ; do
-        	PSSID=$(echo "$LINE" |cut -f2)
-                if [[ "$PSSID" == "$SSID" ]] ; then
-                        ID=$(echo "$LINE" |cut -f1)
-			echo $ID
-			break
-		fi
-        done 
+	wpa_cli -i "$INTERFACE" list_networks | while read LINE ; do
+	    PSSID=$(echo "$LINE" |cut -f2)
+	    if [[ "$PSSID" == "$SSID" ]] ; then
+	        ID=$(echo "$LINE" |cut -f1)
+	        echo "$ID"
+	        break
+	    fi
+	    done 
 }
 
 export -f check_profile_exists
@@ -60,313 +66,313 @@ function add_profile {
 
 	. gettext.sh
 	if [[ $BSSID == '' ]] ; then
-		Xdialog --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Please select a network')" 0 0 
-		return 1 #140914
+	    Xdialog --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Please select a network')" 0 0 
+	    return 1 #140914
 	fi
 
-	BSSID_RESULT="`wpa_cli scan_results -i $INTERFACE | grep "$BSSID"`" #140929
-	SSID="`echo "$BSSID_RESULT" | cut -f 5`" #140929
+	BSSID_RESULT="$(wpa_cli scan_results -i "$INTERFACE" | grep "$BSSID")" #140929
+	SSID="$(echo "$BSSID_RESULT" | cut -f 5)" #140929
 	if [ -z "$SSID" ] ; then #140914...
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Network information for \\\$INTERFACE not available.  Please try again to connect.\"`" 0 0
-		return 1 #140914
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Network information for \$INTERFACE not available.  Please try again to connect.")" 0 0
+	    return 1 #140914
 	fi #140914 end
 	[ "$SSID" = "<hidden>" ] && SSID=''
-	FLAGS="`echo "$BSSID_RESULT" | cut -f 4`" #140929
+	FLAGS="$(echo "$BSSID_RESULT" | cut -f 4)" #140929
 
-	PRIORITY=`max_priority` #140929
+	PRIORITY=$(max_priority) #140929
 	[ "$PRIORITY" ] && ((PRIORITY++)) || PRIORITY=1 #140929
 	
-	ID="`check_profile_exists $SSID`"
-	if [[ ! -z "$ID" ]] ; then
-		RESULT=`wpa_cli -i $INTERFACE set_network $ID priority $PRIORITY`
-		if [[ "$RESULT" != "OK" ]] ; then
-				PARAMETER="priority"
-				Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-		fi
+	ID="$(check_profile_exists "$SSID")"
+	if [[ -n "$ID" ]] ; then
+	    RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" priority "$PRIORITY")
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        PARAMETER="priority"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	    fi
 
-		RESULT=`wpa_cli -i $INTERFACE save_config`
-		if [[ "$RESULT" != "OK" ]] ; then
-				Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
-		fi
-		reset_wpa&
-		reset_dhcp&
-		return 0 #140914
+	    RESULT=$(wpa_cli -i "$INTERFACE" save_config)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
+	    fi
+	    reset_wpa&
+	    reset_dhcp&
+	    return 0 #140914
 	fi
 
-	wpa_cli -i $INTERFACE disconnect
+	wpa_cli -i "$INTERFACE" disconnect
 	
 	if echo "$FLAGS" | grep -q 'WPA'; then #141005
-		ENC=WPA
-		if echo "$FLAGS" | grep -q 'TKIP'; then
-			ENCTYPE=TKIP
-		else
-			ENCTYPE=CCMP
-		fi
-		if echo "$FLAGS" | grep -q 'WPA-'; then #141005
-			PROTO=WPA
-		else
-			PROTO=RSN
-		fi
-		if echo "$FLAGS" | grep -q 'EAP'; then #130822... #141005
-			EAP=1
-		else
-			EAP=0
-		fi #130822 end
+	    ENC=WPA
+	    if echo "$FLAGS" | grep -q 'TKIP'; then
+	        ENCTYPE=TKIP
+	    else
+	        ENCTYPE=CCMP
+	    fi
+	    if echo "$FLAGS" | grep -q 'WPA-'; then #141005
+	        PROTO=WPA
+	    else
+	        PROTO=RSN
+	    fi
+	    if echo "$FLAGS" | grep -q 'EAP'; then #130822... #141005
+	        EAP=1
+	    else
+	        EAP=0
+	    fi #130822 end
 	else
-		if echo "$FLAGS" | grep -q 'WEP'; then #141005
-			ENC=WEP
-		else
-			ENC=NONE
-		fi
+	    if echo "$FLAGS" | grep -q 'WEP'; then #141005
+	        ENC=WEP
+	    else
+	        ENC=NONE
+	    fi
 	fi
 	
-	ID=`wpa_cli -i $INTERFACE add_network`
+	ID=$(wpa_cli -i "$INTERFACE" add_network)
 	if [ -z "$ID" ] || [[ "$ID" == "FAIL" ]] ; then #141005
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to add network')" 0 0
-		wpa_cli -i $INTERFACE scan #140914
-		return 1 #140914
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to add network')" 0 0
+	    wpa_cli -i "$INTERFACE" scan #140914
+	    return 1 #140914
 	fi
 	
 	if [ -z "$SSID" ] ; then #SSID hidden
-		if ! Xdialog  --wmclass "frisbee" --title "Frisbee" --stdout --inputbox "$(gettext 'The SSID is hidden -- please enter the SSID')" 0 0 > /tmp/.frisbee/entry; then #141005 180313
-			rm  /tmp/.frisbee/entry #140914
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
-		SSID=`cat /tmp/.frisbee/entry`
-		rm  /tmp/.frisbee/entry
-		if [ -z "$SSID" ] ; then
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'No SSID provided -- cannot connect')" 0 0 #141005
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
-		SCANSSID=1
+	    if ! Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --stdout --inputbox "$(gettext 'The SSID is hidden -- please enter the SSID')" 0 0 > /tmp/.frisbee/entry; then #141005 180313
+	        rm  /tmp/.frisbee/entry #140914
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
+	    SSID=$(cat /tmp/.frisbee/entry)
+	    rm  /tmp/.frisbee/entry
+	    if [ -z "$SSID" ] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'No SSID provided -- cannot connect')" 0 0 #141005
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
+	    SCANSSID=1
 	fi
 	
-	RESULT=`wpa_cli -i $INTERFACE set_network $ID ssid \""${SSID}"\"`
+	RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" ssid \""${SSID}"\")
 	if [[ "$RESULT" != "OK" ]] ; then
-		PARAMETER="ssid"
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-		wpa_cli -i $INTERFACE remove_network $ID 
-		wpa_cli -i $INTERFACE scan #140914
-		return 1 #140914
+	    PARAMETER="ssid"
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	    wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	    wpa_cli -i "$INTERFACE" scan #140914
+	    return 1 #140914
 	fi
 	
 	if [[ $SCANSSID == 1 ]] ; then
-		RESULT=`wpa_cli -i $INTERFACE set_network $ID scan_ssid 1`
-		if [[ "$RESULT" != "OK" ]] ; then
-			PARAMETER="scan_ssid"
-			Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" scan_ssid 1)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        PARAMETER="scan_ssid"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
 	fi
 	
-	RESULT=`wpa_cli -i $INTERFACE enable_network $ID`
+	RESULT=$(wpa_cli -i "$INTERFACE" enable_network "$ID")
 	if [[ "$RESULT" != "OK" ]] ; then
-		Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Failed to enable network')" 0 0
-		wpa_cli -i $INTERFACE remove_network $ID 
-		wpa_cli -i $INTERFACE scan #140914
-		return 1 #140914
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Failed to enable network')" 0 0
+	    wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	    wpa_cli -i "$INTERFACE" scan #140914
+	    return 1 #140914
 	fi
 	
-	if echo $FLAGS | grep -q 'IBSS'; then #141005
-		RESULT=`wpa_cli -i $INTERFACE set_network $ID mode 1`
-		if [[ "$RESULT" != "OK" ]] ; then
-			PARAMETER="mode"
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
-		RESULT=`wpa_cli -i $INTERFACE ap_scan 2`
-		if [[ "$RESULT" != "OK" ]] ; then
-			PARAMETER="ap_scan"
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
+	if echo "$FLAGS" | grep -q 'IBSS'; then #141005
+	    RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" mode 1)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        PARAMETER="mode"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" ap_scan 2)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        PARAMETER="ap_scan"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
 	fi
 	
 	if [[ "$ENC" == "WPA" ]] ; then
-		MGMT=WPA-PSK #130822...
-		if [ $EAP -eq 1 ] ; then
-#			echo "add_profile - key_mgmt: $(wpa_cli -i $INTERFACE get_network $ID key_mgmt)" >> /tmp/debug.log #DEBUG
-#			echo "add_profile - eap: $(wpa_cli -i $INTERFACE get_network $ID eap)" >> /tmp/debug.log #DEBUG
-			IDENTITY=""
-			MSG="$(gettext 'Please enter your authorisation identity, only if required.')"
-			if Xdialog  --wmclass "frisbee" --title "Frisbee"--stdout --password --inputbox "$MSG" 0 0 > /tmp/.frisbee/entry; then #141005 180313
-				IDENTITY=`cat /tmp/.frisbee/entry`
-				if [ "$IDENTITY" ] ; then
-					MGMT=WPA-EAP
-				fi
-			fi
-			rm  /tmp/.frisbee/entry
-		fi #130822 end
+	    MGMT=WPA-PSK #130822...
+	    if [ $EAP -eq 1 ] ; then
+#           echo "add_profile - key_mgmt: $(wpa_cli -i "$INTERFACE" get_network "$ID" key_mgmt)" >> /tmp/debug.log #DEBUG
+#           echo "add_profile - eap: $(wpa_cli -i "$INTERFACE" get_network "$ID" eap)" >> /tmp/debug.log #DEBUG
+	        IDENTITY=""
+	        MSG="$(gettext 'Please enter your authorisation identity, only if required.')"
+	        if Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"--stdout --password --inputbox "$MSG" 0 0 > /tmp/.frisbee/entry; then #141005 180313
+	            IDENTITY=$(cat /tmp/.frisbee/entry)
+	            if [ "$IDENTITY" ] ; then
+	                MGMT=WPA-EAP
+	            fi
+	        fi
+	        rm  /tmp/.frisbee/entry
+	    fi #130822 end
 	else
-		MGMT=NONE
+	    MGMT=NONE
 	fi
 	
-	RESULT=`wpa_cli -i $INTERFACE set_network $ID key_mgmt $MGMT`
+	RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" key_mgmt "$MGMT")
 	if [[ "$RESULT" != "OK" ]] ; then
-		PARAMETER="key_mgmt"
-		Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-		wpa_cli -i $INTERFACE remove_network $ID 
-		wpa_cli -i $INTERFACE scan #140914
-		return 1 #140914
+	    PARAMETER="key_mgmt"
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	    wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	    wpa_cli -i "$INTERFACE" scan #140914
+	    return 1 #140914
 	fi
 	
 	if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
-		RESULT=`wpa_cli -i $INTERFACE set_network $ID eap PEAP`
-		if [[ "$RESULT" != "OK" ]] ; then
-			RESULT=`wpa_cli -i $INTERFACE set_network $ID eap TTLS`
-			if [[ "$RESULT" != "OK" ]] ; then
-				PARAMETER="eap"
-				Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-				wpa_cli -i $INTERFACE remove_network $ID 
-				wpa_cli -i $INTERFACE scan #140914
-				return 1 #140914
-			fi
-		fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" eap PEAP)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" eap TTLS)
+	        if [[ "$RESULT" != "OK" ]] ; then
+	            PARAMETER="eap"
+	            Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	            wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	            wpa_cli -i "$INTERFACE" scan #140914
+	            return 1 #140914
+	        fi
+	    fi
 	fi #130822 end
 	
 	if [[ "$ENC" == "WPA" ||  "$ENC" == "WEP" ]] ; then
-		if [[ "$ENC" == "WEP" ]] ; then
-		 MSG="$(gettext 'Please enter the ASCII or HEX WEP key with no colons or dashes.\nThe HEX key works most reliably.')" #130822
-		else
-		 if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
-		  MSG="$(gettext 'Please enter the authentication Password.')"
-		 else
-		  MSG="$(gettext 'Please enter the public (pre-shared) Key.')" #130822 end
-		 fi  
-		fi  
-		if ! Xdialog  --wmclass "frisbee" --title "Frisbee" --stdout --password --inputbox "$MSG" 0 0 > /tmp/.frisbee/entry; then #141005 180313
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
-		PASS=`cat /tmp/.frisbee/entry`
-		rm  /tmp/.frisbee/entry
-	 	if [ -z "$PASS" ] ; then
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Invalid Key or Password')" 0 0 #130822
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan
-			return 1 #140914
-		fi
-		if [[ "$ENC" == "WEP" ]] ; then
-			if echo "$PASS" | grep -E -q '^([[:xdigit:]]){10}$|^([[:xdigit:]]){26}$|^([[:xdigit:]]){32}$'; then #141005
-				RESULT=`wpa_cli -i $INTERFACE set_network $ID wep_key0 "$PASS"`
-			    if [[ "$RESULT" != "OK" ]] ; then
-	            		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Set HEX Key Failed')" 0 0 #130822
-		            	wpa_cli -i $INTERFACE remove_network $ID
-		            	wpa_cli -i $INTERFACE scan
-	                	return 1 #140914
-	        	 fi
-			else
-				if echo "$PASS" | grep -E -q '^.{5}$|^.{13}$|^.{16}$'; then #141005
-					RESULT=`wpa_cli -i $INTERFACE set_network $ID wep_key0 \""${PASS}"\"` 
-					if [[ "$RESULT" != "OK" ]] ; then
-						Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Set ASCII Key Failed')" 0 0 #130822
-						wpa_cli -i $INTERFACE remove_network $ID
-						wpa_cli -i $INTERFACE scan
-						return 1 #140914
-					fi
-				else
-					Xdialog  --wmclass "frisbee" --title "Frisbee" --left --msgbox "$(gettext 'Invalid Key\n\nAscii keys must be 5, 13 or 16 characters.\nHex keys must be 10, 26, or 32 characters.')" 0 0 #130822
-					wpa_cli -i $INTERFACE remove_network $ID 
-					wpa_cli -i $INTERFACE scan
-					return 1 #140914
-				fi	
-				
-			fi
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --stdout --left --no-tags  --radiolist "$(gettext 'Key Type?\n\nIf in doubt, try Open first')" 0 0 0  open open open  shared shared shared > /tmp/.frisbee/entry #180313
-            AALG=`cat /tmp/.frisbee/entry`
-            if [[ "$AALG" == "shared" ]] ; then
-				RESULT=`wpa_cli -i $INTERFACE set_network $ID auth_alg SHARED`
-				if [[ "$RESULT" != "OK" ]] ; then
-			         PARAMETER="auth_alg"
-			         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-		            wpa_cli -i $INTERFACE remove_network $ID
-					wpa_cli -i $INTERFACE scan #140914
-					return 1 #140914
-				fi
-			fi
+	    if [[ "$ENC" == "WEP" ]] ; then
+	     MSG="$(gettext 'Please enter the ASCII or HEX WEP key with no colons or dashes.\nThe HEX key works most reliably.')" #130822
+	    else
+	     if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
+	      MSG="$(gettext 'Please enter the authentication Password.')"
+	     else
+	      MSG="$(gettext 'Please enter the public (pre-shared) Key.')" #130822 end
+	     fi  
+	    fi  
+	    if ! Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --stdout --password --inputbox "$MSG" 0 0 > /tmp/.frisbee/entry; then #141005 180313
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
+	    PASS=$(cat /tmp/.frisbee/entry)
+	    rm  /tmp/.frisbee/entry
+	    if [ -z "$PASS" ] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Invalid Key or Password')" 0 0 #130822
+	        wpa_cli -i "$INTERFACE" remove_network "$ID" 
+	        wpa_cli -i "$INTERFACE" scan
+	        return 1 #140914
+	    fi
+	    if [[ "$ENC" == "WEP" ]] ; then
+	        if echo "$PASS" | grep -E -q '^([[:xdigit:]]){10}$|^([[:xdigit:]]){26}$|^([[:xdigit:]]){32}$'; then #141005
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" wep_key0 "$PASS")
+	            if [[ "$RESULT" != "OK" ]] ; then
+	                Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Set HEX Key Failed')" 0 0 #130822
+	                wpa_cli -i "$INTERFACE" remove_network "$ID"
+	                wpa_cli -i "$INTERFACE" scan
+	                return 1 #140914
+	            fi
+	        else
+	            if echo "$PASS" | grep -E -q '^.{5}$|^.{13}$|^.{16}$'; then #141005
+	                RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" wep_key0 \""${PASS}"\") 
+	                if [[ "$RESULT" != "OK" ]] ; then
+	                    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Set ASCII Key Failed')" 0 0 #130822
+	                    wpa_cli -i "$INTERFACE" remove_network "$ID"
+	                    wpa_cli -i "$INTERFACE" scan
+	                    return 1 #140914
+	                fi
+	            else
+	                Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --left --msgbox "$(gettext 'Invalid Key\n\nAscii keys must be 5, 13 or 16 characters.\nHex keys must be 10, 26, or 32 characters.')" 0 0 #130822
+	                wpa_cli -i "$INTERFACE" remove_network "$ID"
+	                wpa_cli -i "$INTERFACE" scan
+	                return 1 #140914
+	            fi
+	            
+	        fi
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --stdout --left --no-tags  --radiolist "$(gettext 'Key Type?\n\nIf in doubt, try Open first')" 0 0 0  open open open  shared shared shared > /tmp/.frisbee/entry #180313
+	        AALG=$(cat /tmp/.frisbee/entry)
+	        if [[ "$AALG" == "shared" ]] ; then
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" auth_alg SHARED)
+	            if [[ "$RESULT" != "OK" ]] ; then
+	                 PARAMETER="auth_alg"
+	                 Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	                wpa_cli -i "$INTERFACE" remove_network "$ID"
+	                wpa_cli -i "$INTERFACE" scan #140914
+	                return 1 #140914
+	            fi
+	        fi
 	
-		else #WPA
-			if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
-				RESULT=`wpa_cli -i $INTERFACE set_network $ID identity \""${IDENTITY}"\"`
-	        	if [[ "$RESULT" != "OK" ]] ; then
-	                	Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Invalid authentication Identifier')" 0 0
-	                	wpa_cli -i $INTERFACE remove_network $ID
-						wpa_cli -i $INTERFACE scan #140914
-	                	return 1 #140914
-	        	fi
-			fi #130822 end
-			if echo "$PASS" | grep -E -q '^([[:xdigit:]]){64}$'; then #141005
-				RESULT=`wpa_cli -i $INTERFACE set_network $ID psk $PASS`
-			else
-				if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
-					RESULT=`wpa_cli -i $INTERFACE set_network $ID password \""${PASS}"\"`
-				else #130822 end
-					RESULT=`wpa_cli -i $INTERFACE set_network $ID psk \""${PASS}"\"`
-				fi #130822
-			fi
-        	if [[ "$RESULT" != "OK" ]] ; then
-				Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Invalid Key or Password')" 0 0
-				wpa_cli -i $INTERFACE remove_network $ID
-				wpa_cli -i $INTERFACE scan #140914
-				return 1 #140914
-			fi
-			RESULT=`wpa_cli -i $INTERFACE set_network $ID pairwise $ENCTYPE`
+	    else #WPA
+	        if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" identity \""${IDENTITY}"\")
+	            if [[ "$RESULT" != "OK" ]] ; then
+	                Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Invalid authentication Identifier')" 0 0
+	                wpa_cli -i "$INTERFACE" remove_network "$ID"
+	                wpa_cli -i "$INTERFACE" scan #140914
+	                return 1 #140914
+	            fi
+	        fi #130822 end
+	        if echo "$PASS" | grep -E -q '^([[:xdigit:]]){64}$'; then #141005
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" psk "$PASS")
+	        else
+	            if [[ "$MGMT" == "WPA-EAP" ]] ; then #130822...
+	                RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" password \""${PASS}"\")
+	            else #130822 end
+	                RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" psk \""${PASS}"\")
+	            fi #130822
+	        fi
 	        if [[ "$RESULT" != "OK" ]] ; then
-				PARAMETER="pairwise"
-				Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-				wpa_cli -i $INTERFACE remove_network $ID
-				wpa_cli -i $INTERFACE scan #140914
-				return 1 #140914
-			fi
-		fi
+	            Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Invalid Key or Password')" 0 0
+	            wpa_cli -i "$INTERFACE" remove_network "$ID"
+	            wpa_cli -i "$INTERFACE" scan #140914
+	            return 1 #140914
+	        fi
+	        RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" pairwise "$ENCTYPE")
+	        if [[ "$RESULT" != "OK" ]] ; then
+	            PARAMETER="pairwise"
+	            Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	            wpa_cli -i "$INTERFACE" remove_network "$ID"
+	            wpa_cli -i "$INTERFACE" scan #140914
+	            return 1 #140914
+	        fi
+	    fi
 	fi
 	
 	
 	if [[ $PROTO != '' ]] ; then
-		RESULT=`wpa_cli -i $INTERFACE set_network $ID proto $PROTO`
-		if [[ "$RESULT" != "OK" ]] ; then
-			PARAMETER="proto"
-			Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-			wpa_cli -i $INTERFACE remove_network $ID 
-			wpa_cli -i $INTERFACE scan #140914
-			return 1 #140914
-		fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" proto $PROTO)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        PARAMETER="proto"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	        wpa_cli -i "$INTERFACE" remove_network "$ID"
+	        wpa_cli -i "$INTERFACE" scan #140914
+	        return 1 #140914
+	    fi
 	fi
 	
-	RESULT=`wpa_cli -i $INTERFACE set_network $ID priority $PRIORITY`
+	RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" priority "$PRIORITY")
 	if [[ "$RESULT" != "OK" ]] ; then
-		PARAMETER="priority"
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
+	    PARAMETER="priority"
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
 	fi
 
-	RESULT=`wpa_cli -i $INTERFACE enable_network $ID`
+	RESULT=$(wpa_cli -i "$INTERFACE" enable_network "$ID")
 	if [[ "$RESULT" != "OK" ]] ; then
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to enable network')" 0 0
-		wpa_cli -i $INTERFACE remove_network $ID 
-		wpa_cli -i $INTERFACE scan #140914
-		return 1 #140914
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to enable network')" 0 0
+	    wpa_cli -i "$INTERFACE" remove_network "$ID"
+	    wpa_cli -i "$INTERFACE" scan #140914
+	    return 1 #140914
 	fi
 	
-	#wpa_cli -i $INTERFACE select_network $ID 
+	#wpa_cli -i "$INTERFACE" select_network "$ID"
 	
-	RESULT=`wpa_cli -i $INTERFACE save_config`
+	RESULT=$(wpa_cli -i "$INTERFACE" save_config)
 	if [[ "$RESULT" != "OK" ]] ; then
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
 	fi
 	
 	. gettext.sh
-	gtkdialog-splash -timeout 15 -placement center -bg lightgreen -text "`eval_gettext \"Profile for \\\$SSID added.\"`
+	gtkdialog-splash -timeout 15 -placement center -bg lightgreen -text "$(eval_gettext "Profile for \$SSID added.")
 	$(gettext 'Network can take a minute or so to reconfigure itself.')
 	$(gettext 'To configure a static IP address, press the Manage Saved Networks button.')" &
 	
@@ -374,7 +380,7 @@ function add_profile {
 	reset_dhcp&
 	
 	if [[ $ENC == "WPA" ]] ; then
-		connection_check&
+	    connection_check&
 	fi
 	return 0 #140914
 }
@@ -385,33 +391,34 @@ export -f   add_profile
 function set_ap_scan {
 	. gettext.sh
 	grep -q '^wireless_autostart=1' /etc/frisbee/frisbee.conf \
-	 && WPACFGFILE="/etc/frisbee/wpa_supplicant.conf" \
-	 || WPACFGFILE="/tmp/wpa_supplicant.conf"
-	VAL=`grep ap_scan $WPACFGFILE`
-	[ ! -z $VAL ] && VAL="`eval_gettext \"Currently \\\${VAL}.\"`" 
+	  && WPACFGFILE="/etc/frisbee/wpa_supplicant.conf" \
+	  || WPACFGFILE="/tmp/wpa_supplicant.conf"
+	VAL=$(grep ap_scan "$WPACFGFILE")
+	[ -n "$VAL" ] && VAL="$(eval_gettext "Currently \$VAL.")" 
 	
-	Xdialog --no-tags --wmclass "frisbee" --title "Frisbee $(gettext 'AP Scan Mode')" --stdout --left --radiolist "$(gettext 'Set the AP Scan Mode (ap_scan WPA parameter).\n\nIt should be set to 1 unless you have an adhoc network, or\nare using ndiswrapper, or some other 3rd party driver.\n\nIt may also be necessary to set it to 2 to connect to a\nhidden SSID with some hardware.') \n  $VAL" 0 0 0 1 1 1 2 2 2 > /tmp/.frisbee/entry #180313
-    APS=`cat /tmp/.frisbee/entry`
-    [ -z $APS ] && return
-    if [[ "$APS" == "1" ]] ; then
-		RESULT=`wpa_cli -i $INTERFACE ap_scan 1`
-		if [[ "$RESULT" != "OK" ]] ; then
-			PARAMETER="ap_scan"
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-			return
-		fi
+	Xdialog --no-tags --wmclass frisbee --title "$(gettext 'Frisbee AP Scan Mode')" --stdout --left --radiolist "$(gettext 'Set the AP Scan Mode (ap_scan WPA parameter).\n\nIt should be set to 1 unless you have an adhoc network, or\nare using ndiswrapper, or some other 3rd party driver.\n\nIt may also be necessary to set it to 2 to connect to a\nhidden SSID with some hardware.') \n  $VAL" 0 0 0 1 1 1 2 2 2 > /tmp/.frisbee/entry #180313
+	APS=$(cat /tmp/.frisbee/entry)
+	[ -z "$APS" ] && return
+	if [[ "$APS" == "1" ]] ; then
+	    RESULT=$(wpa_cli -i "$INTERFACE" ap_scan 1)
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        PARAMETER="ap_scan"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	        return
+	    fi
 	else
-		RESULT=`wpa_cli -i $INTERFACE ap_scan 2`
-		if [[ "$RESULT" != "OK" ]] ; then
-			PARAMETER="ap_scan"
-			Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Failed to set network configuration parameter: \\\$PARAMETER\"`" 0 0
-			return
-		fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" ap_scan 2)
+	    if [[ "$RESULT" != "OK" ]] ; then
+# shellcheck disable=SC2034 # parameter not detected as eval_gettext argument.
+	        PARAMETER="ap_scan"
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Failed to set network configuration parameter: \$PARAMETER")" 0 0
+	        return
+	    fi
 	fi
 	
-	RESULT=`wpa_cli -i $INTERFACE save_config`
+	RESULT=$(wpa_cli -i "$INTERFACE" save_config)
 	if [[ "$RESULT" != "OK" ]] ; then
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
 	fi
 	
 	reset_wpa&
@@ -420,17 +427,17 @@ function set_ap_scan {
 export -f set_ap_scan
 
 #############################################
-		
+	    
 function wpaconf_edit {
 	grep -q '^wireless_autostart=1' /etc/frisbee/frisbee.conf \
-	 && WPACFGFILE="/etc/frisbee/wpa_supplicant.conf" \
-	 || WPACFGFILE="/tmp/wpa_supplicant.conf"
+	  && WPACFGFILE="/etc/frisbee/wpa_supplicant.conf" \
+	  || WPACFGFILE="/tmp/wpa_supplicant.conf"
 	TXTEDITOR=$(grep '^editor=' /etc/frisbee/frisbee.conf | sed 's/.*=\([^ 	#]*\).*/\1/') #140607
-	[ "$(which $TXTEDITOR 2>/dev/null)" ] || TXTEDITOR=defaulttexteditor #140607
+	[ "$(which "$TXTEDITOR" 2>/dev/null)" ] || TXTEDITOR=defaulttexteditor #140607
 	$TXTEDITOR $WPACFGFILE #140607
-	RESULT=`wpa_cli -i $INTERFACE reconfigure`
+	RESULT=$(wpa_cli -i "$INTERFACE" reconfigure)
 	if [[ "$RESULT" != "OK" ]] ; then
-		Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
 	fi
 	
 	reset_wpa&
@@ -442,7 +449,7 @@ export -f wpaconf_edit
 
 function dhcpconf_edit {
 	TXTEDITOR=$(grep '^editor=' /etc/frisbee/frisbee.conf | sed 's/.*=\([^ 	#]*\).*/\1/') #140607
-	[ "$(which $TXTEDITOR 2>/dev/null)" ] || TXTEDITOR=defaulttexteditor #140607
+	[ "$(which "$TXTEDITOR" 2>/dev/null)" ] || TXTEDITOR=defaulttexteditor #140607
 	$TXTEDITOR /etc/frisbee/dhcpcd.conf #140607
 	reset_dhcp&
 }
@@ -451,18 +458,18 @@ export -f dhcpconf_edit
 
 function connection_check {
 	. gettext.sh #140921...
-	gtkdialog-splash -placement center -bg orange -text "`eval_gettext \"Waiting for connection to \\\$SSID.\"`" &
+	gtkdialog-splash -placement center -bg orange -text "$(eval_gettext "Waiting for connection to \$SSID.")" &
 	SPLASHPID=$!
 	for COUNTDOWN in 6 5 4 3 2 1 ; do
-		sleep 10
-	    if wpa_cli -i $INTERFACE status 2>/dev/null | grep -q COMPLETED; then
-			kill $SPLASHPID 2>/dev/null
-			break
-		fi
-		if [ $COUNTDOWN -eq 1 ];then
-			kill $SPLASHPID 2>/dev/null
-			Xdialog  --wmclass "frisbee" --title "Frisbee $(gettext 'Connect')" --left --msgbox "$(gettext 'Wpa_supplicant failed to connect.\n\nVerify that the key or password you entered is correct\nand that your network card supports wpa_supplicant.')" 0 0 #130822
-		fi
+	    sleep 10
+	    if wpa_cli -i "$INTERFACE" status 2>/dev/null | grep -q COMPLETED; then
+	        kill $SPLASHPID 2>/dev/null
+	        break
+	    fi
+	    if [ $COUNTDOWN -eq 1 ];then
+	        kill $SPLASHPID 2>/dev/null
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee Connect')" --left --msgbox "$(gettext 'Wpa_supplicant failed to connect.\n\nVerify that the key or password you entered is correct\nand that your network card supports wpa_supplicant.')" 0 0 #130822
+	    fi
 	done
 }
 export -f   connection_check 
@@ -470,12 +477,12 @@ export -f   connection_check
 #############################################
 
 function current_ip {
-	IFSTATUS="$(wpa_cli -i $INTERFACE status 2>/dev/null)"
+	IFSTATUS="$(wpa_cli -i "$INTERFACE" status 2>/dev/null)"
 	IP="$(echo "$IFSTATUS" | grep ^ip_address | cut -f 2 -d =)"
 	if [ "$(echo "$IFSTATUS" | grep ^wpa_state | cut -f 2 -d =)" = "COMPLETED" ] \
-	 && [ "$IP" ]; then
-		. gettext.sh
-		echo "`eval_gettext \"IP Address: \\\$IP\"`"
+	  && [ "$IP" ]; then
+	    . gettext.sh
+	    echo "$(eval_gettext "IP Address: \$IP")"
 	fi
 }
 export -f   current_ip
@@ -483,15 +490,15 @@ export -f   current_ip
 #############################################
 
 function current_status {
-	IFSTATUS="$(wpa_cli -i $INTERFACE status 2>/dev/null)"
+	IFSTATUS="$(wpa_cli -i "$INTERFACE" status 2>/dev/null)"
 	SSID="$(echo "$IFSTATUS" | grep ^ssid | cut -f 2 -d =)"
 	if [ "$(echo "$IFSTATUS" | grep ^wpa_state | cut -f 2 -d =)" != "COMPLETED" ] \
-	 || [ -z "$(echo "$IFSTATUS" | grep ^ip_address | cut -f 2 -d =)" ] \
-	 || [ -z "$SSID" ]; then
-		echo "$(gettext 'Not Connected')"
-	else	
-		. gettext.sh
-		echo "`eval_gettext \"Connected to \\\$SSID\"`"
+	  || [ -z "$(echo "$IFSTATUS" | grep ^ip_address | cut -f 2 -d =)" ] \
+	  || [ -z "$SSID" ]; then
+	    echo "$(gettext 'Not Connected')"
+	else
+	    . gettext.sh
+	    echo "$(eval_gettext "Connected to \$SSID")"
 	fi
 }
 export -f   current_status
@@ -500,9 +507,9 @@ export -f   current_status
 
 function if_connected {
 	#set -x
-	STATE="$(wpa_cli -i $INTERFACE status 2>/dev/null | grep wpa_state | cut -f 2 -d =)"
-	[ -z "$STATE" -o "$STATE" = "DISCONNECTED" ] \
-		&& return 1
+	STATE="$(wpa_cli -i "$INTERFACE" status 2>/dev/null | grep wpa_state | cut -f 2 -d =)"
+	[ -z "$STATE" ] || [ "$STATE" = "DISCONNECTED" ] \
+	  && return 1
 	return 0
 }
 export -f   if_connected
@@ -513,35 +520,34 @@ function delete_profile {
 	#set -x
 	ID="$1"
 	
-	if [[ -z $ID ]] ; then
-	        Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Please select a network profile')" 0 0
-	        return
+	if [[ -z "$ID" ]] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Please select a network profile')" 0 0
+	    return
 	fi
 	
-	wpa_cli -i $INTERFACE  list_networks | grep "^$ID	"|grep CURRENT
-	[[ $? == 0 ]] && CURRENT=yes
+	wpa_cli -i "$INTERFACE"  list_networks | grep -w "^$ID"|grep CURRENT && CURRENT=yes
 	
-	RESULT=`wpa_cli -i $INTERFACE remove_network $ID`
+	RESULT=$(wpa_cli -i "$INTERFACE" remove_network "$ID")
 	if [[ "$RESULT" != "OK" ]] ; then
-	        Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Failed to delete network profile')" 0 0
-	        return
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Failed to delete network profile')" 0 0
+	    return
 	fi
 	
-	RESULT=`wpa_cli -i $INTERFACE save_config`
+	RESULT=$(wpa_cli -i "$INTERFACE" save_config)
 	if [[ "$RESULT" != "OK" ]] ; then
-	        Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Failed to save configuration')" 0 0
-	        return
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Failed to save configuration')" 0 0
+	    return
 	fi
 	
-	 if [[ ! -z $CURRENT ]] ; then
-		disconnect
-		connect
-		wpa_cli -i $INTERFACE scan >/dev/null
-		sleep 2
-		reset_dhcp&  
+	if [[ -n $CURRENT ]] ; then
+	    disconnect
+	    connect
+	    wpa_cli -i "$INTERFACE" scan >/dev/null
+	    sleep 2
+	    reset_dhcp&  
 	fi
 
-	Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Profile deleted')" 0 0
+	Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Profile deleted')" 0 0
 
 }
 export -f  delete_profile
@@ -551,15 +557,15 @@ export -f  delete_profile
 function get_auth {
 	ID="$1"
 	
-	if [ -z $ID ]  ; then
-	        return
+	if [ -z "$ID" ]  ; then
+	    return
 	fi
 	
 	
-	AUTH=`wpa_cli -i $INTERFACE get_network $ID key_mgmt`
+	AUTH=$(wpa_cli -i "$INTERFACE" get_network "$ID" key_mgmt)
 	if [[ "$AUTH" != "FAIL" ]] ; then
-	        echo $AUTH
-	        return
+	    echo "$AUTH"
+	    return
 	fi
 }
 export -f   get_auth
@@ -569,16 +575,15 @@ export -f   get_auth
 function get_bssid {
 	ID="$1"
 	
-	if [ -z $ID ] ; then 
-	        return
+	if [ -z "$ID" ] ; then 
+	    return
 	fi
 	
-	
-	bssid=`wpa_cli -i $INTERFACE get_network $ID bssid`
+	bssid=$(wpa_cli -i "$INTERFACE" get_network "$ID" bssid)
 	if [[ $bssid == "FAIL" ]] ; then
-	        return
+	    return
 	fi
-	echo $bssid |tr -d \"
+	echo "$bssid" |tr -d \"
 }
 export -f   get_bssid
 
@@ -587,8 +592,8 @@ export -f   get_bssid
 function get_dhcp_auto {
 	IF=$1
 	if [ -z "$IF" ] \
-	 || cat /etc/frisbee/dhcpcd.conf | grep '^denyinterfaces' | grep -qw $IF \
-	 || cat /etc/frisbee/dhcpcd.conf | grep -q "^#$IF static\$"; then #140824
+	  || grep '^denyinterfaces' < /etc/frisbee/dhcpcd.conf | grep -qw "$IF" \
+	  || grep -q "^#$IF static\$" < /etc/frisbee/dhcpcd.conf; then #140824
 	    echo false
 	else
 	    echo true
@@ -601,10 +606,10 @@ export -f   get_dhcp_auto
 function get_dhcp_auto_wireless {
 	SSID=$1
 	if [ -z "$SSID" ] \
-	 || cat /etc/frisbee/dhcpcd.conf | grep -q "^#$SSID static\$"; then
+	  || grep -q "^#$SSID static\$" < /etc/frisbee/dhcpcd.conf; then
 	    echo false
 	else
-		echo true
+	    echo true
 	fi
 }
 export -f   get_dhcp_auto_wireless
@@ -614,7 +619,7 @@ export -f   get_dhcp_auto_wireless
 function get_dhcp_ignored {
 	INTERFACE="$1"
 	if [ "$INTERFACE" ] \
-	 && cat /etc/frisbee/dhcpcd.conf | grep '^denyinterfaces' | grep -qw $INTERFACE ; then #140824
+	  && grep '^denyinterfaces' < /etc/frisbee/dhcpcd.conf | grep -qw "$INTERFACE" ; then #140824
 	    echo true
 	else
 	    echo false
@@ -626,7 +631,7 @@ export -f  get_dhcp_ignored
 
 function get_dns1 {
 	IF=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$IF static\$" -A4|tail -n 1|cut -d= -f2 |cut -d" " -f1
+	grep "^#$IF static\$" -A4 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2 |cut -d" " -f1
 }
 export -f   get_dns1
 
@@ -634,7 +639,7 @@ export -f   get_dns1
 
 function get_dns1_wireless {
 	SSID=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$SSID static\$" -A5|tail -n 1|cut -d= -f2 |cut -d" " -f1
+	grep "^#$SSID static\$" -A5 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2 |cut -d" " -f1
 }
 export -f   get_dns1_wireless
 
@@ -642,7 +647,7 @@ export -f   get_dns1_wireless
 
 function get_dns2 {
 	IF=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$IF static\$" -A4|tail -n 1|cut -d= -f2 |cut -d" " -f2 
+	grep "^#$IF static\$" -A4 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2 |cut -d" " -f2 
 }
 export -f   get_dns2
 
@@ -650,7 +655,7 @@ export -f   get_dns2
 
 function get_dns2_wireless {
 	SSID=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$SSID static\$" -A5|tail -n 1|cut -d= -f2 |cut -d" " -f2 
+	grep "^#$SSID static\$" -A5 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2 |cut -d" " -f2 
 }
 export -f   get_dns2_wireless
 
@@ -659,16 +664,15 @@ export -f   get_dns2_wireless
 function get_enabled {
 	ID="$1"
 	
-	
-	if [ -z $ID ] ; then
-	        return
+	if [ -z "$ID" ] ; then
+	    return
 	fi
 	
-	disabled=`wpa_cli -i $INTERFACE get_network $ID disabled`
+	disabled=$(wpa_cli -i "$INTERFACE" get_network "$ID" disabled)
 	if [[ "$disabled" == "0" ]] ; then
-	        echo "true"
+	    echo "true"
 	else
-	        echo "false"
+	    echo "false"
 	fi
 }
 
@@ -677,26 +681,26 @@ export -f  get_enabled
 #############################################
 
 function get_enc {
-	ID=`echo $1`
-	if [ -z $ID ]  ; then
-	        return
+	ID=$1
+	if [ -z "$ID" ]  ; then
+	    return
 	fi
 	
-	AUTH=`wpa_cli -i $INTERFACE get_network $ID key_mgmt`
+	AUTH=$(wpa_cli -i "$INTERFACE" get_network "$ID" key_mgmt)
 	if [[ "$AUTH" == "NONE" ]] ; then
-	        WEP=`wpa_cli -i $INTERFACE get_network $ID wep_key0`
-	        if [[ "$WEP" != "FAIL" ]] ; then
-	                echo "WEP" 
-	                return
-	        else
-	                echo "OPEN"
-	                return
-	        fi
-	fi
-	ENC=`wpa_cli -i $INTERFACE get_network $ID pairwise`
-	if [[ "$ENC" != "FAIL" ]] ; then
-	        echo $ENC
+	    WEP=$(wpa_cli -i "$INTERFACE" get_network "$ID" wep_key0)
+	    if [[ "$WEP" != "FAIL" ]] ; then
+	        echo "WEP" 
 	        return
+	    else
+	        echo "OPEN"
+	        return
+	    fi
+	fi
+	ENC=$(wpa_cli -i "$INTERFACE" get_network "$ID" pairwise)
+	if [[ "$ENC" != "FAIL" ]] ; then
+	    echo "$ENC"
+	    return
 	fi
 }
 export -f   get_enc
@@ -705,7 +709,7 @@ export -f   get_enc
 
 function get_gateway {
 	IF=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$IF static\$" -A3|tail -n 1|cut -d= -f2
+	grep "^#$IF static\$" -A3 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2
 }
 export -f   get_gateway
 
@@ -713,37 +717,38 @@ export -f   get_gateway
 
 function get_gateway_wireless {
 	SSID=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$SSID static\$" -A4|tail -n 1|cut -d= -f2
+	grep "^#$SSID static\$" -A4 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2
 }
 export -f   get_gateway_wireless
 
 #############################################
 
 function get_interfaces {
-	iwconfig 2>&1 |grep ^[a-z]|while read if line ; do
-	        if [[ $line == "no wireless extensions." ]] ; then
-	                line=wired
+	local wirelessifs
+	wirelessifs="$(iw dev 2>&1 | grep -o 'Interface [^ ]*' | cut -f 2 -d ' ')" #200829
+# shellcheck disable=SC2034 # f1 is intentionally not used.
+	ip link show 2>&1 | grep '^[1-9]' | tr -d : | \
+	while read f1 if line ; do #200829
+	    if echo "$if" | grep -qvF "$wirelessifs" ; then #200829...
+	        line="$(gettext 'wired')"
+	    else
+	        line="$(gettext 'wireless')"
+	    fi
+	    if [[ $if == lo ]] ; then
+	        line="$(gettext 'loopback')"
+	    elif [[ $if == ppp* ]] ; then
+	        line="$(gettext 'ppp')"
+	    fi
+	    if grep '^denyinterfaces' < /etc/frisbee/dhcpcd.conf | grep -qw "$if" ; then #140824
+	        state="$(gettext 'ignored')"
+	    else
+	        if grep "^#$if static\$" < /etc/frisbee/dhcpcd.conf | grep -q "$if" ; then
+	            state="$(gettext 'static')"
 	        else
-	                line=wireless
+	            state="$(gettext 'auto')"
 	        fi
-	        if [[ $if == lo ]] ; then
-	                line=loopback
-	        elif [[ $if == ppp* ]] ; then
-	                line=ppp
-	        fi
-	        cat /etc/frisbee/dhcpcd.conf | grep '^denyinterfaces' | grep -qw $if
-	        if [[ $? == 0 ]] ; then #140824
-	                state=ignored
-	        else
-	                cat /etc/frisbee/dhcpcd.conf | grep "^#$if static\$"  | grep -q $if
-	                if [[ $? == 0 ]] ; then
-	                        state=static
-	                else
-	                        state=auto
-	                fi
-	                
-	        fi
-	        echo "$if|$line|$state"
+	    fi
+	    echo "$if|$line|$state"
 	done    
 	echo
 	echo
@@ -756,17 +761,17 @@ export -f   get_interfaces
 	
 function get_key {
 	ID="$1"
-	if [ -z $ID ]  ; then
-	        return
+	if [ -z "$ID" ]  ; then
+	    return
 	fi
 	
-	wep_key=`wpa_cli -i $INTERFACE get_network $ID wep_key0`
+	wep_key=$(wpa_cli -i "$INTERFACE" get_network "$ID" wep_key0)
 	if [[ $wep_key != "FAIL" ]] ; then
-	        echo "[Key Configured]"
+	    echo "[Key Configured]"
 	fi
-	psk=`wpa_cli -i $INTERFACE get_network $ID psk`
+	psk=$(wpa_cli -i "$INTERFACE" get_network "$ID" psk)
 	if [[ $psk != "FAIL" ]] ; then
-	        echo "[Key Configured]"
+	    echo "[Key Configured]"
 	fi
 }
 export -f   get_key 
@@ -775,7 +780,7 @@ export -f   get_key
 
 function get_log {
 	sync
-	cat /tmp/wpa_supplicant.log 2>/dev/null |tail -n 500 > /tmp/.frisbee/wpa_supplicant_log_tail
+	tail -n 500 < /tmp/wpa_supplicant.log > /tmp/.frisbee/wpa_supplicant_log_tail 2>/dev/null
 }
 export -f   get_log 
 
@@ -783,23 +788,23 @@ export -f   get_log
 
 function get_mask {
 	IF=$1
-	  CIDR=`cat /etc/frisbee/dhcpcd.conf | grep "^#$IF static\$" -A2|tail -n 1 |cut -d= -f2|cut -d\/ -f2`
-	 [ ! $CIDR ] && return
-	  full_octets=$((CIDR/8))
-	  partial_octet=$((CIDR%8))
-	
-	  for ((i=0;i<4;i+=1)); do
-	    if [ $i -lt $full_octets ]; then
-	      mask="${mask}255"
-	    elif [ $i -eq $full_octets ]; then
-	      mask="${mask}$((256 - 2**(8-partial_octet)))"
+	CIDR=$(grep "^#$IF static\$" -A2 < /etc/frisbee/dhcpcd.conf|tail -n 1 |cut -d= -f2|cut -d/ -f2)
+	[ -z "$CIDR" ] && return
+	full_octets=$((CIDR/8))
+	partial_octet=$((CIDR%8))
+
+	for ((i=0;i<4;i+=1)); do
+	    if [ "$i" -lt $full_octets ]; then
+	        mask="${mask}255"
+	    elif [ "$i" -eq $full_octets ]; then
+	        mask="${mask}$((256 - 2**(8-partial_octet)))"
 	    else
-	      mask="${mask}0"
+	        mask="${mask}0"
 	    fi  
-	    test $i -lt 3 && mask="${mask}."
-	  done
+	    test "$i" -lt 3 && mask="${mask}."
+	done
 	
-	  echo $mask
+	echo "$mask"
 }
 export -f   get_mask
 
@@ -807,23 +812,23 @@ export -f   get_mask
 
 function get_mask_wireless {
 	SSID=$1
-	  CIDR=`cat /etc/frisbee/dhcpcd.conf | grep "^#$SSID static\$" -A3|tail -n 1 |cut -d= -f2|cut -d\/ -f2`
-	 [ ! $CIDR ] && return
-	  full_octets=$((CIDR/8))
-	  partial_octet=$((CIDR%8))
-	
-	  for ((i=0;i<4;i+=1)); do
-	    if [ $i -lt $full_octets ]; then
-	      mask="${mask}255"
-	    elif [ $i -eq $full_octets ]; then
-	      mask="${mask}$((256 - 2**(8-partial_octet)))"
+	CIDR=$(grep "^#$SSID static\$" -A3 < /etc/frisbee/dhcpcd.conf|tail -n 1 |cut -d= -f2|cut -d/ -f2)
+	[ -z "$CIDR" ] && return
+	full_octets=$((CIDR/8))
+	partial_octet=$((CIDR%8))
+
+	for ((i=0;i<4;i+=1)); do
+	    if [ "$i" -lt $full_octets ]; then
+	        mask="${mask}255"
+	    elif [ "$i" -eq $full_octets ]; then
+	        mask="${mask}$((256 - 2**(8-partial_octet)))"
 	    else
-	      mask="${mask}0"
+	        mask="${mask}0"
 	    fi  
-	    test $i -lt 3 && mask="${mask}."
-	  done
-	
-	  echo $mask
+	    test "$i" -lt 3 && mask="${mask}."
+	done
+
+	echo "$mask"
 }
 export -f   get_mask_wireless
 
@@ -831,15 +836,14 @@ export -f   get_mask_wireless
 
 function get_priority { 
 	ID="$1"
-	if [ -z $ID ] ; then
-	        return
+	if [ -z "$ID" ] ; then
+	    return
 	fi
 	
-	pri=`wpa_cli -i $INTERFACE get_network $ID priority|tr -d \"`
+	pri=$(wpa_cli -i "$INTERFACE" get_network "$ID" priority|tr -d \")
 	if [[ $pri != "FAIL" ]] ; then
-	        echo $pri
+	    echo "$pri"
 	fi 
-
 }
 export -f   get_priority
 
@@ -848,23 +852,23 @@ export -f   get_priority
 function get_proto {
 	ID="$1"
 	
-	if [ -z $ID ]  ; then
-	        return
+	if [ -z "$ID" ]  ; then
+	    return
 	fi
 	
-	AUTH=`wpa_cli -i $INTERFACE get_network $ID proto`
+	AUTH=$(wpa_cli -i "$INTERFACE" get_network "$ID" proto)
 	if [[ "$AUTH" == "FAIL" ]] ; then
-	        return
+	    return
 	fi
 	
 	if [[ $AUTH == "RSN" ]] ; then
-	        echo "WPA2"
-	        return
+	    echo "WPA2"
+	    return
 	fi
 	
 	if [[ $AUTH == "WPA" ]] ; then
-	        echo "WPA"
-	        return
+	    echo "WPA"
+	    return
 	fi
 	
 	echo "NONE"
@@ -876,16 +880,16 @@ export -f   get_proto
 function get_auth_alg {
 	ID="$1"
 	
-	if [ -z $ID ]  ; then
-	        return
+	if [ -z "$ID" ]  ; then
+	    return
 	fi
 	
-	AUTH=`wpa_cli -i $INTERFACE get_network $ID auth_alg`
+	AUTH=$(wpa_cli -i "$INTERFACE" get_network "$ID" auth_alg)
 	if [[ "$AUTH" == "FAIL" ]] ; then
-	        return
+	    return
 	fi
 	
-	[ -z $AUTH ] && AUTH=NONE
+	[ -z "$AUTH" ] && AUTH=NONE
 	
 	echo "$AUTH" 
 	
@@ -897,11 +901,11 @@ export -f   get_auth_alg
 
 function get_scan_results {
 	if_connected || return
-	wpa_cli -i $INTERFACE scan >/dev/null
-	wpa_cli scan_results -i $INTERFACE | grep ^..:..: | awk -F '\t' '{print $1"|"$2"|"$3"|"$5"|"$4}' | sort -g -r -t \| -k 3 #140607 160801 170621
+	wpa_cli -i "$INTERFACE" scan >/dev/null
+	wpa_cli scan_results -i "$INTERFACE" | grep ^..:..: | awk -F '\t' '{print $1"|"$2"|"$3"|"$5"|"$4}' | sort -g -r -t \| -k 3 #140607 160801 170621
 	
 	for i in 1 2 3 4 5 6 7 8 9 10 11 ; do 
-	echo
+	    echo
 	done
 }
 export -f   get_scan_results
@@ -909,14 +913,14 @@ export -f   get_scan_results
 #############################################
 
 function get_ssid {
-	ID=`cat /tmp/.frisbee/id 2>/dev/null`
-	if [ -z $ID ] ; then
-	        return
+	ID=$(cat /tmp/.frisbee/id 2>/dev/null)
+	if [ -z "$ID" ] ; then
+	    return
 	fi
 	
-	ssid=`wpa_cli -i $INTERFACE get_network $ID ssid | tr -d \"`
+	ssid=$(wpa_cli -i "$INTERFACE" get_network "$ID" ssid | tr -d \")
 	if [[ $ssid != "FAIL" ]] ; then
-	        echo $ssid
+	    echo "$ssid"
 	fi 
 }
 export -f   get_ssid 
@@ -924,8 +928,9 @@ export -f   get_ssid
 #############################################
 
 function get_ssids {
-	wpa_cli -i $INTERFACE list_networks | grep '^[0-9]' | sed 's/	/|/g'| while read line ; do #141005
-	echo $line
+	wpa_cli -i "$INTERFACE" list_networks | grep '^[0-9]' | sed 's/	/|/g'| \
+	while read line ; do #141005
+	    echo "$line"
 	done 
 	echo
 	echo
@@ -938,7 +943,7 @@ export -f   get_ssids
 
 function get_static_ip {
 	IF=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$IF static\$" -A2|tail -n 1|cut -d= -f2|cut -d\/ -f1
+	grep "^#$IF static\$" -A2 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2|cut -d/ -f1
 }
 export -f   get_static_ip
 
@@ -946,7 +951,7 @@ export -f   get_static_ip
 
 function get_static_ip_wireless {
 	SSID=$1
-	cat /etc/frisbee/dhcpcd.conf | grep "^#$SSID static\$" -A3|tail -n 1|cut -d= -f2|cut -d\/ -f1
+	grep "^#$SSID static\$" -A3 < /etc/frisbee/dhcpcd.conf|tail -n 1|cut -d= -f2|cut -d/ -f1
 }
 export -f   get_static_ip_wireless
 
@@ -955,12 +960,13 @@ export -f   get_static_ip_wireless
 function get_status {
 	echo "Wpa_supplicant Status:" > /tmp/.frisbee/status 
 	echo "-------------------------------------------------" >> /tmp/.frisbee/status 
-	wpa_cli -i $INTERFACE status >> /tmp/.frisbee/status 2>/dev/null
-	[ $? -ne 0 ] && echo "Not Active" >> /tmp/.frisbee/status
+	wpa_cli -i "$INTERFACE" status >> /tmp/.frisbee/status 2>/dev/null \
+	  && echo "Not Active" >> /tmp/.frisbee/status
+# shellcheck disable=SC2129 # Allow individual redirects.
 	echo "-------------------------------------------------" >> /tmp/.frisbee/status 
 	echo >> /tmp/.frisbee/status 
-	iwconfig $INTERFACE >> /tmp/.frisbee/status 2>&1
-	ifconfig $INTERFACE >> /tmp/.frisbee/status 2>&1
+	iw dev "$INTERFACE" link >> /tmp/.frisbee/status 2>&1 #200829
+	ip addr show "$INTERFACE" >> /tmp/.frisbee/status 2>&1 #200829
 }
 export -f   get_status 
 
@@ -968,73 +974,24 @@ export -f   get_status
 	
 function get_identity { #130822...
 	ID="$1"
-	if [ -z $ID ]  ; then
-	        return
+	if [ -z "$ID" ]  ; then
+	    return
 	fi
 	
-	ident=`wpa_cli -i $INTERFACE get_network $ID identity | tr -d \"`
+	ident=$(wpa_cli -i "$INTERFACE" get_network "$ID" identity | tr -d \")
 	if [[ $ident != "FAIL" ]] ; then
-	        echo $ident
+	    echo "$ident"
 	fi 
 }
 export -f   get_identity  #130822 end
 
 #############################################
 
-
-function start_dhcp {
-	ZOPTION="" #140824...
-	WIFI_IF="$(cat /etc/frisbee/interface 2> /dev/null)"
-	if [ "$WIFI_IF" ];then
-		OTHERWIFI="$(get_ifs_wireless | grep -vw "$WIFI_IF" | tr '\n' , | sed 's/,$//')"
-		[ "$OTHERWIFI" ] && ZOPTION="-Z $OTHERWIFI"
-	fi
-	setsid dhcpcd -b -d $ZOPTION -f /etc/frisbee/dhcpcd.conf #140824 end
-	sleep 2
-}
-export -f start_dhcp
-
-#############################################
-
-function reset_dhcp {
-	dhcpcd -k
-	killall -9 dhcpcd
-	killall wpa_cli 2>/dev/null
-	start_dhcp
-}
-export -f reset_dhcp
-
-#############################################
-
-function start_wpa {
-	rfkill unblock wlan 2>/dev/null #140221
-	ifconfig $INTERFACE up
-	if grep -q '^wireless_autostart=1' /etc/frisbee/frisbee.conf ; then
-		WPACFGFILE="/etc/frisbee/wpa_supplicant.conf"
-		rm -f /tmp/wpa_supplicant.conf
-	else
-		WPACFGFILE="/tmp/wpa_supplicant.conf"
-		[ -f $WPACFGFILE ] \
-		 || sed -e '/^network=/,/}/d' /etc/frisbee/wpa_supplicant.conf > $WPACFGFILE
-	fi
-	if grep -q '^wpa_log_mode=1' /etc/frisbee/frisbee.conf ; then
-		setsid wpa_supplicant -B -d -Dwext -i$INTERFACE -c$WPACFGFILE > /tmp/wpa_supplicant.log
-	else
-		setsid wpa_supplicant -B -Dwext -i$INTERFACE -c$WPACFGFILE > /tmp/wpa_supplicant.log
-	fi
-	wpa_cli -i $INTERFACE scan >/dev/null
-
-}
-export -f start_wpa
-
-#############################################
-
 function stop_wpa { #140824...
-	busybox pidof wpa_supplicant >/dev/null
-	if [[ $? = 0 ]] ; then
-		wpa_cli terminate
-		sleep 2 
-		wpa_cli terminate 2>/dev/null
+	if ps -C wpa_supplicant >/dev/null; then #200829
+	    wpa_cli terminate
+	    sleep 2 
+	    wpa_cli terminate 2>/dev/null
 	fi
 	killall -9 wpa_supplicant 2>/dev/null
 	rm -rf /var/run/wpa_supplicant/*
@@ -1054,11 +1011,12 @@ export -f reset_wpa
 #############################################
 
 function roam {
-		wpa_cli -i $INTERFACE list_networks | while read LINE ; do
-	                ID=$(echo "$LINE" |cut -f1)
-	                wpa_cli -i $INTERFACE enable_network $ID
+	wpa_cli -i "$INTERFACE" list_networks | \
+	while read LINE ; do
+	    ID=$(echo "$LINE" |cut -f1)
+	    wpa_cli -i "$INTERFACE" enable_network "$ID"
 	done
-	wpa_cli -i $INTERFACE save_config
+	wpa_cli -i "$INTERFACE" save_config
 	sleep 1
 	
 	reset_wpa
@@ -1070,11 +1028,11 @@ export -f roam
 function cleanfile {
 	ECHO=1
 	while read LINE ; do 
-	        [[ $LINE == "#$1" ]] && ECHO=0
-	        [[ $LINE == "#$1 static" ]] && ECHO=0
-	        [[ $ECHO == 2 ]] && ECHO=1
-	        [[ $LINE == "#end $1" ]] && ECHO=2
-	        [[ $ECHO == 1 ]] && echo $LINE
+	    [[ $LINE == "#$1" ]] && ECHO=0
+	    [[ $LINE == "#$1 static" ]] && ECHO=0
+	    [[ $ECHO == 2 ]] && ECHO=1
+	    [[ $LINE == "#end $1" ]] && ECHO=2
+	    [[ $ECHO == 1 ]] && echo "$LINE"
 	done
 }
 export -f   cleanfile 
@@ -1082,109 +1040,106 @@ export -f   cleanfile
 #############################################
 
 function update_dhcp {
-	IF=`echo $1|cut -f1 -d\|`
-	IGNORE=`echo $1|cut -f2 -d\|`
-	AUTO=`echo $1|cut -f3 -d\|`
-	IP=`echo $1|cut -f4 -d\|`
-	SUBNET=`echo $1|cut -f5 -d\|`
-	GATEWAY=`echo $1|cut -f6 -d\|`
-	DNS1=`echo $1|cut -f7 -d\|`
-	DNS2=`echo $1|cut -f8 -d\|`
+	IF=$(echo "$1"|cut -f1 -d\|)
+	IGNORE=$(echo "$1"|cut -f2 -d\|)
+	AUTO=$(echo "$1"|cut -f3 -d\|)
+	IP=$(echo "$1"|cut -f4 -d\|)
+	SUBNET=$(echo "$1"|cut -f5 -d\|)
+	GATEWAY=$(echo "$1"|cut -f6 -d\|)
+	DNS1=$(echo "$1"|cut -f7 -d\|)
+	DNS2=$(echo "$1"|cut -f8 -d\|)
 	
-	if [ ! $IF ]  ;then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Please select an interface')" 0 0 ; return 1 #140901
+	if [ -z "$IF" ] ;then
+	    Xdialog --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Please select an interface')" 0 0 ; return 1 #140901
 	fi
 	
-	IGNOREORIG=`cat /etc/frisbee/dhcpcd.conf |grep '^denyinterfaces'`
-	IGNORELIST=`echo $IGNOREORIG |cut -f2 -d" "|tr , " "`
+	IGNOREORIG=$(grep '^denyinterfaces' < /etc/frisbee/dhcpcd.conf)
+	IGNORELIST=$(echo "$IGNOREORIG" |cut -f2 -d" "|tr , " ")
 	
 	for i in $IGNORELIST ; do
-	        if [[ $IF == $i ]] ; then
-	                IGNORED=1
-	        fi
+	    if [[ $IF == "$i" ]] ; then
+	        IGNORED=1
+	    fi
 	done
 	
 	if [[ $IGNORE == true ]] ; then
-	        if [[ $IGNORED == 1 ]] ; then
-	                return 1 #140901
-	        else
-	                IGNORELIST="$IGNORELIST $IF"
-	        fi
+	    if [[ $IGNORED == 1 ]] ; then
+	        return 1 #140901
+	    else
+	        IGNORELIST="$IGNORELIST $IF"
+	    fi
 	fi
 	
 	if [[ $AUTO == true && $IGNORED == 1 ]] ; then
-	        
-	        IGNORELIST=`for i in $IGNORELIST ; do
-	                if [[ $IF != $i ]] ; then
-	                        echo -n "$i "
-	                fi
-	        done
-	        echo`
+	    IGNORELIST=$(for i in $IGNORELIST ; do
+	        if [[ $IF != "$i" ]] ; then
+	            echo -n "$i "
+	        fi
+	    done
+	    echo)
 	fi
 	
-	IGNORELIST=`echo "$IGNORELIST"|tr " " ,|sed 's/,$//'`
-	IGNORELIST=`echo "denyinterfaces $IGNORELIST"`
+	IGNORELIST="denyinterfaces $(echo "$IGNORELIST"|tr " " ,|sed 's/,$//')"
 	
 	if [[ "$IGNORELIST" != "$IGNOREORIG" ]] ; then
-	        cat /etc/frisbee/dhcpcd.conf |sed "s/^denyinterfaces.*$/$IGNORELIST/" > /tmp/dhcpcd.conf 
-	        mv /tmp/dhcpcd.conf /etc/frisbee
-	        reset_dhcp&
+	    sed "s/^denyinterfaces.*$/$IGNORELIST/" < /etc/frisbee/dhcpcd.conf > /tmp/dhcpcd.conf 
+	    mv /tmp/dhcpcd.conf /etc/frisbee
+	    reset_dhcp&
 	fi
 	
 	if [[ $AUTO == true || $IGNORE == true ]] ; then
-	        cat /etc/frisbee/dhcpcd.conf | grep "interface $IF"
-	        if [[ $? == 0 ]] ; then
-	                cat /etc/frisbee/dhcpcd.conf |cleanfile $IF >  /tmp/dhcpcd.conf 
-	                mv /tmp/dhcpcd.conf /etc/frisbee
-	        fi
-	        return 0 #140901
+	    if grep "interface $IF" < /etc/frisbee/dhcpcd.conf ; then
+	        cleanfile "$IF" < /etc/frisbee/dhcpcd.conf > /tmp/dhcpcd.conf 
+	        mv /tmp/dhcpcd.conf /etc/frisbee
+	    fi
+	    return 0 #140901
 	fi
-	
-	
-	IP=`echo $IP|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	if [ ! $IP ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid IP address')" 0 0 ; return 1 #140901
+
+	IP=$(echo "$IP"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	if [ -z "$IP" ] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid IP address')" 0 0 ; return 1 #140901
 	fi
-	GATEWAY=`echo $GATEWAY|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	if [ ! $GATEWAY ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid gateway')" 0 0  ; return 1 #140901
+	GATEWAY=$(echo "$GATEWAY"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	if [ -z "$GATEWAY" ] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid gateway')" 0 0  ; return 1 #140901
 	fi
-	SUBNET=`echo $SUBNET|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	if [ ! $SUBNET ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 #140901
+	SUBNET=$(echo "$SUBNET"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	if [ -z "$SUBNET" ] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 #140901
 	fi
 	if [ "$DNS1" ];then
-		DNS1=`echo $DNS1|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-		if [ ! $DNS1 ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid IP Address for DNS Server 1')" 0 0  ; return 1 #140901
-		fi
+	    DNS1=$(echo "$DNS1"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	    if [ -z "$DNS1" ] ; then
+	         Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid IP Address for DNS Server 1')" 0 0  ; return 1 #140901
+	    fi
 	fi
-	DNS2=`echo $DNS2|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	SUBNET=`echo $SUBNET|tr "." " "`
+	DNS2=$(echo "$DNS2"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	SUBNET=$(echo "$SUBNET"|tr "." " ")
 	CIDR=0
 	for dec in $SUBNET ; do
-	        case $dec in
-	            255) let CIDR+=8;;
-	            254) let CIDR+=7;;
-	            252) let CIDR+=6;;
-	            248) let CIDR+=5;;
-	            240) let CIDR+=4;;
-	            224) let CIDR+=3;;
-	            192) let CIDR+=2;;
-	            128) let CIDR+=1;;
-	            0);;
-	            *) Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 ;; #140901
-	        esac
+	    case $dec in
+	        255) (( CIDR+=8 ));;
+	        254) (( CIDR+=7 ));;
+	        252) (( CIDR+=6 ));;
+	        248) (( CIDR+=5 ));;
+	        240) (( CIDR+=4 ));;
+	        224) (( CIDR+=3 ));;
+	        192) (( CIDR+=2 ));;
+	        128) (( CIDR+=1 ));;
+	        0);;
+	        *) Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 ;; #140901
+	    esac
 	done
-	
-	
-	cat /etc/frisbee/dhcpcd.conf |cleanfile $IF > /tmp/dhcpcd.conf 
-	echo "#$IF static" >> /tmp/dhcpcd.conf
-	echo "interface $IF " >> /tmp/dhcpcd.conf
-	echo "static ip_address=${IP}/${CIDR} " >> /tmp/dhcpcd.conf
-	echo "static routers=$GATEWAY " >> /tmp/dhcpcd.conf
-	echo "static domain_name_servers=$DNS1 $DNS2" >> /tmp/dhcpcd.conf
-	echo "#end $IF" >> /tmp/dhcpcd.conf
+
+	cleanfile "$IF" < /etc/frisbee/dhcpcd.conf > /tmp/dhcpcd.conf 
+	{
+	echo "#$IF static"
+	echo "interface $IF "
+	echo "static ip_address=${IP}/${CIDR} "
+	echo "static routers=$GATEWAY "
+	echo "static domain_name_servers=$DNS1 $DNS2"
+	echo "#end $IF"
+	} >> /tmp/dhcpcd.conf
 	mv /tmp/dhcpcd.conf /etc/frisbee
 	reset_dhcp&
 	return 0
@@ -1195,72 +1150,73 @@ export -f   update_dhcp
 
 function update_dhcp_wireless {
 	#set -x
-	SSID=`echo $1|cut -f1 -d\|`
-	AUTO=`echo $1|cut -f2 -d\|`
-	IP=`echo $1|cut -f3 -d\|`
-	SUBNET=`echo $1|cut -f4 -d\|`
-	GATEWAY=`echo $1|cut -f5 -d\|`
-	DNS1=`echo $1|cut -f6 -d\|`
-	DNS2=`echo $1|cut -f7 -d\|`
+	SSID=$(echo "$1"|cut -f1 -d\|)
+	AUTO=$(echo "$1"|cut -f2 -d\|)
+	IP=$(echo "$1"|cut -f3 -d\|)
+	SUBNET=$(echo "$1"|cut -f4 -d\|)
+	GATEWAY=$(echo "$1"|cut -f5 -d\|)
+	DNS1=$(echo "$1"|cut -f6 -d\|)
+	DNS2=$(echo "$1"|cut -f7 -d\|)
 
 	if [[ -z $SSID ]] ; then
-	        return 1 #140901
+	    return 1 #140901
 	fi
 	
 	if [[ $AUTO == true ]] ; then
-	     cat /etc/frisbee/dhcpcd.conf | grep "^#$SSID static\$"
-	     if [[ $? == 0 ]] ; then
-	           cat /etc/frisbee/dhcpcd.conf |cleanfile $SSID >  /tmp/dhcpcd.conf 
-	           mv /tmp/dhcpcd.conf /etc/frisbee
+	    if grep "^#$SSID static\$" < /etc/frisbee/dhcpcd.conf ; then
+	        cleanfile "$SSID" < /etc/frisbee/dhcpcd.conf > /tmp/dhcpcd.conf 
+	        mv /tmp/dhcpcd.conf /etc/frisbee
 	    fi
 	    return 0 #140901
 	fi
 	
-	IP=`echo $IP|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	if [ ! $IP ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid IP address')" 0 0 ; return 1 #140901
+	IP=$(echo "$IP"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	if [ -z "$IP" ] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid IP address')" 0 0 ; return 1 #140901
 	fi
-	GATEWAY=`echo $GATEWAY|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	if [ ! $GATEWAY ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid gateway')" 0 0  ; return 1 #140901
+	GATEWAY=$(echo "$GATEWAY"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	if [ -z "$GATEWAY" ] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid gateway')" 0 0  ; return 1 #140901
 	fi
-	SUBNET=`echo $SUBNET|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	if [ ! $SUBNET ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 #140901
+	SUBNET=$(echo "$SUBNET"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	if [ -z "$SUBNET" ] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 #140901
 	fi
 	if [ "$DNS1" ];then
-		DNS1=`echo $DNS1|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-		if [ ! $DNS1 ] ; then
-	         Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid IP address for DNS Server 1')" 0 0  ; return 1 #140901
-		fi
+	    DNS1=$(echo "$DNS1"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	    if [ -z "$DNS1" ] ; then
+	         Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid IP address for DNS Server 1')" 0 0  ; return 1 #140901
+	    fi
 	fi
-	DNS2=`echo $DNS2|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}'`
-	SUBNET=`echo $SUBNET|tr "." " "`
+	DNS2=$(echo "$DNS2"|awk --posix -F"." '{ if ($0~/^([0-9]{1,3}\.){3}[0-9]{1,3}$/ && $1<=255 && $2<=255 && $3<=255 && $4<=255) print $0}')
+	SUBNET=$(echo "$SUBNET"|tr "." " ")
 	CIDR=0
 	for dec in $SUBNET ; do
-	        case $dec in
-	            255) let CIDR+=8;;
-	            254) let CIDR+=7;;
-	            252) let CIDR+=6;;
-	            248) let CIDR+=5;;
-	            240) let CIDR+=4;;
-	            224) let CIDR+=3;;
-	            192) let CIDR+=2;;
-	            128) let CIDR+=1;;
-	            0);;
-	            *) Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 ;; #140901
-	        esac
+	    case $dec in
+	        255) (( CIDR+=8 ));;
+	        254) (( CIDR+=7 ));;
+	        252) (( CIDR+=6 ));;
+	        248) (( CIDR+=5 ));;
+	        240) (( CIDR+=4 ));;
+	        224) (( CIDR+=3 ));;
+	        192) (( CIDR+=2 ));;
+	        128) (( CIDR+=1 ));;
+	        0);;
+	        *) Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid subnet mask')" 0 0  ; return 1 ;; #140901
+	    esac
 	done
 	
 	
-	cat /etc/frisbee/dhcpcd.conf |cleanfile $SSID > /tmp/dhcpcd.conf 
-	echo "#$SSID static" >> /tmp/dhcpcd.conf
-	echo "#interface $INTERFACE" >> /tmp/dhcpcd.conf #140929
-	echo "ssid $SSID" >> /tmp/dhcpcd.conf
-	echo "static ip_address=${IP}/${CIDR} " >> /tmp/dhcpcd.conf
-	echo "static routers=$GATEWAY " >> /tmp/dhcpcd.conf
-	echo "static domain_name_servers=$DNS1 $DNS2" >> /tmp/dhcpcd.conf
-	echo "#end $SSID" >> /tmp/dhcpcd.conf
+	cleanfile "$SSID" < /etc/frisbee/dhcpcd.conf > /tmp/dhcpcd.conf 
+	{
+	echo "#$SSID static"
+	echo "#interface $INTERFACE" #140929
+	echo "ssid $SSID"
+	echo "static ip_address=${IP}/${CIDR} "
+	echo "static routers=$GATEWAY "
+	echo "static domain_name_servers=$DNS1 $DNS2"
+	echo "#end $SSID"
+	} >> /tmp/dhcpcd.conf
 	mv /tmp/dhcpcd.conf /etc/frisbee
 	reset_dhcp&
 	return 0 #140901
@@ -1270,194 +1226,118 @@ export -f   update_dhcp_wireless
 #############################################
 
 function update_profile {
-	ID=`echo $1|cut -f1 -d\|`
-	SSID=`echo $1|cut -f2 -d\|`
-	BSSID=`echo $1|cut -f3 -d\|`
-	ENCKEY=`echo $1|cut -f4 -d\|`
-	PRIORITY=`echo $1|cut -f5 -d\|`
-	ENABLED=`echo $1|cut -f6 -d\|`
-	AUTH=`echo $1|cut -f7 -d\|`
-	ENC=`echo $1|cut -f8 -d\|`
+	ID=$(echo "$1"|cut -f1 -d\|)
+	SSID=$(echo "$1"|cut -f2 -d\|)
+	BSSID=$(echo "$1"|cut -f3 -d\|)
+	ENCKEY=$(echo "$1"|cut -f4 -d\|)
+	PRIORITY=$(echo "$1"|cut -f5 -d\|)
+	ENABLED=$(echo "$1"|cut -f6 -d\|)
+	AUTH=$(echo "$1"|cut -f7 -d\|)
+	ENC=$(echo "$1"|cut -f8 -d\|)
 	echo "$ID $SSID $BSSID $ENCKEY $PRIORITY $ENABLED"
 	
-	wpa_cli  list_networks | grep "^$ID    "|grep CURRENT
-	[[ $? == 0 ]] && CURRENT=yes
-	
-	
-	if [[ -z $ID ]] ; then
-	        Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Please select a profile to update')" 0 0
-	        return
+	wpa_cli  list_networks | grep "^$ID    "|grep CURRENT && CURRENT=yes
+
+	if [[ -z "$ID" ]] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Please select a profile to update')" 0 0
+	    return
 	fi
 	        
 	
-	RESULT=`wpa_cli -i $INTERFACE set_network $ID priority $PRIORITY`
+	RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" priority "$PRIORITY")
 	if [[ "$RESULT" != "OK" ]] ; then
-	        Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid priority')" 0 0
-	        wpa_cli -i $INTERFACE reconfigure
-	        return
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid priority')" 0 0
+	    wpa_cli -i "$INTERFACE" reconfigure
+	    return
 	fi
 	
 	if [[ "$ENABLED" == "true" ]] ; then
-	        RESULT=`wpa_cli -i $INTERFACE enable_network $ID`
-	        if [[ "$RESULT" != "OK" ]] ; then
-	                Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Failed to enable network')" 0 0
-	                wpa_cli -i $INTERFACE reconfigure
-	                return
-	        fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" enable_network "$ID")
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Failed to enable network')" 0 0
+	        wpa_cli -i "$INTERFACE" reconfigure
+	        return
+	    fi
 	else
-	        RESULT=`wpa_cli -i $INTERFACE disable_network $ID`
-	        if [[ "$RESULT" != "OK" ]] ; then
-	                Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to disable network')" 0 0
-	                wpa_cli -i $INTERFACE reconfigure
-	                return
-	        fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" disable_network "$ID")
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to disable network')" 0 0
+	        wpa_cli -i "$INTERFACE" reconfigure
+	        return
+	    fi
 	fi
 	
 	if [[ $BSSID != '' ]] ; then
-	        RESULT=`wpa_cli -i $INTERFACE set_network $ID bssid $BSSID`
-	        if [[ "$RESULT" != "OK" ]] ; then
-	                Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Invalid BSSID')" 0 0
-	                wpa_cli -i $INTERFACE reconfigure
-	                return
-	        fi
+	    RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" bssid "$BSSID")
+	    if [[ "$RESULT" != "OK" ]] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Invalid BSSID')" 0 0
+	        wpa_cli -i "$INTERFACE" reconfigure
+	        return
+	    fi
 	fi
 	
 	if [[ ("$AUTH" == "WPA-PSK" ||  "$ENC" == "WEP") && "$ENCKEY" != "[Key Configured]"  ]] ; then
-	        if [ -z $ENCKEY ] ; then
-	                Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "$(gettext 'Invalid Password')" 0 0   
-	                wpa_cli -i $INTERFACE reconfigure
-	                return
-	        fi
-	        if [[ "$ENC" == "WEP" ]] ; then
-	                if echo "$ENCKEY" | grep -E '^([[:xdigit:]]){10}$|^([[:xdigit:]]){26}$|^([[:xdigit:]]){32}$'; then #141005
-	                    RESULT=`wpa_cli -i $INTERFACE set_network $ID wep_key0 $ENCKEY`
-	                else
-	                    RESULT=`wpa_cli -i $INTERFACE set_network $ID wep_key0 \""${ENCKEY}"\"`
-	                fi
-	                if [[ "$RESULT" != "OK" ]] ; then
-	                        Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid Password')" 0 0
-	                        wpa_cli -i $INTERFACE reconfigure
-	                        return
-	                fi
-	
-	        else
-	                if echo "$ENCKEY" | grep -E '^([[:xdigit:]]){64}$'; then #141005
-							RESULT=`wpa_cli -i $INTERFACE set_network $ID psk $ENCKEY`
-	                else
-	                        RESULT=`wpa_cli -i $INTERFACE set_network $ID psk \""${ENCKEY}"\"`
-	                fi
-	                if [[ "$RESULT" != "OK" ]] ; then
-	                        Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Invalid Password')" 0 0
-	                        wpa_cli -i $INTERFACE reconfigure
-	                        return
-	                fi
-	        fi
-	fi
-	
-	
-	
-	RESULT=`wpa_cli -i $INTERFACE save_config`
-	if [[ "$RESULT" != "OK" ]] ; then
-	        Xdialog  --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
-	        wpa_cli -i $INTERFACE reconfigure
+	    if [ -z "$ENCKEY" ] ; then
+	        Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(gettext 'Invalid Password')" 0 0   
+	        wpa_cli -i "$INTERFACE" reconfigure
 	        return
+	    fi
+	    if [[ "$ENC" == "WEP" ]] ; then
+	        if echo "$ENCKEY" | grep -E '^([[:xdigit:]]){10}$|^([[:xdigit:]]){26}$|^([[:xdigit:]]){32}$'; then #141005
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" wep_key0 "$ENCKEY")
+	        else
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" wep_key0 \""${ENCKEY}"\")
+	        fi
+	        if [[ "$RESULT" != "OK" ]] ; then
+	            Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid Password')" 0 0
+	            wpa_cli -i "$INTERFACE" reconfigure
+	            return
+	        fi
+
+	    else
+	        if echo "$ENCKEY" | grep -E '^([[:xdigit:]]){64}$'; then #141005
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" psk "$ENCKEY")
+	        else
+	            RESULT=$(wpa_cli -i "$INTERFACE" set_network "$ID" psk \""${ENCKEY}"\")
+	        fi
+	        if [[ "$RESULT" != "OK" ]] ; then
+	            Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Invalid Password')" 0 0
+	            wpa_cli -i "$INTERFACE" reconfigure
+	            return
+	        fi
+	    fi
+	fi
+
+	RESULT=$(wpa_cli -i "$INTERFACE" save_config)
+	if [[ "$RESULT" != "OK" ]] ; then
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'Failed to save configuration')" 0 0
+	    wpa_cli -i "$INTERFACE" reconfigure
+	    return
 	fi
 	#[[ $CURRENT == "yes" ]] && reset_wpa
 	reset_wpa
 	reset_dhcp
 	
 	. gettext.sh #140818
-	Xdialog  --wmclass "frisbee" --title "Frisbee" --msgbox "`eval_gettext \"Profile for \\\$SSID updated\"`" 0 0 #140818
+	Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --msgbox "$(eval_gettext "Profile for \$SSID updated")" 0 0 #140818
 }
 export -f   update_profile
-
-#############################################
-
-function connect {
-	#set -x
-	prof=`wpa_cli -i $INTERFACE list_networks|tail -n 1|cut -d " " -f1 `
-	if [[ $prof == "network" ]] ; then
-	        return 1
-	fi
-	wpa_cli -i $INTERFACE status|grep -q COMPLETED 
-	if [[ $? == 0 ]] ; then
-	        #dhcpcd -n 
-	        dhcpcd -n $INTERFACE #180210
-	        return 0
-	fi
-	        ifconfig $INTERFACE up
-	        busybox pidof wpa_supplicant >/dev/null
-	        if [[ $? != 0 ]] ; then
-	                start_wpa
-	        fi
-	        busybox pidof dhcpcd >/dev/null
-	        if [[ $? != 0 ]] ; then
-	                start_dhcp
-	        else #180210
-	                dhcpcd -n $INTERFACE #180210
-	        fi
-	        wpa_cli -i $INTERFACE reconnect 
-	        #dhcpcd -n 
-	
-	sleep 2
-	return 0
-}
-export -f connect
-
-#############################################
-
-
-function disconnect {
-	[ "$INTERFACE" = "none" ] && return
-	wpa_cli -i $INTERFACE disconnect 2>/dev/null
-	sleep 1 
-	wpa_cli -i $INTERFACE disconnect 2>/dev/null
-	busybox pidof wait_disconnect >/dev/null && killall wait_disconnect #140607
-	dhcpcd -k $INTERFACE 
-
-}
-export -f disconnect
-
-#############################################
-
-function wait_disconnect {
-	for i in 1 2 3 ; do
-	        sleep 10
-	        wpa_cli -i $INTERFACE status | grep DISCONNECTED #140607
-	        if [[ $? == 0 ]] ; then
-				return
-	        fi
-	done
-
-dhcpcd -k $INTERFACE 
-}
-export -f wait_disconnect
-
-#############################################
-
-function get_ifs_wireless { #140819...
-	#returns true/0 if interfaces present
-	WIFACES=$(iwconfig 2>&1 | grep '^[a-z]' | grep -v 'no wireless' | cut -f 1 -d ' ')
-	echo "$WIFACES"
-	[ "$WIFACES" ]
-	return $?
-}
-export -f get_ifs_wireless
 
 #############################################
 
 function change_if_wireless {
 	WIFACES="$(get_ifs_wireless)" #140824
 	if [ "$WIFACES" ];then #140824
-		IFACES=''
-		for i in $(echo "$WIFACES" | sort); do #140818
-			IFACES="$IFACES $i $i $i "
-		done
-		Xdialog  --wmclass "frisbee" --title "Frisbee" --stdout --ok-label "$(gettext 'Change')" --no-tags --radiolist "$(gettext 'Please select an interface')"  0 0 0 $IFACES > /tmp/.frisbee/userif #140824... 180313
-		IF=$(cat /tmp/.frisbee/userif)
-		[ "$IF" ] && echo -n "$IF" > /etc/frisbee/userif
+	    IFACES=''
+	    for i in $(echo "$WIFACES" | sort); do #140818
+	        IFACES="$IFACES $i $i $i "
+	    done
+# shellcheck disable=SC2086 # Allow word splitting of $IFACES.
+	    Xdialog  --wmclass frisbee --title "$(gettext 'Frisbee')" --stdout --ok-label "$(gettext 'Change')" --no-tags --radiolist "$(gettext 'Please select an interface')"  0 0 0 $IFACES > /tmp/.frisbee/userif #140824... 180313
+	    IF=$(cat /tmp/.frisbee/userif)
+	    [ "$IF" ] && echo -n "$IF" > /etc/frisbee/userif
 	else
-		Xdialog --wmclass "frisbee" --title "Frisbee"  --msgbox "$(gettext 'No wireless interfaces found.')" 0 0 
+	    Xdialog --wmclass frisbee --title "$(gettext 'Frisbee')"  --msgbox "$(gettext 'No wireless interfaces found.')" 0 0 
 	fi
 }
 export -f change_if_wireless
@@ -1477,12 +1357,12 @@ export -f read_password_from_secret
 
 function save_password_to_secret {
 	#Arguments are user name, password.
-	[ -z "$1" -o -z "$2" ] && return 1
+	[ -z "$1" ] || [ -z "$2" ] && return 1
 	for ONEAPFILE in pap-secrets chap-secrets; do
-		if ! grep -q -s "^\"$1\".\*.\"$2\"" /etc/ppp/$ONEAPFILE; then
-			sed -i -e "/^\"$1\"\t/d" /etc/ppp/$ONEAPFILE
-			echo -e "\"$1\"\t*\t\"$2\"" >> /etc/ppp/$ONEAPFILE
-		fi
+	    if ! grep -q -s "^\"$1\".\*.\"$2\"" /etc/ppp/$ONEAPFILE; then
+	        sed -i -e "/^\"$1\"\t/d" /etc/ppp/$ONEAPFILE
+	        echo -e "\"$1\"\t*\t\"$2\"" >> /etc/ppp/$ONEAPFILE
+	    fi
 	done
 }
 export -f save_password_to_secret
@@ -1494,65 +1374,65 @@ function read_telephone_value {
 	RETVAL=""
 	case "$1" in
 	pppoedemand)
-		RETVAL="false"
-		[ -s /etc/ppp/pppoe.conf ] \
-		 && ! grep -q -s "^DEMAND='*no" /etc/ppp/pppoe.conf \
-		 && RETVAL="true"
-		;;
+	    RETVAL="false"
+	    [ -s /etc/ppp/pppoe.conf ] \
+	      && ! grep -q -s "^DEMAND='*no" /etc/ppp/pppoe.conf \
+	      && RETVAL="true"
+	    ;;
 	pppoedns)
-		RETVAL="false"
-		[ -s /etc/ppp/pppoe.conf ] \
-		 && ! grep -q -s "^DNSTYPE='*SERVER" /etc/ppp/pppoe.conf \
-		 && RETVAL="true"
-		;;
+	    RETVAL="false"
+	    [ -s /etc/ppp/pppoe.conf ] \
+	      && ! grep -q -s "^DNSTYPE='*SERVER" /etc/ppp/pppoe.conf \
+	      && RETVAL="true"
+	    ;;
 	pppoednsvalue)
-		RETVAL="$(grep -q -s "^DNS[12]=\'*" /etc/ppp/pppoe.conf && echo -n "$(sed -n -e "s/^DNS[12]='*\([^\' ]*\).*/\1/p" /etc/ppp/pppoe.conf 2>/dev/null | head -n 2 | tr '\n' ' ' | sed -e 's/ *$//')")"
-		;;
+	    RETVAL="$(grep -q -s "^DNS[12]=\'*" /etc/ppp/pppoe.conf && echo -n "$(sed -n -e "s/^DNS[12]='*\([^\' ]*\).*/\1/p" /etc/ppp/pppoe.conf 2>/dev/null | head -n 2 | tr '\n' ' ' | sed -e 's/ *$//')")"
+	    ;;
 	pppoeuidreq)
-		grep -q -s "^USER='*[^ $]" /etc/ppp/pppoe.conf \
-		 && RETVAL="true" \
-		 || RETVAL="false"
-		;;
+	    grep -q -s "^USER='*[^ $]" /etc/ppp/pppoe.conf \
+	      && RETVAL="true" \
+	      || RETVAL="false"
+	    ;;
 	pppoeuser)
-		RETVAL="$(grep -q -s "^USER=\'*." /etc/ppp/pppoe.conf && echo -n "$(sed -n -e '/^USER=/ s/.*=\([^ ]*\)/\1/p' /etc/ppp/pppoe.conf 2>/dev/null | tr -d \')")"
-		;;
+	    RETVAL="$(grep -q -s "^USER=\'*." /etc/ppp/pppoe.conf && echo -n "$(sed -n -e '/^USER=/ s/.*=\([^ ]*\)/\1/p' /etc/ppp/pppoe.conf 2>/dev/null | tr -d \')")"
+	    ;;
 	pppoepswd)
-		RETVAL="$(echo -n "$(read_password_from_secret "$PPPOEUSER")")"
-		;;
+	    RETVAL="$(echo -n "$(read_password_from_secret "$PPPOEUSER")")"
+	    ;;
 	pppoepaponly)
-		grep -q '^pppoe_paponly=1' /etc/frisbee/frisbee.conf \
-		 && RETVAL="true" \
-		 || RETVAL="false"
-		;;
+	    grep -q '^pppoe_paponly=1' /etc/frisbee/frisbee.conf \
+	      && RETVAL="true" \
+	      || RETVAL="false"
+	    ;;
 	device)
-		RETVAL="$(grep 'GPRSDEV=' /root/.config/gprs.conf | cut -f 2 -d =)"
-		;;
+	    RETVAL="$(grep 'GPRSDEV=' /root/.config/gprs.conf | cut -f 2 -d = | tr -d \")" #200829
+	    ;;
 	apn)
-		RETVAL="$(grep 'GPRSAPN=' /root/.config/gprs.conf | cut -f 2 -d =)"
-		;;
+	    RETVAL="$(grep 'GPRSAPN=' /root/.config/gprs.conf | cut -f 2 -d =)"
+	    ;;
 	number)
-		RETVAL="$(grep 'GPRSNBR=' /root/.config/gprs.conf | cut -f 2 -d =)"
-		[ "$RETVAL" ] \
-		 || RETVAL="$(grep -m 1 '.' /tmp/.frisbee/mobilenbrlist)"
-		;;
+	    RETVAL="$(grep 'GPRSNBR=' /root/.config/gprs.conf | cut -f 2 -d =)"
+	    [ "$RETVAL" ] \
+	      || RETVAL="$(grep -m 1 '.' /tmp/.frisbee/mobilenbrlist)"
+	    ;;
 	pin)
-		RETVAL="$(grep 'GPRSPIN=' /root/.config/gprs.conf | cut -f 2 -d =)"
-		;;
+	    RETVAL="$(grep 'GPRSPIN=' /root/.config/gprs.conf | cut -f 2 -d =)"
+	    ;;
 	uidreq)
-		grep -q -s "^GPRSUSER='*[^ $]" /root/.config/gprs.conf \
-		 && RETVAL="true" \
-		 || RETVAL="false"
-		;;
+	    grep -q -s "^GPRSUSER='*[^ $]" /root/.config/gprs.conf \
+	      && RETVAL="true" \
+	      || RETVAL="false"
+	    ;;
 	gprsuser)
-		RETVAL="$(grep '^GPRSUSER=' /root/.config/gprs.conf | cut -f 2 -d =)"
-		;;
+	    RETVAL="$(grep '^GPRSUSER=' /root/.config/gprs.conf | cut -f 2 -d =)"
+	    ;;
 	gprspswd)
-		RETVAL="$(echo -n "$(read_password_from_secret "$GPRSUSER")")"
-		;;
+	    RETVAL="$(echo -n "$(read_password_from_secret "$GPRSUSER")")"
+	    ;;
 	gprspaponly)
-		RETVAL="$(grep '^GPRSPAPONLY=' /root/.config/gprs.conf | cut -f 2 -d =)"
-		[ "$RETVAL" ] || RETVAL="false"
-		;;
+	    RETVAL="$(grep '^GPRSPAPONLY=' /root/.config/gprs.conf | cut -f 2 -d =)"
+	    [ "$RETVAL" ] || RETVAL="false"
+	    ;;
 	esac
 	echo -n "$RETVAL"
 	[ "$RETVAL" ]
@@ -1563,13 +1443,13 @@ export -f read_telephone_value
 #############################################
 
 #160220 talk to modem, allow time for response... 180721
-function chat_with_modem() { #device passed in.
- local ANSWERFILE=/tmp/.frisbee/answer.txt
- rm -f $ANSWERFILE
- [ -f "/var/lock/LCK..${1##*/}" ] && rm -f "/var/lock/LCK..${1##*/}"
- echo -e "ATZ\r" | microcom -t 1000 $1 > $ANSWERFILE 2>/dev/null #180721
- [ -s $ANSWERFILE ] && grep -q '^OK' $ANSWERFILE #180721
- return $?
+function chat_with_modem { #device passed in.
+	local ANSWERFILE=/tmp/.frisbee/answer.txt
+	rm -f $ANSWERFILE
+	[ -f "/var/lock/LCK..${1##*/}" ] && rm -f "/var/lock/LCK..${1##*/}"
+	echo -e "ATZ\r" | busybox microcom -t 1000 "$1" > $ANSWERFILE 2>/dev/null #180721
+	[ -s $ANSWERFILE ] && grep -q '^OK' $ANSWERFILE #180721
+	return $?
 }
 export -f chat_with_modem
 
@@ -1579,29 +1459,31 @@ export -f chat_with_modem
 function build_mobile_device_list {
 	local DETECTED=''
 	if [ "$(which get_modem_alternate_device 2>/dev/null)" ] \
-	 && grep -q '"ALL"' $(which get_modem_alternate_device 2>/dev/null);then #160201...
-		DETECTED="$(get_modem_alternate_device ALL | sed -e '/^$/ d' -e 's%^%/dev/%')"
+	  && grep -q '"ALL"' "$(which get_modem_alternate_device 2>/dev/null)";then #160201...
+	    DETECTED="$(get_modem_alternate_device ALL | sed -e '/^$/ d' -e 's%^%/dev/%')"
 	else
-		#Compensate for get_modem_alternate_device w/o ALL option
-		for MAINDEV in $(ls /dev/ttyACM* /dev/ttyHS* /dev/ttyUSB* /dev/rfcomm* 2>/dev/null);do
-			[ -c $MAINDEV ] \
-			 && chat_with_modem $MAINDEV \
-			 && DETECTED="$DETECTED $MAINDEV"
-		done
+	    #Compensate for get_modem_alternate_device w/o ALL option
+	    MAINDEVS="$(ls /dev/ttyACM* /dev/ttyHS* /dev/ttyUSB* /dev/rfcomm* 2>/dev/null)"
+	    for MAINDEV in $MAINDEVS;do
+	        [ -c "$MAINDEV" ] \
+	          && chat_with_modem "$MAINDEV" \
+	          && DETECTED="$DETECTED $MAINDEV"
+	    done
 	fi
-	eval $(grep '^GPRS_OTHER_DEVICES=' /etc/ppp/gprs.conf)
-	for OTHERDEV in $(ls $GPRS_OTHER_DEVICES 2>/dev/null); do
-		[ -c $OTHERDEV ] \
-		 && chat_with_modem $OTHERDEV \
-		 && DETECTED="$DETECTED $OTHERDEV"
+	eval "$(grep '^GPRS_OTHER_DEVICES=' /etc/gprs.conf)" #200829
+	OTHERDEVS="$(ls "$GPRS_OTHER_DEVICES" 2>/dev/null)"
+	for OTHERDEV in $OTHERDEVS; do
+	    [ -c "$OTHERDEV" ] \
+	      && ( [ -n "${OTHERDEV#/dev/ttyS[0123]}" ] || setserial -g "$OTHERDEV" | grep -qv 'unknown' ) \
+	      && chat_with_modem "$OTHERDEV" \
+	      && DETECTED="$DETECTED $OTHERDEV" #200829
 	done
 	#130428...
 	if [ -z "$DETECTED" ];then
-		echo -n "--$(gettext 'None detected')--" > /tmp/.frisbee/mobiledevlist
+	    echo -n "--$(gettext 'None detected')--" > /tmp/.frisbee/mobiledevlist
 	else
-		echo "$DETECTED" | sed -e 's/^ //' -e 's/ /\n/g' > /tmp/.frisbee/mobiledevlist
+	    echo "$DETECTED" | sed -e 's/^ //' -e 's/ /\n/g' > /tmp/.frisbee/mobiledevlist
 	fi
-#	echo -e "build_mobile_device_list exit - mobiledevlist:\n'$(cat /tmp/.frisbee/mobiledevlist)'" >> /tmp/debug.log #DEBUG
 }
 
 export -f build_mobile_device_list
@@ -1610,12 +1492,28 @@ export -f build_mobile_device_list
 
 function save_mobile_configuration {
 	[ "$(echo -n "$GPRSDEV" | grep -v '^--')$GPRSAPN$GPRSNBR$GPRSPIN$GPRSUSER$GPRSPSWD$GPRSPAPONLY" ] || return 0
-	for ONEGPRS in GPRSDEV GPRSAPN GPRSNBR GPRSPIN GPRSUSER GPRSPAPONLY; do
-		if [ "$(grep "^${ONEGPRS}=" /root/.config/gprs.conf | cut -f 2 -d =)" != "${!ONEGPRS}" ]; then
-			SEDSCRIPT="s%\(${ONEGPRS}=\).*%\1${!ONEGPRS}%"
-			sed -i -e "$SEDSCRIPT" -e 's/\(GPRSDEV=\)--.*/\1/' /root/.config/gprs.conf
-		fi
-	done
+	echo "GPRSDEV=\"$GPRSDEV\"
+GPRSAPN=$GPRSAPN
+GPRSNBR=$GPRSNBR
+GPRSPIN=$GPRSPIN
+GPRSUSER=$GPRSUSER
+GPRSPAPONLY=$GPRSPAPONLY
+" >/tmp/.config_gprs.conf.tmp #200829...
+	if cmp --quiet /tmp/.config_gprs.conf.tmp /root/.config/gprs.conf; then
+	    [ -z "$GPRSUSER" ] && [ -z "$GPRSPSWD" ] && return
+	    grep -q -s "^\"$GPRSUSER\"	\*	\"$GPRSPSWD\"" /etc/ppp/pap-secrets \
+	      && grep -q -s "^\"$GPRSUSER\"	\*	\"$GPRSPSWD\"" /etc/ppp/chap-secrets \
+	      && return
+	fi
+	if pgrep -f 'frisbee --connect-gprs' >/dev/null; then
+	    Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee')" --icon "$ICONLIB/error.xpm" --msgbox "\n$(gettext 'Changes cannot be saved now because the Frisbee connection window is already active.')\n$(gettext 'If you terminate the connection, you can then save the changes.')\n\n$(gettext 'Otherwise, please go to the active GPRS Connection Log window.')\n" 0 70
+	    return
+	elif pgrep -f 'pgprs --connect' >/dev/null; then
+	    Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee')" --icon "$ICONLIB/error.xpm" --msgbox "\n$(gettext 'Changes cannot be saved now because the Pgprs GPRS Modem Utility is active.')\n$(gettext 'If you terminate the Pgprs connection, you can then save the changes.')\n" 0 70
+	    return
+	fi
+	mv -f /tmp/.config_gprs.conf.tmp /root/.config/gprs.conf
+	save_password_to_secret "$GPRSUSER" "$GPRSPSWD" #200829 end
 	sync
 }
 
@@ -1623,19 +1521,11 @@ export -f save_mobile_configuration
 
 #############################################
 
-function save_mobile_password {
-	save_password_to_secret $GPRSUSER $GPRSPSWD
-}
-
-export -f save_mobile_password
-
-#############################################
-
 function mobile_status {
 	if [ -f /var/run/ppp-gprs.pid ]; then
-		Xdialog --center --wmclass "frisbee" --backtitle "$(gettext 'NOTICE: If the log shows a failure to connect, please click left button')" --title "Frisbee $(gettext 'GPRS connection log')" --ok-label "$(gettext 'DISCONNECT or stop trying')" --cancel-label "$(gettext 'CLOSE window but stay online')" --fixed-font --tailbox /tmp/.frisbee/gprs.log 20 80 &
+	    Xdialog --center --wmclass frisbee --backtitle "$(gettext 'NOTICE: If the log shows a failure to connect, please click left button')" --title "$(gettext 'Frisbee GPRS Connection Log')" --ok-label "$(gettext 'DISCONNECT or stop trying')" --cancel-label "$(gettext 'CLOSE window but stay online')" --fixed-font --logbox /tmp/.gprs_connect.log 20 80 & #200829
 	else
-		Xdialog --center --wmclass "frisbee" --title "Frisbee GPRS"  --msgbox "GPRS connection inactive." 0 0
+	    Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee GPRS')"  --msgbox "GPRS connection inactive." 0 0
 	fi
 }
 
@@ -1645,16 +1535,16 @@ export -f mobile_status
 
 function build_pppoe_interface_list {
 	PPPOEECUR="$(echo "$PPPOEDEV" | grep '^[a-z]')"
-	PPPOEELIST="$(ifconfig | grep -w -o '^[a-z][a-z]*[0-9][0-9]*' |grep -v -E '^lo|^ppp')"
+	PPPOEELIST="$(ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ':' | tr -d '\n')" #200829
 	if [ "$PPPOEELIST" ];then
-		if [ "$PPPOEECUR" ];then
-			echo "$PPPOEELIST" | grep -q -x "$PPPOEECUR" \
-			 && PPPOEELIST="$PPPOEECUR
+	    if [ "$PPPOEECUR" ];then
+	        echo "$PPPOEELIST" | grep -q -x "$PPPOEECUR" \
+	          && PPPOEELIST="$PPPOEECUR
 $(echo -n "$PPPOEELIST" | grep -v -x "$PPPOEECUR")"
-		fi
-		echo -n "$PPPOEELIST" > /tmp/.frisbee/pppoedevlist
+	    fi
+	    echo -n "$PPPOEELIST" > /tmp/.frisbee/pppoedevlist
 	else
-		echo -n "--None Detected--" > /tmp/.frisbee/pppoedevlist
+	    echo -n "--None Detected--" > /tmp/.frisbee/pppoedevlist
 	fi
 }
 
@@ -1663,24 +1553,25 @@ export -f build_pppoe_interface_list
 #############################################
 
 function save_pppoe_configuration {
+# shellcheck disable=SC2153 # PPPOEDNS set by dialog.
 	[ "$PPPOEDEV$PPPOEDEMAND$PPPOEDNS$PPPOEDNSVALUE$PPPOEUSER$PPPOEPSWD" ] || return 0
 	[ -f /etc/ppp/pppoe.conf ] || return 1
 	
 	[ "$PPPOEDEMAND" = "true" ] \
-	 && DEMAND="$(grep 'DEMAND=[0-9]' /etc/ppp/pppoe.conf | head -n 1 | cut -f 2 -d =)" \
-	 || DEMAND="no"
+	  && DEMAND="$(grep 'DEMAND=[0-9]' /etc/ppp/pppoe.conf | head -n 1 | cut -f 2 -d =)" \
+	  || DEMAND="no"
 	[ "$DEMAND" = "" ] &&  DEMAND="300"
 
 	if [ "$PPPOEDNS" = "true" ];then
-		PPPOEDNS1=$(echo -n "$PPPOEDNSVALUE" | cut -f 1 -d ' ')
-		PPPOEDNS2=$(echo -n "$PPPOEDNSVALUE" | tr -s ' ' | cut -f 2 -d ' ')
-		[ "$PPPOEDNS1" = "" ] && DNSTYPE=NOCHANGE || DNSTYPE=SPECIFY
-		PEERDNS=no
+	    PPPOEDNS1=$(echo -n "$PPPOEDNSVALUE" | cut -f 1 -d ' ')
+	    PPPOEDNS2=$(echo -n "$PPPOEDNSVALUE" | tr -s ' ' | cut -f 2 -d ' ')
+	    [ "$PPPOEDNS1" = "" ] && DNSTYPE=NOCHANGE || DNSTYPE=SPECIFY
+	    PEERDNS=no
 	else
-		DNSTYPE=SERVER
-		PPPOEDNS1=""
-		PPPOEDNS2=""
-		PEERDNS=yes
+	    DNSTYPE=SERVER
+	    PPPOEDNS1=""
+	    PPPOEDNS2=""
+	    PEERDNS=yes
 	fi
 	
 	sed -e "s/^ETH=.*/ETH=$PPPOEDEV/" \
@@ -1693,17 +1584,17 @@ function save_pppoe_configuration {
 	 -e "s/^FIREWALL=.*/FIREWALL=$PPPOEFIREWALL/" \
 	 /etc/ppp/pppoe.conf > /tmp/pppoe.tmp
 	[ -s /tmp/pppoe.tmp ] \
-	 && ! cmp -s /tmp/pppoe.tmp /etc/ppp/pppoe.conf \
-	 && cp -f /tmp/pppoe.tmp /etc/ppp/pppoe.conf
+	  && ! cmp -s /tmp/pppoe.tmp /etc/ppp/pppoe.conf \
+	  && cp -f /tmp/pppoe.tmp /etc/ppp/pppoe.conf
 
 	if [ "$PPPOEPAPONLY" = "true" ];then
-		grep -q '^pppoe_paponly=1' /etc/frisbee/frisbee.conf \
-		 || sed -i -e '/^pppoe_paponly=/ s/=.*/=1/' \
-		     /etc/frisbee/frisbee.conf
+	    grep -q '^pppoe_paponly=1' /etc/frisbee/frisbee.conf \
+	      || sed -i -e '/^pppoe_paponly=/ s/=.*/=1/' \
+	         /etc/frisbee/frisbee.conf
 	else
-		grep -q '^pppoe_paponly=0' /etc/frisbee/frisbee.conf \
-		 || sed -i -e '/^pppoe_paponly=/ s/=.*/=0/' \
-		     /etc/frisbee/frisbee.conf
+	    grep -q '^pppoe_paponly=0' /etc/frisbee/frisbee.conf \
+	      || sed -i -e '/^pppoe_paponly=/ s/=.*/=0/' \
+	         /etc/frisbee/frisbee.conf
 	fi
 
 	FIREWALLLIST="$(echo -e "STANDALONE\nMASQUERADE\nNONE" | grep -v "$PPPOEFIREWALL")"
@@ -1715,7 +1606,7 @@ export -f save_pppoe_configuration
 #############################################
 
 function save_pppoe_password {
-	save_password_to_secret $PPPOEUSER $PPPOEPSWD
+	save_password_to_secret "$PPPOEUSER" "$PPPOEPSWD"
 }
 
 export -f save_pppoe_password
@@ -1725,7 +1616,7 @@ export -f save_pppoe_password
 function connect_pppoe {
 	echo -n > /tmp/pppoe.log
 	pppoe-start 2>&1 | grep '.' >> /tmp/pppoe.log &
-	Xdialog --center --wmclass "frisbee" --backtitle "$(gettext 'NOTICE: If the log shows a failure to connect, please click left button')" --title "Frisbee $(gettext 'PPPoE connection log')" --ok-label "$(gettext 'DISCONNECT or stop trying')" --cancel-label "$(gettext 'CLOSE window but stay online')" --fixed-font --tailbox /tmp/pppoe.log 20 80 &
+	Xdialog --center --wmclass frisbee --backtitle "$(gettext 'NOTICE: If the log shows a failure to connect, please click left button')" --title "$(gettext 'Frisbee PPPoE Connection Log')" --ok-label "$(gettext 'DISCONNECT or stop trying')" --cancel-label "$(gettext 'CLOSE window but stay online')" --fixed-font --tailbox /tmp/pppoe.log 20 80 &
 }
 
 export -f connect_pppoe
@@ -1737,6 +1628,22 @@ function disconnect_pppoe {
 }
 
 export -f disconnect_pppoe
+
+#############################################
+
+function connect_mobile { #200829...
+	if pgrep -f 'frisbee --connect-gprs' | grep -qwv "$PPID"; then
+	    Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee')" --icon "$ICONLIB/error.xpm" --msgbox "\n$(gettext 'Cannot connect now because the Frisbee connection window is already active.')\n$(gettext 'If you terminate the connection, you can then connect.')\n\n$(gettext 'Otherwise, please go to the active GPRS Connection Log window.')\n" 0 70
+	    return
+	elif pgrep -x pgprs >/dev/null; then
+	    Xdialog --center --wmclass frisbee --title "$(gettext 'Frisbee')" --icon "$ICONLIB/error.xpm" --msgbox "\n$(gettext 'Cannot connect now because the Pgprs GPRS Modem Utility is active.')\n$(gettext 'If you terminate the Pgprs connection, you can then connect.')\n" 0 70
+	    return
+	fi
+	ps -C pgprs,frisbee-gprs-connect >/dev/null 2>&1 && return
+	frisbee --connect-gprs &
+}
+
+export -f connect_mobile
 
 #############################################
 

--- a/woof-code/rootfs-packages/pgprs/etc/gprs.conf
+++ b/woof-code/rootfs-packages/pgprs/etc/gprs.conf
@@ -1,10 +1,6 @@
 # /etc/ppp/gprs.conf - constants for pgprs and frisbee (gprs)
 # State data is retained in /root/.config/gprs.conf.
 
-# Lock file descriptor numbers controlling access by pgprs and frosbee:
-GPRS_SETUP_LOCK_FD=111
-GPRS_CONNECT_LOCK_FD=112
-
 # Access numbers:
 GPRS_ACCESS_NUMBERS='*99# #777 *99***1# *99***2# *99***3# *99***4#'
 

--- a/woof-code/rootfs-packages/pgprs/etc/ppp/chatscripts/gprs-connect-chat
+++ b/woof-code/rootfs-packages/pgprs/etc/ppp/chatscripts/gprs-connect-chat
@@ -48,7 +48,7 @@
 	ABORT		'\nERROR\r'
 	''			\rAT
 	TIMEOUT		12
-	SAY			"\ndefining PDP context...\n"
+	SAY			"\nDefining PDP context...\n"
 	OK			@/etc/ppp/chatscripts/gprs-cpin_command
 	OK			@/etc/ppp/chatscripts/gprs-cgdcont_command
 #	OK			AT+CGQREQ=1,0,0,0,0,0
@@ -56,9 +56,9 @@
 	OK			ATH
 	OK			ATE1
 	OK			AT+CSQ
-	+CSQ       	ATDT\T
+	+CSQ		ATD\T
 	TIMEOUT		22
-	SAY			"\nwaiting for connect...\n"
+	SAY			"\nWaiting for connect...\n"
 	CONNECT		""
 	SAY			"\nConnected."
 	SAY			"\nIf the following ppp negotiations fail,\n"

--- a/woof-code/rootfs-packages/pgprs/pet.specs
+++ b/woof-code/rootfs-packages/pgprs/pet.specs
@@ -1,1 +1,1 @@
-pgprs-2.0.2|pgprs|2.0.2||Network|116K||pgprs-2.0.2.pet||Connect via GPRS modem||||
+pgprs-3.0|pgprs|3.0||Network|124K||pgprs-3.0.pet|+gtkdialog&ge0.8.4|Connect via GPRS modem||||

--- a/woof-code/rootfs-packages/pgprs/pinstall.sh
+++ b/woof-code/rootfs-packages/pgprs/pinstall.sh
@@ -18,8 +18,10 @@ if [ "$(pwd)" = "/" ];then
   chmod -f a-x  usr/bin/pgprs-connect
  fi
 
+ #Remove old gprs.conf, to use new one. 200607
+ rm -f etc/ppp/gprs.conf
+
  #Remove old state gprs.conf, to generate new one.
- rm -f etc/gprs.conf
  rm -f root/.config/gprs.conf
 
  #Remove replaced options file, if not used by frisbee.
@@ -44,5 +46,5 @@ if [ "$(pwd)" = "/" ];then
  fi
 fi
 
-#Replace placeholder with /usr/sbin link to moved pgprs script.
+#v3.0 Replace placeholder with /usr/sbin/ link for moved pgprs script.
 ln -snf /usr/local/pgprs/pgprs usr/sbin/

--- a/woof-code/rootfs-packages/pgprs/usr/local/pgprs/pgprs
+++ b/woof-code/rootfs-packages/pgprs/usr/local/pgprs/pgprs
@@ -1,103 +1,25 @@
 #! /bin/bash
+# shellcheck disable=SC1091 #Skip sourced checks.
 # PGPRS 2.x: Common interface to Puppy Generic GPRS Modem Utility
 
-#set -x; test -f /tmp/xerrs.log && exec 1>&2 || exec &>/tmp/debug.log #send feedback and trace to xerrs.log or debug.log
+#200622 (v3.0) Offer to disconnect existing connection; become current manager after setup; remove lock usage; move version & help options out of main loop; move etc gprs.conf; complete internationalization; resolve shellcheck warnings.
+
+export VERSION='3.0'  #UPDATE this with each release!
 
 export TEXTDOMAIN=pgprs
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
-export VERSION='2.0.2'  #UPDATE this with each release!
-
-[ -f /root/.config/gprs.conf ] \
- || echo -e "GPRSDEV=\nGPRSAPN=\nGPRSNBR=\nGPRSPIN=\nGPRSUSER=\nGPRSPAPONLY=" > /root/.config/gprs.conf
-mkdir -p /var/lock/gprs
-mkdir -p /tmp/.pgprs
-ICONLIB=/usr/local/lib/X11/pixmaps
-[ -f /usr/share/pixmaps/pgprs.svg ] \
- && export PGPRSICON=/usr/share/pixmaps/pgprs.svg \
- || export PGPRSICON=/usr/share/pixmaps/pgprs.png
-
-#Lock management - for unblocked locking only.
-eval $(grep '^GPRS_SETUP_LOCK_FD=' /etc/ppp/gprs.conf)
-eval $(grep '^GPRS_CONNECT_LOCK_FD=' /etc/ppp/gprs.conf)
-[ "$GPRS_SETUP_LOCK_FD" -a "$GPRS_CONNECT_LOCK_FD" ] || exit 1 
-eval exec "$GPRS_SETUP_LOCK_FD>/var/lock/gprs/setup"
-eval exec "$GPRS_CONNECT_LOCK_FD>/var/lock/gprs/connect"
-
-function disconnect_gprs {
- local PPPDPID=$(cat /var/run/ppp-gprs.pid)
- local CONNECTEDDEV
- [ "$PPPDPID" ] \
-  && CONNECTEDDEV="$(ps -p $PPPDPID | grep 'pppd' | grep -v 'grep' | grep -o '/dev/[a-z][^ ]*')"
- if [ "$CONNECTEDDEV" ];then
-  kill $PPPDPID
-  rm -f /var/run/ppp-gprs.pid
-  gtkdialog-splash -timeout 10 -placement center -bg orange -text "$(eval_gettext "Modem device \\\$CONNECTEDDEV disconnected")"
- fi
-}
-
 OPTION="$1"
 case $(basename "$0") in
- pgprs-shell) OPTION="--setup" ;;
- pgprs-connect) OPTION="--connect" ;;
- pgprs) [ -z "$OPTION" ] && OPTION="--setup" ;;
+    pgprs-shell) OPTION="--setup" ;;
+    pgprs-connect) OPTION="--connect" ;;
+    pgprs) [ -z "$OPTION" ] && OPTION="--setup" ;;
 esac
-
-while [ "$OPTION" ]; do
- OPT=$OPTION; OPTION=''
- case "$OPT" in
-  -s|--setup)
-   if [ -z "$(busybox pidof pgprs-connect)" ] \
-     && flock --exclusive --nonblock $GPRS_SETUP_LOCK_FD; then #lock setup
-    /usr/local/pgprs/pgprs-setup
-    [ $? -eq 2 -a -z "$(busybox pidof pgprs-connect)" ] \
-     && OPTION='--connect'
-    flock --unlock $GPRS_SETUP_LOCK_FD #unlock setup
-   else
-    if [ -n "$(busybox pidof pgprs-setup)" -o -n "$(busybox pidof pgprs-connect)" ]; then
-     Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Setup')" --icon $ICONLIB/error.xpm --msgbox "\n$(gettext 'PGPRS cannot start now because it is already active.')\n\n$(gettext 'Please use the active PGPRS session.')\n" 0 70
-    elif [ -n "$(busybox pidof frisbee-main)" ]; then
-     Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Setup')" --icon $ICONLIB/error.xpm --ok-label "OK" --cancel-label $(gettext 'Retry') --yesno "\n$(gettext 'PGPRS cannot start now because the Frisbee network manager is active.')\n\n$(gettext 'If you terminate Frisbee, you can Retry PGPRS.')\n" 0 70
-     [ $? -eq 1 ] && OPTION='--setup' #1 = retry
-    else #stale lock - delete, recreate and retry
-     rm -f /var/lock/gprs/setup
-     eval exec "$GPRS_SETUP_LOCK_FD>/var/lock/gprs/setup"
-     echo "basename $0: Stale 'setup' lock detected and replaced" 1>&2
-     OPTION='--setup'
-    fi
-   fi
-   ;;
-  -c|--connect)
-   #If no setup in place, do it now...
-   . /root/.config/gprs.conf
-   if [ "$GPRSDEV" -a "$GPRSNBR" -a "$GPRSAPN" ]; then
-    if flock --exclusive --nonblock $GPRS_CONNECT_LOCK_FD; then #lock if no dialog active
-     /usr/local/pgprs/pgprs-connect
-     [ $? -eq 0 -a -z "$(busybox pidof pgprs-setup)" ] \
-      && OPTION='--setup'
-     flock --unlock $GPRS_CONNECT_LOCK_FD #unlock connect
-    elif [ -n "$(busybox pidof pgprs-connect)" -o -n "$(busybox pidof frisbee-gprs-connect)" ]; then
-     Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Connect')" --icon $ICONLIB/info.xpm --msgbox "\n$(eval_gettext "Modem device '\$GPRSDEV' connection window is active.")\n\n$(gettext 'Please go to the active GPRS Connection Log window.')\n" 0 70
-    else #stale lock - delete, recreate and retry
-     rm -f /var/lock/gprs/connect
-     eval exec "$GPRS_CONNECT_LOCK_FD>/var/lock/gprs/connect"
-     echo "basename $0: Stale 'connect' lock detected and replaced" 1>&2
-     OPTION='--connect'
-    fi
-   else
-    OPTION='--setup'
-   fi
-   ;;
-  -d|--disconnect)
-   if [ -s /var/run/ppp-gprs.pid ];then
-    disconnect_gprs
-   fi
-   ;;
-  -v|--version)
-		echo "$VERSION"
-		;;
- *) echo "$(gettext 'Usage: pgprs [option]')
+case "$OPTION" in
+    -s|--setup|-c|--connect|-d|--disconnect) ;;
+    -v|--version) echo "$VERSION"; exit ;;
+    *) echo "$(gettext 'Usage: pgprs [option]')
  
 $(gettext 'Manage 3G/GPRS network connections')
 
@@ -107,8 +29,61 @@ $(gettext 'Options'):
   -d, --disconnect  $(gettext 'Disconnect from active GPRS network')
   -v, --version     $(gettext 'Display pgprs version')
   -h, --help        $(gettext 'Display this help and exit')
-"
-   ;;
- esac
+"; exit ;;
+esac
+
+[ -f /root/.config/gprs.conf ] \
+  || echo -e "GPRSDEV=\nGPRSAPN=\nGPRSNBR=\nGPRSPIN=\nGPRSUSER=\nGPRSPAPONLY=" > /root/.config/gprs.conf
+mkdir -p /tmp/.pgprs
+export ICONLIB=/usr/local/lib/X11/pixmaps
+if [ -f /usr/share/pixmaps/pgprs.svg ]; then
+    export PGPRSICON=/usr/share/pixmaps/pgprs.svg
+else
+    export PGPRSICON=/usr/share/pixmaps/pgprs.png
+fi
+
+function disconnect_gprs {
+    local GPRS_PPPD_PID
+    local CONNECTED_DEVICE
+    GPRS_PPPD_PID="$(cat /var/run/ppp-gprs.pid 2>/dev/null)"
+    if [ -n "$GPRS_PPPD_PID" ]; then
+# shellcheck disable=SC2034 # Variable used in gettext message
+        CONNECTED_DEVICE="$(pgrep -ax 'pppd' | grep -w "^$GPRS_PPPD_PID" | grep -o '/dev/[^ ]*')"
+        kill "$GPRS_PPPD_PID"
+        sleep 0.1 #200607
+        rm -f /var/run/ppp-gprs.pid
+        gtkdialog-splash -timeout 10 -placement center -bg orange -text "$(eval_gettext "Modem device \$CONNECTED_DEVICE disconnected")"
+    fi
+}
+
+while [ "$OPTION" ]; do
+    OPT=$OPTION; OPTION=''
+    case "$OPT" in
+      -s|--setup)
+        if pgrep -x 'pgprs' | grep -qwv "$$"; then #200622...
+            Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Setup')" --icon $ICONLIB/error.xpm --ok-label "$(gettext 'OK')" --msgbox "\n$(gettext 'PGPRS cannot start now because it is already active.')\n\n$(gettext 'Please use the active PGPRS session.')\n" 0 70
+            exit
+        fi
+        /usr/local/pgprs/pgprs-setup
+        STATUS=$? #200611...
+        [ $STATUS -eq 2 ] && OPTION='--connect'
+        [ $STATUS -eq 0 ] || [ $STATUS -eq 2 ] && which connectwizard_exec >/dev/null 2>&1 \
+          && connectwizard_exec pgprs
+        ;;
+      -c|--connect)
+        #If no setup in place, do it now...
+        . /root/.config/gprs.conf
+        if [ "$GPRSDEV" ] && [ "$GPRSNBR" ] && [ "$GPRSAPN" ]; then
+            /usr/local/pgprs/pgprs-connect && OPTION='--setup' #0 = configure, 1 = done, 255 = abort
+        else
+            OPTION='--setup'
+        fi
+        ;;
+      -d|--disconnect)
+        if [ -s /var/run/ppp-gprs.pid ]; then
+            disconnect_gprs
+        fi
+        ;;
+    esac
 done
 exit 0

--- a/woof-code/rootfs-packages/pgprs/usr/local/pgprs/pgprs-connect
+++ b/woof-code/rootfs-packages/pgprs/usr/local/pgprs/pgprs-connect
@@ -1,10 +1,12 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=SC1091 # Skip sourced checks.
 #120131 rodin.s: internationalized.
 #130505 rerwin: ensure network_tray icon shows wireless modem
 #130812 rerwin: Modification as version 1.5 for Puppy integration
 #151222 rerwin: Add device name to 'not detected' message
 #160116 rerwin: restore display of current connection; disconnect network if resolveconf absent.
 #180720 Revert 130505 -- network_tray ignores.
+#200607 (v3.0) Correct display of connect log to work around Xdialog regression; correct not-connected logic; make pppd detach after connection; specify busybox microcom because full version interprets -t as "work in telnet mode" instead of timeout; add version to window title; prevent running if pgprs or frisbee connect window active; replace pidof with ps -C; complete internationalization; accommodate busybox 'tail'; resolve shellcheck warnings.
 
 . /root/.config/gprs.conf #130812...
 
@@ -14,100 +16,151 @@ export TEXTDOMAIN=pgprs
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
+CONNECTLOG=/tmp/.gprs_connect.log #200607
+
 # connect
 function connect_func () {
-	export TEXTDOMAIN=pgprs
-	export OUTPUT_CHARSET=UTF-8
-	. gettext.sh
-	echo -e "$(eval_gettext "Attempting connection through \$GPRSDEV to APN \$GPRSAPN...\n")" #130812
-	if [ ! -x /usr/sbin/resolvconf ];then #160116...
-	 if [ -x /usr/sbin/networkdisconnect ];then #but not ppp interface.
-	  /usr/sbin/networkdisconnect
-	 else 
-	  [ -n "$(busybox pidof wpa_supplicant)" ] \
-	   && wpa_cli terminate #kills any running wpa_supplicant
-	  if [ -x /etc/rc.d/rc.network ];then 
-	   /etc/rc.d/rc.network stop
-	  else
-	   dhcpcd -k
-	  fi
-	 fi
-	fi
-	[ -e /dev/ppp ] || mknod /dev/ppp c 108 0
-	# Start PPP daemon...
-	# For sanity, keep a lock on the serial line (lock).
-	logger "pgprs: $(eval_gettext "Starting PPP daemon for \$GPRSDEV")"
-	/usr/sbin/pppd $GPRSDEV \
-	 call gprs-generated \
-	 connect "chat -v -T $GPRSNBR -f /etc/ppp/chatscripts/gprs-connect-chat" \
-	 disconnect "chat -v -s -S -f /etc/ppp/chatscripts/gprs-disconnect-chat" \
-	 linkname gprs \
-	 nodetach \
-	 lock
-	local STATUS=$?
-	echo "$(eval_gettext "Exit status is \$STATUS")" #130812
-	echo "$(gettext 'DISCONNECTED')"
-	logger "pgprs: $(eval_gettext "pppd exit status for \$GPRSDEV is \$STATUS")"
-	exit $STATUS
+    export TEXTDOMAIN=pgprs
+    export OUTPUT_CHARSET=UTF-8
+    . gettext.sh
+    echo -e "$(eval_gettext "Attempting connection through \$GPRSDEV to APN \$GPRSAPN...")\n" >> $CONNECTLOG #130812 200607
+    if [ ! -x /usr/sbin/resolvconf ]; then #160116...
+        if [ -x /usr/sbin/networkdisconnect ]; then #but not ppp interface.
+            /usr/sbin/networkdisconnect
+        else
+            ps -C wpa_supplicant >/dev/null \
+              && wpa_cli terminate #kills any running wpa_supplicant #200607
+            if [ -x /etc/rc.d/rc.network ]; then
+                /etc/rc.d/rc.network stop
+            else
+                dhcpcd -k
+            fi
+        fi
+    fi
+    [ -e /dev/ppp ] || mknod /dev/ppp c 108 0
+    # Start PPP daemon...
+    # For sanity, keep a lock on the serial line (lock).
+    logger "pgprs: $(eval_gettext "Starting PPP daemon for \$GPRSDEV")"
+    /usr/sbin/pppd "$GPRSDEV" \
+      call gprs-generated \
+      connect "chat -v -T $GPRSNBR -f /etc/ppp/chatscripts/gprs-connect-chat" \
+      disconnect "chat -v -s -S -f /etc/ppp/chatscripts/gprs-disconnect-chat" \
+      linkname gprs \
+      updetach \
+      lock \
+      >> $CONNECTLOG 2>&1 #200607
+    local STATUS=$?
+# shellcheck disable=SC2005 # echo needed for newline.
+    echo "$(eval_gettext "Exit status is \$STATUS")" >> $CONNECTLOG #130812 200607
+    logger "pgprs: $(eval_gettext "pppd exit status for \$GPRSDEV is \$STATUS")"
+    if [ -s /var/run/ppp-gprs.pid ]; then #200607...
+# shellcheck disable=SC2005 # echo needed for newline.
+        echo "$(gettext 'CONNECTED')" >> $CONNECTLOG
+    else
+# shellcheck disable=SC2005 # echo needed for newline.
+        echo "$(gettext 'NOT CONNECTED')" >> $CONNECTLOG
+    fi
+    sleep 2 #Let connection_dialog_func show the entire log before stopping the feed.
+    TAILPID="$(pgrep -f "tail -f $CONNECTLOG")"
+    [ -n "$TAILPID" ] && kill "$TAILPID"
+    exit $STATUS
 }
 export -f connect_func
 
 #160116 connect dialog...
 function connection_dialog_func () {
-	local DISCSTOP="$(gettext 'DISCONNECT')"
-	Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Connection Log')" --backtitle "$(eval_gettext "NOTICE: If log shows a failure to connect, click '\$DISCSTOP', to exit.")" --ok-label "$DISCSTOP or stop trying" --cancel-label "$(gettext 'CLOSE window but stay online')" --fixed-font --tailbox /tmp/.gprs_connect.log 25 82
-	local STATUS=$?
-	if [ $STATUS -eq 0 -a -s /var/run/ppp-gprs.pid ];then
-		PPPDPID=$(cat /var/run/ppp-gprs.pid)
-		if [ "$PPPDPID" ];then
-			kill $PPPDPID
-			rm -f /var/run/ppp-gprs.pid
-			gtkdialog-splash -timeout 15 -placement center -bg orange -text "$(eval_gettext "Mobile device \$GPRSDEV disconnected")"
-		fi
-	fi
-	return $STATUS
+    local READLOG='cat' #200607...
+    local TAIL_PATH
+    TAIL_PATH="$(which tail)"
+    if [ -n "$CONNECT_PID" ] && [ -n "$TAIL_PATH" ]; then
+        if [ -L "$TAIL_PATH" ]; then #busybox tail, cannot follow (-f)
+            gtkdialog-splash -timeout 10 -placement center -bg orange -text "$(eval_gettext "Attempting connection to APN \$GPRSAPN.")  $(gettext 'Please wait.')" &
+            sleep 10
+        else
+            READLOG="tail -f"
+        fi
+    fi
+    $READLOG $CONNECTLOG | \
+      Xdialog --center --wmclass pgprs --title "$(eval_gettext "Pgprs \$VERSION - GPRS Connection Log")" --backtitle "$(gettext 'NOTICE: If log shows a failure to connect, click DISCONNECT to exit.')" --ok-label "$(gettext 'DISCONNECT or stop trying')" --cancel-label "$(gettext 'CLOSE window but stay online')" --logbox - 25 82
+    local STATUS=$? #0 = disconnect/stop, 1 = close but stay connected, 255 = abort
+    if [ $STATUS -eq 0 ] && [ -s /var/run/ppp-gprs.pid ]; then #200607 end
+        local GPRS_PPPD_PID=$(cat /var/run/ppp-gprs.pid)
+        if [ -n "$GPRS_PPPD_PID" ]; then
+            kill "$GPRS_PPPD_PID"
+            sleep 0.1 #200607
+            rm -f /var/run/ppp-gprs.pid
+            gtkdialog-splash -timeout 15 -placement center -bg orange -text "$(eval_gettext "Mobile device \$GPRSDEV disconnected")"
+        fi
+    fi
+    # Return 0 = configure/setup, 1 = done, 255 = abort #200607...
+    [ $STATUS -ne 0 ] && return $STATUS
+    Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Connect')" --icon "$ICONLIB/info.xpm" --ok-label "$(gettext 'Yes')" --cancel-label "$(gettext 'No')" --yesno "\n$(gettext 'Not connected.')\n\n$(gettext 'Return to configuration setup window?')\n" 10 60
+    return $?
 }
 
+while true; do #200607...
+    if pgrep -f 'pgprs --connect' | grep -qwv "$PPID"; then
+        Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Connect')" --icon "$ICONLIB/error.xpm" --ok-label "$(gettext 'Configure')" --cancel-label "$(gettext 'Retry')" --yesno "\n$(gettext 'PGPRS cannot start now because a Pgprs Connection window is already active.')\n\n$(gettext 'If you terminate the connection, you can Retry connecting.')\n\n$(gettext "Otherwise, you can go to Setup or use 'X' to exit.")\n" 0 70
+        STATUS=$? #0 = configure, 1 = retry, 255 = abort
+        [ $STATUS -eq 1 ] && continue || exit $STATUS
+    elif pgrep -f 'frisbee --connect-gprs' >/dev/null; then
+        Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Connect')" --icon "$ICONLIB/error.xpm" --ok-label "$(gettext 'OK')" --cancel-label "$(gettext 'Retry')" --yesno "\n$(gettext 'PGPRS cannot start now because Frisbee mobile wireless (GPRS) is active.')\n\n$(gettext 'If you terminate the Frisbee connection, you can Retry connecting.')\n" 0 70
+        STATUS=$? #0 = configure, 1 = retry, 255 = abort
+        [ $STATUS -eq 1 ] && continue
+        [ $STATUS -eq 0 ] && exit 1 || exit $STATUS
+    else break
+    fi
+done
+
 #160116...
-if [ -f /var/run/ppp-gprs.pid ];then
-	connection_dialog_func
-	exit $? #0 = disonnect/stop, 1 = close but stay connected, 255 = abort
+if [ -s /var/run/ppp-gprs.pid ]; then
+    GPRS_PPPD_PID="$(grep -ow '[0-9]*' /var/run/ppp-gprs.pid)" #200607...
+    #Kill connection if not for current device.
+    if pgrep -ax 'pppd' | grep -w "^$GPRS_PPPD_PID" | grep -qv "$GPRSDEV"; then
+        kill "$GPRS_PPPD_PID"
+        rm -f /var/run/ppp-gprs.pid
+    fi
+    CONNECT_PID=''
+    connection_dialog_func
+    exit $? #0 = configure/setup, 1 = done, 255 = abort
 fi #160116 end
 
 echo "#Generated by pgprs-connect" > /etc/ppp/peers/gprs-generated
 echo "call gprs-editable" >> /etc/ppp/peers/gprs-generated
-if [ "$GPRSUSER" ];then #130812
-	echo -e "auth\nuser $GPRSUSER" >> /etc/ppp/peers/gprs-generated
-	[ "$GPRSPAPONLY" = "true" ] \
-	 && echo "require-pap" >> /etc/ppp/peers/gprs-generated
+if [ "$GPRSUSER" ]; then #130812
+    echo -e "auth\nuser $GPRSUSER" >> /etc/ppp/peers/gprs-generated
+    [ "$GPRSPAPONLY" = "true" ] \
+     && echo "require-pap" >> /etc/ppp/peers/gprs-generated
 else
-	echo "noauth" >> /etc/ppp/peers/gprs-generated
+    echo "noauth" >> /etc/ppp/peers/gprs-generated
 fi
 
-[ "${GPRSPIN}" != "" -a "${GPRSPIN}" != "gprspin" ] \
- && SAVEVAL="AT+CPIN=\"$GPRSPIN\"" \
- || SAVEVAL="AT"
-[ "$SAVEVAL" != "$(cat /etc/ppp/chatscripts/gprs-cpin_command 2>/dev/null | grep -v ^\')" ] \
+[ -n "${GPRSPIN}" ] && [ "${GPRSPIN}" != "gprspin" ] \
+  && SAVEVAL="AT+CPIN=\"$GPRSPIN\"" \
+  || SAVEVAL="AT"
+[ "$SAVEVAL" != "$(grep -v "^'" < /etc/ppp/chatscripts/gprs-cpin_command)" ] \
  && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cpin_command #130812 end
 SAVEVAL="AT+CGDCONT=1,\"IP\",\"$GPRSAPN\""
-[ "$SAVEVAL" != "$(cat /etc/ppp/chatscripts/gprs-cgdcont_command 2>/dev/null | grep -v ^\')" ] \
- && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cgdcont_command
-SAVEVAL="ATD$GPRSNBR"
-[ "$SAVEVAL" != "$(cat /etc/ppp/chatscripts/gprs-dial_command 2>/dev/null | grep -v ^\')" ] \
- && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-dial_command
+[ "$SAVEVAL" != "$(grep -v "^'" < /etc/ppp/chatscripts/gprs-cgdcont_command)" ] \
+  && echo "$SAVEVAL" > /etc/ppp/chatscripts/gprs-cgdcont_command
 
-if [ -c $GPRSDEV ] \
- && echo ATZ | microcom -t 200 $GPRSDEV 2>/dev/null | grep -q 'ATZ'; then #130812 151224 160104
-	echo -n > /tmp/.gprs_connect.log
-	connect_func 2>&1 > /tmp/.gprs_connect.log &
-	if [ $? -eq 0 ];then
-		connection_dialog_func #160116
-		exit $? #0 = disonnect/stop, 1 = close but stay connected, 255 = abort
-	else
-		Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Connection Log')" --backtitle "\n$(gettext 'The attempt to connect was unsuccessful:')\n" --ok-label "$(gettext 'Configure')" --cancel-label $(gettext 'Close') --fixed-font --tailbox /tmp/.gprs_connect.log 25 82
-	fi
+if [ -c "$GPRSDEV" ] \
+  && echo ATZ | busybox microcom -t 200 "$GPRSDEV" 2>/dev/null | grep -q 'ATZ'; then #130812 151224 160104
+    echo -n > $CONNECTLOG
+    connect_func & #200607
+# shellcheck disable=SC2181 # status test necessary due to '&' above.
+    if [ $? -eq 0 ]; then
+        CONNECT_PID=$! #200607
+        connection_dialog_func #160116
+        # Returns 0 = configure/setup, 1 = done, 255 = abort #200607...
+        STATUS=$? #200607
+    else
+        Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Connect')" --backtitle "\n$(gettext 'The attempt to connect was unsuccessful:')\n" --ok-label "$(gettext 'Configure')" --cancel-label "$(gettext 'Close')" --logbox $CONNECTLOG 25 82
+        STATUS=$? #200607
+    fi
 else
-	Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Connect')" --icon $ICONLIB/error.xpm --ok-label "$(gettext 'Configure')" --cancel-label $(gettext 'Close') --yesno "\n$(gettext 'Cannot connect.')\n\n$(eval_gettext "Modem device '\$GPRSDEV' is not accessable")\n$(gettext 'It might not be plugged in.')\n" 10 60
+    Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Connect')" --icon "$ICONLIB/error.xpm" --ok-label "$(gettext 'Configure')" --cancel-label "$(gettext 'Close')" --yesno "\n$(gettext 'Cannot connect.')\n\n$(eval_gettext "Modem device '\$GPRSDEV' is not accessable")\n$(gettext 'It might not be plugged in.')\n" 10 60
+    STATUS=$? #200607
 fi
-STATUS=$?
-exit $STATUS #0 = Configure, 1 = Cancel, 255 = abort
+#STATUS: #0 = configure/setup, 1 = done, 255 = abort #200607
+exit $STATUS

--- a/woof-code/rootfs-packages/pgprs/usr/local/pgprs/pgprs-setup
+++ b/woof-code/rootfs-packages/pgprs/usr/local/pgprs/pgprs-setup
@@ -1,4 +1,5 @@
 #! /bin/bash
+# shellcheck disable=SC2086,SC1091 # Double-quotes escaped; skip sourced checks.
 # PGPRS SETUP: Puppy Generic GPRS Modem Setup Utility
 #(c) Copyright Aug. 2008 Lloyd Standish www.voluntary-simplicity.org/linux                         
 #2007 Lesser GPL licence v2 (http://www.fsf.org/licensing/licenses/lgpl.html)
@@ -10,75 +11,124 @@
 #140129 Rework gtkdialog result evaluation to avoid syntax error from space character in EXIT variable.
 #150214 Allow absence of user and password, to indicate 'no authentication'.
 #160101 (v2.0) Change device & number fields to comboboxes, with lists in configuration file; rewrite modem-re-probe to avoid restarting the dialog; reorganize window layout; move "connect" message into window to eliminate separate dialog; move initialization logic to new pgprs interface script; add chat_with_modem function to protect from modem-stats hanging for some devices; separate config files for state data (/root/.config/gprs.conf) and constants (/etc/ppp/gprs.conf); add 'Connect' button; add locks to avoid duplicate instances and conflicts with frisbee gprs.
-#180721 Replace modem-stats with corrected use of microcom.
+#170510 (v2.0.2) Correct dialogs for cleanup.
+#180721 (v2.0.3) Replace modem-stats with corrected use of busybox microcom.
+#200608 (v3.0) Correct get_modem_alternate_device version check for 'ALL'; test for nonexistant hardware with setserial, to avoid broken pipes; move etc gprs.conf; add conflict check before save; add quotes to GPRSDEV in /root/.config/gprs.conf; change 'OK' button to 'Save'; complete internationalization; resolve shellcheck warnings.
+
+#set -x; test -f /tmp/xerrs.log && exec 1>&2 || exec &>/tmp/debug.log #send feedback and trace to xerrs.log or debug.log
 
 export TEXTDOMAIN=pgprs #160101
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
-
-#set -x; test -f /tmp/xerrs.log && exec 1>&2 || exec &>/tmp/debug.log #send feedback and trace to xerrs.log or debug.log
+NONE_DETECTED="$(gettext 'None detected')" #Used by build_device_list called in dialog
+export NONE_DETECTED
 
 #130812 The following values are maintained in /root/.config/gprs.conf and copied to operational locations at time of connection....
 # device file: argument to pppd invocation, not copied
 # user: /etc/ppp/peers/pgprs_auth (also pap-secrets)
 #       (If no user specified, pgprs_auth contains 'noauth'.)
 # password: etc/ppp/pap-secrets
-# phone: /etc/ppp/chatscripts/gprs-dial_command
+# phone: argument to connect chat (-T), not copied
 # APN /etc/ppp/chatscripts/gprs-cgdcont_command
 # PIN /etc/ppp/chatscripts/gprs-cpin_command
 
 #160220 talk to modem, allow time for response... 180721
 chat_with_modem() { #device passed in.
- local ANSWERFILE=/tmp/.pgprs/answer.txt
- rm -f $ANSWERFILE
- [ -f "/var/lock/LCK..${1##*/}" ] && rm "/var/lock/LCK..${1##*/}"
- echo -e "ATZ\r" | microcom -t 1000 $1 > $ANSWERFILE 2>/dev/null #180721
- [ -s $ANSWERFILE ] && grep -q '^OK' $ANSWERFILE #180721
- return $?
+    local ANSWERFILE=/tmp/.pgprs/answer.txt
+    rm -f $ANSWERFILE
+    [ -f "/var/lock/LCK..${1##*/}" ] && rm "/var/lock/LCK..${1##*/}"
+    echo -e "ATZ\r" | busybox microcom -t 1000 "$1" > "$ANSWERFILE" 2>/dev/null #180721
+    [ -s $ANSWERFILE ] && grep -q '^OK' $ANSWERFILE #180721
+    return $?
 }
 export -f chat_with_modem
 
 function build_device_list {
-	local DETECTED=''
-	if grep -q 'ALL' $(which get_modem_alternate_device 2>/dev/null);then
-		DETECTED="$(get_modem_alternate_device ALL | sed -e '/^$/ d' -e 's%^%/dev/%')"
-	else
-		#Compensate for get_modem_alternate_device w/o ALL option
-		for MAINDEV in $(ls /dev/ttyACM* /dev/ttyHS* /dev/ttyUSB* /dev/rfcomm* 2>/dev/null); do
-			[ -c $MAINDEV ] \
-			 && chat_with_modem $MAINDEV \
-			 && DETECTED="$DETECTED $MAINDEV"
-		done
-	fi
-	local GPRS_OTHER_DEVICES=$(grep '^GPRS_OTHER_DEVICES=' /etc/ppp/gprs.conf | grep -o '=.*' | tr -d = | tr -d \')
-	for OTHERDEV in $(ls $GPRS_OTHER_DEVICES 2>/dev/null); do
-		[ -c $OTHERDEV ] \
-		 && chat_with_modem $OTHERDEV \
-		 && DETECTED="$DETECTED $OTHERDEV"
-	done
-	if [ "$DETECTED" = "" ]; then
-		echo -n "--$(gettext 'None detected')--" > /tmp/.pgprs/devlist
-	else
-		echo "$DETECTED" | sed -e 's/^ //' -e 's/ /\n/g' > /tmp/.pgprs/devlist
-	fi
+    export TEXTDOMAIN=pgprs
+    export OUTPUT_CHARSET=UTF-8
+    local DETECTED=''
+    if grep -qw 'ALL' "$(which get_modem_alternate_device 2>/dev/null)"; then #200608
+        DETECTED="$(get_modem_alternate_device ALL | sed -e '/^$/ d' -e 's%^%/dev/%')"
+    else
+        #Compensate for get_modem_alternate_device w/o ALL option
+        for MAINDEV in /dev/ttyACM* /dev/ttyHS* /dev/ttyUSB* /dev/rfcomm*; do
+            [ -c "$MAINDEV" ] \
+              && chat_with_modem "$MAINDEV" \
+              && DETECTED="$DETECTED $MAINDEV"
+        done
+    fi
+    local GPRS_OTHER_DEVICES
+    GPRS_OTHER_DEVICES=$(grep '^GPRS_OTHER_DEVICES=' /etc/gprs.conf | grep -o '=.*' | tr -d = | tr -d \') #200608
+    for OTHERDEV in $GPRS_OTHER_DEVICES; do
+        [ -z "$OTHERDEV" ] && break
+        [ -c "$OTHERDEV" ] \
+          && ( [ -n "${OTHERDEV#/dev/ttyS[0123]}" ] || setserial -g "$OTHERDEV" | grep -qv 'unknown' ) \
+          && chat_with_modem "$OTHERDEV" \
+          && DETECTED="$DETECTED $OTHERDEV" #200608
+    done
+    if [ "$DETECTED" = "" ]; then
+        echo -n "--${NONE_DETECTED}--" > /tmp/.pgprs/devlist
+    else
+        echo "$DETECTED" | sed -e 's/^ //' -e 's/ /\n/g' > /tmp/.pgprs/devlist
+    fi
 }
 export -f build_device_list
+
+function save_password_to_secret {
+    #Arguments are user name, password.
+    [ -z "$1" ] || [ -z "$2" ] && return 1
+    for ONEAPFILE in pap-secrets chap-secrets; do
+        if ! grep -q -s "^\"$1\".\*.\"$2\"" /etc/ppp/$ONEAPFILE; then
+            sed -i -e "/^\"$1\"\t/d" /etc/ppp/$ONEAPFILE
+            echo -e "\"$1\"\t*\t\"$2\"" >> /etc/ppp/$ONEAPFILE
+        fi
+    done
+}
+
+function save_configuration { #200608...
+    [ "$(echo -n "$GPRSDEV" | grep -v '^--')$GPRSAPN$GPRSNBR$GPRSPIN$GPRSUSER$GPRSPSWD$GPRSPAPONLY" ] || return 0
+    echo "GPRSDEV=\"$GPRSDEV\"
+GPRSAPN=$GPRSAPN
+GPRSNBR=$GPRSNBR
+GPRSPIN=$GPRSPIN
+GPRSUSER=$GPRSUSER
+GPRSPAPONLY=$GPRSPAPONLY
+" >/tmp/.config_gprs.conf.tmp
+    if cmp --quiet /tmp/.config_gprs.conf.tmp /root/.config/gprs.conf; then
+        [ -z "$GPRSUSER" ] && [ -z "$GPRSPSWD" ] && return
+        grep -q -s "^\"$GPRSUSER\"	\*	\"$GPRSPSWD\"" /etc/ppp/pap-secrets \
+          && grep -q -s "^\"$GPRSUSER\"	\*	\"$GPRSPSWD\"" /etc/ppp/chap-secrets \
+          && return
+    fi
+    while ps -C frisbee-gprs-connect,pgprs-connect >/dev/null 2>&1; do
+        if pgrep -x 'pgprs-connect' >/dev/null; then
+            Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Setup')" --icon "$ICONLIB/error.xpm" --ok-label "$(gettext 'OK')" --cancel-label "$(gettext 'Retry')" --yesno "\n$(gettext 'Changes cannot be saved now because the Connection window is already active.')\n$(gettext 'If you terminate the connection, you can retry saving the changes.')\n\n$(gettext 'Otherwise, please go to the active GPRS Connection Log window.')\n" 0 70
+        elif pgrep -f 'frisbee --connect-gprs' >/dev/null; then
+            Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Setup')" --icon "$ICONLIB/error.xpm" --ok-label "$(gettext 'OK')" --cancel-label "$(gettext 'Retry')" --yesno "\n$(gettext 'Changes cannot be saved now because Frisbee Mobile wireless (GPRS) is active.')\n$(gettext "If you terminate Frisbee's Mobile connection, you can retry saving the changes.")\n" 0 70
+        fi
+        [ $? -eq 1 ] && continue || return
+    done
+    mv -f /tmp/.config_gprs.conf.tmp /root/.config/gprs.conf
+    save_password_to_secret "$GPRSUSER" "$GPRSPSWD"
+    sync
+}
 
 . /root/.config/gprs.conf
 
 while true; do
-	#160101 end
-	[ "$GPRSUSER" ] \
-	 && GPRSPSWD="$(cat /etc/ppp/*secrets | grep "^\"$GPRSUSER\"" | tail -n 1 | tr '\t' ' ' | tr -s ' ' | cut -f 3 -d ' ' | tr -d \" | tr -d '\n')" \
-	 || GPRSPSWD="" #130812
+    #160101 end
+    [ "$GPRSUSER" ] \
+      && GPRSPSWD="$(cat /etc/ppp/*secrets | grep "^\"$GPRSUSER\"" | tail -n 1 | tr '\t' ' ' | tr -s ' ' | cut -f 3 -d ' ' | tr -d \" | tr -d '\n')" \
+      || GPRSPSWD="" #130812
 
-	export PGPRS_MAIN_DIALOG="
- <window title=\"Pgprs $VERSION - $(gettext 'GPRS Configure')\" image-name=\"$PGPRSICON\">
+# shellcheck disable=SC2089,SC2090 # Backslashed quotes in data intended.
+    PGPRS_MAIN_DIALOG="
+ <window title=\"$(eval_gettext "Pgprs \$VERSION - GPRS Configure")\" image-name=\"$PGPRSICON\">
  <vbox>
  <text use-markup=\"true\"> <label>\"<b>$(gettext 'GPRS Connection Settings')</b>\"</label></text>
  <frame>
   <hbox space-expand=\"false\" space-fill=\"false\">
-    <text wrap=\"false\" xalign=\"0\" space-expand=\"true\" space-fill=\"true\" tooltip-text=\"$(gettext 'If your modem needs a device file not found automatically, you can add it to GPRS_OTHER_DEVICES in file /etc/ppp/gprs.conf.')\">
+    <text wrap=\"false\" xalign=\"0\" space-expand=\"true\" space-fill=\"true\" tooltip-text=\"$(gettext 'If your modem needs a device file not found automatically, you can add it to GPRS_OTHER_DEVICES in file /etc/gprs.conf.')\">
       <label>$(gettext 'Modem Device File:')</label>
     </text>
     <comboboxtext>
@@ -93,14 +143,14 @@ while true; do
       <label>$(gettext 'After modem change:')</label>
     </text>
     <button>
-   	  <input file stock=\"gtk-refresh\"></input>
-   	  <label>$(gettext 'Refresh')</label>
-   	  <action>refresh:GPRSDEV</action>
-   	</button>
+         <input file stock=\"gtk-refresh\"></input>
+         <label>$(gettext 'Refresh')</label>
+         <action>refresh:GPRSDEV</action>
+       </button>
   </hbox>
   <hbox space-expand=\"false\" space-fill=\"false\">
     <text wrap=\"false\" xalign=\"0\" space-expand=\"true\" space-fill=\"true\" tooltip-text=\"$(gettext 'Required')\">
-      <label>APN:</label>
+      <label>$(gettext 'APN:')</label>
     </text>
     <entry>
       <input>echo -n $GPRSAPN</input>
@@ -113,7 +163,7 @@ while true; do
       <label>$(gettext 'Access number:')</label>
     </text>
     <comboboxtext>
-      <input>grep '^GPRS_ACCESS_NUMBERS=' /etc/ppp/gprs.conf | grep -o '=.*' | tr -d = | tr -d \' | tr ' ' '\n' > /tmp/.pgprs/numberlist</input>
+      <input>grep '^GPRS_ACCESS_NUMBERS=' /etc/gprs.conf | grep -o '=.*' | tr -d = | tr -d \' | tr ' ' '\n' > /tmp/.pgprs/numberlist</input>
       <default>$(echo -n \"$GPRSNBR\" | grep '..*' || echo \"--Error--\")</default>
       <input file>/tmp/.pgprs/numberlist</input>
       <variable>GPRSNBR</variable>
@@ -161,11 +211,20 @@ while true; do
  </frame>
   
   <hbox space-expand=\"false\" space-fill=\"false\">
-   <button ok></button>
-   <button cancel></button>
+   <button>
+     <input file stock=\"gtk-save\"></input>
+     <label>$(gettext 'Save')</label>
+     <action type=\"exit\">Save</action>
+   </button>
+   <button>
+     <input file stock=\"gtk-cancel\"></input>
+     <label>$(gettext 'Cancel')</label>
+     <action type=\"exit\">Cancel</action>
+   </button>
    <button>
      <input file stock=\"gtk-connect\"></input>
      <label>$(gettext 'Connect')</label>
+    <action type=\"exit\">Connect</action>
    </button>
   </hbox>
 
@@ -175,55 +234,45 @@ while true; do
  </vbox>
  </window>
 " #130812 160101
-	gtkdialog --program=PGPRS_MAIN_DIALOG > /tmp/.pgprs/setup_gtkdialog_out #140129
-	[ -s /tmp/.pgprs/setup_gtkdialog_out ] && . /tmp/.pgprs/setup_gtkdialog_out #140129
-	rm -f /tmp/.pgprs/setup_gtkdialog_out #140129
+# shellcheck disable=SC2089,SC2090 # Backslashed quotes in data intended.
+    export PGPRS_MAIN_DIALOG
+    gtkdialog --program=PGPRS_MAIN_DIALOG > /tmp/.pgprs/setup_gtkdialog_out #140129
+    [ -s /tmp/.pgprs/setup_gtkdialog_out ] && . /tmp/.pgprs/setup_gtkdialog_out #140129
+    rm -f /tmp/.pgprs/setup_gtkdialog_out #140129
 
-	[ "$EXIT" != "OK" -a "$EXIT" != "Connect" ] && exit 1
+    [ "$EXIT" != 'Save' ] && [ "$EXIT" != 'Connect' ] && exit 1 #200608
 
-	LACK=""
-	if [ "${GPRSDEV:0:1}" != "/" ]; then
-		LACK="$LACK
-		$(gettext 'Modem device file')" #130812
-	fi
-	if [ "${GPRSAPN}" = "" ]; then
-		LACK="$LACK
-		APN" #130812
-	fi
-	if [ "$GPRSNBR" = "" ]; then
-		LACK="$LACK
-		$(gettext 'Telephone')" #130812
-	fi
-	if [ "$GPRSUSER" = "" -a "$GPRSPSWD" ]; then #150214
-		LACK="$LACK
-		$(gettext 'Username')" #130812
-	fi
-	if [ "$GPRSPSWD" = "" -a "$GPRSUSER" ]; then #150214
-		LACK="$LACK
-		$(gettext 'Password')" #130812
-	fi
-	[ "$LACK" = "" ] && break #160101
-	Xdialog --center --wmclass pgprs --title "Pgprs $(gettext 'GPRS Configure')" --icon /usr/local/lib/X11/pixmaps/error.xpm --msgbox "$(gettext 'The following must not be left blank:')\n$LACK" 0 0 #130812 151222
+    LACK=""
+    if [ "${GPRSDEV:0:1}" != "/" ]; then
+        LACK="$LACK
+        $(gettext 'Modem device file')" #130812
+    fi
+    if [ -z "${GPRSAPN}" ]; then
+        LACK="$LACK
+        APN" #130812
+    fi
+    if [ -z "$GPRSNBR" ]; then
+        LACK="$LACK
+        $(gettext 'Telephone')" #130812
+    fi
+    if [ -z "$GPRSUSER" ] && [ -n "$GPRSPSWD" ]; then #150214
+        LACK="$LACK
+        $(gettext 'Username')" #130812
+    fi
+    if [ -z "$GPRSPSWD" ] && [ -n "$GPRSUSER" ]; then #150214
+        LACK="$LACK
+        $(gettext 'Password')" #130812
+    fi
+    [ -z "$LACK" ] && break #160101
+    Xdialog --center --wmclass pgprs --title "$(gettext 'Pgprs GPRS Configure')" --icon $ICONLIB/error.xpm --ok-label "$(gettext 'OK')" --msgbox "$(gettext 'The following must not be left blank:')\n$LACK" 0 0 #130812 151222
 done #160101
 
-[ "${GPRSDEV:0:2}" = "--" ] && GPRSDEV=$(grep '^GPRSDEV=' /root/.config/gprs.conf | grep -o '[^= ]*$') #160101...
-for ONEGPRS in GPRSDEV GPRSAPN GPRSNBR GPRSPIN GPRSUSER GPRSPAPONLY; do
-	if [ "$(grep "^${ONEGPRS}=" /root/.config/gprs.conf | cut -f 2 -d =)" != "${!ONEGPRS}" ]; then
-		SEDSCRIPT="s%\(${ONEGPRS}=\).*%\1${!ONEGPRS}%"
-		sed -i "$SEDSCRIPT" /root/.config/gprs.conf
-	fi
-done
-sync #160101 end
-if [ "$GPRSUSER" ] \
- && ! grep -q -s "^\"$GPRSUSER\".\*.\"$GPRSPSWD\"" /etc/ppp/pap-secrets; then
-	sed -i -e "/^\"$GPRSUSER\"\t/d" /etc/ppp/pap-secrets
-	echo "\"$GPRSUSER\"	*	\"$GPRSPSWD\"" >> /etc/ppp/pap-secrets
-	chmod 600 /etc/ppp/pap-secrets
-fi #130812 end
+[ "${GPRSDEV:0:2}" = "--" ] && GPRSDEV=$(grep '^GPRSDEV=' /root/.config/gprs.conf | cut -f 2 -d = | tr -d \") #160101... 200608
+save_configuration #200608
 
 case "$EXIT" in
- OK) exit 0 ;;
- Connect) exit 2 ;;
- Cancel|abort) exit 1 ;; #Performed by gtkdialog - aborts script too.
-*) exit 255 ;;
+    OK) exit 0 ;;
+    Connect) exit 2 ;;
+    Cancel|abort) exit 1 ;; #Performed by gtkdialog - aborts script too.
+    *) exit 255 ;;
 esac

--- a/woof-code/rootfs-packages/pgprs/usr/share/pixmaps/pgprs.svg
+++ b/woof-code/rootfs-packages/pgprs/usr/share/pixmaps/pgprs.svg
@@ -1,1 +1,1 @@
-
+(Replaced by link to puppy/wireless.svg during installation.)

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard
@@ -30,6 +30,7 @@
 #170418 rerwin: leave frisbee state unchanged after choosing new defaultconnect.
 #170510 rerwin: replace 170309 implemention with connectwizard_exec; kill other connectwizard dialogs, to avoid conflict; exit if dialog killed; support optional pupdial.
 #180919 add peasywifi support.
+#200817 remove change current exec to pgprs because pgprs 3.0 does it before a connect.
 
 export TEXTDOMAIN=connectwizard
 export OUTPUT_CHARSET=UTF-8
@@ -123,7 +124,7 @@ fi
 FLAGPUPDIAL="" #170510...
 CONNECTPUPDIAL=""
 if [ "`which pupdial 2>/dev/null`" != "" ];then
- FLAGPUPDIAL="<radiobutton><label>$(gettext "PupDial (modem dialup)")</label><variable>RADIOPUPDIAL</variable><default>'$DEFPUPDIAL'</default></radiobutton>"
+ FLAGPUPDIAL="<radiobutton><label>$(gettext "PupDial (modem dialup)")</label><variable>RADIOPUPDIAL</variable><default>$DEFPUPDIAL</default></radiobutton>"
  CONNECTPUPDIAL='
  <hbox space-expand="true" space-fill="true">
    <button space-expand="false" space-fill="false">
@@ -177,7 +178,6 @@ if which pgprs >/dev/null 2>&1;then #160120
  <hbox space-expand="true" space-fill="true">
    <button space-expand="false" space-fill="false">
      '"`/usr/lib/gtkdialog/xml_button-icon wireless.svg big`"'
-     <action>connectwizard_exec pgprs</action>
      <action>/usr/sbin/pgprs --setup &</action>
      <action type="exit">exit</action>
    </button>

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard_exec
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard_exec
@@ -9,35 +9,34 @@ if [ -f /root/.connectwizardrc ];then
 else
  CURRENT_EXEC='connectwizard'
 fi
-if [ "$NEWEXEC" != "$CURRENT_EXEC" ];then
- [ "$CURRENT_EXEC" != 'connectwizard' ] \
-  && /usr/local/apps/Connect/AppRun --disconnect
- case "$CURRENT_EXEC" in
-  net-setup.sh)
-   killall dhcpcd 2>/dev/null
-   EXECPIDS="$(ps -fC gtkdialog | grep '\WNETWIZ_' | tr -s ' ' | cut -f 2-3 -d ' ' | tr '\n' ' ')"
-   ;;
-  sns)
-   EXECPIDS="$(ps -fC gtkdialog | grep '\WSNS_' | tr -s ' ' | cut -f 2-3 -d ' ' | tr '\n' ' ')"
-   ;;
-  frisbee)
-   which frisbee >/dev/null 2>&1 && frisbee --test_active \
-    && frisbee --deactivate
-   EXECPIDS="$(ps -fC gtkdialog | grep '\WFRISBEE_' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC frisbee-main,frisbee | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
-   ;;
-  pupdial)
-   EXECPIDS="$(ps -fC gtkdialog | grep -E '\WHOTDIALOG|PupDial' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass pupdial' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC pupdial_wizard,pupdial | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
-   ;;
-  pgprs)
-   EXECPIDS="$(ps -fC gtkdialog | grep '\WPGPRS_' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass pgprs' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC pgprs-connect,pgprs-setup,pgprs | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
-   ;;
-  peasywifi)
-   EXECPIDS="$(ps -fC gtkdialog,gtkdialog3 | grep '\WPEASYWIFI_' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass peasywifi' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC peasywifi | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
-   ;;
-  *) EXECPIDS='' ;;
- esac
- [ -n "$EXECPIDS" ] && kill $EXECPIDS
- echo "$CURRENT_EXEC" > /tmp/.connectwizard_previous_exec
- echo "CURRENT_EXEC=$NEWEXEC" > /root/.connectwizardrc
-fi
+[ "$NEWEXEC" = "$CURRENT_EXEC" ] && exit 0
+[ "$CURRENT_EXEC" != 'connectwizard' ] \
+ && /usr/local/apps/Connect/AppRun --disconnect
+case "$CURRENT_EXEC" in
+ net-setup.sh)
+  killall dhcpcd 2>/dev/null
+  EXECPIDS="$(ps -fC gtkdialog | grep '\WNETWIZ_' | tr -s ' ' | cut -f 2-3 -d ' ' | tr '\n' ' ')"
+  ;;
+ sns)
+  EXECPIDS="$(ps -fC gtkdialog | grep '\WSNS_' | tr -s ' ' | cut -f 2-3 -d ' ' | tr '\n' ' ')"
+  ;;
+ frisbee)
+  which frisbee >/dev/null 2>&1 && frisbee --test_active \
+   && frisbee --deactivate
+  EXECPIDS="$(ps -fC gtkdialog | grep '\WFRISBEE_' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass frisbee' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC frisbee-gprs-connect,frisbee-main,frisbee | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
+  ;;
+ pupdial)
+  EXECPIDS="$(ps -fC gtkdialog | grep -E '\WHOTDIALOG|PupDial' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass pupdial' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC pupdial_wizard,pupdial | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
+  ;;
+ pgprs)
+  EXECPIDS="$(ps -fC gtkdialog | grep '\WPGPRS_' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass pgprs' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC pgprs-connect,pgprs-setup,pgprs | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
+  ;;
+ peasywifi)
+  EXECPIDS="$(ps -fC gtkdialog,gtkdialog3 | grep '\WPEASYWIFI_' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps -fC Xdialog | grep 'wmclass peasywifi' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')$(ps --no-headers -fC peasywifi | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')"
+  ;;
+ *) EXECPIDS='' ;;
+esac
+[ -n "$EXECPIDS" ] && kill $EXECPIDS
+echo "$CURRENT_EXEC" > /tmp/.connectwizard_previous_exec
+echo "CURRENT_EXEC=$NEWEXEC" > /root/.connectwizardrc
 exit 0

--- a/woof-code/rootfs-skeleton/usr/sbin/network_default_connect
+++ b/woof-code/rootfs-skeleton/usr/sbin/network_default_connect
@@ -12,6 +12,7 @@
 #180919 add peasywifi support.
 #180923 replace specific exec paths with 'which'; move network wizard.
 #181209 add argument, adapt network stats reset moved from rc.sysinit.
+#200817 if no profiles present, ensure connectwizard is 'current'.
 
 if [ "$1" = '--sysinit' ]; then #181209...
  ETHERNETDIR=network_ethernet
@@ -97,6 +98,7 @@ case $NETCHOICE in
   /usr/local/simple_network_setup/rc.network &
  ;;
  connectwizard) #101007 shinobar
+  connectwizard_exec connectwizard #200817
   #170717 (161215) rewritten...
   /etc/rc.d/rc.network_basic #this only sets up interface 'lo'.
   /etc/rc.d/rc.network_eth &   #test for wired network.

--- a/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
+++ b/woof-code/rootfs-skeleton/usr/sbin/networkdisconnect
@@ -85,7 +85,7 @@ case "$DISCONNECTEXEC" in #170412...
 esac #170309
 
 sleep 0.1 #200425
-for ONENETIF in `ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' ' | tr -d : | tr -d '\n'`; do #200206
+for ONENETIF in `ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d ' ' | tr -d : | tr '\n' ' '`; do #200206
  ip link set $ONENETIF down 2> /dev/null #200206
  [ "`iw dev ${ONENETIF} info | grep -w "ssid"`" != "" ] \
   && iw dev $ONENETIF connect off #100309 200206


### PR DESCRIPTION
The GPRS display of the progress of a connection attempt has failed to complete in recent Puppy releases due to a regression in the Xdialog "logbox" and "textbox" options.  Once the initial line(s) were shown, subsequent lines failed to appear, implying that the connection had stalled.  The GPRS functions now use the only remaining technique that works: piping the output of the "tail --follow" command.  For easyOS, which uses the busybox version of "tail" which does not support --follow, the display is delayed to allow the full log to display.

In addition, improvements are made to the messaging related to potential conflicts between pgprs and frisbee mobile if they are used at the same time.

The other changes, which maintain the existing wifi/ethernet functionality, are to the coding format, replacement of the deprecated ifconfig and iwconfig commands, replacement of the uses of the busybox "ps" command by pgrep and ps with options, and resolution of warnings produced by the "shellcheck" tool.  The code is now fully internationalized as domains "frisbee" and "pgprs".

With the major changes in code indentation (whitespace), the git difference listings are daunting; for better detail, the kdiff3 tool produces side-by-side listings showing the changes in each line.

The "connectwizard+" commit changes the point at which pgprs makes itself the "current manager", so that its setup/cofiguration window can be viewed without impacting current networking until an attempt is made to connect.