### PR TITLE
Create asktosave_session

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/asktosave_session
+++ b/woof-code/rootfs-skeleton/usr/sbin/asktosave_session
@@ -1,0 +1,50 @@
+#!/bin/sh
+#GUI dialog for saving session at PUPMODE 13
+# --file parameter for saving user response in /tmp/session_ramdisk_result to be read by /etc/rc.d/rc.shutdown
+
+. /etc/eventmanager
+. /etc/rc.d/PUPSTATE
+
+if [ $PUPMODE -ne 13 ]; then
+ echo "Not PUPMODE 13"
+ exit 
+fi
+
+if [ "$1" == "--file" ]; then
+ xMAKE_ANSWER="y"
+fi
+
+# if $RAMSAVEINTERVAL > 0, session is saved automatically
+ if [ "$RAMSAVEINTERVAL" ] && [ $RAMSAVEINTERVAL -gt 0 ] ; then
+   RETVAL=0
+ elif [ "$ASKTOSAVE" = "false" ]; then
+   RETVAL=0
+ else
+  
+  if [ "$(pidof X)" != "" ] || [ "$(pidof Xorg)" != "" ]
+   DLGEXE="Xdialog"
+  else
+   DLGEXE="dialog"
+  fi
+ 
+  $DLGEXE --timeout 60 --yes-label "$(gettext 'SAVE')" --no-label "$(gettext 'NO SAVE')" --yesno "$(gettext 'Press ENTER key to save session... 
+Or, press TAB then ENTER to not save session... 
+Or, wait 60 seconds to shutdown without saving session...')" 0 0
+   
+   RETVAL=$?
+ 
+ fi
+ 
+ if[ "$xMAKE_ANSWER" != "" ]; then
+  
+  if [ $RETVAL -eq 0 ]; then
+   echo "RAMDISK_SAVE_SESSION=y" > /tmp/session_ramdisk_result
+  else
+   echo "RAMDISK_SAVE_SESSION=n" > /tmp/session_ramdisk_result
+  fi
+ 
+ else
+  rm -f /tmp/session_ramdisk_result 2>/dev/null
+ fi
+ 
+ exit $RETVAL

--- a/woof-code/rootfs-skeleton/usr/sbin/asktosave_session
+++ b/woof-code/rootfs-skeleton/usr/sbin/asktosave_session
@@ -23,6 +23,7 @@ fi
   
   if [ "$(pidof X)" != "" ] || [ "$(pidof Xorg)" != "" ]
    DLGEXE="Xdialog"
+   [ "$DISPLAY" == "" ] && export DISPLAY=:0
   else
    DLGEXE="dialog"
   fi


### PR DESCRIPTION
asktosave_session is a dialog for saving session in PUPMODE 13 if autosave is not enabled

It works the same asktosave_func in /etc/rc.d/rc.shutdown but it can also create an answer file saved in /tmp/session_ramdisk_result in order to be used by /etc/rc.d/rc.shutdown script upon reboot/shutdown