### PR TITLE
enable hinting when using /etc/fonts from Debian

### DIFF
--- a/woof-code/packages-templates/xorg_base_new/FIXUPHACK
+++ b/woof-code/packages-templates/xorg_base_new/FIXUPHACK
@@ -41,6 +41,13 @@ done
 
 #if /etc/fonts/fonts.conf is not present, use traditional Puppy-style font settings
 if [ -f etc/fonts/fonts.conf ];then
+	# if using Debian's fontconfig-config, enable hinting to make fonts more readable
+	if [ -e usr/share/fontconfig/conf.avail/10-hinting-slight.conf -a ! -e etc/fonts/conf.d/10-hinting-slight.conf ]; then
+		ln -s /usr/share/fontconfig/conf.avail/10-hinting-slight.conf etc/fonts/conf.d/
+	fi
+	if [ -e usr/share/fontconfig/conf.avail/10-autohint.conf -a ! -e etc/fonts/conf.d/10-autohint.conf ]; then
+		ln -s /usr/share/fontconfig/conf.avail/10-autohint.conf etc/fonts/conf.d/
+	fi
 	rm -rf etc/fonts-puppy
 else
 	rm -rf etc/fonts


### PR DESCRIPTION
The way Puppy renders fonts breaks some websites. This PR makes fonts more readable, and more similar to the way text is rendered in other distros.