### PR TITLE
rc.sysinit: remove alsa file leftover

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -645,6 +645,9 @@ if which dbus-uuidgen >/dev/null 2>&1 ; then
 	ln -snf /var/run/dbus /run/dbus
 fi
 
+#remove file leftover by alsa script if exists
+rm -f /tmp/snd-kmod.lst 2>/dev/null
+
 #----------------------
 /etc/rc.d/rc.services & #run scripts in /etc/rc.d/init.d
 #----------------------


### PR DESCRIPTION
The new alsa creates /tmp/snd-kmod.lst when stopped. This will be removed on system init before alsa service start to avoid problems.