### PR TITLE
/proc/apm is a file, not a directory

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/poweroff
+++ b/woof-code/rootfs-skeleton/sbin/poweroff
@@ -20,7 +20,7 @@ if [ "$script" == "" ]; then
  script=${0##*/}
 fi
 
-if [ -d /proc/acpi ] || [ -d /proc/apm ]; then
+if [ -d /proc/acpi ] || [ -f /proc/apm ]; then
  can_shutdown=1
 else
  can_shutdown=0


### PR DESCRIPTION
This wrong check causes `poweoff` to display a prompt on ARM machines, where /proc/acpi doesn't exists but /proc/apm does.