### PR TITLE
Open a terminal on Ctrl-Alt-t

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -182,6 +182,7 @@
 <Key mask="A" key="#">desktop#</Key>
 <Key mask="A" key="F1">root:9</Key>
 <Key mask="A" key="F2">window</Key>
+<Key mask="CA" key="t">exec:defaultterminal</Key>
 
 
 <!-- Include external rc files -->


### PR DESCRIPTION
This key binding is common across DEs and distros and we should have it if we want to be user friendly.