### PR TITLE
88-puppy-autodetect.rules: Improve event filtering

### DIFF
--- a/woof-code/rootfs-skeleton/etc/udev/rules.d/88-puppy-autodetect.rules
+++ b/woof-code/rootfs-skeleton/etc/udev/rules.d/88-puppy-autodetect.rules
@@ -3,8 +3,8 @@
 
 ###CAMERA###
 #digital camera plugged in via usb...
-ACTION=="add", SUBSYSTEM=="usb", ENV{ID_GPHOTO2}=="1", RUN+="/usr/sbin/pupautodetect camera"
+ACTION=="add", SUBSYSTEM=="usb", DEVTYPE="*interface", ENV{ID_GPHOTO2}=="1", RUN+="/usr/sbin/pupautodetect camera"
 
 ###MTP Device###
 #mtp device plugged in via usb...
-ACTION=="add", SUBSYSTEM=="usb", ENV{ID_MTP_DEVICE}=="1", RUN+="/usr/sbin/pupautodetect android-device"
+ACTION=="add", SUBSYSTEM=="usb", DEVTYPE="*interface", ENV{ID_MTP_DEVICE}=="1", RUN+="/usr/sbin/pupautodetect android-device"


### PR DESCRIPTION
Improve event filter to avoid running multiple instances of pupcamera and pupmtp when a device was plugged in. Only one event will trigger