### PR TITLE
rc.sysinit: improve dbus support

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -613,6 +613,24 @@ if [ -z "$ISITAMAC" ];then #don't run this block on mac
  fi
 fi
 
+# dbus
+if which dbus-uuidgen >/dev/null 2>&1 ; then
+	mkdir -p /var/lib/dbus /var/run/dbus
+	rm -f /var/lib/dbus/machine-id /etc/machine-id
+	chown messagebus /var/run/dbus
+	chgrp messagebus /var/run/dbus
+	dbus-uuidgen > /var/lib/dbus/machine-id
+	ln -snf /var/lib/dbus/machine-id /etc/machine-id
+	ln -snf /var/run/dbus /run/dbus
+fi
+
+#start dbus-daemon
+if which dbus-daemon >/dev/null 2>&1 ; then
+ if [ "$(pidof dbus-daemon)" == "" ]; then
+  dbus-daemon --system
+ fi
+fi
+
 #----------------------
 sleep 5 # in some cases network modules take some time to load
 #100814 100903 record cumulative tx/rx, see also network_tray and rc.shutdown.
@@ -632,17 +650,6 @@ if [ -e /initrd/tmp/wireless.conf ] ; then
 			echo -e "y\ny" | bbwireless.sh -s >/dev/null 2>&1 # should start network and make bbwireless default network tool
 		fi
 	fi
-fi
-
-# dbus
-if which dbus-uuidgen >/dev/null 2>&1 ; then
-	mkdir -p /var/lib/dbus /var/run/dbus
-	rm -f /var/lib/dbus/machine-id /etc/machine-id
-	chown messagebus /var/run/dbus
-	chgrp messagebus /var/run/dbus
-	dbus-uuidgen > /var/lib/dbus/machine-id
-	ln -snf /var/lib/dbus/machine-id /etc/machine-id
-	ln -snf /var/run/dbus /run/dbus
 fi
 
 #----------------------


### PR DESCRIPTION
Start dbus-daemon first before starting any services.
Some services requires dbus-daemon running. This will improve installing major desktop environments if users want to install.