### PR TITLE
Support more build systems in new2dir

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/new2dir
+++ b/woof-code/rootfs-skeleton/usr/bin/new2dir
@@ -25,7 +25,20 @@ usage() {
 	echo "Exiting script."
 }
 
-if [ "$1 $2$3" != "make install" ];then #180915
+if [ "$1 $2$3" != "make install" ] && \
+   [ "$1 $2 $3 $4" != "meson -C _builddir install" ] && \
+   [ "$1 $2 $3 $4" != "meson -C _build install" ] && \
+   [ "$1 $2 $3 $4" != "meson -C build install" ] && \
+   [ "$1 $2$3$4" != "meson install" ] && \
+   [ "$1 $2 $3 $4" != "ninja -C builddir install" ] && \
+   [ "$1 $2 $3 $4" != "ninja -C build install" ] && \
+   [ "$1 $2 $3 $4" != "ninja -C _build install" ] && \
+   [ "$1 $2$3$4" != "ninja install" ] && \
+   [ "$1 $2 $3 $4" != "samu -C builddir install" ] && \
+   [ "$1 $2 $3 $4" != "samu -C build install" ] && \
+   [ "$1 $2 $3 $4" != "samu -C _build install" ] && \
+   [ "$1 $2$3$4" != "samu install" ]
+then #180915
  usage
  exit
 fi


### PR DESCRIPTION
This PR addresses this issue: https://github.com/puppylinux-woof-CE/woof-CE/issues/1904

Added support for using `new2dir` with the following build tools: meson, ninja, samurai

This means you can package up a wider variety of source code projects into PET packages using `new2dir`.

The extra commands added have been taken from commands I've encountered "in the wild".