### PR TITLE
xwin: fix computer arch detection for auto config

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -264,7 +264,7 @@ else
 	xorgwizard-automatic
 fi
 
-if [ "$(uname -m)" == "x86" ] || [ "$(uname -m)" == "x86_64" ]; then
+if [ "$(uname -m | grep -E "[i|x]*86")" != "" ] || [ "$(uname -m)" == "x86_64" ]; then
  config_video
 fi
 


### PR DESCRIPTION
Auto configuration for x86 system doesn't work because "uname -m" does not always return x86 sometimes it returns i386/i486/i586/i686