### PR TITLE
make Dark Gray window borders smaller

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes/Dark_gray-jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes/Dark_gray-jwmrc
@@ -3,8 +3,9 @@
 
 	<WindowStyle>
 		<Font>DejaVu Sans-10</Font>
-		<Width>3</Width>
-		<Height>22</Height>
+		<Width>1</Width>
+		<Corner>0</Corner>
+		<Height>20</Height>
 		<Active>
 			<Foreground>black</Foreground>
 			<Background>#e2e2de</Background>


### PR DESCRIPTION
I revived this theme as part of my ARM Chromebook porting effort, because I want a relatively dark, neutral and boring (boring is good) theme that doesn't eat up a lot of screen space.