### PR TITLE
pupautodetect: Tweak for pupcamera and pupmtp

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/pupautodetect
+++ b/woof-code/rootfs-skeleton/usr/sbin/pupautodetect
@@ -25,11 +25,31 @@ please_install() {
 
 case $1 in
  camera)
+   
+  #kill pupcamera gui first if present
+  pupcampids=$(busybox ps | grep "gtkdialog" | grep "PCAMGUI" | awk '{ print $1 }' | tr '\n' ' ')
+   
+  for xpid in $pupcampids
+  do
+   kill $xpid
+  done
+   
   pupcamera &
+ 
  ;;
  android-device)
   if [ "$(which pupmtp)" != "" ]; then
+  
+   #kill pupmtp gui first if present
+   pupmtppids=$(busybox ps | grep "gtkdialog" | grep "PMTPGUI" | awk '{ print $1 }' | tr '\n' ' ')
+   
+   for xpid in $pupmtppids
+   do
+    kill $xpid
+   done
+  
    pupmtp &
+  
   elif [ "$(which mtpdevice)" != "" ]; then
    mtpdevice mount &
   else


### PR DESCRIPTION
Refresh the pupmtp and pupcamera GUI. Kill the present pids then start a new one instead of running pupcamera and pupmtp in multiple instance in every plug of PTP and MTP devices