### PR TITLE
rc.sysinit: Added isolated folder

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -37,7 +37,7 @@
 #130504 moved up, i think fbcon needs to be loaded before intel, nouveau modules load.
 #160609 rerwin: Add wait for USB3 driver.
 
-PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/X11R7/bin
+PATH=/lib/puppy/bin:/lib/puppy/sbin:/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/X11R7/bin
 . /etc/rc.d/functions_x
 
 #================================================================


### PR DESCRIPTION
Due to unorthodox puppy scripts which has filenames having conflicts with the mainstream distro package. It can cause troubles when it was overwritten. The solution here was to put puppy scripts on a isolated folder and set it as first priority on $PATH this will prevent puppy scripts from being overwritten upon updating packages from mainstream distro