### PR TITLE
SNS 2.3.3 sns: correct dBm sort for positive values; initialize udevmodulelist

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.3.2|simple_network_setup|2.3.2||Network|140K||simple_network_setup-2.3.2.pet|+gtkdialog|Barry's simple network manager||||
+simple_network_setup-2.3.3|simple_network_setup|2.3.3||Network|140K||simple_network_setup-2.3.3.pet|+gtkdialog|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -41,8 +41,9 @@
 #190525 v2.3: Add version to main window; re-check SNS running, in case slow to terminate; for interface change, kill current connection.
 #200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
 #200521 v2.3.2: Correct damage to SNS_error dialog window title syntax; export version.
+#201001 v2.3.3: Change SRLINES to handle (erroneously) positive signal level for sort; ensure driver names placed in udevmodulelist for immediate use.
 
-export VERSION='2.3.2'  #UPDATE this with each release!
+export VERSION='2.3.3'  #UPDATE this with each release!
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -122,6 +123,10 @@ do
  if [ "$IF_DRIVER" == "ndiswrapper" ];then
   WINDRVR="`ndiswrapper -l | grep '^[a-zA-Z0-9]' | cut -f 1 -d ' '`"
   IF_INFO="MS Windows driver '${WINDRVR}'"
+ fi
+ if [ ! -e /tmp/simple_network_setup/udevmodulelist/$IF_DRIVER ];then #201001...
+  mkdir -p /tmp/simple_network_setup/udevmodulelist
+  touch /tmp/simple_network_setup/udevmodulelist/$IF_DRIVER
  fi
 
   #want to manipulate the info string for display purposes...
@@ -436,7 +441,7 @@ if [ "$IF_INTTYPE" == "Wireless" ];then
   echo "STEP1c: ifconfig $INTERFACE down" >> /tmp/sns_wireless_log
   ifconfig $INTERFACE down #100313
   #convert each found network into a single line... 110203
-  SRLINES="`echo "$SCANRESULT" | grep -v 'Scan completed' | tr '|' ' ' | tr '\n' '|' | sed -e 's%       Cell %\n%g' | tr -s ' ' | sed -e 's%\(Signal level=\)\(-[0-9][0-9]*\)%\1@\2@%' | sort -g -r -t @ -k 2 | sed -e 's%\(Signal level=\)@\(-[0-9][0-9]*\)@%\1\2%'`" #170619
+  SRLINES="`echo "$SCANRESULT" | grep -v 'Scan completed' | tr '|' ' ' | tr '\n' '|' | sed -e 's%       Cell %\n%g' | tr -s ' ' | sed -e 's%\(Signal level=\)\([0-9-]\+\)%\1@\2@%' | sort -g -r -t @ -k 2 | sed -e 's%\(Signal level=\)@\([0-9-]\+\)@%\1\2%'`" #170619 #201001
   echo "$SRLINES" |
   while read ONELINE
   do


### PR DESCRIPTION
This matches the version provided for older Puppies.  Some wifi hardware produces positive signal levels when placed very close to an access point/router but appeared last in the sorted network list.  Newly added networking dongles would not have been seen if their driver names were not already in udevmodulelist.