### PR TITLE
petget: remove duplicate routine

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/petget
+++ b/woof-code/rootfs-skeleton/usr/local/petget/petget
@@ -298,13 +298,6 @@ else
  dialog --timeout 3 --msgbox "$(gettext 'Done. Updating menus and help pages')" 0 0
 fi
 
-#w0910 update image cache...
-if [ -f /root/.packages/${PKGNAME}.files ];then
- if [ "`grep 'usr/share/icons/hicolor' /root/.packages/${PKGNAME}.files`" != "" ];then
-  gtk-update-icon-cache -f /usr/share/icons/hicolor/
- fi
-fi
-
 #master help index has to be updated...
 #Reconstruct configuration files for JWM, Fvwm95, IceWM...
 if [ "$INSTALLEDCAT" != "none" ];then


### PR DESCRIPTION
gtk-update-icon-cache is already performed by z_update_system_cache.sh in installpkg.sh so remove that routine on petget script