### PR TITLE
xorg-autoconf: added support for boot parameters

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -9,6 +9,14 @@ PCILIST="$(busybox lspci 2>/dev/null)"
 [ "$MODLIST" == "" ] && MODLIST="$(lsmod 2>/dev/null)" 
 [ "$PCILIST" == "" ] && PCILIST="$(lspci -nD 2>/dev/null | sed "s#^0000:##g")"
 
+if [ -e /etc/keymap.conf ]; then
+ KBSELECT="$(cat /etc/keymap.conf | head -n 1)"
+elif [ -e /etc/keymap ]; then
+ KBSELECT="$(cat /etc/keymap | head -n 1)"
+else
+ KBSELECT="us"
+fi
+
 #Detect udev
 UDEVD="$(which udevd)" 
 [ "$UDEVD" == "" ] && UDEVD="$(which systemd-udevd)" 
@@ -1223,7 +1231,7 @@ echo 'Section "InputDevice"
 	Driver      "kbd"
 	Option      "XkbRules" "xorg"
 	Option      "XkbModel" "pc102" #xkbmodel0
-	Option      "XkbLayout" "us" #xkeymap0
+	Option      "XkbLayout" "'$KBSELECT'" #xkeymap0
 	#Option      "XkbVariant" "" #xkbvariant0
 	Option      "XkbOptions" "terminate:ctrl_alt_bksp" #xkboptions0
 EndSection
@@ -1265,7 +1273,7 @@ echo 'Section "InputClass"
 	Identifier "Keyboard Defaults"
 	MatchIsKeyboard "yes"
 	Option      "XkbModel" "pc104" #xkbmodel0
-	Option      "XkbLayout" "us" #xkeymap0
+	Option      "XkbLayout" "'$KBSELECT'" #xkeymap0
 	#Option      "XkbVariant" "" #xkbvariant0
 	Option      "XkbOptions" "terminate:ctrl_alt_bksp" #xkboptions0
 EndSection


### PR DESCRIPTION
xorg-autoconf now reads /etc/keymap or /etc/keymap.conf set by boot parameter