### PR TITLE
rc.services: Some fix for Dbus

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.services
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.services
@@ -7,8 +7,17 @@ sleep 6
 
 for service_script in /etc/init.d/*
 do
- [ -x $service_script ] && $service_script start
+ if [ -x $service_script ]; then
+  #Check if the script contains dbus-daemon
+  if [ "$(cat $service_script | grep "dbus-daemon")" == "" ]; then
+   $service_script start
+  elif [ "$(pidof dbus-daemon)" == "" ]; then
+   #run dbus-daemon script if the dbus-daemon is not running
+   $service_script start
+  fi
+ fi
 done
+
 unset service_script
 
 ###END###


### PR DESCRIPTION
If service script contains dbus-daemon but dbus-daemon is already running. Don't run the script unless dbus-daemon does not run.