### PR TITLE
installpkg.sh: Added handling of lib symlinks

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -443,7 +443,7 @@ cat /var/packages/package-files/${DLPKG_NAME}.files | grep -E '*\.so$|*\.so\.*' 
 while IFS= read -r line
 do
 
-if [ -f $line ]; then
+if [ -f "$line" ]; then
 
   dname3="$(dirname $line)"
   soname="$(basename $line)"
@@ -454,7 +454,7 @@ if [ -f $line ]; then
   
    if [ "$(cat /var/packages/package-files/${DLPKG_NAME}.files | grep "$slink")" == "" ]; then
   
-      srcf=$(readlink $slink 2>/dev/null)
+      srcf=$(readlink "$slink" 2>/dev/null)
     
       if [ "$srcf" != "" ]; then
      

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -432,6 +432,56 @@ if [ -f $DIRECTSAVEPATH/puninstall.sh ];then
  mv -f $DIRECTSAVEPATH/puninstall.sh /root/.packages/${DLPKG_NAME}.remove
 fi
 
+#Look for symbolic links created by post-scripts and update package file list
+#remove temp list first
+rm -rf /tmp/slink-append.txt 2>/dev/null
+
+#List all the library files in the package
+cat /var/packages/package-files/${DLPKG_NAME}.files | grep -E '*\.so$|*\.so\.*' > /tmp/libfiles2.txt
+
+#Evaluate the library files
+while IFS= read -r line
+do
+
+if [ -f $line ]; then
+
+  dname3="$(dirname $line)"
+  soname="$(basename $line)"
+  soname2="${soname%*.so.*}"
+ 
+  for slink in $(find $dname -name "${soname2}.so*" -maxdepth 1 -type l)
+  do
+  
+   if [ "$(cat /var/packages/package-files/${DLPKG_NAME}.files | grep "$slink")" == "" ]; then
+  
+      srcf=$(readlink $slink 2>/dev/null)
+    
+      if [ "$srcf" != "" ]; then
+     
+        so_bname="$(basename $srcf 2>/dev/null)"
+          
+	  #check if the source file of the symlink was correct
+          if [ $so_bname != "" ] && [ "$so_bname" == "$soname" ]; then    
+	     if [ ! -f /tmp/slink-append.txt ]; then
+	      echo "$slink" > /tmp/slink-append.txt
+	     elif [ "$(cat /tmp/slink-append.txt | grep "$slink")" == "" ]; then
+	      echo "$slink" >> /tmp/slink-append.txt
+	     fi
+          fi
+      fi
+    fi
+ 
+   done
+ 
+fi
+ 
+done < /tmp/libfiles2.txt
+
+cat /tmp/slink-append.txt >> /var/packages/package-files/${DLPKG_NAME}.files
+rm -rf /tmp/slink-append.txt 2>/dev/null
+
+
+
 #w465 <pkgname>.pet.specs is in older pet pkgs, just dump it...
 #maybe a '$APKGNAME.pet.specs' file created by dir2pet script...
 rm -f $DIRECTSAVEPATH/*.pet.specs 2>/dev/null

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -458,7 +458,7 @@ if [ -f $line ]; then
     
       if [ "$srcf" != "" ]; then
      
-        so_bname="$(basename $srcf 2>/dev/null)"
+        so_bname="$(basename "$srcf" 2>/dev/null)"
           
 	  #check if the source file of the symlink was correct
           if [ $so_bname != "" ] && [ "$so_bname" == "$soname" ]; then    


### PR DESCRIPTION
Some post install scripts creates symlinks for library files. However when a package was uninstalled. Those generated symlinks does not include upon removal. Which leaves broken symlinks in the system and makes the filesystem cluttered.

This code will search for symlinks generated by the post install script and added to package list of files in order to remove those generated symlinks upon package removal