### PR TITLE
xorg-autoconf: Improved fallback

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -1003,6 +1003,25 @@ EndSection
 	
 }
 
+write_fallback_guess(){
+
+if [ -e /sys/firmware/efi ]; then
+ drvname="fbdev"
+else
+  if [ "$(ls /dev/fb* 2>/dev/null)" != "" ]; then
+   drvname="fbdev"
+  else
+   drvname="vesa"
+  fi
+fi
+
+echo 'Section "Device"
+	Identifier  "Card0"
+	Driver      "'$drvname'" #card0driver
+EndSection
+'
+
+}	
 
 #Look for available input drivers
 if [ ! -e $XORG_MODULE_PATH/input/kbd_drv.so ]; then
@@ -1319,53 +1338,65 @@ else
 
 #Probe video cards and generate configuration
 
-vcards=$(ls /sys/class/drm/card*/device/vendor | sed -e "s#\/device\/vendor##g" | xargs basename)
+ if [ -e /sys/class/drm ]; then
+  vcards=$(ls /sys/class/drm/card*/device/vendor 2>/dev/null | sed -e "s#\/device\/vendor##g" | xargs basename 2>/dev/null)
+ else
+  vcards=""
+ fi
 
-for vcard in $vcards
-do
+ if [ "$vcards" != "" ]; then
 
-	vid="$(cat /sys/class/drm/$vcard/device/vendor | cut -f 2 -d 'x' 2>/dev/null)"
-	dvid="$(cat /sys/class/drm/$vcard/device/device | cut -f 2 -d 'x' 2>/dev/null)"
-	cnum="$(echo $vcard | sed -e "s#card##g" 2>/dev/null)"
+	for vcard in $vcards
+	do
 
-	case $vid in
-		8086) probe_intel "${vid}:${dvid}" "$cnum" ;;
-		5333) probe_s3 "${vid}:${dvid}" "$cnum" ;;
-		121a) probe_3dfx "${vid}:${dvid}" "$cnum" ;;
-		18ca) probe_xgi "${vid}:${dvid}" "$cnum" ;;
-		10de) probe_nvidia "${vid}:${dvid}" "$cnum" ;;
-		1092) probe_diamond "${vid}:${dvid}" "$cnum" ;;
-		1023) probe_trident "${vid}:${dvid}" "$cnum" ;;
-                1002|1022) probe_amd "${vid}:${dvid}" "$cnum" ;;		
-		1412|1106) probe_via "${vid}:${dvid}" "$cnum" ;;
-		15ad|fffe) probe_vmware "${vid}:${dvid}" "$cnum" ;;
-		1013) write_generic "${vid}:${dvid}" "$cnum" cirrus ;;
-		1039) write_generic "${vid}:${dvid}" "$cnum" sis ;;
-		102b) write_generic "${vid}:${dvid}" "$cnum" mga ;;
-		10c8) write_generic "${vid}:${dvid}" "$cnum" neomagic ;;
-		100c) write_generic "${vid}:${dvid}" "$cnum" tseng ;;
-		1a03) write_generic "${vid}:${dvid}" "$cnum" ast ;;
-		1142) write_generic "${vid}:${dvid}" "$cnum" apm ;;
-		edd8) write_generic "${vid}:${dvid}" "$cnum" ark ;;
-		102c) write_generic "${vid}:${dvid}" "$cnum" chips ;;
-		105d) write_generic "${vid}:${dvid}" "$cnum" i128 ;;
-		126f) write_generic "${vid}:${dvid}" "$cnum" siliconmotion ;;
-		1011) write_generic "${vid}:${dvid}" "$cnum" tga ;;
-		1078) write_generic "${vid}:${dvid}" "$cnum" cyrix ;;
-		10a9) write_generic "${vid}:${dvid}" "$cnum" newport ;;
-		100b) write_generic "${vid}:${dvid}" "$cnum" nsc ;;
-		1163) write_generic "${vid}:${dvid}" "$cnum" rendition ;;
-		80ee) write_generic "${vid}:${dvid}" "$cnum" vboxvideo ;;
-		10e0) write_generic "${vid}:${dvid}" "$cnum" imstt ;;
-		104e) write_generic "${vid}:${dvid}" "$cnum" oak ;;
-		003d) write_generic "${vid}:${dvid}" "$cnum" i740 ;;
-		10b4) write_generic "${vid}:${dvid}" "$cnum" s3virge ;;
-		1179) write_generic "${vid}:${dvid}" "$cnum" trident ;;
-		1115|104c|3d3d) write_generic "${vid}:${dvid}" "$cnum" glint ;;		
-		*) write_fallback "${vid}:${dvid}" "$cnum";;
-	esac
+		vid="$(cat /sys/class/drm/$vcard/device/vendor | cut -f 2 -d 'x' 2>/dev/null)"
+		dvid="$(cat /sys/class/drm/$vcard/device/device | cut -f 2 -d 'x' 2>/dev/null)"
+		cnum="$(echo $vcard | sed -e "s#card##g" 2>/dev/null)"
 
-done
+		case $vid in
+			8086) probe_intel "${vid}:${dvid}" "$cnum" ;;
+			5333) probe_s3 "${vid}:${dvid}" "$cnum" ;;
+			121a) probe_3dfx "${vid}:${dvid}" "$cnum" ;;
+			18ca) probe_xgi "${vid}:${dvid}" "$cnum" ;;
+			10de) probe_nvidia "${vid}:${dvid}" "$cnum" ;;
+			1092) probe_diamond "${vid}:${dvid}" "$cnum" ;;
+			1023) probe_trident "${vid}:${dvid}" "$cnum" ;;
+					1002|1022) probe_amd "${vid}:${dvid}" "$cnum" ;;		
+			1412|1106) probe_via "${vid}:${dvid}" "$cnum" ;;
+			15ad|fffe) probe_vmware "${vid}:${dvid}" "$cnum" ;;
+			1013) write_generic "${vid}:${dvid}" "$cnum" cirrus ;;
+			1039) write_generic "${vid}:${dvid}" "$cnum" sis ;;
+			102b) write_generic "${vid}:${dvid}" "$cnum" mga ;;
+			10c8) write_generic "${vid}:${dvid}" "$cnum" neomagic ;;
+			100c) write_generic "${vid}:${dvid}" "$cnum" tseng ;;
+			1a03) write_generic "${vid}:${dvid}" "$cnum" ast ;;
+			1142) write_generic "${vid}:${dvid}" "$cnum" apm ;;
+			edd8) write_generic "${vid}:${dvid}" "$cnum" ark ;;
+			102c) write_generic "${vid}:${dvid}" "$cnum" chips ;;
+			105d) write_generic "${vid}:${dvid}" "$cnum" i128 ;;
+			126f) write_generic "${vid}:${dvid}" "$cnum" siliconmotion ;;
+			1011) write_generic "${vid}:${dvid}" "$cnum" tga ;;
+			1078) write_generic "${vid}:${dvid}" "$cnum" cyrix ;;
+			10a9) write_generic "${vid}:${dvid}" "$cnum" newport ;;
+			100b) write_generic "${vid}:${dvid}" "$cnum" nsc ;;
+			1163) write_generic "${vid}:${dvid}" "$cnum" rendition ;;
+			80ee) write_generic "${vid}:${dvid}" "$cnum" vboxvideo ;;
+			10e0) write_generic "${vid}:${dvid}" "$cnum" imstt ;;
+			104e) write_generic "${vid}:${dvid}" "$cnum" oak ;;
+			003d) write_generic "${vid}:${dvid}" "$cnum" i740 ;;
+			10b4) write_generic "${vid}:${dvid}" "$cnum" s3virge ;;
+			1179) write_generic "${vid}:${dvid}" "$cnum" trident ;;
+			1115|104c|3d3d) write_generic "${vid}:${dvid}" "$cnum" glint ;;		
+			*) write_fallback "${vid}:${dvid}" "$cnum";;
+		esac
+
+	done
+
+ else
+
+  write_fallback_guess
+
+ fi
 
 fi
 


### PR DESCRIPTION
Fallback to vesa or fbdev if /sys/class/drm is missing