### PR TITLE
Draw less when moving or resizing windows on ARM

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/pinstall.sh
+++ b/woof-code/rootfs-packages/jwm_config/pinstall.sh
@@ -1,3 +1,11 @@
 #!/bin/sh
 
+. etc/DISTRO_SPECS
+
 rm -f root/.jwm/jwmrc-personal_old
+
+# windows are slow to move or resize if drawing is slow
+case "${DISTRO_TARGETARCH}" in
+    x86*) ;;
+    *) sed 's/>opaque</>outline</g' -i root/.jwm/jwmrc-personal root/.jwm/backup/jwmrc-personal ;;
+esac


### PR DESCRIPTION
The outline mode is also more convenient with small screens, because you get to see what's below the window you're moving.