### PR TITLE
Remove empty submenus and extra separators in the JWM menu

### DIFF
--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/empty-menus.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/empty-menus.patch
@@ -1,0 +1,81 @@
+diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2021-02-24 09:26:15.392214890 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2021-02-24 09:28:01.540157679 +0200
+@@ -108,20 +108,34 @@ show_help()
+ void
+ process_directory(GMenuTreeDirectory *directory, char *menheight)
+ {
+-	int hasSeparator = 0;
++	int hasSeparator = 0, first = 1;
+ 	char *mheight = menheight;
+ 	
+-  g_printf("<Menu label=\"%s\" icon=\"%s\" height=\"%s\">\n",
+-            gmenu_tree_directory_get_name(directory),
+-            gmenu_tree_directory_get_icon(directory),
+-            mheight);
+-
+   GMenuTreeItemType entryType;
+ 
+   GSList *entryList = gmenu_tree_directory_get_contents (directory);
+ 
+   GSList *l;
+ 
++  /* if the menu has no items, don't show an empty menu */
++  for (l = entryList; l; l = l->next)
++  {
++    GMenuTreeItem *item = l->data;
++
++    if (gmenu_tree_item_get_type (GMENU_TREE_ITEM(item)) == GMENU_TREE_ITEM_ENTRY)
++    {
++      goto start;
++    }
++  }
++
++  goto done;
++
++start:
++  g_printf("<Menu label=\"%s\" icon=\"%s\" height=\"%s\">\n",
++            gmenu_tree_directory_get_name(directory),
++            gmenu_tree_directory_get_icon(directory),
++            mheight);
++
+   for (l = entryList; l; l = l->next)
+   {
+ 
+@@ -134,18 +148,26 @@ process_directory(GMenuTreeDirectory *di
+ 		case GMENU_TREE_ITEM_DIRECTORY:
+ 		  if (hasSeparator)
+ 		  {
+-				process_separator(GMENU_TREE_SEPARATOR(item));
++				if (!first)
++				{
++					process_separator(GMENU_TREE_SEPARATOR(item));
++				}
+ 				hasSeparator = 0;
+ 		  }
+ 			process_directory(GMENU_TREE_DIRECTORY(item),menheight);
++			first = 0;
+ 			break;
+ 		case GMENU_TREE_ITEM_ENTRY:
+ 		  if (hasSeparator)
+ 		  {
+-				process_separator(GMENU_TREE_SEPARATOR(item));
++				if (!first)
++				{
++					process_separator(GMENU_TREE_SEPARATOR(item));
++				}
+ 				hasSeparator = 0;
+ 		  }
+ 			process_entry(GMENU_TREE_ENTRY(item));
++			first = 0;
+ 			break;
+ 		case GMENU_TREE_ITEM_SEPARATOR:
+ 			hasSeparator = 1;
+@@ -156,6 +178,7 @@ process_directory(GMenuTreeDirectory *di
+ 
+   }
+   g_printf("</Menu>\n");
++done:
+   g_slist_free (entryList);
+ }
+ 

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
@@ -15,8 +15,9 @@ build() {
     rm -f /usr/lib/libgnome-menu.so*
 
     tar -xjf xdg_puppy-0.7.6-9.tar.bz2
-    cd xdg_puppy-0.7.6-9/jwm-xdgmenu
-    gcc $CFLAGS -DGMENU_I_KNOW_THIS_IS_UNSTABLE `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --cflags glib-2.0 libgnome-menu` jwm-xdgmenu.c $LDFLAGS `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --libs glib-2.0 libgnome-menu` -o /usr/bin/jwm-xdgmenu
+    cd xdg_puppy-0.7.6-9
+    patch -p1 < ../empty-menus.patch
+    gcc $CFLAGS -DGMENU_I_KNOW_THIS_IS_UNSTABLE `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --cflags glib-2.0 libgnome-menu` jwm-xdgmenu/jwm-xdgmenu.c $LDFLAGS `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --libs glib-2.0 libgnome-menu` -o /usr/bin/jwm-xdgmenu
 
     # we don't need these
     rm -rf /usr/bin/gnome-menu-spec-test /usr/lib /usr/include /usr/share/locale


### PR DESCRIPTION
In a barebones puplet, the games menu is present but has zero items, and if a submenu has zero items, the separator after it is still present:

![menus](https://user-images.githubusercontent.com/1471149/108982399-71b82e80-7696-11eb-9b2d-4186e90f5fed.png)
