### PR TITLE
Add symbolic arrow icons to the GTK 3 template

### DIFF
--- a/woof-code/packages-templates/gtk3_FIXUPHACK
+++ b/woof-code/packages-templates/gtk3_FIXUPHACK
@@ -6,3 +6,17 @@ if [ -f usr/lib/${ARCHDIR}/libgtk-3-0/gtk-query-immodules-3.0 ] ; then
 	ln -sv ../lib/${ARCHDIR}/libgtk-3-0/gtk-query-immodules-3.0 \
 			usr/bin/gtk-query-immodules-3.0
 fi
+
+# raleigh-reloaded and possibly other themes need the arrow symbolic icons
+if [ -d usr/share/icons/Adwaita ]; then
+	cd usr/share/icons/Adwaita
+	rm -rf [0-9]*x* cursor* scalable-*
+	find scalable -type f | while read ICON; do
+		case $ICON in
+		*/pan-*) ;;
+		*) rm -f $ICON ;;
+		esac
+	done
+	rmdir scalable/* 2>/dev/null
+	cd ../../../..
+fi


### PR DESCRIPTION
adwaita-icon-theme is a pretty big package and it contains many .png images, which may increase the main SFS size a lot, because they're compressed.

raleigh-reloaded, and by extension, [gtk3_flat_grey_rounded](https://github.com/dimkr/gtk3_flat_grey_rounded), needs the arrow icons for comboboxes, etc'.

Luckily, we need only the arrow icons (as far as I see), and the SVG ones are enough:

```
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui/pan-down-symbolic.svg
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui/pan-end-symbolic.svg
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui/pan-start-symbolic.svg
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui/pan-up-symbolic.svg
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui/pan-start-symbolic-rtl.svg
packages-bullseye/gtk+3/usr/share/icons/Adwaita/scalable/ui/pan-end-symbolic-rtl.svg
packages-bullseye/gtk+3/usr/share/icons/Adwaita/index.theme
```

Almost zero increase in size, and GTK 3 applications look much better now.