### PR TITLE
plogin: Added executable permissions for .desktop

### DIFF
--- a/woof-code/rootfs-skeleton/bin/plogin
+++ b/woof-code/rootfs-skeleton/bin/plogin
@@ -78,6 +78,7 @@ Exec=${APP}
 Terminal=false
 Type=Application
 Icon=/usr/share/pixmaps/puppy/save.svg" > ${USER_HOME}/Desktop/${APP}.desktop
+  		chmod +x ${USER_HOME}/Desktop/${APP}.desktop
 		fi
 		;;
 	*)


### PR DESCRIPTION
Some desktops environment does run automatically when desktop is double clicked unless it the permission was set to executable