### PR TITLE
rc.shutdown: Add answer file for PUPMODE 13

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -61,9 +61,9 @@ while [ "`pidof snapmergepuppy`" ]; do sleep 1 ; done
 cd /
 sync
 echo "Killing X and all X apps..."
-killall -9 X > /dev/null 2>&1 #just a precaution...
+killall -TERM X > /dev/null 2>&1 #just a precaution...
+killall -TERM Xorg > /dev/null 2>&1 #just a precaution...
 sleep 1
-killall -3 X > /dev/null 2>&1
 sync
 
 #MU warns may need to do this for dillo...
@@ -150,10 +150,10 @@ if [ $PUPMODE -eq 5 ];then
  fi
 fi #end ifpupmode5
 
-if [ $PUPMODE -eq 13 ];then
+if [ $PUPMODE -eq 13 ]; then
  #read a file named /tmp/session_ramdisk_result, the answer file whether save the ramdisk session to savefile or not
  #It contains variable RAMDISK_SAVE_SESSION where the values are 'y' or 'n'
- if [ -e /tmp/session_ramdisk_result ] && [ -s /tmp/session_ramdisk_result ]; then
+ if [ -s /tmp/session_ramdisk_result ]; then
   . /tmp/session_ramdisk_result
  fi
 fi

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -150,6 +150,14 @@ if [ $PUPMODE -eq 5 ];then
  fi
 fi #end ifpupmode5
 
+if [ $PUPMODE -eq 13 ];then
+ #read a file named /tmp/session_ramdisk_result, the answer file whether save the ramdisk session to savefile or not
+ #It contains variable RAMDISK_SAVE_SESSION where the values are 'y' or 'n'
+ if [ -e /tmp/session_ramdisk_result ] && [ -s /tmp/session_ramdisk_result ]; then
+  . /tmp/session_ramdisk_result
+ fi
+fi
+
 if [ "$PUPSAVE" != "" ];then
  #f.s. and partition where ${DISTRO_FILE_PREFIX}save.2fs is located...
  SAVEFS="`echo -n "$PUPSAVE" | cut -f 2 -d ','`"
@@ -262,8 +270,15 @@ case $PUPMODE in
  13) #PDEV1 and PUPSFS and PUPSAVE 
   #/initrd/pup_rw has tmpfs, pup_ro1 has ${DISTRO_FILE_PREFIX}save.2fs file (PUPSAVE), pup_ro2 has PUPSFS file. 
   #the above are in aufs at /.
-  asktosave_func
-  if [ $? -eq 0 ]; then 
+  if [ "$RAMDISK_SAVE_SESSION" == "" ]; then
+   asktosave_func
+   retval=$?
+  elif [ "$RAMDISK_SAVE_SESSION" == "y" ]; then
+   retval=0
+  else
+   retval=1
+  fi
+  if [ $retval -eq 0 ]; then 
     echo "$(printf "$(gettext 'Saving session to %s (%s)...')" "${SAVEFILE}" "${SAVEPART}")" >/dev/console
     /usr/sbin/snapmergepuppy /initrd/pup_ro1 /initrd/pup_rw
   fi 


### PR DESCRIPTION
The answer file for PUPMODE 13 if auto saved ramdisk session was disabled was extremely handy for shutdown scenario such as calling shutdown/reboot from ConsoleKit. It works like shutdownconfig. While the user is logged in and before the shutdown it can use to ask user whether save the ramdisk and save the user response before start the shutdown process rather asking the user while in the middle of shutdown process