### PR TITLE
Use the Name and Comment fields for menu entries (#2089)

### DIFF
--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/2089.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/2089.patch
@@ -1,0 +1,34 @@
+diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2021-03-09 08:37:51.266137600 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2021-03-10 22:19:11.973052643 +0200
+@@ -165,11 +165,28 @@ process_directory(GMenuTreeDirectory *di
+ void
+ process_entry(GMenuTreeEntry *entry)
+ {
++  const char *tmp;
++  char *exec;
++  size_t len;
+ 
+-  g_printf("<Program label=\"%s\" icon=\"%s\">%s</Program>\n",
++  tmp = gmenu_tree_entry_get_exec (entry);
++  exec = tmp;
++  len = strlen(exec);
++  if ((len > 3) && (exec[len - 3] == ' ') && (exec[len - 2] == '%'))
++  {
++    exec = g_strndup(exec, len - 3);
++  }
++
++  g_printf("<Program label=\"%s\" icon=\"%s\" tooltip=\"%s\">%s</Program>\n",
+             gmenu_tree_entry_get_name(entry),
+             gmenu_tree_entry_get_icon (entry),
+-            gmenu_tree_entry_get_exec (entry));
++            gmenu_tree_entry_get_comment (entry),
++            exec);
++
++  if (exec != tmp)
++  {
++    g_free(exec);
++  }
+ }
+ 
+ /*=============================================================================

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
@@ -17,6 +17,7 @@ build() {
     tar -xjf xdg_puppy-0.7.6-9.tar.bz2
     cd xdg_puppy-0.7.6-9
     patch -p1 < ../empty-menus.patch
+    patch -p1 < ../2089.patch
     gcc $CFLAGS -DGMENU_I_KNOW_THIS_IS_UNSTABLE `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --cflags glib-2.0 libgnome-menu` jwm-xdgmenu/jwm-xdgmenu.c $LDFLAGS `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --libs glib-2.0 libgnome-menu` -o /usr/bin/jwm-xdgmenu
 
     # we don't need these


### PR DESCRIPTION
I'm testing this change in https://github.com/dimkr/woof-CE/actions/runs/634897823.

If the build passes, it should produce dpupos-8.0-prepreprealpha6 (x86_64 and ARM) in https://github.com/dimkr/woof-CE/releases. I'll be able to take a look only later today, after work 😸 

I think, maybe fixing this issue will require a more extensive patch:

```
$ grep -e ^Name= -e ^GenericName= -e ^Comment= /usr/share/applications/geany.desktop
Name=Geany
GenericName=Integrated Development Environment
Comment=A fast and lightweight IDE using GTK+
```

gnome-menus (or at least, the old version we're using) doesn't have a function that gets the GenericName field, which may be more appropriate in some cases, like Geany. I want to see how the menus look once I remove the modifications petbuilds do to the menu entries, then decide whether or not to patch gnome-menus to fetch GenericName and use it instead of Comment.