### PR TITLE
Run a second PulseAudio instance for spot (#2117)

### DIFF
--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -68,7 +68,7 @@ if [ -f usr/bin/start-pulseaudio-x11 ]; then
 #!/bin/sh -e
 # hack: we don't have a user session bus or systemd for service activation
 pulseaudio --start
-grep -q =true ~/.spot-status && run-as-spot pulseaudio --start
+grep -q =true ~/.spot-status 2>/dev/null && run-as-spot pulseaudio --start
 exec start-pulseaudio-x11.real
 EOF
 	chmod 755 usr/bin/start-pulseaudio-x11

--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -68,6 +68,7 @@ if [ -f usr/bin/start-pulseaudio-x11 ]; then
 #!/bin/sh -e
 # hack: we don't have a user session bus or systemd for service activation
 pulseaudio --start
+grep -q =true ~/.spot-status && run-as-spot pulseaudio --start
 exec start-pulseaudio-x11.real
 EOF
 	chmod 755 usr/bin/start-pulseaudio-x11

--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -73,3 +73,6 @@ exec start-pulseaudio-x11.real
 EOF
 	chmod 755 usr/bin/start-pulseaudio-x11
 fi
+
+# because pulseaudio is not bus-activated, it must not exit when idle
+echo "exit-idle-time = -1" >> etc/pulse/daemon.conf


### PR DESCRIPTION
Testing the fix in https://github.com/dimkr/woof-CE/actions/runs/651627964 (already tested manually, by modifying /usr/bin/start-pulseaudio-x11)