### PR TITLE
If Comment is missing or empty, create a menu entry without a tooltip

### DIFF
--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/2089.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/2089.patch
@@ -1,15 +1,18 @@
 diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
---- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2021-03-09 08:37:51.266137600 +0200
-+++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2021-03-10 22:19:11.973052643 +0200
-@@ -165,11 +165,28 @@ process_directory(GMenuTreeDirectory *di
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2021-03-10 22:39:55.078630581 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2021-03-14 21:39:50.935884915 +0200
+@@ -165,11 +165,39 @@ process_directory(GMenuTreeDirectory *di
  void
  process_entry(GMenuTreeEntry *entry)
  {
-+  const char *tmp;
++  const char *tmp, *comment;
 +  char *exec;
 +  size_t len;
  
 -  g_printf("<Program label=\"%s\" icon=\"%s\">%s</Program>\n",
+-            gmenu_tree_entry_get_name(entry),
+-            gmenu_tree_entry_get_icon (entry),
+-            gmenu_tree_entry_get_exec (entry));
 +  tmp = gmenu_tree_entry_get_exec (entry);
 +  exec = tmp;
 +  len = strlen(exec);
@@ -18,12 +21,22 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 +    exec = g_strndup(exec, len - 3);
 +  }
 +
-+  g_printf("<Program label=\"%s\" icon=\"%s\" tooltip=\"%s\">%s</Program>\n",
-             gmenu_tree_entry_get_name(entry),
-             gmenu_tree_entry_get_icon (entry),
--            gmenu_tree_entry_get_exec (entry));
-+            gmenu_tree_entry_get_comment (entry),
-+            exec);
++  comment = gmenu_tree_entry_get_comment (entry);
++  if (comment && comment[0])
++  {
++    g_printf("<Program label=\"%s\" icon=\"%s\" tooltip=\"%s\">%s</Program>\n",
++              gmenu_tree_entry_get_name(entry),
++              gmenu_tree_entry_get_icon (entry),
++              comment,
++              exec);
++  }
++  else
++  {
++    g_printf("<Program label=\"%s\" icon=\"%s\">%s</Program>\n",
++              gmenu_tree_entry_get_name(entry),
++              gmenu_tree_entry_get_icon (entry),
++              exec);
++  }
 +
 +  if (exec != tmp)
 +  {


### PR DESCRIPTION
Observed on a slacko 7.x build, in the Firefox menu entry: mozilla-firefox.desktop doesn't have a comment field, and `sprintf("%s", NULL) == "(null)"`.

![menu](https://user-images.githubusercontent.com/1471149/111081966-7e4ddb00-850e-11eb-9826-6172cdb37fd5.png)
