### PR TITLE
rc.shutdown: remove alsa file leftover

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -80,6 +80,9 @@ done
 
 [ "$PUNIONFS" = "aufs" ] && sfs_load --cli stop
 
+#remove file leftover by alsa script
+rm -f /tmp/snd-kmod.lst 2>/dev/null
+
 ### cleanly unmount cifs shares from /usr/share/Shares
 # must be done here otherwise hang later at mount -a -r at rc.cleanup
 # samba rox app


### PR DESCRIPTION
the new alsa creates /tmp/snd-kmod.lst when stopped . This will be removed on shutdown to avoid conflicts