### PR TITLE
Fix and enable fossa64 adrv support

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -265,9 +265,9 @@ else
 	EXTRAS_LIST="${EXTRAS_LIST//||/|}" #replace double "||" with "|"
 fi
 if [ -n "${DUMMY}" ];then
-	PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | grep -vE "${EXTRAS_LIST}" | cut -f 2 -d '|' | tr '\n' ' '`" 
+	PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | sed s/#.*//g | grep -vE "${EXTRAS_LIST}" | cut -f 2 -d '|' | tr '\n' ' '`"
 else
-	PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | cut -f 2 -d '|' | tr '\n' ' '`"
+	PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | sed s/#.*//g | cut -f 2 -d '|' | tr '\n' ' '`"
 fi
 PKGLIST="${PKGLIST}"
 copy_pkgs_to_build "${PKGLIST}" rootfs-complete

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -25,7 +25,7 @@ KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"
-ADRV_INC=""
+ADRV_INC="abiword asunder claws-mail conky conky-gtk deadbeef Dunst-config get_libreoffice gftp gmeasures gnumeric goffice gogglesmm gplanarity gtkhash guvcview gwaveedit haiku hexchat homebank htop iqpuzzle isomaster ListDDF lxrandr notecase osmo PackIt palemoon peasyport picpuz pmirrorget pnethood pplog psip PupClockset Pup-SysInfo QtNote rubix simplegtkradio simplescreenrecorder yahtzeez"
 ## YDRV_INC=""
 YDRV_INC=""
 ## FDRV_INC="" #this one is very experimental and it's recommended to be left unset

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -25,7 +25,7 @@ KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"
-ADRV_INC="abiword asunder claws-mail conky conky-gtk deadbeef Dunst-config get_libreoffice gftp gmeasures gnumeric goffice gogglesmm gplanarity gtkhash guvcview gwaveedit haiku hexchat homebank htop iqpuzzle isomaster ListDDF lxrandr notecase osmo PackIt palemoon peasyport picpuz pmirrorget pnethood pplog psip PupClockset Pup-SysInfo QtNote rubix simplegtkradio simplescreenrecorder yahtzeez"
+ADRV_INC="abiword asunder claws-mail clipit conky conky-gtk deadbeef Dunst-config easytag eboardchess findnrun fpm2 galculator gatotray gdmap get_libreoffice gexec gftp gmeasures gnumeric goffice gogglesmm gplanarity gtkhash guvcview gview gwaveedit haiku hardinfo hexalate hexchat hiawatha homebank htop inkscapelite iqpuzzle isomaster ListDDF lxrandr notecase osmo PackIt palemoon pdvdrsab peasyport picpuz pmirrorget pnethood pplog psip PupClockset Pup-SysInfo qpdfview QtNote rubix simplegtkradio simplescreenrecorder simsu uextract uget UrxvtControl xvkbd yahtzeez"
 ## YDRV_INC=""
 YDRV_INC=""
 ## FDRV_INC="" #this one is very experimental and it's recommended to be left unset


### PR DESCRIPTION
I couldn't understand why every time I built fossa64, GCC failed during 3builddistro because libgmp was missing. gmp wasn't copied into rootfs-complete, and it does include the correct, libgmp10 dependency of GCC:

```
yes|gmp|libgmp10,libgmpxx4ldbl,libgmp-dev,libgmp3-dev|exe,dev,doc,nls| #in precise, this was only in devx, but abiword needs it.
```

I couldn't understand why it's not copied, if there's a `yes` there, and why every fossa64 build fails when I enable adrv.

Now, I finally found it. The problem is here:

```
        DUMMY=XXXX #unless they make a Qld beer proggy 'XXXX' will never match; besides need a trailing field
        EXTRAS_LIST="${EXTRAS_LIST// /|}${DUMMY}"
        EXTRAS_LIST="${EXTRAS_LIST//^|}" #strip leading "|"
        EXTRAS_LIST="${EXTRAS_LIST//||/|}" #replace double "||" with "|"
fi
if [ -n "${DUMMY}" ];then
        PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' grep -vE "${EXTRAS_LIST}" | cut -f 2 -d '|' | tr '\n' ' '`"
```

`EXTRAS_LIST=abiword|gnumeric...` and the `gmp` line contains one of these substrings, `abiword`, **in a comment**, so gmp is removed from the list of packages that go into rootfs-complete.