### PR TITLE
poweroff: added support -r parameter

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/poweroff
+++ b/woof-code/rootfs-skeleton/sbin/poweroff
@@ -2,14 +2,23 @@
 #110505 support sudo for non-root user.
 #140622 shinobar avoid freeze on a virtual terminal
 
+script=""
+
 for i in $@ ; do
 	case $i in
 		debug) echo > /tmp/debugshutdown ; shift ;;
 		shell) echo > /tmp/shutdownshell ; shift ;;
+		-r)
+		  if [ "$script" == "" ]; then
+		   script="reboot"
+		  fi
+		shift ;;
 	esac
 done
 
-script=${0##*/}
+if [ "$script" == "" ]; then
+ script=${0##*/}
+fi
 
 if [ -d /proc/acpi ] || [ -d /proc/apm ]; then
  can_shutdown=1

--- a/woof-code/rootfs-skeleton/sbin/poweroff
+++ b/woof-code/rootfs-skeleton/sbin/poweroff
@@ -9,7 +9,7 @@ for i in $@ ; do
 		debug) echo > /tmp/debugshutdown ; shift ;;
 		shell) echo > /tmp/shutdownshell ; shift ;;
 		-r)
-		  if [ "$script" == "" ]; then
+		  if [ "${0##*/}" == "shutdown" ] && [ "$script" == "" ]; then
 		   script="reboot"
 		  fi
 		shift ;;


### PR DESCRIPTION
the shutdown command sometimes symlinked to poweroff, other applications call for "shutdown -r" command to reboot but instead it shutdown the system. So added support for -r parameter will redirect to reboot