### PR TITLE
Make PulseAudio+pa-applet work on Bullseye

### DIFF
--- a/woof-code/packages-templates/gtk3_FIXUPHACK
+++ b/woof-code/packages-templates/gtk3_FIXUPHACK
@@ -7,13 +7,14 @@ if [ -f usr/lib/${ARCHDIR}/libgtk-3-0/gtk-query-immodules-3.0 ] ; then
 			usr/bin/gtk-query-immodules-3.0
 fi
 
-# raleigh-reloaded and possibly other themes need the arrow symbolic icons
+# raleigh-reloaded and possibly other themes need the arrow symbolic icons, and
+# pa-applet needs the speaker icons
 if [ -d usr/share/icons/Adwaita ]; then
 	cd usr/share/icons/Adwaita
 	rm -rf [0-9]*x* cursor* scalable-*
 	find scalable -type f | while read ICON; do
 		case $ICON in
-		*/pan-*) ;;
+		*/pan-*|*/audio-volume-*) ;;
 		*) rm -f $ICON ;;
 		esac
 	done

--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -17,6 +17,7 @@ chmod 755 usr/local/bin/pavu.sh
 
 cat > usr/local/bin/ppavol << EOF
 #!/bin/ash
+type pa-applet >/dev/null 2>&1 && exit
 #todo gettext
 if ! type yad >/dev/null 2>&1 ; then
 	echo "yad must be installed"

--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -61,3 +61,14 @@ case $DISTRO_BINARY_COMPAT in
 	rm -f /tmp/default.pa
 	;;
 esac
+
+if [ -f usr/bin/start-pulseaudio-x11 ]; then
+	mv -f usr/bin/start-pulseaudio-x11 usr/bin/start-pulseaudio-x11.real
+	cat << EOF > usr/bin/start-pulseaudio-x11
+#!/bin/sh -e
+# hack: we don't have a user session bus or systemd for service activation
+pulseaudio --start
+exec start-pulseaudio-x11.real
+EOF
+	chmod 755 usr/bin/start-pulseaudio-x11
+fi

--- a/woof-code/rootfs-skeleton/bin/xdg_autostart.sh
+++ b/woof-code/rootfs-skeleton/bin/xdg_autostart.sh
@@ -28,7 +28,7 @@ verify_not_running() {
 
 #=================================================
 
-for i in $HOME/.config/autostart/*.desktop
+for i in /etc/xdg/autostart/*.desktop
 do
 	if ! [ -f $i ] ; then
 		continue
@@ -41,12 +41,12 @@ done
 
 #=================================================
 
-for i in /etc/xdg/autostart/*.desktop
+for i in $HOME/.config/autostart/*.desktop
 do
 	if ! [ -f $i ] ; then
 		continue
 	fi
-	if [ -f $HOME/.config/autostart/${i} ] ; then
+	if [ -f /etc/xdg/autostart/${i} ] ; then
 		continue
 	fi
 	if ! verify_not_running $i ; then


### PR DESCRIPTION
There's a .desktop file that runs start-pulseaudio-x11, which runs pactl, which performs D-Bus calls.

Normally, D-Bus auto-starts pulseaudio via systemd, but we don't have that, and using a separate "session bus" instance of D-Bus is problematic when it's root that's logged in. Therefore, I forced start-pulseaudio-x11 to start pulseaudio itself with a wrapper script.

Also, I made sure pulseaudio is started before pa-applet, which doesn't display anything if this is not the case.

Firefox audio now passes through pulseaudio and volume can be changed via the pa-applet tray icon.