### PR TITLE
Allow EXTRA_COMMANDS to enable the firewall by default

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -394,8 +394,28 @@ export GUI="<window title=\"Firewall Setup $version\" icon-name=\"$winicon\">
 		</hbox>
 	</vbox>
 </window>"
-eval $(gtkdialog -p GUI -c 2>/dev/null) 2>/dev/null
-echo $EXIT
+if [ "$1" = "enable" ]; then
+	echo "Enabling firewall"
+	EXIT=Doit
+	GENERIC=true
+	LOGGING=false
+	MAIN=true
+	EX=false
+	CONFIG_SSH=false
+	CONFIG_CUPS=false
+	CONFIG_SAMBA=false
+	CONFIG_SAMBA_CLIENT=false
+	CONFIG_DLNA=false
+	CONFIG_NTP=false
+	CONFIG_FTP=false
+	CONFIG_HTTP=false
+	CONFIG_DNS=false
+	CONFIG_DHCP=false
+	CONFIG_NFS=false
+else
+	eval $(gtkdialog -p GUI -c 2>/dev/null) 2>/dev/null
+	echo $EXIT
+fi
 case "$EXIT" in
 	Doit)echo "GENERIC=$GENERIC
 LOGGING=$LOGGING
@@ -1318,7 +1338,7 @@ echo "Load rules for mangle table ..."
 EOF_REST
 
 if [ -f "$TMPFW" ];then
-	[ $state = 1 ] && /etc/init.d/rc.firewall stop && sleep 1
+	[ $state = 1 -a "$1" != "enable" ] && /etc/init.d/rc.firewall stop && sleep 1
 	echo "copying firewall"
 	cp -af "$TMPFW" /etc/init.d/rc.firewall
 	chmod 755 /etc/init.d/rc.firewall
@@ -1327,6 +1347,8 @@ else
 	echo "Something went wrong"
 	exit
 fi
+
+[ "$1" = "enable" ] && exit
 
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &


### PR DESCRIPTION
File sharing through LAN, Puppy servers, etc' are uncommon, and having the firewall already enabled by the time you connect to the internet is a sane default.