### PR TITLE
Disable the Firefox sync menu

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -34,6 +34,8 @@ defaultPref("extensions.pocket.enabled", false);
 defaultPref("extensions.screenshots.disabled", true);
 defaultPref("browser.messaging-system.whatsNewPanel.enabled", false);
 defaultPref("browser.uitour.enabled", false);
+defaultPref("identity.fxaccounts.enabled", false);
+defaultPref("identity.fxaccounts.toolbar.enabled", false);
 
 // privacy
 defaultPref("privacy.trackingprotection.enabled", true);


### PR DESCRIPTION
Yet another Firefox UI annoyance! This toolbar button shows annoying notifications.