### PR TITLE
Build cdrtools later, before 3builddistro

### DIFF
--- a/.github/workflows/slacko-7.yml
+++ b/.github/workflows/slacko-7.yml
@@ -51,10 +51,6 @@ jobs:
         key: ${{ github.workflow }}-local-repositories-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-local-repositories-
-    - name: Install cdrtools
-      run: |
-        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
-        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
     - name: Prepare build environment
       run: |
         [ -f local-repositories/vercmp ] || (curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o ../local-repositories/vercmp -)
@@ -141,6 +137,10 @@ jobs:
         sudo dpkg --add-architecture i386
         sudo apt-get update -qq
         sudo apt-get install -y --no-install-recommends libuuid1:i386
+    - name: Install cdrtools
+      run: |
+        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
+        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output

--- a/.github/workflows/slacko64-7.yml
+++ b/.github/workflows/slacko64-7.yml
@@ -51,10 +51,6 @@ jobs:
         key: ${{ github.workflow }}-local-repositories-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-local-repositories-
-    - name: Install cdrtools
-      run: |
-        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
-        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
     - name: Prepare build environment
       run: |
         [ -f local-repositories/vercmp ] || (curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o ../local-repositories/vercmp -)
@@ -136,6 +132,10 @@ jobs:
         key: ${{ github.workflow }}-petbuild-output-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-petbuild-output-
+    - name: Install cdrtools
+      run: |
+        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
+        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -71,10 +71,6 @@ jobs:
         key: ${{ github.workflow }}-local-repositories-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-local-repositories-
-    - name: Install cdrtools
-      run: |
-        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
-        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
     - name: Prepare build environment
       run: |
         [ -f local-repositories/vercmp ] || (curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o ../local-repositories/vercmp -)
@@ -156,6 +152,10 @@ jobs:
         key: ${{ github.workflow }}-petbuild-output-${{ github.sha }}
         restore-keys: |
           ${{ github.workflow }}-petbuild-output-
+    - name: Install cdrtools
+      run: |
+        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
+        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output


### PR DESCRIPTION
This makes CI fail very quickly if 0setup failed.