### PR TITLE
installpkg.sh: Added a failsafe

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -73,6 +73,7 @@ DL_SAVE_FLAG=$(cat /var/local/petget/nd_category 2>/dev/null)
 
 clean_and_die () {
   rm -f /root/.packages/${DLPKG_NAME}.files
+  [ "$PUPMODE" != "2" ] && busybox mount -t aufs -o remount,udba=reval unionfs / #remount with faster evaluation mode.
   exit 1
 }
 


### PR DESCRIPTION
For non-PUPMODE 2  only.
Since PPM runs udba=notify upon installation  and return to udba=reval after package extraction. Revert to udba=reval if the package extraction failed.