### PR TITLE
Add a package template for dmz-cursor-theme

### DIFF
--- a/woof-code/packages-templates/dmz-cursor-theme_FIXUPHACK
+++ b/woof-code/packages-templates/dmz-cursor-theme_FIXUPHACK
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+mkdir -p root/.icons
+ln -s ../../usr/share/icons/DMZ-White root/.icons/


### PR DESCRIPTION
Dark Gray uses DMZ-White, and if it's not available, we fall back to the generic X cursor.