### PR TITLE
fixed new2dir: find repo root dir if 1 levels deep, not just 2

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/new2dir
+++ b/woof-code/rootfs-skeleton/usr/bin/new2dir
@@ -72,7 +72,7 @@ CURRDIR="`pwd`"
 UPONE="`dirname "$CURRDIR"`"
 PKGDIR="../`basename "$CURRDIR"`"
 xPKGDIR="`basename "$CURRDIR"`"
-if [ "`echo "$PKGDIR" | grep '[0-9]'`" = "" ];then
+if [ ! -d ".git" ] && [ "`echo "$PKGDIR" | grep '[0-9]'`" = "" ];then
  PKGDIR="../../`basename "$UPONE"`"
  xPKGDIR="`basename "$UPONE"`"
 fi


### PR DESCRIPTION
Update to https://github.com/puppylinux-woof-CE/woof-CE/commit/81c38f30ba714ec5e4c87be004fa65d236721fd5 .. apologies..

Can build PETs from root dir of git repo, or from inside a level deeper (e.g. a "build" dir, used by cmake projects).
