### PR TITLE
fix new2dir: prevent build-related cache files going into PETs

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/new2dir
+++ b/woof-code/rootfs-skeleton/usr/bin/new2dir
@@ -286,7 +286,7 @@ cat /tmp/pkginstall.list \
   | tr '\t' '&' \
   | egrep '^[345]&open&|^0&chmod&' \
   | grep --extended-regexp -v '&/dev/tty&|&/dev/null&|&/root/\.packages/|&'"$PWD"'|&/root/'"$PWD"'|&/tmp/|&/root/\.icewm/|&/proc/|&/sys/|DotPupTmpDir|/\.myownmenuerc' \
-  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/' \
+  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/|&/root/.ccache' \
   | cut -f3 -d'&' \
   | sort -u > ${RELPATH}/${EXE_PKGNAME}.files #120220 120602
 
@@ -301,7 +301,7 @@ cat /tmp/pkginstall.list \
   | tr '\t' '&' \
   | grep '^0&mkdir&' \
   | grep --extended-regexp -v '&/dev/tty&|&/dev/null&|&/root/\.packages/|&'"$PWD"'|&/root/'"$PWD"'|&/tmp/|&/root/\.icewm/|&/proc/|&/sys/|DotPupTmpDir|/\.myownmenuerc' \
-  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/' \
+  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/|&/root/.ccache' \
   | cut -f 3 -d '&' \
   | sed -e 's/^\/\//\//g' > /tmp/${EXE_PKGNAME}.dirs
 
@@ -314,7 +314,7 @@ cat /tmp/pkginstall.list \
   | tr '\t' '&' \
   | grep '^0&symlink&' \
   | grep --extended-regexp -v '&/dev/tty&|&/dev/null&|&/root/\.packages/|&'"$PWD"'|&/root/'"$PWD"'|&/tmp/|&/root/\.icewm/|&/proc/|&/sys/|DotPupTmpDir|/\.myownmenuerc' \
-  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/' \
+  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/|&/root/.ccache' \
   | cut -f 4 -d '&' >> ${RELPATH}/${EXE_PKGNAME}.files
 
 sync
@@ -326,7 +326,7 @@ cat /tmp/pkginstall.list \
   | tr '\t' '&' \
   | grep '^0&rename&' \
   | grep --extended-regexp -v '&/dev/tty&|&/dev/null&|&/root/\.packages/|&'"$PWD"'|&/root/'"$PWD"'|&/tmp/|&/root/\.icewm/|&/proc/|&/sys/|DotPupTmpDir|/\.myownmenuerc' \
-  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/' \
+  | grep -E -v '&/initrd|&/mnt/|&/root/.*/CMakeFiles/|&/root/.ccache' \
   | cut -f 3,4 -d '&' \
   | tr '\n' ' ' > /tmp/${EXE_PKGNAME}.moved.files
 


### PR DESCRIPTION
Added an ignore for ccache stuff that otherwise ends up in the PET as `/root/.ccache/**`