### PR TITLE
rc.shutdown: Add dbus service termination

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -78,6 +78,9 @@ do
 done
 #note, /etc/rc.d/rc.services does same, with 'start' parameter.
 
+#terminate dbus daemon
+killall dbus-daemon 2>/dev/null
+
 [ "$PUNIONFS" = "aufs" ] && sfs_load --cli stop
 
 ### cleanly unmount cifs shares from /usr/share/Shares


### PR DESCRIPTION
After the services stopped, stop the dbus-daemon