### PR TITLE
new2dir: better package versions for git repos

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/new2dir
+++ b/woof-code/rootfs-skeleton/usr/bin/new2dir
@@ -92,8 +92,19 @@ if [ "`echo "$PKGDIR" | grep '[0-9]'`" = "" ];then
       [ "$(pwd)" = "/" ] && break
     done)
     up=$(cat /tmp/upcount 2>/dev/null && rm /tmp/upcount)
+
+    # if this commit is tagged, and the tag starts with a number, then
+    # use the tag as the version
+    git_release=
+    git_release=$(git tag -l --contains $git_commit_hash 2>/dev/null)
+    git_release=$(echo "$git_release" | sed 's/^v//g')
     # now create the new package name
-    symlinked_dir_with_ver=$xPKGDIR-$(date -u +"%Y%m%d")$git_commit_hash
+    if [ "$(echo "$git_release" | grep '[0-9]')" != "" ];then
+      symlinked_dir_with_ver=$xPKGDIR-$git_release
+    else
+      symlinked_dir_with_ver=$xPKGDIR-$(date -u +"%Y%m%d")$git_commit_hash
+    fi
+
     # create a symlink of that name, pointing to $CURRDIR, and
     # set our PKGDIR as the versioned symlink to $CURRDIR
     ln -sf $xPKGDIR ${up}$symlinked_dir_with_ver \


### PR DESCRIPTION
If building a PET using new2dir from a GitHub repo, this update will cause new2dir 
to use the current branches git tag (if any and contains numbers) as package version, 
instead of date+hash.

This means we get nicer package versions, while still obeying the "versions must 
contain numbers" rule in dir2pet (and prob elsewhere). 
