### PR TITLE
SNS 2.4, 2.4.1: Improve automatic network connection, etc.

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
+++ b/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
@@ -1,5 +1,5 @@
 # Accumulate list of modules to be loaded, for use by rc.network.
 
 ENV{MODALIAS}=="?*", ACTION=="add", SUBSYSTEM=="?*", \
-  PROGRAM="/bin/grep -sq '=sns' /root/.connectwizardrc", \
+  PROGRAM="/usr/bin/test -s /etc/simple_network_setup/connections", \
   RUN+="/usr/local/simple_network_setup/build_udevmodulelist"

--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.3.3|simple_network_setup|2.3.3||Network|140K||simple_network_setup-2.3.3.pet|+gtkdialog|Barry's simple network manager||||
+simple_network_setup-2.4.1|simple_network_setup|2.4.1||Network|144K||simple_network_setup-2.4.1.pet|+gtkdialog|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/build_udevmodulelist
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/build_udevmodulelist
@@ -1,10 +1,44 @@
-#!/bin/sh
-# Add a null file for each module being loaded, for rc.network to await.
-# Invoked by udev rules file 51-simple_network_setup.rules
+#!/bin/bash
+# Add a file to directory udevmodulelist for each module being loaded.
+# The file contains the name of the module expected to be loaded, for rc.network to await.
+# The name may be different from the file name if a networking device is aliased to multiple driver modules or if a driver is blacklisted. 
+# Invoked by udev rule file 51-simple_network_setup.rules
+#201017 v2.4: Rewritten to save module names expected to be loaded, accessed by connection driver name (from /sys/class/net/*/device/driver link). 
 
-MODULE="$(/sbin/modprobe -i --use-blacklist --show-depends $MODALIAS 2>/dev/null \
-  | tail -n 1 | rev | cut -f 1 -d '/' | rev | cut -f 1 -d '.')"
-[ "$MODULE" = "" ] && exit
-[ ! -d /tmp/simple_network_setup/udevmodulelist ] \
-  && mkdir -p /tmp/simple_network_setup/udevmodulelist
-touch /tmp/simple_network_setup/udevmodulelist/${MODULE//-/_/}
+[ -z "$MODALIAS" ] && exit
+usleep 1000 #precaution for multiple cores
+MODULES="$(/sbin/modprobe -i --config /dev/null \
+  --show-depends $MODALIAS 2>/dev/null | \
+  grep -E '/kernel/drivers/net/|/kernel/drivers/staging/' | \
+  grep -o '[^/]*\.ko' | cut -f 1 -d '.')"
+if [ -n "$MODULES" ]; then
+    MODULE="$(/sbin/modprobe -i --show-depends $MODALIAS 2>/dev/null | \
+      grep -E '/kernel/drivers/net/|/kernel/drivers/staging/' | \
+      grep -o '[^/]*\.ko' | cut -f 1 -d '.' | tail -n 1)"
+    if [ -f /etc/rc.d/MODULESCONFIG-backend_modprobe ]; then
+        . /etc/rc.d/MODULESCONFIG-backend_modprobe #get PREFLIST
+    elif [ -f /etc/rc.d/MODULESCONFIG ]; then
+        . /etc/rc.d/MODULESCONFIG #get PREFLIST
+    else
+        PREFLIST=''
+    fi
+    if [ -n "$PREFLIST" ]; then
+        PREFHIT="$(echo -n "$PREFLIST" | tr ' ' '\n' | grep "^${MODULE}:" | head -n 1)"
+        if [ -n "$PREFHIT" ];then
+            grep -hso '^blacklist  *[^ ]*' /etc/modprobe.d/* | tr -s ' ' > /tmp/sns_blacklist.conf
+            PREFMODS="$(echo -n "$PREFHIT" | cut -f 2-9 -d ':' | tr ':' ' ')"
+            for PREFMOD in $PREFMODS; do #format can have multiple ':', ex: 8139cp:8139too:8139xx (last is most preferred).
+                echo "blacklist $MODULE" >> /tmp/sns_blacklist.conf
+                xMODULE="$(/sbin/modprobe -i --config /tmp/sns_blacklist.conf \
+                  --show-depends $MODALIAS 2>/dev/null | \
+                  tail -n 1 | grep -o '[^/]*\.ko' | cut -f 1 -d '.')"
+                [ "$xMODULE" = "$PREFMOD" ] && MODULE="$xMODULE"
+            done
+            rm -f /tmp/sns_blacklist.conf
+        fi
+    fi
+    mkdir -p /tmp/simple_network_setup/udevmodulelist
+    for ONEMODULE in $MODULES; do
+        echo "$MODULE" > /tmp/simple_network_setup/udevmodulelist/${ONEMODULE//-/_}
+    done
+fi

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -35,6 +35,7 @@
 #190210 v2.2: Avoid wait after link timeout.
 #190525 v2.3: Allow for udev list updates; correct module loading & connection checks; add/restore wait for interfaces to configure.
 #200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
+#201017 v2.4: Change module detection to handle multiple aliases for a device and driver preferences; ignore driver names when gathering connection MAC addresses; remove use of devpaths, which are no longer created; wait for link up 1 second as well as 3 & 5. 
 
 #If version is changed, ensure that new VERSION is set in the sns script. #190525
 
@@ -127,49 +128,64 @@ CONNECTION_DRIVER_LIST="$(cut -f 3 -d '|' /etc/simple_network_setup/connections 
 [ -z "$CONNECTION_DRIVER_LIST" ] && exit
 CONNECTION_DRIVER_COUNT="$(echo "$CONNECTION_DRIVER_LIST" | grep -vE '^$' | wc -l)" #190525
 CONNECTION_DRIVER_PATTERNS="$(echo "$CONNECTION_DRIVER_LIST" | sed 's%.*%/&.ko%')"
-CONNECTION_BUILTIN_PATTERNS="$(grep -soF "${CONNECTION_DRIVER_PATTERNS}" /lib/modules/$(uname -r)/modules.builtin | sed 's%/\(.*\)\.ko%|\1|%')"
-
-WAITCNT=0 ; WAITDRVRS=8 ; WAITMAX=12 #180108 190525
-#wait for interfaces to become available...
-#note, do not test for wlan0 or wlan1 (etc) to become available, as these can change depending on plugged-in devices.
-[ "$ARGUMENT" != 'start' ] && sleep 1 # Unless started by sns, allow time for all module loading to be initiated. #190525
-while [ 1 ];do #190525
- # Collect names of modules identified by udev events...
- UDEV_RULE_LIST="$(ls -1 /tmp/simple_network_setup/udevmodulelist/ 2>/dev/null)"
- # Collect names of any modules substituted by backend_modprobe...
- SUBSTITUTE_LIST="$(grep -sho '^MODULE=[^ ]*' /tmp/pup_event_backend/pup_event_module_devpath_log* \
-   | cut -f2 -d =)"
- LOADED_CONNECTION_MODULE_PATTERNS=''
- if [ -n "${UDEV_RULE_LIST}${SUBSTITUTE_LIST}${CONNECTION_BUILTIN_PATTERNS}" ];then #190525
-  # Get names of connection modules being loaded & the number of them (except substitutes)...
-  ACTIVE_CONNECTION_MODULE_LIST="$(echo "$CONNECTION_DRIVER_LIST" | grep -xF "${UDEV_RULE_LIST}${SUBSTITUTE_LIST}" | grep -vE '^$')"
-  ACTIVE_CONNECTION_MODULE_COUNT="$(echo "$CONNECTION_DRIVER_LIST" | grep -xF "${UDEV_RULE_LIST}" | grep -vE '^$' | wc -l)"
-  if [ $ACTIVE_CONNECTION_MODULE_COUNT -ge $CONNECTION_DRIVER_COUNT ] \
-    || [ $WAITCNT -ge $WAITDRVRS ];then #190525
-   LOADED_CONNECTION_MODULE_PATTERNS="$(lsmod | cut -f 1 -d ' ' | grep -xF "${ACTIVE_CONNECTION_MODULE_LIST}" | sed 's%^.*%|&|%')"
-   LOADED_CONNECTION_MODULE_COUNT="$(echo "$LOADED_CONNECTION_MODULE_PATTERNS" | grep -vE '^$' | wc -l)"
-   [ $LOADED_CONNECTION_MODULE_COUNT -ge $ACTIVE_CONNECTION_MODULE_COUNT ] && break
+CONNECTION_BUILTIN_DRIVERS="$(grep -soF "${CONNECTION_DRIVER_PATTERNS}" /lib/modules/$(uname -r)/modules.builtin | sed 's%.*/\([^/]*\)\.ko%\1%')" #201017...
+if [ -n "$CONNECTION_BUILTIN_DRIVERS" ];then
+ CONNECTION_MODULE_LIST="$(echo -n "$CONNECTION_DRIVER_LIST" | grep -vF "$CONNECTION_BUILTIN_DRIVERS")"
+else
+ CONNECTION_MODULE_LIST="$CONNECTION_DRIVER_LIST"
+fi
+if [ -n "$CONNECTION_MODULE_LIST" ];then #201017
+ WAITCNT=0 ; WAITDRVRS=8 ; WAITMAX=12 #180108 190525
+ #wait for interfaces to become available...
+ #note, do not test for wlan0 or wlan1 (etc) to become available, as these can change depending on plugged-in devices.
+ [ "$ARGUMENT" != 'start' ] && sleep 1 # Unless started by sns, allow time for all module loading to be initiated. #190525
+ while [ 1 ];do #190525
+  # Collect names of modules identified by udev events...
+  UDEV_RULE_LIST="$(ls -1 /tmp/simple_network_setup/udevmodulelist/ 2>/dev/null)"
+  # Collect names of any modules substituted by backend_modprobe...
+  #201017 udevmodulelist may include files for multiple drivers for same device; they identify the module expected to be loaded, based on default (last alias listed), blacklisting and preference.
+  LOADED_CONNECTION_MODULE_PATTERNS=''
+  if [ -n "$UDEV_RULE_LIST" ];then #190525 201017
+   # Get names of connection modules being loaded & the number of them (except substitutes)...
+   ACTIVE_CONNECTION_MODULE_NAME_PATH_LIST="$(echo "$CONNECTION_MODULE_LIST" | \
+     grep -xF "${UDEV_RULE_LIST}" | \
+     sed 's%^.*%/tmp/simple_network_setup/udevmodulelist/&%' | tr '\n' ' ')" #201017
+   if [ -n "$ACTIVE_CONNECTION_MODULE_NAME_PATH_LIST" ];then #201017
+    ACTIVE_CONNECTION_MODULE_LOAD_LIST="$(cat $ACTIVE_CONNECTION_MODULE_NAME_PATH_LIST | \
+      sort -u | sed 's%^.*/%%')" #201017
+    if [ -n "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" ];then #201017
+     ACTIVE_CONNECTION_MODULE_COUNT="$(echo "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" | wc -l)" #201017
+     if [ $ACTIVE_CONNECTION_MODULE_COUNT -ge $CONNECTION_DRIVER_COUNT ] \
+       || [ $WAITCNT -ge $WAITDRVRS ];then #190525
+      LOADED_CONNECTION_MODULE_PATTERNS="$(lsmod | cut -f 1 -d ' ' | \
+        grep -xF "${ACTIVE_CONNECTION_MODULE_LOAD_LIST}" | sed 's%^.*%|&|%')" #201017
+      LOADED_CONNECTION_MODULE_COUNT="$(echo "$LOADED_CONNECTION_MODULE_PATTERNS" | grep -vE '^$' | wc -l)"
+      [ $LOADED_CONNECTION_MODULE_COUNT -ge $ACTIVE_CONNECTION_MODULE_COUNT ] && break
+     fi #190525
+    fi #201017
+   fi #201017
   fi #190525
- fi #190525
- [ $WAITCNT -ge $WAITDRVRS ] && break #all modules not loaded.
- sleep 1
- WAITCNT=$(($WAITCNT + 1))
-done
-
-AVAILABLE_CONNECTIONS='' #190525...
-if [ -n "${LOADED_CONNECTION_MODULE_PATTERNS}${CONNECTION_BUILTIN_PATTERNS}" ];then
- CONNECTION_MACADDRESSES="$(grep -F "${LOADED_CONNECTION_MODULE_PATTERNS}${CONNECTION_BUILTIN_PATTERNS}" /etc/simple_network_setup/connections |  cut -f 6 -d '|' | sort -u)"
- CONNECTION_MACADDRESS_COUNT="$(echo "$CONNECTION_MACADDRESSES" | grep -vE '^$' | wc -l)"
- while [ 1 ];do
-  ACTIVE_MACADDRESS_PATTERNS="$(ifconfig -a | grep 'Link encap:Ethernet' | grep -o 'HWaddr .*' | cut -f 2 -d ' ' | sed 's%^.*%|&|%')"
-  AVAILABLE_CONNECTIONS="$(grep -F "${LOADED_CONNECTION_MODULE_PATTERNS}${CONNECTION_BUILTIN_PATTERNS}" /etc/simple_network_setup/connections | grep -F "${ACTIVE_MACADDRESS_PATTERNS}")"
-  AVAILABLE_CONNECTION_COUNT="$(echo "$AVAILABLE_CONNECTIONS" | grep -vE '^$' | wc -l)"
-  [ $AVAILABLE_CONNECTION_COUNT -ge $CONNECTION_MACADDRESS_COUNT ] && break
-  [ $WAITCNT -ge $WAITMAX ] && break 
+  [ $WAITCNT -ge $WAITDRVRS ] && break #all modules not loaded.
   sleep 1
   WAITCNT=$(($WAITCNT + 1))
  done
-fi
+fi #201017
+[ -z "$LOADED_CONNECTION_MODULE_PATTERNS" ] \
+  && [ -z "$CONNECTION_BUILTIN_DRIVERS" ] \
+  && cancel_splash_and_exit #201017
+
+AVAILABLE_CONNECTIONS='' #190525...
+CONNECTION_MACADDRESSES="$(cut -f 6 -d '|' /etc/simple_network_setup/connections | sort -u)" #201017
+CONNECTION_MACADDRESS_COUNT="$(echo "$CONNECTION_MACADDRESSES" | grep -vE '^$' | wc -l)"
+while [ 1 ];do
+ ACTIVE_MACADDRESS_PATTERNS="$(ifconfig -a | grep 'Link encap:Ethernet' | grep -o 'HWaddr .*' | cut -f 2 -d ' ' | sed 's%^.*%|&|%')"
+ AVAILABLE_CONNECTIONS="$(grep -F "${ACTIVE_MACADDRESS_PATTERNS}" /etc/simple_network_setup/connections)" #201017
+ AVAILABLE_CONNECTION_COUNT="$(echo "$AVAILABLE_CONNECTIONS" | wc -l)"
+ [ $AVAILABLE_CONNECTION_COUNT -ge $CONNECTION_MACADDRESS_COUNT ] && break
+ [ $WAITCNT -ge $WAITMAX ] && break 
+ sleep 1
+ WAITCNT=$(($WAITCNT + 1))
+done
 [ $WAITCNT -gt 0 ] && echo "SNS rc.network: waited for ethernet interfaces: seconds=${WAITCNT}" #180115
 echo "$AVAILABLE_CONNECTIONS" > /tmp/sns_connections_available
 [ -z "$AVAILABLE_CONNECTIONS" ] && cancel_splash_and_exit #181109 end
@@ -209,11 +225,11 @@ if [ -s /tmp/sns_connections_wireless ];then #170924
   ifconfig $INTERFACE up
   [ $? -ne 0 ] && continue
   echo " SUCCESS: ifconfig ${INTERFACE} up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-  sleep 3
-  SECS=3
+  sleep 1 #201017
+  SECS=1 #201017
   ESSID_PATTERNS="$(sed 's/.*/ESSID:"&"/' /tmp/simple_network_setup/essids-want)"
   echo " EXECUTING SCAN: iwlist ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706
-  for I in 1 2;do
+  for I in 1 2 3;do #201017
    SCANRESULT="`iwlist $INTERFACE scan | grep -E 'Address:|Channel:|Frequency:|Quality[:=]|Encryption key:|ESSID:|Scan completed|No scan results'`" ###SCANNING### 110203 180706
    echo " SCANRESULT=${SCANRESULT}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
    #note, possible to get: 'wlan0     No scan results' so delay then try again...
@@ -222,9 +238,9 @@ if [ -s /tmp/sns_connections_wireless ];then #170924
    else
     SCAN_WANTS="$(echo "$SCANRESULT" | grep -m 1 'Scan completed')"
    fi
-   [ "$SCANRESULT" != "" -o $I -gt 1 ] && break
+   [  -n "$SCANRESULT" ] || [ $I -ge 3 ] && break #201017
    sleep 2
-   SECS=5
+   SECS=$(($SECS + 2)) #201017
    echo " EXECUTING SCAN AGAIN: iwlist ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706
   done
   ifconfig $INTERFACE down

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -41,9 +41,11 @@
 #190525 v2.3: Add version to main window; re-check SNS running, in case slow to terminate; for interface change, kill current connection.
 #200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
 #200521 v2.3.2: Correct damage to SNS_error dialog window title syntax; export version.
-#201001 v2.3.3: Change SRLINES to handle (erroneously) positive signal level for sort; ensure driver names placed in udevmodulelist for immediate use.
-
-export VERSION='2.3.3'  #UPDATE this with each release!
+#201001 v2.3.3: Change SRLINES to handle (erroneously) positive signal level for sort.
+#201017 v2.4: Change module detection to handle multiple aliases for a device and driver preferences (in rc.network & build_udevmodulelist).
+#201110 v2.4.1: Test for connection with udhdpc (peasywifi), as well as dhcpcd; make SNS current before networkdisconnect.
+ 
+export VERSION='2.4.1'  #UPDATE this with each release!
 
 export TEXTDOMAIN=sns___sns
 export OUTPUT_CHARSET=UTF-8
@@ -124,22 +126,18 @@ do
   WINDRVR="`ndiswrapper -l | grep '^[a-zA-Z0-9]' | cut -f 1 -d ' '`"
   IF_INFO="MS Windows driver '${WINDRVR}'"
  fi
- if [ ! -e /tmp/simple_network_setup/udevmodulelist/$IF_DRIVER ];then #201001...
-  mkdir -p /tmp/simple_network_setup/udevmodulelist
-  touch /tmp/simple_network_setup/udevmodulelist/$IF_DRIVER
- fi
 
-  #want to manipulate the info string for display purposes...
-  CNTLINE=0;FINALINFO=""
-  for ONEWORD in $IF_INFO
-  do
-   CNTWORD=`echo "$ONEWORD" | wc -c`
-   CNTLINE=`expr $CNTLINE + $CNTWORD`
-   [ $CNTLINE -gt $BIGGESTCNT ] && BIGGESTCNT=$CNTLINE #use for window width.
-   [ $CNTLINE -gt 60 ] && break
-   FINALINFO="${FINALINFO}${ONEWORD} " #ensures whole words only in string.
-  done
-  IF_INFO="`echo -n "$FINALINFO"  | tr '[&|"<>]' ' ' | tr -s ' '`" #'geany. filter out chars that mess up xml.
+ #want to manipulate the info string for display purposes...
+ CNTLINE=0;FINALINFO=""
+ for ONEWORD in $IF_INFO
+ do
+  CNTWORD=`echo "$ONEWORD" | wc -c`
+  CNTLINE=`expr $CNTLINE + $CNTWORD`
+  [ $CNTLINE -gt $BIGGESTCNT ] && BIGGESTCNT=$CNTLINE #use for window width.
+  [ $CNTLINE -gt 60 ] && break
+  FINALINFO="${FINALINFO}${ONEWORD} " #ensures whole words only in string.
+ done
+ IF_INFO="`echo -n "$FINALINFO"  | tr '[&|"<>]' ' ' | tr -s ' '`" #'geany. filter out chars that mess up xml.
 
  IF_INTTYPE='Wired'
  if interface_is_wireless ${INTERFACE} ; then
@@ -152,7 +150,7 @@ do
  ALL_IF_BUS="${ALL_IF_BUS}|${IF_BUS}"
  ALL_IF_INFO="${ALL_IF_INFO}|${IF_INFO}"
  INTERFACEBUTTONS="${INTERFACEBUTTONS} 
-  <button><label>${INTERFACE}</label><action type=\"exit\">Interface_${INTERFACE}</action></button>"
+ <button><label>${INTERFACE}</label><action type=\"exit\">Interface_${INTERFACE}</action></button>"
  #save all data about each interface on one line...
  #ex: wlan1|Wireless|ath5k|pci|Support for 5xxx series of Atheros 802.11 wireless LAN cards
  echo "${INTERFACE}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}" >> /tmp/sns_interfaces
@@ -179,10 +177,10 @@ $ALL_IF_INFO\"</label></text>
 #test if connected to internet...
 FLAGINTERNETSTATUS='no'
 WORKINGIF=''
-if [ "`pidof dhcpcd`" != "" ];then
+if [ "`pidof dhcpcd udhcpc`" != "" ];then #201110
  if [ "`grep -v '^#' /etc/resolv.conf`" != "" ];then
   PSALL="`busybox ps`"
-  PSDHCPCD="`echo "$PSALL" | grep 'dhcpcd'`"
+  PSDHCPCD="`echo "$PSALL" | grep -E 'dhcpcd|udhcpc'`" #201110
   for ONEIF in `ifconfig | grep '^[a-z]' | cut -f 1 -d ' ' | grep -v '^lo' | tr '\n' ' '`
   do
    if [ "`echo "$PSDHCPCD" | grep "$ONEIF"`" != "" ];then
@@ -262,9 +260,9 @@ if [ -s /etc/simple_network_setup/connections ];then
   grep -qswv 'sns' /root/.connectwizardrc \
    && DISCONNECT_EXIT='EXITRESTART' \
    || DISCONNECT_EXIT='EXITNOW' #190223
-  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_no.svg`<label>$(gettext 'Disconnect Now')</label><action>/usr/sbin/networkdisconnect</action>$CONNECTWIZEXEC_XML<action type=\"exit\">${DISCONNECT_EXIT}</action></button>" #190223
+  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_no.svg`<label>$(gettext 'Disconnect Now')</label>$CONNECTWIZEXEC_XML<action>/usr/sbin/networkdisconnect</action><action type=\"exit\">${DISCONNECT_EXIT}</action></button>" #190223 201110
  else
-  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_yes.svg`<label>$(gettext 'Connect Now')</label><action>/usr/sbin/networkdisconnect</action>$CONNECTWIZEXEC_XML<action>/usr/local/simple_network_setup/rc.network start & </action><action>connect_button_splash</action><action type=\"exit\">EXITNOW</action></button>" #170505 190223
+  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_yes.svg`<label>$(gettext 'Connect Now')</label>$CONNECTWIZEXEC_XML<action>/usr/sbin/networkdisconnect</action><action>/usr/local/simple_network_setup/rc.network start & </action><action>connect_button_splash</action><action type=\"exit\">EXITNOW</action></button>" #170505 190223 201110
  fi
  grep -qswv 'sns' /root/.connectwizardrc \
   && DISCONNECT_XML="$(gettext '<b>Note:</b> The current connection was started by another network tool.  To control it with SNS, disconnect now, then re-connect or choose an interface.')" \


### PR DESCRIPTION
build_udevmodulelist rewritten to save module names expected to be loaded (considering preferences and default substitutions), accessed by connection driver name (from /sys/class/net/*/device/driver link); rc.network module detection updated to handle multiple aliases for a device, and driver preferences.

rc.network updated to ignore driver names when gathering connection MAC addresses; remove use of devpaths, which are no longer created; and wait for "link up" 1 second as well as 3 & 5 seconds.

sns updated to test for connection with udhdpc (peasywifi), as well as dhcpcd, and to make SNS the current network manager before networkdisconnect (because networkdisconnect stops previous manager).