### PR TITLE
Create a package template for fonts-liberation, without rarely used fonts

### DIFF
--- a/woof-code/packages-templates/fonts-liberation_FIXUPHACK
+++ b/woof-code/packages-templates/fonts-liberation_FIXUPHACK
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+list='LiberationMono-Regular.ttf
+LiberationSans-Regular.ttf
+LiberationSans-Bold.ttf
+LiberationSerif-Regular.ttf
+LiberationSerif-Bold.ttf'
+
+liberation=$(find . -name LiberationSans-Regular.ttf)
+dir=$(dirname $liberation)
+
+mkdir -p TTF
+for i in $list
+do
+	mv ${dir}/${i} TTF/
+done
+
+rm -rf usr etc
+
+mkdir -p usr/share/fonts/default/
+mv TTF usr/share/fonts/default/
+


### PR DESCRIPTION
This short list of fonts plus the trimmed DejaVu font package we use, gives a great size to website appearance ratio. With the addition of this trimmed down Liberation fonts package, websites like GitHub look normal.