### PR TITLE
rc.sysinit: remove alsa file leftover

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -151,6 +151,8 @@ if [ $PUPMODE -eq 2 ] ; then
 fi
 #===============
 
+rm -f /tmp/snd-kmod.lst 2>/dev/null
+
 if [ "$BOOT_DIRTYWRITE" ];then #120704 see /etc/rc.d/BOOTCONSTRAINED, variable set in 3builddistro.
  #i have set this as 1500 which is 15 seconds (default is 5 seconds).
  echo $BOOT_DIRTYWRITE > /proc/sys/vm/dirty_writeback_centisecs #refer: http://www.lesswatts.org/tips/disks.php


### PR DESCRIPTION
Just remove /tmp/snd-kmod.lst  if still exists. Sometimes /tmp/snd-kmod.lst retained due to improper shutdown