### PR TITLE
Cache petbuilds across CI runs and publish ISO+devx

### DIFF
--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -25,6 +25,14 @@ on:
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
+    branches:
+      - ci
+      - testing
+    inputs:
+      release_name:
+        description: 'Release name'
+        required: true
+        default: 'prepreprealpha1'
 
 jobs:
   build:
@@ -40,9 +48,8 @@ jobs:
       uses: actions/cache@v2
       with:
         path: local-repositories
-        key: ${{ github.workflow }}-local-repositories-${{ hashFiles('kernel-kit/**') }}-${{ github.sha }}
+        key: ${{ github.workflow }}-local-repositories-${{ github.sha }}
         restore-keys: |
-          ${{ github.workflow }}-local-repositories-${{ hashFiles('kernel-kit/**') }}-
           ${{ github.workflow }}-local-repositories-
     - name: Install cdrtools
       run: |
@@ -99,13 +106,76 @@ jobs:
         cd ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit
         sudo cp -f slacko64-build.conf build.conf
         sudo -E ./build.sh
-    - name: Copy kernel-kit output
-      run: sudo cp -a ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output kernel-kit-output
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_64_x86_64_slackware64_15.0
         echo | sudo ./2createpackages
+    - name: Get cached petbuild-sources
+      id: get_petbuild_sources_cache
+      uses: actions/cache@v2
+      with:
+        path: petbuild-sources
+        key: ${{ github.workflow }}-petbuild-sources-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-petbuild-sources-
+    - name: Move cached petbuild-sources
+      run: sudo mv petbuild-sources ../woof-out_x86_64_x86_64_slackware64_15.0
+    - name: Get cached petbuild-cache
+      id: get_petbuild_cache
+      uses: actions/cache@v2
+      with:
+        path: petbuild-cache
+        key: ${{ github.workflow }}-petbuild-cache-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-petbuild-cache-
+    - name: Move cached petbuild-cache
+      run: sudo mv petbuild-cache ../woof-out_x86_64_x86_64_slackware64_15.0
+    - name: Get cached petbuild-output
+      id: get_petbuild_output_cache
+      uses: actions/cache@v2
+      with:
+        path: petbuild-output
+        key: ${{ github.workflow }}-petbuild-output-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-petbuild-output-
+    - name: Move cached petbuild-output
+      run: sudo mv petbuild-output ../woof-out_x86_64_x86_64_slackware64_15.0
     - name: 3builddistro
       run: |
         cd ../woof-out_x86_64_x86_64_slackware64_15.0
         sudo -E ./3builddistro
+    - name: Move cached directories
+      run: |
+        sudo mv ../woof-out_x86_64_x86_64_slackware64_15.0/petbuild-{sources,cache,output} .
+        sudo mv ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output kernel-kit-output
+    - name: Create Release
+      if: github.event_name == 'workflow_dispatch'
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: slacko64-8.0-${{ github.event.inputs.release_name }}
+        release_name: slacko64-8.0-${{ github.event.inputs.release_name }}
+        draft: false
+        prerelease: true
+    - name: Upload ISO
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/woof-output-slacko64-8.0/slacko64-8.0.iso
+        asset_name: slacko64-8.0.iso
+        asset_content_type: application/octet-stream
+    - name: Upload devx
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/woof-output-slacko64-8.0/devx_slacko64_8.0.sfs
+        asset_name: devx_slacko64_8.0.sfs
+        asset_content_type: application/octet-stream

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -63,8 +63,6 @@ jobs:
         echo "dash dash/sh boolean false" | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
-    - name: Fix cache ownership
-      run: sudo chown -R root:root local-repositories
     - name: merge2out
       run: |
         (echo 3; echo 2; echo 4; echo; echo) | sudo -E ./merge2out
@@ -118,8 +116,6 @@ jobs:
         key: ${{ github.workflow }}-petbuild-sources-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-petbuild-sources-
-    - name: Move cached petbuild-sources
-      run: sudo mv petbuild-sources ../woof-out_x86_64_x86_64_slackware64_15.0
     - name: Get cached petbuild-cache
       id: get_petbuild_cache
       uses: actions/cache@v2
@@ -128,8 +124,6 @@ jobs:
         key: ${{ github.workflow }}-petbuild-cache-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-petbuild-cache-
-    - name: Move cached petbuild-cache
-      run: sudo mv petbuild-cache ../woof-out_x86_64_x86_64_slackware64_15.0
     - name: Get cached petbuild-output
       id: get_petbuild_output_cache
       uses: actions/cache@v2
@@ -138,10 +132,10 @@ jobs:
         key: ${{ github.workflow }}-petbuild-output-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-petbuild-output-
-    - name: Move cached petbuild-output
-      run: sudo mv petbuild-output ../woof-out_x86_64_x86_64_slackware64_15.0
     - name: 3builddistro
       run: |
+        sudo chown -R root:root petbuild-output
+        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_64_x86_64_slackware64_15.0/
         cd ../woof-out_x86_64_x86_64_slackware64_15.0
         sudo -E ./3builddistro
     - name: Move cached directories

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -40,9 +40,9 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Create local-repositories
+    - name: Create cache directories
       run: |
-        mkdir -p local-repositories
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2

--- a/kernel-kit/slacko64-build.conf
+++ b/kernel-kit/slacko64-build.conf
@@ -73,8 +73,9 @@ remove_sublevel=yes
 ### squashfs compression ###
 ## unset this for the default of your mksquashfs binary
 #COMP="-comp gzip"
-COMP="-comp xz"
+#COMP="-comp xz"
 #COMP="-comp xz -b 512K"
+SFSCOMP='-comp zstd -Xcompression-level 19 -b 512K'
 
 ## strip kernel modules?
 ## warning: this might cause issues

--- a/woof-distro/x86_64/slackware64/15.0/_00build.conf
+++ b/woof-distro/x86_64/slackware64/15.0/_00build.conf
@@ -57,9 +57,10 @@ LICK_IN_ISO=yes
 
 ## compression method to be used (SFS files)
 #SFSCOMP='-comp xz -Xbcj x86 -b 512K'
-SFSCOMP='-comp xz'
+#SFSCOMP='-comp xz'
 #SFSCOMP='-comp gzip'
 #SFSCOMP='-noI -noD -noF -noX'
+SFSCOMP='-comp zstd -Xcompression-level 19 -b 512K'
 
 ## if "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH"
 ## This is usually not needed


### PR DESCRIPTION
Manually triggered builds produce a tag+GitHub release with ISO and devx:

![Screenshot 2021-02-20 at 16 03 35](https://user-images.githubusercontent.com/1471149/108608139-ba899200-73cd-11eb-9bab-8b702c6c3427.png)
