### PR TITLE
remasterpup2: Some improvements

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -96,6 +96,7 @@ KERNELVER="`uname -r`"
 . /etc/DISTRO_SPECS
 PUPPYSFS="$DISTRO_PUPPYSFS" #ex: puppy.sfs
 ZDRVSFS="$DISTRO_ZDRVSFS"   #ex: zdrv.sfs
+FDRVSFS="$DISTRO_FDRVSFS"   #ex: fdrv.sfs
 SFSBASE="`basename $PUPPYSFS .sfs`" #ex: puppy
 
 PPATTERN="/initrd${PUP_LAYER}"
@@ -386,6 +387,25 @@ $(gettext 'Then click OK...')"
 	[ $? -eq 0 ] && MKZDRV="yes" || MKZDRV=""
 	[ $? -eq 255 ] && exit #130223
 
+	m_16_1="$(eval_gettext 'Include depmod files on remastered CD?')
+	$(eval_gettext 'The puppy will boot faster if included')"
+
+	Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_1" 0 0
+	retval=$?
+
+	if [ $retval -eq 0 ]; then
+	ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd"	# 28dec09 modules.*
+	elif [ $retval -eq 255 ]; then
+	exit #130223
+	else
+	ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"	# 28dec09 modules.*
+	fi
+	
+	m_16_2="$(eval_gettext 'Do you like to make ${FDRVSFS}, the separate firmware driver file?')"
+	Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_2" 0 0
+	[ $? -eq 0 ] && MKFDRV="yes" || MKFDRV=""
+	[ $? -eq 255 ] && exit #130223
+
 	# set compression
 	/usr/lib/gtkdialog/box_yesno --yes-label "xz (default)" --no-label "gzip" --yes-first --info \
 	--yes-icon "execute.svg" --no-icon "execute.svg" \
@@ -397,6 +417,18 @@ $(gettext 'Then click OK...')"
 	#COMP="-noI -noD -noF -noX" #fast tests zzzzzz
 	echo "COMP=${COMP}"
 	# -
+	
+	blk1=`Xdialog --wrap --no-cancel --stdout --title "$m_01" --combobox "Before we start, select compression block size first\nThe larger the block, the smaller the puppy will be created.\nHowever large blocks will increase on CPU overhead\nYou may leave it blank if you have any doubts" 11 66 128K 256K 512K 1M`
+
+	if [ "$blk1" == "" ] ||  [ "$blk1" == "0" ]; then
+	 blk1="128K"
+	fi
+	
+	BLKSIZE="$blk1"
+
+	echo "BLOCK_SIZE=$blk1"
+
+	COMP="$COMP -b $BLKSIZE"
 
 	m_18="$(eval_gettext 'Creating the ${PUPPYSFS} file in ${WKGMNTPT}/puppylivecdbuild/.')
 $(gettext 'This can take quite a long time, so please wait.... and wait...')
@@ -425,6 +457,13 @@ $(gettext 'Please wait...')"
 		mksquashfs /lib $WKGMNTPT/puppylivecdbuild/$ZDRVSFS -keep-as-directory -e /lib/[^m]* $ANOTHER_REMOVE
 		ANOTHER_REMOVE="/lib/modules"
 	fi
+	
+	if [ "$MKFDRV" = "yes" ]; then
+	  rm -f $WKGMNTPT/puppylivecdbuild/$FDRVSFS 2> /dev/null
+	  mksquashfs /lib $WKGMNTPT/puppylivecdbuild/$FDRVSFS -keep-as-directory -e /lib/[^f]* $ANOTHER_REMOVE
+	  ANOTHER_REMOVE="$ANOTHER_REMOVE /lib/firmware"
+	fi
+	
 	#120605 Omit certain /dev subdir content and modem components loaded from firmware tarballs...
 	[ -d /dev/snd ] && [ "`ls /dev/snd`" != "" ] && DIRDEVSNDFILES="/dev/snd/*" #120721
 	[ -d /dev/.udev ] && DIRDEVUDEV="/dev/.udev"
@@ -478,6 +517,72 @@ $(gettext 'Please wait...')"
 		mkdir -p /tmp/root/.config/rox.sourceforge.net/ROX-Filer/
 		cp -af /root/.config/rox.sourceforge.net/ROX-Filer/Options /tmp/root/.config/rox.sourceforge.net/ROX-Filer/
 	fi
+	
+	#Include xdg autostart
+	if [ -e /root/.config/autostart ] && [ ! -d /tmp/root/.config/autostart ];then
+	 mkdir -p /tmp/root/.config/autostart/
+	fi
+	
+	cp -rf /root/.config/autostart/* /tmp/root/.config/autostart/ 2>/dev/null
+	
+	
+	#Include lxde settings
+	#libfm
+	if [ -e /root/.config/libfm ] && [ ! -d /tmp/root/.config/libfm ];then
+	 mkdir -p /tmp/root/.config/libfm/
+	fi
+	
+	cp -rf /root/.config/libfm/* /tmp/root/.config/libfm/ 2>/dev/null
+	
+	#lxpanel
+	if [ -e /root/.config/lxpanel ] && [ ! -d /tmp/root/.config/lxpanel ];then
+	 mkdir -p /tmp/root/.config/lxpanel
+	fi
+	
+	cp -rf /root/.config/lxpanel/* /tmp/root/.config/lxpanel/ 2>/dev/null
+	
+	#lxsession
+	if [ -e /root/.config/lxsession ] && [ ! -d /tmp/root/.config/lxsession ];then
+	 mkdir -p /tmp/root/.config/lxsession
+	fi
+	
+	cp -rf /root/.config/lxsession/* /tmp/root/.config/lxsession/ 2>/dev/null
+	
+	#openbox
+	if [ -e /root/.config/openbox ] && [ ! -d /tmp/root/.config/openbox ];then
+	 mkdir -p /tmp/root/.config/openbox
+	fi
+	
+	cp -rf /root/.config/openbox/* /tmp/root/.config/openbox/ 2>/dev/null	
+	
+	#pcmanfm
+	if [ -e /root/.config/pcmanfm ] && [ ! -d /tmp/root/.config/pcmanfm ];then
+	 mkdir -p /tmp/root/.config/pcmanfm
+	fi
+	
+	cp -rf /root/.config/pcmanfm/* /tmp/root/.config/pcmanfm/ 2>/dev/null	
+	
+
+	#Include xfce4 desktop settings
+	if [ -e /root/.config/xfce4 ] && [ ! -d /tmp/root/.config/xfce4 ];then
+	 mkdir -p /tmp/root/.config/xfce4/
+	fi
+	
+	cp -rf /root/.config/xfce4/* /tmp/root/.config/xfce4/ 2>/dev/null
+	
+	#Remove xfce screen resolution settings
+	if [ -f /tmp/root/.config/xfce4/xfconf/xfce-perchannel-xml/displays.xml ];then
+	 
+	rm /tmp/root/.config/xfce4/xfconf/xfce-perchannel-xml/displays.xml
+
+	echo '<?xml version="1.0" encoding="UTF-8"?>
+
+	<channel name="displays" version="1.0">
+	  <property name="Notify" type="bool" value="true"/>
+	</channel>' > /tmp/root/.config/xfce4/xfconf/xfce-perchannel-xml/displays.xml
+
+	fi
+	
 	#v411 tidy up, remove desktop drive icons...
 	grep -v '/tmp/pup_event_frontend/drive_' /tmp/root/Choices/ROX-Filer/PuppyPin > /tmp/remaster-PuppyPin
 	mv -f /tmp/remaster-PuppyPin /tmp/root/Choices/ROX-Filer/PuppyPin


### PR DESCRIPTION
* Add option to include depmod files. Including depmod files in ZDRV makes booting time faster.
* Add option to create FDRV module. Because upon remastering /lib/firmware was included on main puppy sfs which makes the puppy bloat if the total file size of /lib/firmware was huge.
* Added adjustable block size compression for more granular control of compression regarding SFS file size output 
* Inclusion of XFCE and LXDE settings on remastering