### PR TITLE
Make the GTK+ 3 gtkdialog more backwards-compatible

### DIFF
--- a/woof-code/rootfs-petbuilds/gtkdialog/compat.patch
+++ b/woof-code/rootfs-petbuilds/gtkdialog/compat.patch
@@ -1,0 +1,75 @@
+From e570075d19cf2e90a2d5160e510e661deb5aaa30 Mon Sep 17 00:00:00 2001
+From: Dima Krasner <dima@dimakrasner.com>
+Date: Fri, 12 Mar 2021 09:21:02 +0200
+Subject: [PATCH] automatically replace deprecated widgets
+
+---
+ src/automaton.c | 13 +++++++++++++
+ 1 file changed, 13 insertions(+)
+
+diff --git a/src/automaton.c b/src/automaton.c
+index 080284c..af27140 100644
+--- a/src/automaton.c
++++ b/src/automaton.c
+@@ -1063,12 +1063,17 @@ instruction_execute_push(
+ 			Widget = widget_colorbutton_create(Attr, tag_attributes, Widget_Type);
+ 			push_widget(Widget, Widget_Type);
+ 			break;
++#if !GTK_CHECK_VERSION(3,0,0)
+ 		case WIDGET_COMBOBOX:
+ 			Widget = widget_combobox_create(Attr, tag_attributes, Widget_Type);
+ 			push_widget(Widget, Widget_Type);
+ 			break;
++#endif
+ 		case WIDGET_COMBOBOXENTRY:
+ 		case WIDGET_COMBOBOXTEXT:
++#if GTK_CHECK_VERSION(3,0,0)
++		case WIDGET_COMBOBOX:
++#endif
+ 			Widget = widget_comboboxtext_create(Attr, tag_attributes, Widget_Type);
+ 			push_widget(Widget, Widget_Type);
+ 			break;
+@@ -1131,12 +1136,14 @@ instruction_execute_push(
+ 			Widget = widget_hseparator_create(Attr, tag_attributes, Widget_Type);
+ 			push_widget(Widget, Widget_Type);
+ 			break;
++#if !GTK_CHECK_VERSION(3,0,0)
+ 		case WIDGET_LIST:
+ 			Widget = widget_list_create(Attr, tag_attributes, Widget_Type);
+ 			scrolled_window = put_in_the_scrolled_window(Widget, Attr,
+ 				tag_attributes, Widget_Type);
+ 			push_widget(scrolled_window, WIDGET_SCROLLEDW);		
+ 			break;
++#endif
+ 		case WIDGET_MENU:
+ 			Widget = widget_menu_create(Attr, tag_attributes, Widget_Type);
+ 			push_widget(Widget, Widget_Type);
+@@ -1182,12 +1189,14 @@ instruction_execute_push(
+ 			Widget = widget_statusbar_create(Attr, tag_attributes, Widget_Type);
+ 			push_widget(Widget, Widget_Type);
+ 			break;
++#if !GTK_CHECK_VERSION(3,0,0)
+ 		case WIDGET_TABLE:
+ 			Widget = widget_table_create(Attr, tag_attributes, Widget_Type);
+ 			scrolled_window = put_in_the_scrolled_window(Widget, Attr,
+ 				tag_attributes, Widget_Type);
+ 			push_widget(scrolled_window, WIDGET_SCROLLEDW);		
+ 			break;
++#endif
+ 		case WIDGET_TERMINAL:
+ 			Widget = widget_terminal_create(Attr, tag_attributes, Widget_Type);
+ 			scrolled_window = put_in_the_scrolled_window(Widget, Attr,
+@@ -1204,6 +1213,10 @@ instruction_execute_push(
+ 			break;
+ #if GTK_CHECK_VERSION(2,4,0)
+ 		case WIDGET_TREE:
++#if GTK_CHECK_VERSION(3,0,0)
++		case WIDGET_LIST:
++		case WIDGET_TABLE:
++#endif
+ 			Widget = widget_tree_create(Attr, tag_attributes, Widget_Type);
+ 			scrolled_window = put_in_the_scrolled_window(Widget, Attr,
+ 				tag_attributes, Widget_Type);
+-- 
+2.25.1
+

--- a/woof-code/rootfs-petbuilds/gtkdialog/petbuild
+++ b/woof-code/rootfs-petbuilds/gtkdialog/petbuild
@@ -8,6 +8,7 @@ build() {
     patch -p1 < ../no-doc.patch
     # -fcommon is required for GCC 10 https://github.com/puppylinux-woof-CE/gtkdialog/pull/90
     if pkg-config --atleast-version=3.24.0 gtk+-3.0; then
+        patch -p1 < ../compat.patch
         CFLAGS="$CFLAGS -fcommon" ./configure --prefix=/usr --bindir=/usr/sbin --enable-gtk3
     else
         CFLAGS="$CFLAGS -fcommon" ./configure --prefix=/usr --bindir=/usr/sbin


### PR DESCRIPTION
This should many (most? all?) old gtkdialog packages work with the GTK+ 3 build of gtkdialog, by replacing combobox with combobxotext, and tree or list with table. Same as the fixes that went into woof-CE, but at runtime.

https://github.com/puppylinux-woof-CE/gtkdialog/pull/92
