### PR TITLE
removepreview.sh: Some improvements

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/removepreview.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/removepreview.sh
@@ -27,9 +27,11 @@
 export TEXTDOMAIN=petget___removepreview.sh
 export OUTPUT_CHARSET=UTF-8
 [ "$(locale | grep '^LANG=' | cut -d '=' -f 2)" ] && ORIGLANG="$(locale | grep '^LANG=' | cut -d '=' -f 2)"
-. /etc/rc.d/PUPSTATE  #111228 this has PUPMODE and SAVE_LAYER.
+[ -e /etc/rc.d/PUPSTATE ] && . /etc/rc.d/PUPSTATE  #111228 this has PUPMODE and SAVE_LAYER.
 . /etc/DISTRO_SPECS #has DISTRO_BINARY_COMPAT, DISTRO_COMPAT_VERSION
 . /root/.packages/DISTRO_PKGS_SPECS
+
+[ "$PUPMODE" == "" ] && PUPMODE=2
 
 #Check if the / is layered fs
 ISLAYEREDFS="$(mount | grep "on / type" | grep "unionfs")"


### PR DESCRIPTION
If /etc/rc.d/PUPSTATE was missing, use PUPMODE=2.
This allows to use PPM in pristine root filesystem under chroot process