### PR TITLE
BogoMIPS can be super low on some ARM boards

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_startup
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/frontend_startup
@@ -6,6 +6,9 @@
 
 #exec &>/tmp/${0##*/}.log ; set -x #debug
 
+. /etc/DISTRO_SPECS
+. /etc/rc.d/BOOTCONSTRAINED
+
 rm -f /tmp/services/x_display
 
 sleep 3 #1 #let the dust settle after X has started. 120718 reduce 2 to 1. 121105 try 2, see also /usr/sbin/delayedrun. 121212
@@ -14,8 +17,13 @@ DELAYFACTOR=0
 CPUMHZ=`grep -m 1 -i '^cpu MHz' /proc/cpuinfo | tr -d ' ' | cut -f 2 -d ':' | cut -f 1 -d '.'` #my laptop: 933.000
 if [ $CPUMHZ ];then
  [ $CPUMHZ -gt 100 ] && DELAYFACTOR=$((1600 / $CPUMHZ)) #120829 L18L: need 1 sec for my 1514 MHZ CPU.  #`expr 1100 \/ $CPUMHZ`
-else #120718 raspi: 697.95  my laptop: 4789.47
- BOGOMIPS=`grep -m 1 -i '^bogomips' /proc/cpuinfo | tr -d ' ' | cut -f 2 -d ':' | cut -f 1 -d '.'`
+else #120718 raspi: 697.95  my laptop: 4789.47  c201: <= 48
+ case "$DISTRO_TARGETARCH" in
+  arm*) [ "$BOOT_BOARD" != "raspi" ] && BOGOMIPS=700 ;;
+ esac
+ if [ ! "$BOGOMIPS" ]; then
+  BOGOMIPS=`grep -m 1 -i '^bogomips' /proc/cpuinfo | tr -d ' ' | cut -f 2 -d ':' | cut -f 1 -d '.'`
+ fi
  [ $BOGOMIPS ] && [ $BOGOMIPS -gt 200 ] && DELAYFACTOR=`expr 2100 \/ $BOGOMIPS`
 fi
 [ $DELAYFACTOR -gt 0 ] && sleep $DELAYFACTOR
@@ -116,7 +124,6 @@ if [ "$BACKENDON" = "false" ];then #see /etc/eventmanager.
 	killall udevd 2>/dev/null
 	exit 2
 else
-	. /etc/rc.d/BOOTCONSTRAINED
 	[ "$BOOT_UDEVDCHILDREN" ] && UOPT="--children-max=${BOOT_UDEVDCHILDREN}"
 	if ! pidof udevd >/dev/null 2>&1 ; then
 		UDEV_LOG=2 udevd --daemon --resolve-names=early ${UOPT} &

--- a/woof-code/rootfs-skeleton/usr/sbin/delayedrun
+++ b/woof-code/rootfs-skeleton/usr/sbin/delayedrun
@@ -6,11 +6,19 @@
 # probably a security hole, need to look at it again later.
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@}
 
+. /etc/DISTRO_SPECS
+. /etc/rc.d/BOOTCONSTRAINED
+
 sleep 1 # let the dust settle first.
 
-# slow cpus need more delay.... raspi: 697.95  my laptop: 4789.47
+# slow cpus need more delay.... raspi: 697.95  my laptop: 4789.47  c201: <= 48
 DELAYFACTOR=0
-BOGOMIPS=`grep -m 1 -i '^bogomips' /proc/cpuinfo | tr -d ' ' | cut -f 2 -d ':' | cut -f 1 -d '.'`
+case "$DISTRO_TARGETARCH" in
+  arm*) [ "$BOOT_BOARD" != "raspi" ] && BOGOMIPS=800 ;;
+esac
+if [ ! "$BOGOMIPS" ]; then
+  BOGOMIPS=`grep -m 1 -i '^bogomips' /proc/cpuinfo | tr -d ' ' | cut -f 2 -d ':' | cut -f 1 -d '.'`
+fi
 [ $BOGOMIPS ] && DELAYFACTOR=$((800 / $BOGOMIPS))
 [ $DELAYFACTOR -gt 0 ] && sleep $DELAYFACTOR
 


### PR DESCRIPTION
Even multiplying it by the number of cores won't work, because it's <= 48 on some pretty capable ARM platforms (at least some Rockchip boards).