### PR TITLE
rc.shutdown: Skip Dbus when stopping services

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -74,7 +74,10 @@ killall dpid 2>/dev/null
 # some packages have a service script that requires stopping...
 for service_script in $(ls /etc/init.d/* | sort -r)
 do
-	[ -x $service_script ] && $service_script stop
+  #Stop service except for dbus. Dbus will be stopped later...
+  if [ -x $service_script ] && [ "$(cat $service_script | grep "dbus-daemon")" == "" ]; then
+   $service_script stop
+  fi
 done
 #note, /etc/rc.d/rc.services does same, with 'start' parameter.
 


### PR DESCRIPTION
Dbus-daemon service scripts will be skipped from stopping services. Because dbus-daemon will be killed after services stopped and disconnects from network