### PR TITLE
Ignore kernel-kit cache if kernel-kit directory has changed

### DIFF
--- a/.github/workflows/slacko-7.yml
+++ b/.github/workflows/slacko-7.yml
@@ -89,8 +89,6 @@ jobs:
       with:
         path: kernel-kit-output
         key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-        restore-keys: |
-          ${{ github.workflow }}-kernel-kit-output-
     - name: Move cached kernel-kit output
       run: sudo mv kernel-kit-output ../woof-out_x86_x86_slackware_14.2/kernel-kit/output
     - name: Install kernel-kit dependencies
@@ -104,9 +102,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}-${{ github.sha }}
-        restore-keys: |
-          ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}-
+        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
     - name: kernel-kit
       if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/slacko64-7.yml
+++ b/.github/workflows/slacko64-7.yml
@@ -89,8 +89,6 @@ jobs:
       with:
         path: kernel-kit-output
         key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-        restore-keys: |
-          ${{ github.workflow }}-kernel-kit-output-
     - name: Move cached kernel-kit output
       run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output
     - name: Install kernel-kit dependencies
@@ -104,9 +102,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}-${{ github.sha }}
-        restore-keys: |
-          ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}-
+        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
     - name: kernel-kit
       if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -94,8 +94,6 @@ jobs:
       with:
         path: kernel-kit-output
         key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-        restore-keys: |
-          ${{ github.workflow }}-kernel-kit-output-
     - name: Move cached kernel-kit output
       run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output
     - name: Install kernel-kit dependencies
@@ -109,9 +107,7 @@ jobs:
       uses: actions/cache@v2
       with:
         path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}-${{ github.sha }}
-        restore-keys: |
-          ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}-
+        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
     - name: kernel-kit
       if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
       run: |


### PR DESCRIPTION
~Testing~ Tested in https://github.com/dimkr/woof-CE/runs/2029885716 and https://github.com/dimkr/woof-CE/runs/2030772615 ~another build I'll run afterwards~.