### PR TITLE
Add keyboard shorcuts to maximize, minimize and snap windows

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -177,6 +177,16 @@
 <Key key="Return">select</Key>
 <Key key="Escape">escape</Key>
 
+<Key mask="4" key="Up">maximize</Key>
+<Key mask="4" key="Down">minimize</Key>
+<Key mask="4" key="Left">maxleft</Key>
+<Key mask="4" key="Right">maxright</Key>
+
+<Key mask="A" key="equal">maximize</Key>
+<Key mask="A" key="minus">minimize</Key>
+<Key mask="A" key="bracketleft">maxleft</Key>
+<Key mask="A" key="bracketright">maxright</Key>
+
 <Key mask="A" key="Tab">next</Key>
 <Key mask="A" key="F4">close</Key>
 <Key mask="A" key="#">desktop#</Key>


### PR DESCRIPTION
The first group is borrowed from Windows, and the second from Chrome OS.