### PR TITLE
Mount a tmpfs at /run

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -196,6 +196,9 @@ busybox mount -t sysfs none /sys ;STATUS=$((STATUS+$?))
 mkdir -p /dev/shm #120503 if kernel mounts a f.s. on /dev, removes my skeleton /dev
 busybox mount -t tmpfs -o size=${QTRFREERAM}k shmfs /dev/shm ;STATUS=$((STATUS+$?))
 
+mkdir -p /run
+busybox mount -t tmpfs -o nosuid,nodev,noexec,mode=755,size=${QTRFREERAM}k run /run ;STATUS=$((STATUS+$?))
+
 # kernel modules.builtin/order can also be found in /etc/modules
 # if somehow they're missing from /lib/modules, they will be copied back
 KERNVER="`uname -r`"


### PR DESCRIPTION
/run contains temporary files and they pollute the save file.