### PR TITLE
Add support for redirecting petbuilds to adrv (#2113)

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -269,12 +269,23 @@ done
 
 echo "Copying petbuilds to rootfs-complete"
 
+MAINPKGS=
+
 for NAME in $PKGS; do
     mkdir -p ../packages-${DISTRO_FILE_PREFIX}/${NAME}
     cp -a ../petbuild-output/${NAME}-latest/* ../packages-${DISTRO_FILE_PREFIX}/${NAME}/
     (echo ":${NAME}:|pet|"; cat ../rootfs-petbuilds/${NAME}/pet.specs) >> ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}
+
+    # redirect packages with menu entries to adrv; ROX-Filer is a 'core' package like JWM
+    if [ -n "$ADRV_INC" ] && [ "$NAME" != "rox-filer" ] && [ -n "`ls ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/applications/*.desktop 2>/dev/null`" ]; then
+        ADRV_INC="$ADRV_INC $NAME"
+    elif [ -n "$MAINPKGS" ]; then
+        MAINPKGS="$MAINPKGS $NAME"
+    else
+        MAINPKGS="$NAME"
+    fi
 done
 
-(cd .. && copy_pkgs_to_build "$PKGS" rootfs-complete)
+(cd .. && copy_pkgs_to_build "$MAINPKGS" rootfs-complete)
 
 echo


### PR DESCRIPTION
~Will work once #2135 is merged~ merged

This support is optional: if adrv is enabled, petbuilds with .desktop files are automatically moved to it.