### PR TITLE
Update some slacko 7.x applications using petbuilds

### DIFF
--- a/woof-code/rootfs-petbuilds/aaa_pup_c/pet.specs
+++ b/woof-code/rootfs-petbuilds/aaa_pup_c/pet.specs
@@ -1,1 +1,1 @@
-aaa_pup_c-1|aaa_pup_c|1||BuildingBlock|348||aaa_pup_c-1.pet|+cairo,+gtk+3|basic pup apps|puppy|||
+aaa_pup_c-1|aaa_pup_c|1||BuildingBlock|348||aaa_pup_c-1.pet|+cairo|basic pup apps|puppy|||

--- a/woof-code/rootfs-petbuilds/aaa_pup_c/petbuild
+++ b/woof-code/rootfs-petbuilds/aaa_pup_c/petbuild
@@ -7,9 +7,15 @@ download() {
 }
 
 build() {
-    gcc $CFLAGS `pkg-config --cflags gtk+-3.0` -Dgtk_status_icon_set_tooltip=gtk_status_icon_set_tooltip_text pm13tray-15ce69654167abee4a3b937f22cb84b276843006.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/pm13tray
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        DEPENDENCY=gtk+-3.0
+    else
+        DEPENDENCY=gtk+-2.0
+    fi
 
-    gcc $CFLAGS `pkg-config --cflags gtk+-3.0` pngoverlay-gtk2-15ce69654167abee4a3b937f22cb84b276843006.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/sbin/pngoverlay-gtk2
+    gcc $CFLAGS `pkg-config --cflags $DEPENDENCY` -Dgtk_status_icon_set_tooltip=gtk_status_icon_set_tooltip_text pm13tray-15ce69654167abee4a3b937f22cb84b276843006.c $LDFLAGS `pkg-config --libs $DEPENDENCY` -o /usr/bin/pm13tray
+
+    gcc $CFLAGS `pkg-config --cflags $DEPENDENCY` pngoverlay-gtk2-15ce69654167abee4a3b937f22cb84b276843006.c $LDFLAGS `pkg-config --libs $DEPENDENCY` -o /usr/sbin/pngoverlay-gtk2
     gcc $CFLAGS `pkg-config --cflags cairo` pngoverlay-cairo-15ce69654167abee4a3b937f22cb84b276843006.c $LDFLAGS `pkg-config --libs cairo` -o /usr/sbin/pngoverlay-cairo
 
     gcc $CFLAGS debdb2pupdb-66f9c9d6cefe318f2b9181a6a53c99b54651416a.c $LDFLAGS -o /usr/local/petget/debdb2pupdb

--- a/woof-code/rootfs-petbuilds/firewallstatus/petbuild
+++ b/woof-code/rootfs-petbuilds/firewallstatus/petbuild
@@ -4,7 +4,11 @@ download() {
 
 build() {
     cd firewallstatus-0.7
-    gcc $CFLAGS `pkg-config --cflags gtk+-3.0` firewallstatus.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/firewallstatus
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        gcc $CFLAGS `pkg-config --cflags gtk+-3.0` firewallstatus.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/firewallstatus
+    else
+        gcc $CFLAGS `pkg-config --cflags gtk+-2.0` firewallstatus.c $LDFLAGS `pkg-config --libs gtk+-2.0` -o /usr/bin/firewallstatus
+    fi
     mkdir -p /usr/share/doc/nls/firewallstatus
     xgettext --keyword="_" firewallstatus.c -o /usr/share/doc/nls/firewallstatus/firewallstatus.pot
     install -D -m 644 firewallstatus.desktop /root/.config/autostart/firewallstatus.desktop

--- a/woof-code/rootfs-petbuilds/freememapplet/petbuild
+++ b/woof-code/rootfs-petbuilds/freememapplet/petbuild
@@ -5,6 +5,10 @@ download() {
 build() {
     tar -xjf freememapplet-2.8.6.tar.bz2
     cd freememapplet-2.8.6
-    patch -p1 < ../gtk3.patch
-    gcc $CFLAGS `pkg-config --cflags gtk+-3.0` freememapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/freememapplet_tray
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        patch -p1 < ../gtk3.patch
+        gcc $CFLAGS `pkg-config --cflags gtk+-3.0` freememapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/freememapplet_tray
+    else
+        gcc $CFLAGS `pkg-config --cflags gtk+-2.0` freememapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-2.0` -o /usr/bin/freememapplet_tray
+    fi
 }

--- a/woof-code/rootfs-petbuilds/geany/petbuild
+++ b/woof-code/rootfs-petbuilds/geany/petbuild
@@ -6,7 +6,11 @@ build() {
     tar -xjf geany-1.37.1.tar.bz2
     cd geany-1.37.1
     patch -p1 < ../defaults.patch
-    ./configure --prefix=/usr --disable-plugins --disable-vte
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        ./configure --prefix=/usr --disable-plugins --disable-vte
+    else
+        ./configure --prefix=/usr --disable-plugins --disable-vte --enable-gtk2
+    fi
     make install
     sed -e 's/^Categories=.*/Categories=TextEditor;/' -e 's/^Name=Geany$/& text editor/' -e '/^Name\[/d' -e 's/=geany %F/=geany/' -i /usr/share/applications/geany.desktop
     rm -rf /usr/lib/pkgconfig /usr/lib/python* /usr/share/icons/Tango /usr/include /usr/lib/*.la /usr/lib/*.a /usr/share/doc

--- a/woof-code/rootfs-petbuilds/gpicview/petbuild
+++ b/woof-code/rootfs-petbuilds/gpicview/petbuild
@@ -5,7 +5,11 @@ download() {
 build() {
     tar -xJf gpicview-0.2.5.tar.xz
     cd gpicview-0.2.5
-    ./configure --prefix=/usr --enable-gtk3
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        ./configure --prefix=/usr --enable-gtk3
+    else
+        ./configure --prefix=/usr
+    fi
     make install
     sed -e 's/^Name=Image Viewer$/Name=GPicView image viewer/' -e '/^Name\[/d' -e 's/gpicview %f/gpicview/' -i /usr/share/applications/gpicview.desktop
 }

--- a/woof-code/rootfs-petbuilds/gtkdialog/pet.specs
+++ b/woof-code/rootfs-petbuilds/gtkdialog/pet.specs
@@ -1,1 +1,1 @@
-gtkdialog-0.8.4a|gtkdialog|0.8.4a||BuildingBlock|256||gtkdialog-0.8.4a.pet|+gtk+3|gtkialog is a small utility for fast and easy GUI building|puppy|||
+gtkdialog-0.8.4a|gtkdialog|0.8.4a||BuildingBlock|256||gtkdialog-0.8.4a.pet||gtkialog is a small utility for fast and easy GUI building|puppy|||

--- a/woof-code/rootfs-petbuilds/gtkdialog/petbuild
+++ b/woof-code/rootfs-petbuilds/gtkdialog/petbuild
@@ -7,6 +7,10 @@ build() {
     cd gtkdialog-0.8.4a
     patch -p1 < ../no-doc.patch
     # -fcommon is required for GCC 10 https://github.com/puppylinux-woof-CE/gtkdialog/pull/90
-    CFLAGS="$CFLAGS -fcommon" ./configure --prefix=/usr --bindir=/usr/sbin --enable-gtk3
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        CFLAGS="$CFLAGS -fcommon" ./configure --prefix=/usr --bindir=/usr/sbin --enable-gtk3
+    else
+        CFLAGS="$CFLAGS -fcommon" ./configure --prefix=/usr --bindir=/usr/sbin
+    fi
     make install
 }

--- a/woof-code/rootfs-petbuilds/lxtask/pet.specs
+++ b/woof-code/rootfs-petbuilds/lxtask/pet.specs
@@ -1,1 +1,1 @@
-lxtask-0.1.10|lxtask|0.1.10||System|348||lxtask-0.1.10.pet|+gtk+3|Process manager|puppy|||
+lxtask-0.1.10|lxtask|0.1.10||System|348||lxtask-0.1.10.pet||Process manager|puppy|||

--- a/woof-code/rootfs-petbuilds/lxtask/petbuild
+++ b/woof-code/rootfs-petbuilds/lxtask/petbuild
@@ -5,7 +5,11 @@ download() {
 build() {
     tar -xJf lxtask-0.1.10.tar.xz
     cd lxtask-0.1.10
-    ./configure --prefix=/usr --enable-gtk3
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        ./configure --prefix=/usr --enable-gtk3
+    else
+        ./configure --prefix=/usr
+    fi
     make install
     sed -e 's/^Categories=.*/Categories=System;/' -e 's/^Name=Task Manager$/Name=LXTask task manager/' -e '/^Name\[/d' -e 's/^Icon=.*/Icon=execute.svg/' -i /usr/share/applications/lxtask.desktop
 }

--- a/woof-code/rootfs-petbuilds/mtpaint/pet.specs
+++ b/woof-code/rootfs-petbuilds/mtpaint/pet.specs
@@ -1,1 +1,1 @@
-mtpaint-3.50.05|mtpaint|3.50.05||Graphic|800||mtpaint-3.50.05.pet|+gtk+3|Painting program to create pixel art and manipulate digital photos|puppy|||
+mtpaint-3.50.05|mtpaint|3.50.05||Graphic|800||mtpaint-3.50.05.pet||Painting program to create pixel art and manipulate digital photos|puppy|||

--- a/woof-code/rootfs-petbuilds/mtpaint/petbuild
+++ b/woof-code/rootfs-petbuilds/mtpaint/petbuild
@@ -5,7 +5,11 @@ download() {
 build() {
     unzip -q mtpaint-3.50.05.zip
     cd mtPaint-96cd3788c4f89973350981dbc71d449cabdac297
-    ./configure gtk3 gtkfilesel gtkcolsel cflags nojp2 notiff nowebp nolcms intl --prefix=/usr
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        ./configure gtk3 gtkfilesel gtkcolsel cflags nojp2 notiff nowebp nolcms intl --prefix=/usr
+    else
+        ./configure gtk2 gtkfilesel gtkcolsel cflags nojp2 notiff nowebp nolcms intl --prefix=/usr
+    fi
     make
     make install
     sed -e 's/^Categories=.*/Categories=RasterGraphics;/' -e 's/^Name=mtPaint$/& image editor/' -e 's/=mtpaint %F/=mtpaint/' -e 's/^Icon=mtpaint$/&.png/' -i doc/mtpaint.desktop

--- a/woof-code/rootfs-petbuilds/netmon_wce/petbuild
+++ b/woof-code/rootfs-petbuilds/netmon_wce/petbuild
@@ -4,7 +4,11 @@ download() {
 
 build() {
     cd netmon_wce-3.3
-    gcc $CFLAGS `pkg-config --cflags gtk+-3.0` netmon_wce.c $LDFLAGS `pkg-config --libs gtk+-3.0` -liw -lm -o /usr/bin/netmon_wce
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        gcc $CFLAGS `pkg-config --cflags gtk+-3.0` netmon_wce.c $LDFLAGS `pkg-config --libs gtk+-3.0` -liw -lm -o /usr/bin/netmon_wce
+    else
+        gcc $CFLAGS `pkg-config --cflags gtk+-2.0` netmon_wce.c $LDFLAGS `pkg-config --libs gtk+-2.0` -liw -lm -o /usr/bin/netmon_wce
+    fi
     mkdir -p /usr/share/doc/nls/netmon_wce
     xgettext --keyword="_" netmon_wce.c -o /usr/share/doc/nls/netmon_wce/netmon_wce.pot
     for i in po/*.po; do

--- a/woof-code/rootfs-petbuilds/powerapplet_tray/petbuild
+++ b/woof-code/rootfs-petbuilds/powerapplet_tray/petbuild
@@ -3,7 +3,11 @@ download() {
 }
 
 build() {
-    gcc $CFLAGS `pkg-config --cflags gtk+-3.0` powerapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/powerapplet_tray
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        gcc $CFLAGS `pkg-config --cflags gtk+-3.0` powerapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/powerapplet_tray
+    else
+        gcc $CFLAGS `pkg-config --cflags gtk+-2.0` powerapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-2.0` -o /usr/bin/powerapplet_tray
+    fi
     mkdir -p /usr/share/doc/nls/powerapplet_tray
     xgettext --keyword="_" powerapplet_tray.c -o /usr/share/doc/nls/powerapplet_tray/powerapplet_tray.pot
 }

--- a/woof-code/rootfs-petbuilds/xarchiver/pet.specs
+++ b/woof-code/rootfs-petbuilds/xarchiver/pet.specs
@@ -1,1 +1,1 @@
-xarchiver-0.5.4.17|xarchiver|0.5.4.17||Utility|396||xarchiver-0.5.4.17.pet|+gtk+3|Xarchiver is a lightweight desktop independent archive manager built with the GTK+2|puppy|||
+xarchiver-0.5.4.17|xarchiver|0.5.4.17||Utility|396||xarchiver-0.5.4.17.pet||Xarchiver is a lightweight desktop independent archive manager built with the GTK+2|puppy|||

--- a/woof-code/rootfs-petbuilds/xarchiver/petbuild
+++ b/woof-code/rootfs-petbuilds/xarchiver/petbuild
@@ -5,7 +5,11 @@ download() {
 build() {
     tar -xzf xarchiver-0.5.4.17.tar.gz
     cd xarchiver-0.5.4.17
-    ./configure --prefix=/usr --disable-doc --disable-plugin
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        ./configure --prefix=/usr --disable-doc --disable-plugin
+    else
+        ./configure --prefix=/usr --disable-doc --disable-plugin --enable-gtk2
+    fi
     make install
     sed -e 's/^Categories=.*/Categories=Utility;/' -e 's/^Name=Xarchiver$/& archive manager/' -e 's/=xarchiver %f/=xarchiver/' -i /usr/share/applications/xarchiver.desktop
 }

--- a/woof-code/rootfs-petbuilds/yad/petbuild
+++ b/woof-code/rootfs-petbuilds/yad/petbuild
@@ -7,7 +7,11 @@ build() {
     cd yad-0.42.1
     autoreconf -if
     intltoolize --force
-    ./configure --prefix=/usr --disable-pfd --with-gtk=gtk3
+    if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        ./configure --prefix=/usr --disable-pfd --with-gtk=gtk3
+    else
+        ./configure --prefix=/usr --disable-pfd
+    fi
     make install
     rm -rf /usr/share/locale /usr/share/aclocal
 }

--- a/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
+++ b/woof-distro/x86/slackware/14.2/DISTRO_PKGS_SPECS-slackware-14.2
@@ -44,7 +44,7 @@ yes|bin86|bin|exe>dev,dev,doc,nls
 yes|binutils|binutils|exe>dev,dev,doc,nls
 yes|bison|bison|exe>dev,dev,doc,nls
 yes|boost|boost|exe>dev,dev,doc,nls
-yes|busybox||exe,dev>null,doc,nls
+no|busybox||exe,dev>null,doc,nls
 yes|bzip2|bzip2|exe,dev,doc,nls
 yes|ca-certificates|ca-certificates|exe,dev,doc,nls
 yes|cabextract||exe,dev,doc,nls
@@ -79,7 +79,7 @@ yes|dictd||exe,dev
 yes|didiwiki||exe,dev
 yes|diffstat|diffstat|exe,dev>null,doc,nls
 yes|diffutils|diffutils|exe,dev>null,doc,nls
-yes|disktype||exe,dev>null,doc,nls
+no|disktype||exe,dev>null,doc,nls
 no|djvulibre||exe,dev,doc,nls
 yes|djvulibre|djvulibre|exe,dev,doc,nls
 yes|dmidecode||exe,dev,doc,nls
@@ -109,11 +109,11 @@ yes|ffconvert||exe
 yes|ffmpeg||exe,dev,doc
 yes|file|file|exe,dev,doc,nls
 yes|findutils|findutils|exe,dev>null,doc,nls
-yes|firewallstatus||exe,dev
+no|firewallstatus||exe,dev
 yes|flac|flac|exe,dev,doc,nls
 yes|flex|flex|exe>dev,dev,doc,nls
 yes|fpm2||exe,dev,doc
-yes|freememapplet||exe,dev
+no|freememapplet||exe,dev
 yes|freetype|freetype|exe,dev,doc,nls
 yes|fribidi|fribidi|exe,dev,doc,nls
 yes|frugalpup||exe
@@ -132,7 +132,7 @@ yes|gdb|gdb|exe>dev,dev,doc,nls
 yes|gdbm|gdbm|exe,dev,doc,nls
 yes|gdk-pixbuf2|gdk-pixbuf2|exe,dev,doc,nls
 yes|gdmap||exe,dev>null,doc,nls
-yes|geany||exe,dev,doc,nls
+no|geany||exe,dev,doc,nls
 no|get_browser||exe
 yes|get_libreoffice||exe
 yes|getcurpos||exe,dev
@@ -163,7 +163,7 @@ yes|gparted|gparted|exe,dev,doc,nls
 yes|gperf|gperf|exe,dev,doc,nls
 yes|gphoto2||exe,dev
 yes|gphotofs||exe,dev
-yes|gpicview||exe,dev,doc,nls
+no|gpicview||exe,dev,doc,nls
 yes|gptfdisk||exe,dev,doc,nls
 yes|grep|grep|exe,dev>null,doc,nls
 yes|groff|groff|exe>dev,dev,doc,nls
@@ -173,7 +173,7 @@ yes|grub4dos||exe
 yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls
 yes|gtk+|gtk+2,libffi|exe,dev,doc,nls
 yes|gtk+3|gtk+3,at-spi2-atk,at-spi2-core|exe,dev,doc,nls
-yes|gtkdialog||exe,dev,doc>dev
+no|gtkdialog||exe,dev,doc>dev
 yes|gtkmm2|gtkmm2|exe,dev,doc,nls
 no|gtk_theme_flat_grey_rounded||exe
 yes|gtk_theme_gradient_grey||exe
@@ -206,7 +206,7 @@ yes|iptables|iptables|exe,dev,doc,nls
 yes|isomaster||exe,dev,doc,nls
 yes|iw|iw|exe,dev,doc,nls
 yes|jasper|jasper|exe,dev,doc,nls
-yes|jwm||exe,dev,doc,nls
+no|jwm||exe,dev,doc,nls
 yes|keyutils|keyutils|exe,dev,doc,nls
 yes|kernel_headers_musl||exe>dev
 yes|kmod|kmod|exe,dev,doc,nls
@@ -304,7 +304,7 @@ yes|linux-header|kernel-headers|exe>dev,dev,doc,nls
 yes|llvm-cut|llvm|exe,dev>null,doc,nls
 yes|lvm2|lvm2|exe,dev,doc,nls
 yes|lxrandr||exe,dev,doc,nls
-yes|lxtask||exe,dev,doc,nls
+no|lxtask||exe,dev,doc,nls
 yes|lxterminal||exe,dev,doc,nls
 yes|lzip||exe,dev,doc,nls
 yes|lzo|lzo|exe,dev,doc,nls
@@ -321,8 +321,8 @@ yes|mozilla-nss|mozilla-nss|exe,dev,doc,nls
 yes|mpfr|mpfr|exe,dev,doc,nls
 yes|MPlayer||exe,dev,doc
 yes|mpscan||exe,dev
-yes|mtpaint||exe,dev,doc,nls
-yes|mtpaint_help||exe
+no|mtpaint||exe,dev,doc,nls
+no|mtpaint_help||exe
 yes|mtr|mtr|exe
 yes|musl||exe,dev>dev
 yes|nano|nano|exe,dev,doc,nls
@@ -330,7 +330,7 @@ yes|nasm||exe>dev,dev,doc,nls
 yes|nbtscan||exe,dev
 yes|ncurses|ncurses|exe,dev,doc,nls
 yes|neon|neon|exe>dev,dev,doc,nls
-yes|netmon_wce||exe,dev,doc,nls
+no|netmon_wce||exe,dev,doc,nls
 yes|netpbm||exe,dev,doc
 yes|net-tools|net-tools|exe,dev,doc,nls
 yes|network_roxapp_samba||exe
@@ -379,7 +379,7 @@ yes|pnscan||exe,dev,doc,nls #peasyport
 yes|polkit|polkit|exe,dev,doc,nls
 yes|poppler|poppler,lcms2|exe,dev,doc,nls
 yes|popt|popt|exe,dev,doc,nls
-yes|powerapplet_tray||exe,dev
+no|powerapplet_tray||exe,dev
 yes|ppp|ppp|exe,dev>null,doc,nls
 yes|precord||exe
 yes|prename||exe
@@ -399,12 +399,12 @@ yes|qpdf|qpdf|exe,dev,doc,nls| #needed for cups
 yes|rdesktop|rdesktop,libsamplerate|exe,dev,doc,nls
 yes|readline|readline|exe,dev,doc,nls
 yes|retrovol||exe,dev,nls
-yes|rox-filer||exe,dev
+no|rox-filer||exe,dev
 yes|rp-pppoe||exe,dev
 yes|rsync|rsync|exe,dev,doc,nls
 yes|rtmpdump||exe,dev,doc,nls
 yes|rubix||exe,dev
-yes|rxvt-unicode||exe,dev>null,doc,nls
+no|rxvt-unicode||exe,dev>null,doc,nls
 yes|samba||exe,dev,doc
 yes|sane-backends||exe,dev,doc,nls
 yes|SaveFolderBackup||exe
@@ -427,7 +427,7 @@ yes|subversion|subversion|exe>dev,dev,doc,nls
 yes|sudo|sudo|exe,dev,doc,nls 
 yes|svgalib|svgalib|exe,dev,doc
 yes|switch2||exe,dev,doc
-yes|sylpheed||exe,doc>exe,dev,nls>null
+no|sylpheed||exe,doc>exe,dev,nls>null
 yes|sys-info||exe
 yes|sysfsutils|sysfsutils|exe,dev,doc,nls
 yes|syslinux|syslinux|exe,dev>null,doc,nls| #must use my pet syslinux pkg..
@@ -436,7 +436,7 @@ yes|tas||exe,nls
 yes|tcl|tcl,tk|exe>dev,dev,doc,nls
 yes|tcpdump|tcpdump|exe,dev,doc,nls
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
-yes|transmission||exe,dev,doc,nls
+no|transmission||exe,dev,doc,nls
 yes|uextract||exe,dev,doc,nls
 yes|unrar||exe,dev,doc,nls
 yes|updates_notice||exe
@@ -459,20 +459,20 @@ yes|wvstreams||exe,dev,doc,nls
 yes|x11proto|dri2proto,dri3proto,presentproto,xcmiscproto,compositeproto,xf86miscproto,fontsproto,printproto,renderproto,xf86dgaproto,xproto,dmxproto,glproto,xcb-proto,xf86bigfontproto,bigreqsproto,randrproto,xf86vidmodeproto,resourceproto,xineramaproto,scrnsaverproto,fontcacheproto,kbproto,videoproto,fixesproto,inputproto,xextproto,xf86driproto,damageproto,recordproto|exe>dev,dev,doc,nls
 yes|x264||exe,dev
 yes|x265||exe,dev
-yes|xarchive||exe,doc>exe,dev>null,nls
+no|xarchive||exe,doc>exe,dev>null,nls
 yes|xcb-util|xcb-util|exe,dev,doc,nls
 yes|xcb-util-keysyms|xcb-util-keysyms|exe,dev,doc,nls
 yes|xclip||exe,dev,doc,nls
-yes|xcur2png||exe,dev,doc
-yes|xdelta||exe,dev
-yes|xdg_puppy_jwm||exe
+no|xcur2png||exe,dev,doc
+no|xdelta||exe,dev
+no|xdg_puppy_jwm||exe
 no|Xdialog||exe,dev,doc,nls
-yes|xdialog||exe,dev,doc,nls
+no|xdialog||exe,dev,doc,nls
 yes|xf86-video-fbdev||exe,dev,doc| #virtualbox with UEFI needs this
 no|xinvaders3d||exe,dev
 yes|xfdiff||exe,dev,nls
 yes|x-keyboard||exe,dev
-yes|xlockmore||exe,dev
+no|xlockmore||exe,dev
 yes|xorg-cf-files|xorg-cf-files|exe>dev,dev,doc,nls
 yes|xorg_base_new|appres,bdftopcf,bitmap,editres,evieext,fontconfig,fonttosfnt,fslsfonts,fstobdf,iceauth,libdmx,libfontenc,libFS,libICE,libSM,libX11,libXau,libXaw,libXcomposite,libXcursor,libXdamage,libXdmcp,libXevie,libXext,libXfixes,libXfont,libXfontcache,libXft,libXi,libXinerama,libxkbfile,libXmu,libXp,libXpm,libXpresent,libXrandr,libXrender,libXres,libXScrnSaver,libXt,libXtst,libXv,libXvMC,libXxf86dga,libXxf86misc,libXxf86vm,listres,luit,makedepend,mkcomposecache,mkfontdir,mkfontscale,mtdev,rendercheck,sessreg,setxkbmap,showfont,smproxy,viewres,x11perf,xauth,xbacklight,xbiff,xclipboard,xclock,xconsole,xcursorgen,xditview,xdpyinfo,xdriinfo,xev,xf86dga,xfontsel,xgamma,xhost,xinit,xkbcomp,xkbutils,xkill,xload,xmag,xmessage,xmodmap,xprop,xrandr,xrdb,xrefresh,xset,xsetroot,xsm,xstdcmap,xvidtune,xvinfo,xwd,xwininfo,libdrm,xinput,xkeyboard-config,xbitmaps|exe,dev,doc,nls
 yes|xsane||exe,dev>null,doc,nls
@@ -483,7 +483,7 @@ yes|xvidcore||exe,dev
 yes|xvkbd||exe,dev
 yes|xwd|xwd|exe,dev,doc,nls
 yes|xz|xz|exe,dev,doc,nls
-yes|yad||exe,dev,doc,nls
+no|yad||exe,dev,doc,nls
 yes|yasm|yasm|exe>dev,dev,doc,nls
 yes|YASSM||exe
 yes|zip|infozip|exe,dev>null,doc,nls

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_PKGS_SPECS-slackware64-14.2
@@ -44,7 +44,7 @@ yes|bin86|bin|exe>dev,dev,doc,nls
 yes|binutils|binutils|exe>dev,dev,doc,nls
 yes|bison|bison|exe>dev,dev,doc,nls
 yes|boost|boost|exe>dev,dev,doc,nls
-yes|busybox||exe,dev>null,doc,nls
+no|busybox||exe,dev>null,doc,nls
 yes|bzip2|bzip2|exe,dev,doc,nls
 yes|ca-certificates|ca-certificates|exe,dev,doc,nls
 yes|cabextract||exe,dev,doc,nls
@@ -79,7 +79,7 @@ yes|dictd||exe,dev
 yes|didiwiki||exe,dev
 yes|diffstat|diffstat|exe,dev>null,doc,nls
 yes|diffutils|diffutils|exe,dev>null,doc,nls
-yes|disktype||exe,dev>null,doc,nls
+no|disktype||exe,dev>null,doc,nls
 no|djvulibre||exe,dev,doc,nls
 yes|djvulibre|djvulibre|exe,dev,doc,nls
 yes|dmidecode||exe,dev,doc,nls
@@ -109,11 +109,11 @@ yes|ffconvert||exe
 yes|ffmpeg||exe,dev,doc
 yes|file|file|exe,dev,doc,nls
 yes|findutils|findutils|exe,dev>null,doc,nls
-yes|firewallstatus||exe,dev
+no|firewallstatus||exe,dev
 yes|flac|flac|exe,dev,doc,nls
 yes|flex|flex|exe>dev,dev,doc,nls
 yes|fpm2||exe,dev,doc
-yes|freememapplet||exe,dev
+no|freememapplet||exe,dev
 yes|freetype|freetype|exe,dev,doc,nls
 yes|fribidi|fribidi|exe,dev,doc,nls
 yes|frugalpup||exe
@@ -132,7 +132,7 @@ yes|gdb|gdb|exe>dev,dev,doc,nls
 yes|gdbm|gdbm|exe,dev,doc,nls
 yes|gdk-pixbuf2|gdk-pixbuf2|exe,dev,doc,nls
 yes|gdmap||exe,dev>null,doc,nls
-yes|geany||exe,dev,doc,nls
+no|geany||exe,dev,doc,nls
 yes|get_libreoffice||exe
 no|get_browser||exe
 yes|getcurpos||exe,dev
@@ -164,7 +164,7 @@ yes|gparted|gparted|exe,dev,doc,nls
 yes|gperf|gperf|exe,dev,doc,nls
 yes|gphoto2||exe,dev
 yes|gphotofs||exe,dev
-yes|gpicview||exe,dev,doc,nls
+no|gpicview||exe,dev,doc,nls
 yes|gptfdisk||exe,dev,doc,nls
 yes|grep|grep|exe,dev>null,doc,nls
 yes|groff|groff|exe>dev,dev,doc,nls
@@ -174,7 +174,7 @@ yes|grub4dos||exe
 yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls
 yes|gtk+|gtk+2,libffi|exe,dev,doc,nls
 yes|gtk+3|gtk+3,at-spi2-atk,at-spi2-core|exe,dev,doc,nls
-yes|gtkdialog||exe,dev,doc>dev
+no|gtkdialog||exe,dev,doc>dev
 yes|gtkmm2|gtkmm2|exe,dev,doc,nls
 no|gtk_theme_flat_grey_rounded||exe
 yes|gtk_theme_gradient_grey||exe
@@ -210,7 +210,7 @@ yes|iptables|iptables|exe,dev,doc,nls
 yes|isomaster||exe,dev,doc,nls
 yes|iw|iw|exe,dev,doc,nls
 yes|jasper|jasper|exe,dev,doc,nls
-yes|jwm||exe,dev,doc,nls
+no|jwm||exe,dev,doc,nls
 yes|keyutils|keyutils|exe,dev,doc,nls
 yes|kernel_headers_musl||exe>dev
 yes|kmod|kmod|exe,dev,doc,nls
@@ -308,7 +308,7 @@ yes|linux-header|kernel-headers|exe>dev,dev,doc,nls
 yes|llvm-cut|llvm|exe,dev>null,doc,nls
 yes|lvm2|lvm2|exe,dev,doc,nls
 yes|lxrandr||exe,dev,doc,nls
-yes|lxtask||exe,dev,doc,nls
+no|lxtask||exe,dev,doc,nls
 yes|lxterminal||exe,dev,doc,nls
 yes|lzip||exe,dev,doc,nls
 yes|lzo|lzo|exe,dev,doc,nls
@@ -326,8 +326,8 @@ yes|mozilla-nss|mozilla-nss|exe,dev,doc,nls
 yes|mpfr|mpfr|exe,dev,doc,nls
 yes|MPlayer||exe,dev,doc
 yes|mpscan||exe,dev
-yes|mtpaint||exe,dev,doc,nls
-yes|mtpaint_help||exe
+no|mtpaint||exe,dev,doc,nls
+no|mtpaint_help||exe
 yes|mtr|mtr|exe
 yes|musl||exe,dev>dev
 yes|nano|nano|exe,dev,doc,nls
@@ -335,7 +335,7 @@ yes|nasm||exe>dev,dev,doc,nls
 yes|nbtscan||exe,dev
 yes|ncurses|ncurses|exe,dev,doc,nls
 yes|neon|neon|exe>dev,dev,doc,nls
-yes|netmon_wce||exe,dev,doc,nls
+no|netmon_wce||exe,dev,doc,nls
 yes|netpbm||exe,dev,doc
 yes|net-tools|net-tools|exe,dev,doc,nls
 yes|network_roxapp_samba||exe
@@ -384,7 +384,7 @@ yes|pnscan||exe,dev,doc,nls #peasyport
 yes|polkit|polkit|exe,dev,doc,nls
 yes|poppler|poppler,lcms2|exe,dev,doc,nls
 yes|popt|popt|exe,dev,doc,nls
-yes|powerapplet_tray||exe,dev
+no|powerapplet_tray||exe,dev
 yes|ppp|ppp|exe,dev>null,doc,nls
 yes|precord||exe
 yes|prename||exe
@@ -404,12 +404,12 @@ yes|qpdf|qpdf|exe,dev,doc,nls| #needed for cups
 yes|rdesktop|rdesktop,libsamplerate|exe,dev,doc,nls
 yes|readline|readline|exe,dev,doc,nls
 yes|retrovol||exe,dev,nls
-yes|rox-filer||exe,dev
+no|rox-filer||exe,dev
 yes|rp-pppoe||exe,dev
 yes|rsync|rsync|exe,dev,doc,nls
 yes|rtmpdump||exe,dev,doc,nls
 yes|rubix||exe,dev
-yes|rxvt-unicode||exe,dev>null,doc,nls
+no|rxvt-unicode||exe,dev>null,doc,nls
 yes|samba||exe,dev,doc
 yes|sane-backends||exe,dev,doc,nls
 yes|sbsigntools||exe>dev,dev,doc>dev
@@ -433,7 +433,7 @@ yes|subversion|subversion|exe>dev,dev,doc,nls
 yes|sudo|sudo|exe,dev,doc,nls 
 yes|svgalib|svgalib|exe,dev,doc
 yes|switch2||exe,dev,doc
-yes|sylpheed||exe,doc>exe,dev,nls>null
+no|sylpheed||exe,doc>exe,dev,nls>null
 yes|sys-info||exe
 yes|sysfsutils|sysfsutils|exe,dev,doc,nls
 yes|syslinux|syslinux|exe,dev>null,doc,nls| #must use my pet syslinux pkg..
@@ -442,7 +442,7 @@ yes|tas||exe,nls
 yes|tcl|tcl,tk|exe>dev,dev,doc,nls
 yes|tcpdump|tcpdump|exe,dev,doc,nls
 yes|texinfo|texinfo|exe>dev,dev,doc,nls
-yes|transmission||exe,dev,doc,nls
+no|transmission||exe,dev,doc,nls
 yes|uextract||exe,dev,doc,nls
 yes|unrar||exe,dev,doc,nls
 yes|updates_notice||exe
@@ -465,20 +465,20 @@ yes|wvstreams||exe,dev,doc,nls
 yes|x11proto|dri2proto,dri3proto,presentproto,xcmiscproto,compositeproto,xf86miscproto,fontsproto,printproto,renderproto,xf86dgaproto,xproto,dmxproto,glproto,xcb-proto,xf86bigfontproto,bigreqsproto,randrproto,xf86vidmodeproto,resourceproto,xineramaproto,scrnsaverproto,fontcacheproto,kbproto,videoproto,fixesproto,inputproto,xextproto,xf86driproto,damageproto,recordproto|exe>dev,dev,doc,nls
 yes|x264||exe,dev
 yes|x265||exe,dev
-yes|xarchive||exe,doc>exe,dev>null,nls
+no|xarchive||exe,doc>exe,dev>null,nls
 yes|xcb-util|xcb-util|exe,dev,doc,nls
 yes|xcb-util-keysyms|xcb-util-keysyms|exe,dev,doc,nls
 yes|xclip||exe,dev,doc,nls
-yes|xcur2png||exe,dev,doc
-yes|xdelta||exe,dev
-yes|xdg_puppy_jwm||exe
+no|xcur2png||exe,dev,doc
+no|xdelta||exe,dev
+no|xdg_puppy_jwm||exe
 no|Xdialog||exe,dev,doc,nls
-yes|xdialog||exe,dev,doc,nls
+no|xdialog||exe,dev,doc,nls
 yes|xf86-video-fbdev||exe,dev,doc| #virtualbox with UEFI needs this
 no|xinvaders3d||exe,dev
 yes|xfdiff||exe,dev,nls
 yes|x-keyboard||exe,dev
-yes|xlockmore||exe,dev
+no|xlockmore||exe,dev
 yes|xorg-cf-files|xorg-cf-files|exe>dev,dev,doc,nls
 yes|xorg_base_new|appres,bdftopcf,bitmap,editres,evieext,fontconfig,fonttosfnt,fslsfonts,fstobdf,iceauth,libdmx,libfontenc,libFS,libICE,libSM,libX11,libXau,libXaw,libXcomposite,libXcursor,libXdamage,libXdmcp,libXevie,libXext,libXfixes,libXfont,libXfontcache,libXft,libXi,libXinerama,libxkbfile,libXmu,libXp,libXpm,libXpresent,libXrandr,libXrender,libXres,libXScrnSaver,libXt,libXtst,libXv,libXvMC,libXxf86dga,libXxf86misc,libXxf86vm,listres,luit,makedepend,mkcomposecache,mkfontdir,mkfontscale,mtdev,rendercheck,sessreg,setxkbmap,showfont,smproxy,viewres,x11perf,xauth,xbacklight,xbiff,xclipboard,xclock,xconsole,xcursorgen,xditview,xdpyinfo,xdriinfo,xev,xf86dga,xfontsel,xgamma,xhost,xinit,xkbcomp,xkbutils,xkill,xload,xmag,xmessage,xmodmap,xprop,xrandr,xrdb,xrefresh,xset,xsetroot,xsm,xstdcmap,xvidtune,xvinfo,xwd,xwininfo,libdrm,xinput,xkeyboard-config,xbitmaps|exe,dev,doc,nls
 yes|xsane||exe,dev>null,doc,nls
@@ -489,7 +489,7 @@ yes|xvidcore||exe,dev
 yes|xvkbd||exe,dev
 yes|xwd|xwd|exe,dev,doc,nls
 yes|xz|xz|exe,dev,doc,nls
-yes|yad||exe,dev,doc,nls
+no|yad||exe,dev,doc,nls
 yes|yasm|yasm|exe>dev,dev,doc,nls
 yes|YASSM||exe
 yes|zip|infozip|exe,dev>null,doc,nls


### PR DESCRIPTION
This will make 7.x more consistent with 8.x, while fixing problems like protocols the old Transmission version doesn't support. This is the only application changed to the GTK+ 3 version.

The "backport" of tray icon improvements is probably the most visible change.