### PR TITLE
Wait before starting network, but without blocking init

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -654,11 +654,13 @@ if which dbus-daemon >/dev/null 2>&1 ; then
 fi
 
 #----------------------
-sleep 5 # in some cases network modules take some time to load
-#100814 100903 record cumulative tx/rx, see also network_tray and rc.shutdown.
-#181209 tx/rx logic now included in network_default_connect...
-# Connect "current" or default network through eth0, frisbee, sns, network wizard, pgprs-connect, etc.
-network_default_connect --sysinit #181209
+(
+ sleep 5 # in some cases network modules take some time to load
+ #100814 100903 record cumulative tx/rx, see also network_tray and rc.shutdown.
+ #181209 tx/rx logic now included in network_default_connect...
+ # Connect "current" or default network through eth0, frisbee, sns, network wizard, pgprs-connect, etc.
+ network_default_connect --sysinit #181209
+) &
 #----------------------
 
 echo -n ", printing, etc.)..." >/dev/console


### PR DESCRIPTION
Assuming this `sleep 5` is actually needed and it's not some ancient hack useful for a single laptop in 2010, why block the rest of the init process (i.e. audio, login, etc')?

EDIT: I wonder how many users will notice that Slacko 7.0.1 (?) boots much faster, or mention how optimized and fast it feels compared to 6.x, without knowing it's this `sleep 5` that's no longer blocking :)