### PR TITLE
Remove menu entries that don't work in barebones puplets

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -653,7 +653,7 @@ fi
 
 # bcrypt_gui needs bcrypt
 if [ ! -e rootfs-complete/usr/bin/bcrypt ]; then
-	rm -f rootfs-complete/usr/share/applications/crypt_gui.desktop rootfs-complete/usr/sbin/bcrypt_gui
+	rm -f rootfs-complete/usr/share/applications/bcrypt_gui.desktop rootfs-complete/usr/sbin/bcrypt_gui
 fi
 
 # pupmtp needs simple-mtpfs

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -131,6 +131,10 @@ and edit it to include your customised package list.
 			grep -q 'yes|pburn|' $PKGSSPECS && state=false
 			[ "$DISTRO_TARGETARCH" = "arm" ] && state=false
 			;;
+		pgprs)
+			state=false
+			grep -q 'yes|ppp|' $PKGSSPECS && state=true
+			;;
 		*)
 			state=true
 			grep -q "yes|${d}|" $PKGSSPECS && state=false # don't overwrite user chosen specs

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -637,6 +637,26 @@ if [ "$SDFLAG" ];then
 	fi
 fi
 
+# puppyPDF needs Abiword
+if [ ! -e rootfs-complete/usr/bin/abiword ]; then
+	rm -f rootfs-complete/usr/share/applications/puppyPDF-convert-file-to-PDF.desktop rootfs-complete/usr/sbin/puppypdf
+fi
+
+# pdict needs dict
+if [ ! -e rootfs-complete/usr/bin/dict ]; then
+	rm -f rootfs-complete/usr/share/applications/Pdict-online-dictionary.desktop rootfs-complete/usr/sbin/pdict
+fi
+
+# bcrypt_gui needs bcrypt
+if [ ! -e rootfs-complete/usr/bin/bcrypt ]; then
+	rm -f rootfs-complete/usr/share/applications/crypt_gui.desktop rootfs-complete/usr/sbin/bcrypt_gui
+fi
+
+# pupmtp needs simple-mtpfs
+if [ ! -e usr/bin/simple-mtpfs ]; then
+	rm -f rootfs-complete/usr/share/applications/pupmtp.desktop rootfs-complete/usr/sbin/pupmtp
+fi
+
 #130326 script to adjust fonts to suit 96 dpi (puppy used to have 78 dpi)...
 [ ! -d rootfs-complete/usr/share/ptheme ] && rootfs-complete/usr/sbin/hackfontsize #don't execute if we have ptheme
 


### PR DESCRIPTION
The ARM Chromebook images don't have many preinstalled applications and there's a number of menu entries that point to applications that don't work without third-party dependencies.

These applications either fail silently, or ask the user to install these dependencies. All Puppies have these dependencies and if they're left out in DISTRO_PKGS_SPECS, this is probably intentional and the menu entries should be removed in 3builddistro.