### PR TITLE
rc.shutdown: Terminate dbus service

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -123,6 +123,9 @@ for i in /sys/class/net/* ; do
 	fi
 done
 
+#terminate dbus daemon
+killall dbus-daemon 2>/dev/null
+
 killall udevd > /dev/null 2>&1
 
 #first time booted puppy, there may not have been any persistent storage...


### PR DESCRIPTION
After the services stopped and the network disconnected, stop the dbus-daemon