### PR TITLE
restore the blank /etc/resolv.conf from before #1972

### DIFF
--- a/woof-code/rootfs-skeleton/etc/resolv.conf
+++ b/woof-code/rootfs-skeleton/etc/resolv.conf
@@ -1,1 +1,1 @@
-nameserver 8.8.8.8
+# nameservers go in here


### PR DESCRIPTION
This is a purely cosmetic change.

One might argue that having a pre-configured DNS server may cause leak of private data (DNS queries) to a specific DNS server, if you set up your internet connection manually, in the short time window between the `ifconfig` and the modification of `/etc/resolv.conf`. Most people use DHCP, though.