### PR TITLE
make dialog windows opaque when using a compositor

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes/Dark_gray-jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes/Dark_gray-jwmrc
@@ -13,6 +13,7 @@
 		<Foreground>black</Foreground>
 		<Background>#999999</Background>
 		<Outline>black</Outline>
+		<Opacity>1.0</Opacity>
 	</WindowStyle>
 
 	<TrayStyle>


### PR DESCRIPTION
I'm using `picom` (compton fork) and rendering is slow on the C201, when there's a translucent window. I wasted hours trying to figure out why some windows are transparent, after configuring `picom` not to do this. Then, while trying to patch JWM for an unrelated reason, I found this:

```
./src/settings.c:   settings.inactiveClientOpacity = (unsigned int)(0.75 * UINT_MAX);
```
To avoid breaking other themes and changing the looks of existing Puppies, I changed the default window opacity of windows to 1.0, only in the Dark Gray theme that I use on the C201.