### PR TITLE
Add a browser-centric pinboard layout

### DIFF
--- a/woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals/Dark Gray
+++ b/woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals/Dark Gray
@@ -1,7 +1,7 @@
 ICON="/usr/share/pixmaps/puppy/puppy_theme_dark_gray.svg"
 PTHEME_ICONS="StandardSvg"
 PTHEME_ICONS_GTK="Puppy Standard"
-PTHEME_ROX_PIN="Puppy Standard"
+PTHEME_ROX_PIN="Cloud"
 PTHEME_ROX_DRIVEICONS="Puppy bottom"
 PTHEME_GTK="Raleigh"
 PTHEME_JWM_COLOR="Dark_gray"

--- a/woof-code/rootfs-packages/ptheme/usr/share/ptheme/rox_pinboard/Cloud
+++ b/woof-code/rootfs-packages/ptheme/usr/share/ptheme/rox_pinboard/Cloud
@@ -1,0 +1,8 @@
+  <icon x="32" y="32" label="file">/usr/local/bin/defaultfilemanager</icon>
+  <icon x="96" y="32" label="setup">/usr/sbin/wizardwizard</icon>
+  <icon x="160" y="32" label="console">/usr/local/bin/defaultterminal</icon>
+  <icon x="32" y="128" label="browse">/usr/local/bin/defaultbrowser</icon>
+  <icon x="96" y="128" label="email">/usr/local/bin/defaultemail</icon>
+  <icon x="160" y="128" label="connect">/usr/local/apps/Connect</icon>
+  <icon x="1248" y="32" label="lock">/usr/local/apps/Xlock</icon>
+  <icon x="1248" y="128" label="trash">/usr/local/apps/Trash</icon>


### PR DESCRIPTION
It's less minimal than the minimal layout, but has the basics needed for a Chromebook-style laptop covered (Just the file, setup, console, browse, email and connect icons).

The ARM Chromebook port won't come with many applications, expecting the user to use cloud tools or install applications.