### PR TITLE
remove the minor version from SFS names if remove_sublevel=yes

### DIFF
--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -6,7 +6,7 @@ on:
       - ci
       - testing
     paths:
-      - 'woof-distro/x86_64/slackware/**'
+      - 'woof-distro/x86_64/slackware64/14.2/**'
       - 'woof-code/**'
       - '!woof-code/support/arm_**'
       - 'woof-arch/x86_64/**'
@@ -15,6 +15,13 @@ on:
       - '!**.png'
       - '!**.htm'
       - '!**.html'
+  pull_request:
+    branches:
+      - testing
+    paths:
+      - 'woof-distro/x86_64/slackware64/14.2/**'
+      - 'kernel-kit/build.sh'
+      - 'kernel-kit/slacko64-build.conf'
   schedule:
     - cron: '0 0 * * 4'
 

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -57,6 +57,7 @@ jobs:
         sudo install -D -m 644 woof-code/rootfs-skeleton/usr/local/petget/categories.dat /usr/local/petget/categories.dat
         echo "dash dash/sh boolean false" | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+        sudo ln -s bash /bin/ash
     - name: Fix cache ownership
       run: sudo chown -R root:root local-repositories
     - name: merge2out

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -430,6 +430,7 @@ if [ "$AUFS" != "no" ] ; then
 fi
 
 export FDRV=fdrv-${kernel_version}-${package_name_suffix}.sfs
+[ "$remove_sublevel" = "yes" ] && export FDRV=fdrv-`grep 'Kernel Configuration' .config | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}.sfs
 
 if [ -n "$fware" ] ; then
 	FIRMWARE_OPT=git
@@ -983,8 +984,10 @@ esac
 
 if [ "$kit_kernel" = "yes" ]; then
 	KERNEL_MODULES_SFS_NAME="kernel-modules-${kernel_version}${custom_suffix}-${package_name_suffix}.sfs"
+	[ "$remove_sublevel" = "yes" ] && KERNEL_MODULES_SFS_NAME="kernel-modules-`grep 'Kernel Configuration' ${KERNEL_SOURCES_DIR}/usr/src/linux/.config | cut -f 3 -d ' ' | cut -f 1-2 -d .`${custom_suffix}-${package_name_suffix}.sfs"
 else
 	KERNEL_MODULES_SFS_NAME="kernel-modules-${kernel_version}-${package_name_suffix}.sfs"
+	[ "$remove_sublevel" = "yes" ] && KERNEL_MODULES_SFS_NAME="kernel-modules-`grep 'Kernel Configuration' ${KERNEL_SOURCES_DIR}/usr/src/linux/.config | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}.sfs"
 fi
 
 if [ "$STRIP_KMODULES" = "yes" ] ; then

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -297,6 +297,16 @@ fi
 log_msg "Linux: ${kernel_major_version}${kmv}${kmr}" #${kernel_series}.
 
 # ===============================
+
+# if remove_sublevel=yes, we want use the kernel major version as the version of
+# the output - e.g. kernel_sources-4.19-slacko64.sfs for 4.19.172
+if [ "$remove_sublevel" = "yes" ]; then
+	package_version=${kernel_major_version}
+else
+	package_version=${kernel_version}
+fi
+
+# ===============================
 if [ "$AUFS" != "no" ] ; then
 	if [ ! "$aufsv" ] ; then
 		git_aufs_branch ${kernel_version} # sets $aufsv
@@ -429,8 +439,7 @@ if [ "$AUFS" != "no" ] ; then
 	fi
 fi
 
-export FDRV=fdrv-${kernel_version}-${package_name_suffix}.sfs
-[ "$remove_sublevel" = "yes" ] && export FDRV=fdrv-`echo $kernel_version | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}.sfs
+export FDRV=fdrv-${package_version}-${package_name_suffix}.sfs
 
 if [ -n "$fware" ] ; then
 	FIRMWARE_OPT=git
@@ -906,13 +915,9 @@ mv ${linux_kernel_dir} ../output ## ../output/${linux_kernel_dir}
 
 ## make fatdog kernel module package
 if [ "$kit_kernel" = "yes" ]; then
-	OUTPUT_VERSION="${kernel_version}${custom_suffix}-${package_name_suffix}"
+	OUTPUT_VERSION="${package_version}${custom_suffix}-${package_name_suffix}"
 else
-	if [ "$remove_sublevel" = "yes" ] ; then
-		OUTPUT_VERSION="`grep 'Kernel Configuration' .config | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}"
-	else
-		OUTPUT_VERSION="${kernel_version}-${package_name_suffix}"
-	fi
+	OUTPUT_VERSION="${package_version}-${package_name_suffix}"
 fi
 mv ../output/${linux_kernel_dir}/boot/vmlinuz \
 	../output/vmlinuz-${OUTPUT_VERSION}
@@ -936,9 +941,9 @@ if [ "$AUFS" != "no" ] ; then
 			output/${linux_kernel_dir}
 fi
 if [ "$kit_kernel" = "yes" ]; then
-	KERNEL_SOURCES_DIR="kernel_sources-${kernel_version}${custom_suffix}-${package_name_suffix}"
+	KERNEL_SOURCES_DIR="kernel_sources-${package_version}${custom_suffix}-${package_name_suffix}"
 else
-	KERNEL_SOURCES_DIR="kernel_sources-${kernel_version}-${package_name_suffix}"
+	KERNEL_SOURCES_DIR="kernel_sources-${package_version}-${package_name_suffix}"
 fi
 if [ "$CREATE_SOURCES_SFS" != "no" ]; then
 	log_msg "Creating a kernel sources SFS"
@@ -983,11 +988,9 @@ esac
 
 
 if [ "$kit_kernel" = "yes" ]; then
-	KERNEL_MODULES_SFS_NAME="kernel-modules-${kernel_version}${custom_suffix}-${package_name_suffix}.sfs"
-	[ "$remove_sublevel" = "yes" ] && KERNEL_MODULES_SFS_NAME="kernel-modules-`grep 'Kernel Configuration' ${KERNEL_SOURCES_DIR}/usr/src/linux/.config | cut -f 3 -d ' ' | cut -f 1-2 -d .`${custom_suffix}-${package_name_suffix}.sfs"
+	KERNEL_MODULES_SFS_NAME="kernel-modules-${package_version}${custom_suffix}-${package_name_suffix}.sfs"
 else
-	KERNEL_MODULES_SFS_NAME="kernel-modules-${kernel_version}-${package_name_suffix}.sfs"
-	[ "$remove_sublevel" = "yes" ] && KERNEL_MODULES_SFS_NAME="kernel-modules-`grep 'Kernel Configuration' ${KERNEL_SOURCES_DIR}/usr/src/linux/.config | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}.sfs"
+	KERNEL_MODULES_SFS_NAME="kernel-modules-${package_version}-${package_name_suffix}.sfs"
 fi
 
 if [ "$STRIP_KMODULES" = "yes" ] ; then

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -430,7 +430,7 @@ if [ "$AUFS" != "no" ] ; then
 fi
 
 export FDRV=fdrv-${kernel_version}-${package_name_suffix}.sfs
-[ "$remove_sublevel" = "yes" ] && export FDRV=fdrv-`grep 'Kernel Configuration' .config | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}.sfs
+[ "$remove_sublevel" = "yes" ] && export FDRV=fdrv-`echo $kernel_version | cut -f 3 -d ' ' | cut -f 1-2 -d .`-${package_name_suffix}.sfs
 
 if [ -n "$fware" ] ; then
 	FIRMWARE_OPT=git


### PR DESCRIPTION
Fixes this issue in CI builds:

```

2021-02-01T10:54:33.8202211Z Installing HUGE kernel to build/
2021-02-01T10:55:06.8272990Z 
2021-02-01T10:55:06.8274431Z *** No checksum found for huge-4.19-slacko64.tar.bz2
2021-02-01T10:55:06.8275173Z *** Download was successful, so creating checksum...
2021-02-01T10:55:06.8275591Z 
2021-02-01T10:55:07.6582318Z huge-4.19-slacko64.tar.bz2: OK
2021-02-01T10:55:07.6605852Z Kernel is 4.19-slacko64 version
2021-02-01T10:55:07.7744725Z vmlinuz-4.19-slacko64
2021-02-01T10:55:08.2265486Z fdrv-4.19.172-slacko64.sfs
2021-02-01T10:55:10.9586998Z kernel-modules-4.19.172-slacko64.sfs
2021-02-01T10:55:13.2124131Z mv: cannot stat 'kernel-modules*4.19-slacko64*': No such file or directory
```

Right now, the image produced is bootable and looks like Slacko 7.0, but /lib/modules doesn't exist because there's no kernel modules SFS.