### PR TITLE
remasterpup2: Added remaster options and improvements

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -118,7 +118,27 @@ fi
 SAVEPART="$PDEV1" #from PUPSTATE.
 CDR="/dev/$SAVEPART"
 
+#Choose remaster options
+xmsg="$(gettext 'Select Remaster Options') 
+ 
+ $(gettext 'Remaster CD: Create a remastered Puppy CD (Good for booting from CD)')
+ $(gettext 'Remaster SFS: Create a remastered SFS Files (Good for live usb setup)')
+ " 
+ 
+ lbl_41="$(gettext 'Remaster CD')"
+ lbl_42="$(gettext 'Remaster SFS')"
+ 
+ Xdialog --wrap --left --title "$m_01" --ok-label "$lbl_41" --cancel-label "$lbl_42" --yesno "$xmsg" 0 90
+ retval=$?
+ 
+ [ $retval -eq 0 ] && xCDREMASTER="yes"
+ [ $retval -eq 1 ] && xCDREMASTER=""
+ 
+ [ $retval -eq 255 ] && exit
+
 #choose where to create isolinux-builds/ directory...
+if [ "$xCDREMASTER" != "" ]; then
+
 m_05="$(gettext 'Welcome! This little program takes a snapshot of your current system and create a ISO file.')
 
 $(eval_gettext 'A Puppy live-CD has 4 main files: vmlinuz, isolinux.cfg, initrd.gz and ${PUPPYSFS}. Note, in some builds of Puppy there may also be a 5th file, ${ZDRVSFS}.')
@@ -126,6 +146,18 @@ $(eval_gettext 'A Puppy live-CD has 4 main files: vmlinuz, isolinux.cfg, initrd.
 $(eval_gettext "It is \${PUPPYSFS} that mainly interests us here: it has the entire Puppy filesystem, everything from '/' down. What this script does is rebuild this file \${PUPPYSFS}, with everything currently under '/' -- that is, all user-installed packages, all mounted .sfs extension files, everything, gets combined into one file, \${PUPPYSFS}.")
 
 $(gettext 'Click OK button to continue (or close window to quit)...')"
+
+else
+
+m_05="$(gettext 'Welcome! This little program takes a snapshot of your current system and create a SFS modules.')
+
+$(eval_gettext "It is \${PUPPYSFS} that mainly interests us here: it has the entire Puppy filesystem, everything from '/' down. What this script does is rebuild this file \${PUPPYSFS}, with everything currently under '/' -- that is, all user-installed packages, all mounted .sfs extension files, everything, gets combined into one file, \${PUPPYSFS}.")
+
+$(gettext 'Click OK button to continue (or close window to quit)...')"
+
+fi
+
+
 Xdialog --wrap --left --title "$m_01" --msgbox "$m_05" 0 80
 
 [ $? -ne 0 ] && exit
@@ -209,7 +241,13 @@ fi
 
 [ "$SCHOICES" = "" ] && exit #precaution.
 
-m_13="$(gettext 'A working area is required in which to create the new live-CD iso file.')
+if [ "$xCDREMASTER" != "" ]; then
+ RFILE="live-CD iso"
+else
+ RFILE="puppy sfs"
+fi
+
+m_13="$(gettext 'A working area is required in which to create the new ${RFILE} file.')
 $(eval_gettext 'Here are the available partitions. You must choose one that has at least ${SIZENEEDEDM}M free space on it.') $(gettext 'You will need an extra 100 - 300MB space (whatever the size of ISO file is going to be).')
 
 $(eval_gettext 'If the partition that you would like to use has less than ${SIZENEEDEDM}M free space on it, you will need to quit this script and delete some files.')
@@ -217,6 +255,8 @@ $(eval_gettext 'If the partition that you would like to use has less than ${SIZE
 $(gettext 'Note 1: you can use a usb drive, but it needs to have been plugged in before running this script, so that it will get detected.')
 ${TMPFSMSG}
 $(gettext 'Highlight desired choice then click OK button...')"
+
+
 echo '#!/bin/sh' > /tmp/savedlg
 echo -n "Xdialog --wrap --left --stdout --title \"$m_01\" --menubox \"$m_13\" 0 80 5 " >> /tmp/savedlg
 echo "$SCHOICES"  >> /tmp/savedlg
@@ -266,12 +306,18 @@ if [ "$NEW" = "yes" ]; then  ###### long skip if, cleating new sfs
 	if [ -d $WKGMNTPT/puppylivecdbuild ];then
 		[ -f $WKGMNTPT/puppylivecdbuild/$PUPPYSFS ] && rm -f $WKGMNTPT/puppylivecdbuild/$PUPPYSFS
 		[ -f $WKGMNTPT/puppylivecdbuild/$ZDRVSFS ] && rm -f $WKGMNTPT/puppylivecdbuild/$ZDRVSFS
+        	
+		CDMSG=""
+		[ "$xCDREMASTER" != "" ] && CDMSG="
+		
+		$(gettext 'Note, if you choose to retain the files: The next operation is this script will will read files from a CD, however they will not over-write existing files. Therefore, any customised files will be retained.')
+		
+		"
+		
 		m_41="$(eval_gettext 'Directory ${WKGMNTPT}/puppylivecdbuild already exists.')
 
 $(gettext "Normally, this would be created fresh, empty. However, it exists from a previous execution of 'remasterpup2' script (this program), with files in it. You may choose to leave these files in-place, for the current remaster. If uncertain, click the 'Erase' button.")
-
-$(gettext 'Note, if you choose to retain the files: The next operation is this script will will read files from a CD, however they will not over-write existing files. Therefore, any customised files will be retained.')
-
+$CDMSG
 $(gettext "WARNING: If the files in 'puppylivecdbuild' are for a different version of Puppy, click the 'Erase' button.")
 $(gettext "Again, warning, if at all uncertain, click the 'Erase' button.")
 
@@ -296,27 +342,6 @@ $(gettext '(You may view the directory contents with a file-manager to satisfy y
 	fi
 	
 	
-	 xmsg="$(gettext 'Select Remaster Options') 
- 
- $(gettext 'Remaster CD: Create a remastered Puppy CD (Good for booting from CD)')
- $(gettext 'Remaster SFS: Create a remastered SFS Files (Good for live usb setup)')
- " 
- 
- lbl_41="$(gettext 'Remaster CD')"
- lbl_42="$(gettext 'Remaster SFS')"
- 
- Xdialog --wrap --left --title "$m_01" --ok-label "$lbl_41" --cancel-label "$lbl_42" --yesno "$xmsg" 0 90
- retval=$?
- 
- [ $retval -eq 0 ] && xCDREMASTER="yes"
- 
- if [ $retval -eq 1 ]; then
-  xCDREMASTER=""
-  mkdir -p $WKGMNTPT/puppylivecdbuild
- fi
- 
- [ $retval -eq 255 ] && exit
- 
 if [ "$xCDREMASTER" != "" ]; then
 
 	m_40="$(gettext 'This remaster program needs to read some files off the current live-CD.')
@@ -422,16 +447,17 @@ if [ "$xCDREMASTER" != "" ]; then
 		retval=$?
 
 		if [ $retval -eq 0 ]; then
-		ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd"	# 28dec09 modules.*
+		  ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd"	# 28dec09 modules.*
 		elif [ $retval -eq 255 ]; then
-		exit #130223
+		 exit #130223
 		else
-		ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"	# 28dec09 modules.*
+		  ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"	# 28dec09 modules.*
 		fi
 	
 	else
 	 MKZDRV=""
 	 ANOTHER_REMOVE="/lib/modules /lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"
+	 [ ! -e $WKGMNTPT/puppylivecdbuild ] && mkdir -p $WKGMNTPT/puppylivecdbuild
 	fi
 	
 	m_16_2="$(eval_gettext 'Do you like to make ${FDRVSFS}, the separate firmware driver file?')"
@@ -722,13 +748,32 @@ $(eval_gettext "After examining /tmp/root, click 'Ok' to add /root in \${PUPPYSF
 
 	#######START WORKING ON /etc#######
 	rm -rf /tmp/etc 2> /dev/null
+	
 	#do some work on /etc before add it to the .sfs...
 	cp -a /initrd${PUP_LAYER}/etc /tmp/etc #pristine /etc.
+	
 	#maybe this has been modified...
 	cp -af /etc/ld.so.conf /tmp/etc/
+	
+	mkdir -p /tmp/etc/ld.so.conf.d 2>/dev/null
+	cp -af /etc/ld.so.conf.d/* /tmp/etc/ld.so.conf.d/
+	
+	mkdir -p /tmp/etc/init.d 2>/dev/null
+	cp -af /etc/init.d/* /tmp/etc/init.d/
+	
+	mkdir -p /tmp/etc/udev/rules.d 2>/dev/null
+	cp -af /etc/udev/rules.d/* /tmp/etc/udev/rules.d/
+	rm -f /tmp/etc/udev/rules.d/*-persistent-net.rules
+	
+	mkdir -p /tmp/etc/xdg/autostart 2>/dev/null
+	cp -af /etc/xdg/autostart/* /tmp/etc/xdg/autostart/
+	
+        mkdir -p /tmp/etc/xdg/menus 2>/dev/null
+	cp -af /etc/xdg/menus/* /tmp/etc/xdg/menus/
 
 	#.packages/ .files, copy any files installed to /etc...
 	echo -n "" > /tmp/allpkgs.files
+	
 	for ONEPKG in `ls -1 /root/.packages/*.files 2>/dev/null | tr "\n" " "`
 	do
 		grep '^/etc/' $ONEPKG | \
@@ -882,20 +927,37 @@ fi
 if [ "$NEW" = "yes" ]; then	#120628: no change id-string for reuse
 	sync
 	#100913 need to update file DISTRO_SPECS in initrd.gz, so init script can find puppy files...
-	mv -f $WKGMNTPT/puppylivecdbuild/initrd.gz /tmp #note $WKGMNTPT may be non-linux fs.
-	cd /tmp
-	gunzip initrd.gz
-	mkdir initrd-tree-tmp1
-	cd initrd-tree-tmp1
-	cat ../initrd | cpio -i -d -m
-	sync
-	rm -f ../initrd
-	cp -a -f /tmp/DISTRO_SPECSupdated ./DISTRO_SPECS #see earlier.
-	find . | cpio -o -H newc | gzip -9 > $WKGMNTPT/puppylivecdbuild/initrd.gz
-	sync
-	cd ..
-	rm -rf initrd-tree-tmp1
-	cd /root
+	if [ -f $WKGMNTPT/puppylivecdbuild/initrd.gz ]; then
+		mv -f $WKGMNTPT/puppylivecdbuild/initrd.gz /tmp #note $WKGMNTPT may be non-linux fs.
+		cd /tmp
+		gunzip initrd.gz
+		mkdir initrd-tree-tmp1
+		cd initrd-tree-tmp1
+		cat ../initrd | cpio -i -d -m
+		sync
+		rm -f ../initrd
+		cp -a -f /tmp/DISTRO_SPECSupdated ./DISTRO_SPECS #see earlier.
+		find . | cpio -o -H newc | gzip -9 > $WKGMNTPT/puppylivecdbuild/initrd.gz
+		sync
+		cd ..
+		rm -rf initrd-tree-tmp1
+		cd /root
+	elif [ -f $WKGMNTPT/puppylivecdbuild/initrd.xz ]; then
+		mv -f $WKGMNTPT/puppylivecdbuild/initrd.xz /tmp #note $WKGMNTPT may be non-linux fs.
+		cd /tmp
+		unxz initrd.xz
+		mkdir initrd-tree-tmp1
+		cd initrd-tree-tmp1
+		cat ../initrd | cpio -i -d -m
+		sync
+		rm -f ../initrd
+		cp -a -f /tmp/DISTRO_SPECSupdated ./DISTRO_SPECS #see earlier.
+		find . | cpio -o -H newc | xz --check=crc32 --lzma2=dict=1MB > $WKGMNTPT/puppylivecdbuild/initrd.xz
+		sync
+		cd ..
+		rm -rf initrd-tree-tmp1
+		cd /root
+	fi
 fi #120628 end
 
 if [ -f $WKGMNTPT/puppylivecdbuild/efi.img ] ; then

--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -420,7 +420,7 @@ if [ "$xCDREMASTER" != "" ]; then
 			sync
 			(
 			cd $CDMNTPT
-			for F in ${ZDRVSFS} vmlinuz initrd.gz  grldr *efi* *EFI* *.c32 *.sh *.lst *.xpm *.jpg *.png *.bin *.cfg *.msg *.16 *.HTM* *.ICO *.INF help boot
+			for F in ${ZDRVSFS} vmlinuz initrd.*z  grldr *efi* *EFI* *.c32 *.sh *.lst *.xpm *.jpg *.png *.bin *.cfg *.msg *.16 *.HTM* *.ICO *.INF help boot
 			do
 				#130223 -n means do not override an existing file... 130304 hmmm, -n not supported, use -u ...
 				[ -e "$F" ] && cp -a -u $F $WKGMNTPT/puppylivecdbuild/

--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -294,111 +294,144 @@ $(eval_gettext 'Directory ${WKGMNTPT}/puppylivecdbuild already exists.')
 $(gettext 'If you want to re-use the files in it, and not re-read files from the CD (or virtual-CD), just click the window close-box to bypass this operation.')
 $(gettext '(You may view the directory contents with a file-manager to satisfy yourself whether these files should be re-used)')"
 	fi
+	
+	
+	 xmsg="$(gettext 'Select Remaster Options') 
+ 
+ $(gettext 'Remaster CD: Create a remastered Puppy CD (Good for booting from CD)')
+ $(gettext 'Remaster SFS: Create a remastered SFS Files (Good for live usb setup)')
+ " 
+ 
+ lbl_41="$(gettext 'Remaster CD')"
+ lbl_42="$(gettext 'Remaster SFS')"
+ 
+ Xdialog --wrap --left --title "$m_01" --ok-label "$lbl_41" --cancel-label "$lbl_42" --yesno "$xmsg" 0 90
+ retval=$?
+ 
+ [ $retval -eq 0 ] && xCDREMASTER="yes"
+ 
+ if [ $retval -eq 1 ]; then
+  xCDREMASTER=""
+  mkdir -p $WKGMNTPT/puppylivecdbuild
+ fi
+ 
+ [ $retval -eq 255 ] && exit
+ 
+if [ "$xCDREMASTER" != "" ]; then
+
 	m_40="$(gettext 'This remaster program needs to read some files off the current live-CD.')
 
-$(gettext "However, if a CD-image file (which has filename extension .iso) is mounted, the files may be read from that. We refer to this as a 'virtual CD'. To mount a virtual CD, just click on a .iso file.")
+	$(gettext "However, if a CD-image file (which has filename extension .iso) is mounted, the files may be read from that. We refer to this as a 'virtual CD'. To mount a virtual CD, just click on a .iso file.")
 
-$(eval_gettext "WARNING: Be sure that the live-CD or .iso file is the correct one for the currently running Puppy, which is '\${DISTRO_NAME}', version \${DISTRO_VERSION}. As a check, it must have in it the file '\${DISTRO_PUPPYSFS}'")
+	$(eval_gettext "WARNING: Be sure that the live-CD or .iso file is the correct one for the currently running Puppy, which is '\${DISTRO_NAME}', version \${DISTRO_VERSION}. As a check, it must have in it the file '\${DISTRO_PUPPYSFS}'")
 
-$(gettext "If you want to read the files off a .iso file rather than a CD/DVD, please click on the .iso file right now (before clicking the 'OK' button below)")
-$(gettext "Alternatively, if you want to read the files off a Puppy live-CD, insert it in drive, then click 'OK' button.")${m_42}"
-	Xdialog --wrap --left  --title "$m_01" --msgbox "$m_40" 0 80
+	$(gettext "If you want to read the files off a .iso file rather than a CD/DVD, please click on the .iso file right now (before clicking the 'OK' button below)")
+	$(gettext "Alternatively, if you want to read the files off a Puppy live-CD, insert it in drive, then click 'OK' button.")${m_42}"
+		Xdialog --wrap --left  --title "$m_01" --msgbox "$m_40" 0 80
 
-	if [ $? -eq 0 ];then #130223 big if "BIGIF2"
-		#130222 fix this...
-		VIRTUALCD=""
-		#130301 crap, earlier was using losetup-FULL from util-linux git, now using older 2.21.1, it needs -a param,
-		#but also truncates long lines (same as bb losetup) -- what a nuisance...
-		for ONELOOP in `cat /proc/mounts | grep -E '(^/dev/loop.*)( udf | iso9660 )' | cut -f 1 -d ' ' | tr '\n' ' '` #130308 /dev/loop only
-		do
-			oPTN="^${ONELOOP} "
-			ONEISO="$(cat /proc/mounts | grep "$oPTN" | cut -f 2 -d ' ' | rev | cut -f 1 -d '+' | cut -f 1 -d '/' | rev)" #130301
-			[ "$ONEISO" = "" ] && continue #130301 precaution.
-			ONELOOP=$(echo "$ONELOOP" | sed 's|/loop/|/loop|')
-			VIRTUALCD="${VIRTUALCD} ${ONELOOP} ${ONEISO}"
-		done
-		m_14="$(gettext 'This remaster program needs to read some files off the current live-CD.')
-$(gettext 'You can also use a .iso file if it is already mounted as a virtual CD (you would need to have previously clicked on a .iso file to mount it).')"
-		MSG="$m_14"
-		choice_cdd filter #130308 Use filtering.
-
-		CDPATTERN="/dev/$BURNERDRV "
-		CDMNTPT="`mount | grep "$CDPATTERN" | tr -s " " | cut -f 3 -d " "`"
-		if [ "$CDMNTPT" != "" ];then
-			if [ ! -f $CDMNTPT/initrd.gz ];then #130308 In theory, this will now never be true.
-				#091212 weird bug, no processes but when run this, x restarts...
-				xFUSER="`fuser -m /dev/$BURNERDRV 2>/dev/null`" #do this first, seems to fix it.
-				[ "$xFUSER" != "" ] && fuser -k -m /dev/$BURNERDRV
-				sync
-				umount /dev/$BURNERDRV 2> /dev/null
-				if [ $? -ne 0 ];then
-					m_15="$(gettext 'Mounted CD, get rid of it before running this program!')"
-					Xdialog --wrap --left  --title "$m_02" --msgbox "$m_15" 0 0
-					exit
-				fi
-				CDMNTPT=""
-			fi
-		fi
-
-		if [ "$CDMNTPT" = "" ];then
-			m_16="$(eval_gettext 'Please insert the current Puppy live-CD into drive ${BURNERDRV}.')
-$(gettext 'Then click OK...')"
-			while [ 1 ];do
-				Xdialog --wrap --left  --title "$m_01" --msgbox "$m_16" 0 0
-				[ $? -eq 0  ] || exit	# 22jun09
-				case $BURNERDRV in
-					loop*) #ISO.. already mounted
-						CDMNTPT=$(mount | grep "^/dev/$BURNERDRV " | cut -f 3 -d ' ')
-						;;
-					*) #CD
-						#now mount it...
-						CDMNTPT="/mnt/$BURNERDRV"
-						mkdir -p /mnt/$BURNERDRV
-						mount -t iso9660 /dev/$BURNERDRV /mnt/$BURNERDRV
-						[ $? -eq 0 ] && break
-						;;
-				esac
+		if [ $? -eq 0 ];then #130223 big if "BIGIF2"
+			#130222 fix this...
+			VIRTUALCD=""
+			#130301 crap, earlier was using losetup-FULL from util-linux git, now using older 2.21.1, it needs -a param,
+			#but also truncates long lines (same as bb losetup) -- what a nuisance...
+			for ONELOOP in `cat /proc/mounts | grep -E '(^/dev/loop.*)( udf | iso9660 )' | cut -f 1 -d ' ' | tr '\n' ' '` #130308 /dev/loop only
+			do
+				oPTN="^${ONELOOP} "
+				ONEISO="$(cat /proc/mounts | grep "$oPTN" | cut -f 2 -d ' ' | rev | cut -f 1 -d '+' | cut -f 1 -d '/' | rev)" #130301
+				[ "$ONEISO" = "" ] && continue #130301 precaution.
+				ONELOOP=$(echo "$ONELOOP" | sed 's|/loop/|/loop|')
+				VIRTUALCD="${VIRTUALCD} ${ONELOOP} ${ONEISO}"
 			done
-		fi
+			m_14="$(gettext 'This remaster program needs to read some files off the current live-CD.')
+	$(gettext 'You can also use a .iso file if it is already mounted as a virtual CD (you would need to have previously clicked on a .iso file to mount it).')"
+			MSG="$m_14"
+			choice_cdd filter #130308 Use filtering.
 
-		#now get the files off it...
-		m_17="$(eval_gettext 'Copying files from CD to ${WKGMNTPT}/puppylivecdbuild/, please wait...')"
-		Xdialog --wrap --left  --title "$m_01" --no-buttons --ignore-eof   --infobox "$m_17" 0 0 0 &
-		XPID=$!
-		mkdir -p $WKGMNTPT/puppylivecdbuild
-		#now copy the files... # v431JP HTM, ICO, INF
-		sync
-		(
-		cd $CDMNTPT
-		for F in ${ZDRVSFS} vmlinuz initrd.gz  grldr *efi* *EFI* *.c32 *.sh *.lst *.xpm *.jpg *.png *.bin *.cfg *.msg *.16 *.HTM* *.ICO *.INF help boot
-		do
-			#130223 -n means do not override an existing file... 130304 hmmm, -n not supported, use -u ...
-			[ -e "$F" ] && cp -a -u $F $WKGMNTPT/puppylivecdbuild/
+			CDPATTERN="/dev/$BURNERDRV "
+			CDMNTPT="`mount | grep "$CDPATTERN" | tr -s " " | cut -f 3 -d " "`"
+			if [ "$CDMNTPT" != "" ];then
+				if [ ! -f $CDMNTPT/initrd.gz ];then #130308 In theory, this will now never be true.
+					#091212 weird bug, no processes but when run this, x restarts...
+					xFUSER="`fuser -m /dev/$BURNERDRV 2>/dev/null`" #do this first, seems to fix it.
+					[ "$xFUSER" != "" ] && fuser -k -m /dev/$BURNERDRV
+					sync
+					umount /dev/$BURNERDRV 2> /dev/null
+					if [ $? -ne 0 ];then
+						m_15="$(gettext 'Mounted CD, get rid of it before running this program!')"
+						Xdialog --wrap --left  --title "$m_02" --msgbox "$m_15" 0 0
+						exit
+					fi
+					CDMNTPT=""
+				fi
+			fi
+
+			if [ "$CDMNTPT" = "" ];then
+				m_16="$(eval_gettext 'Please insert the current Puppy live-CD into drive ${BURNERDRV}.')
+	$(gettext 'Then click OK...')"
+				while [ 1 ];do
+					Xdialog --wrap --left  --title "$m_01" --msgbox "$m_16" 0 0
+					[ $? -eq 0  ] || exit	# 22jun09
+					case $BURNERDRV in
+						loop*) #ISO.. already mounted
+							CDMNTPT=$(mount | grep "^/dev/$BURNERDRV " | cut -f 3 -d ' ')
+							;;
+						*) #CD
+							#now mount it...
+							CDMNTPT="/mnt/$BURNERDRV"
+							mkdir -p /mnt/$BURNERDRV
+							mount -t iso9660 /dev/$BURNERDRV /mnt/$BURNERDRV
+							[ $? -eq 0 ] && break
+							;;
+					esac
+				done
+			fi
+
+			#now get the files off it...
+			m_17="$(eval_gettext 'Copying files from CD to ${WKGMNTPT}/puppylivecdbuild/, please wait...')"
+			Xdialog --wrap --left  --title "$m_01" --no-buttons --ignore-eof   --infobox "$m_17" 0 0 0 &
+			XPID=$!
+			mkdir -p $WKGMNTPT/puppylivecdbuild
+			#now copy the files... # v431JP HTM, ICO, INF
 			sync
-		done
-		)
-		umount /dev/$BURNERDRV 2> /dev/null
-		kill $XPID
+			(
+			cd $CDMNTPT
+			for F in ${ZDRVSFS} vmlinuz initrd.gz  grldr *efi* *EFI* *.c32 *.sh *.lst *.xpm *.jpg *.png *.bin *.cfg *.msg *.16 *.HTM* *.ICO *.INF help boot
+			do
+				#130223 -n means do not override an existing file... 130304 hmmm, -n not supported, use -u ...
+				[ -e "$F" ] && cp -a -u $F $WKGMNTPT/puppylivecdbuild/
+				sync
+			done
+			)
+			umount /dev/$BURNERDRV 2> /dev/null
+			kill $XPID
 
-	fi #end "BIGIF2"
+		fi #end "BIGIF2"
+	fi
 
-	m_16_1="$(eval_gettext 'Do you like to make ${ZDRVSFS}, the separate driver file?')"
-	Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_1" 0 0
-	[ $? -eq 0 ] && MKZDRV="yes" || MKZDRV=""
-	[ $? -eq 255 ] && exit #130223
+	if [ "$xCDREMASTER" != "" ]; then
 
-	m_16_1="$(eval_gettext 'Include depmod files on remastered CD?')
-	$(eval_gettext 'The puppy will boot faster if included')"
+		m_16_1="$(eval_gettext 'Do you like to make ${ZDRVSFS}, the separate driver file?')"
+		Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_1" 0 0
+		[ $? -eq 0 ] && MKZDRV="yes" || MKZDRV=""
+		[ $? -eq 255 ] && exit #130223
 
-	Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_1" 0 0
-	retval=$?
+		m_16_1="$(eval_gettext 'Include depmod files on remastered CD?')
+		$(eval_gettext 'The puppy will boot faster if included')"
 
-	if [ $retval -eq 0 ]; then
-	ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd"	# 28dec09 modules.*
-	elif [ $retval -eq 255 ]; then
-	exit #130223
+		Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_1" 0 0
+		retval=$?
+
+		if [ $retval -eq 0 ]; then
+		ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd"	# 28dec09 modules.*
+		elif [ $retval -eq 255 ]; then
+		exit #130223
+		else
+		ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"	# 28dec09 modules.*
+		fi
+	
 	else
-	ANOTHER_REMOVE="/lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"	# 28dec09 modules.*
+	 MKZDRV=""
+	 ANOTHER_REMOVE="/lib/modules /lib/modules/$KERNELVER/initrd /lib/modules/*/modules.*"
 	fi
 	
 	m_16_2="$(eval_gettext 'Do you like to make ${FDRVSFS}, the separate firmware driver file?')"
@@ -818,9 +851,11 @@ $(eval_gettext "Click 'Ok' to add /etc in \${PUPPYSFS} file...")"
 	chmod a+r $WKGMNTPT/puppylivecdbuild/* >/dev/null 2>&1
 	chmod a-x $WKGMNTPT/puppylivecdbuild/*.sfs >/dev/null 2>&1
 
-fi ###### end of long skip if, cleating new sfs
+fi ###### end of long skip if, creating new sfs
 
 #=================================================================
+
+if [ "$xCDREMASTER" != "" ]; then
 
 m_25="$(gettext 'Almost ready to create the new ISO file!')
 
@@ -910,5 +945,16 @@ m_28="$(eval_gettext '${WKGMNTPT}/puppylivecdbuild/ files left in existence.')
 $(gettext "Click 'Ok' button to quit...")"
 Xdialog --wrap --left  --title "$m_01" --msgbox "$MSG
 $m_28" 0 0
+
+else
+ sync
+ xmsg="$(eval_gettext 'Newly remastered puppy sfs files is created at
+
+${WKGMNTPT}/puppylivecdbuild/')
+
+$(gettext "Click 'Ok' button to quit...")"
+ Xdialog --wrap --left  --title "$m_01" --msgbox "$xmsg" 0 0
+ exit
+fi
 
 ### END ###

--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -577,6 +577,9 @@ $(gettext 'Please wait...')"
 	cp -af /root/.jwmrc-tray /tmp/root/ #v411
 	cp -af /root/.fvwm95rc /tmp/root/
 	cp -af /root/.icewm/menu /tmp/root/.icewm/
+	cp -rf /root/.fonts /tmp/root/
+	cp -rf /root/.icons /tmp/root/
+	
 	#rox desktop settings...
 	cp -af /root/Choices/ROX-Filer/PuppyPin /tmp/root/Choices/ROX-Filer/
 	cp -af /root/Choices/ROX-Filer/globicons /tmp/root/Choices/ROX-Filer/
@@ -597,6 +600,8 @@ $(gettext 'Please wait...')"
 	fi
 	
 	cp -rf /root/.config/autostart/* /tmp/root/.config/autostart/ 2>/dev/null
+	
+	rm -f /tmp/root/.config/autostart/lxrandr-autostart.desktop 2>/dev/null
 	
 	
 	#Include lxde settings

--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -464,6 +464,15 @@ if [ "$xCDREMASTER" != "" ]; then
 	Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_2" 0 0
 	[ $? -eq 0 ] && MKFDRV="yes" || MKFDRV=""
 	[ $? -eq 255 ] && exit #130223
+	
+	if [ "$MKFDRV" != "yes" ]; then
+	 m_16_3="$(eval_gettext 'Include firmware drivers on Puppy SFS file?')"
+	 Xdialog --wrap --left  --title "$m_01" --default-no --ok-label "$Yes_lbl" --cancel-label "$No_lbl" --yesno "$m_16_3" 0 0
+	 [ $? -eq 0 ] && INCLUDEFW="yes" || INCLUDEFW=""
+	 [ $? -eq 255 ] && exit #130223
+	else
+	 INCLUDEFW=""
+	fi
 
 	# set compression
 	/usr/lib/gtkdialog/box_yesno --yes-label "xz (default)" --no-label "gzip" --yes-first --info \
@@ -521,6 +530,11 @@ $(gettext 'Please wait...')"
 	  rm -f $WKGMNTPT/puppylivecdbuild/$FDRVSFS 2> /dev/null
 	  mksquashfs /lib $WKGMNTPT/puppylivecdbuild/$FDRVSFS -keep-as-directory -e /lib/[^f]* $ANOTHER_REMOVE
 	  ANOTHER_REMOVE="$ANOTHER_REMOVE /lib/firmware"
+	else
+	   rm -f $WKGMNTPT/puppylivecdbuild/$FDRVSFS 2> /dev/null
+	   if [ "$INCLUDEFW" != "yes" ]; then
+	    ANOTHER_REMOVE="$ANOTHER_REMOVE /lib/firmware"
+	   fi
 	fi
 	
 	#120605 Omit certain /dev subdir content and modem components loaded from firmware tarballs...

--- a/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
+++ b/woof-code/rootfs-skeleton/usr/sbin/remasterpup2
@@ -603,6 +603,9 @@ $(gettext 'Please wait...')"
 	
 	cp -rf /root/.config/xfce4/* /tmp/root/.config/xfce4/ 2>/dev/null
 	
+	#Remove recent on whiskermenu settings
+	find /tmp/root/.config/xfce4/panel/ -type f -name "whiskermenu*.rc" -exec sed -i -e "s#recent=.*#recent=#g" '{}' \;
+
 	#Remove xfce screen resolution settings
 	if [ -f /tmp/root/.config/xfce4/xfconf/xfce-perchannel-xml/displays.xml ];then
 	 


### PR DESCRIPTION
remasterpup2 has now two modes to choose from:
* Remaster CD: Create a remastered Puppy either disc or ISO file
* Remaster SFS: Creates Puppy SFS and FDRV files only. (No need for inserting the corresponding Puppy CD or mounting corresponding Puppy ISO images)