### PR TITLE
Add a barebones dpup bullseye template

### DIFF
--- a/.github/workflows/bullseye64.yml
+++ b/.github/workflows/bullseye64.yml
@@ -1,0 +1,209 @@
+name: bullseye64
+
+on:
+  push:
+    branches:
+      - ci
+      - testing
+    paths:
+      - 'woof-distro/x86_64/debian/bullseye64/**'
+      - 'kernel-kit/**'
+      - 'woof-code/**'
+      - '!woof-code/support/arm_**'
+      - 'woof-arch/x86_64/**'
+      - 'merge2out'
+      - '!**.svg'
+      - '!**.png'
+      - '!**.htm'
+      - '!**.html'
+      - '!**.desktop'
+      - '!**.po'
+      - '!**.mo'
+      - '!**/README*'
+  pull_request:
+    branches:
+      - testing
+    paths:
+      - 'woof-distro/x86_64/debian/bullseye64/**'
+      - 'kernel-kit/**'
+      - 'woof-code/**'
+      - '!woof-code/support/arm_**'
+      - 'woof-arch/x86_64/**'
+      - 'merge2out'
+      - '!**.svg'
+      - '!**.png'
+      - '!**.htm'
+      - '!**.html'
+      - '!**.desktop'
+      - '!**.po'
+      - '!**.mo'
+      - '!**/README*'
+  schedule:
+    - cron: '0 0 * * 4'
+  workflow_dispatch:
+    branches:
+      - ci
+      - testing
+    inputs:
+      version:
+        description: 'Version number'
+        required: true
+        default: '9.0.0'
+      suffix:
+        description: 'Release name suffix, with leading -'
+        required: false
+        default: '-prepreprealpha1'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+    - name: Create cache directories
+      run: |
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        ln -s `pwd`/local-repositories ../local-repositories
+    - name: Get cached local-repositories
+      uses: actions/cache@v2
+      with:
+        path: local-repositories
+        key: ${{ github.workflow }}-local-repositories-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-local-repositories-
+    - name: Prepare build environment
+      run: |
+        [ -f local-repositories/vercmp ] || (curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o ../local-repositories/vercmp -)
+        sudo install -m 755 local-repositories/vercmp /usr/local/bin/vercmp
+        sudo install -D -m 644 woof-code/rootfs-skeleton/usr/local/petget/categories.dat /usr/local/petget/categories.dat
+        echo "dash dash/sh boolean false" | sudo debconf-set-selections
+        sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
+        sudo ln -s bash /bin/ash
+    - name: merge2out
+      run: |
+        (echo 3; echo 1; echo 1; echo; echo) | sudo -E ./merge2out
+    - name: Set version
+      if: github.event_name == 'workflow_dispatch'
+      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_debian_bullseye64/DISTRO_SPECS
+    - name: Set compression algorithm
+      if: github.event_name != 'workflow_dispatch'
+      run: |
+        echo | sudo tee -a ../woof-out_x86_64_x86_64_debian_bullseye64/_00build.conf
+        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_64_x86_64_debian_bullseye64/_00build.conf
+    - name: 0setup
+      run: |
+        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        sudo -E ./0setup
+    - name: 1download
+      run: |
+        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        sudo -E ./1download
+    - name: Get cached kernel-kit output
+      if: github.event_name != 'workflow_dispatch'
+      id: get_kernel_kit_output_cache
+      uses: actions/cache@v2
+      with:
+        path: kernel-kit-output
+        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output
+    - name: Install kernel-kit dependencies
+      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
+        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
+    - name: Get cached ~/.ccache
+      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
+      uses: actions/cache@v2
+      with:
+        path: ~/.ccache
+        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
+    - name: kernel-kit
+      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
+      run: |
+        cd ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit
+        sudo cp -f bullseye64-build.conf build.conf
+        sudo -E ./build.sh
+    - name: 2createpackages
+      run: |
+        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        echo | sudo -E ./2createpackages
+    - name: Get cached petbuild-sources
+      uses: actions/cache@v2
+      with:
+        path: petbuild-sources
+        key: ${{ github.workflow }}-petbuild-sources-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-petbuild-sources-
+    - name: Get cached petbuild-cache
+      if: github.event_name != 'workflow_dispatch'
+      uses: actions/cache@v2
+      with:
+        path: petbuild-cache
+        key: ${{ github.workflow }}-petbuild-cache-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-petbuild-cache-
+    - name: Get cached petbuild-output
+      if: github.event_name != 'workflow_dispatch'
+      uses: actions/cache@v2
+      with:
+        path: petbuild-output
+        key: ${{ github.workflow }}-petbuild-output-${{ github.sha }}
+        restore-keys: |
+          ${{ github.workflow }}-petbuild-output-
+    - name: Install cdrtools
+      run: |
+        [ -f local-repositories/mkisofs ] || (curl -L https://sourceforge.net/projects/cdrtools/files/alpha/cdrtools-3.02a09.tar.bz2/download | tar -xjf- && cd cdrtools-3.02 && make -j`nproc` && mv mkisofs/OBJ/x86_64-linux-cc/mkisofs ../local-repositories/mkisofs)
+        sudo install -m 755 local-repositories/mkisofs /usr/local/bin/mkisofs
+    - name: 3builddistro
+      run: |
+        sudo chown -R root:root petbuild-output
+        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_64_x86_64_debian_bullseye64/
+        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        sudo -E HOME=/root ./3builddistro
+    - name: Create Release
+      if: github.event_name == 'workflow_dispatch'
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: dpupbullseye64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
+        release_name: dpupbullseye64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
+        draft: false
+        prerelease: true
+    - name: Upload ISO
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/woof-output-dpupbullseye64-${{ github.event.inputs.version }}/dpupbullseye64-${{ github.event.inputs.version }}.iso
+        asset_name: dpupbullseye64-${{ github.event.inputs.version }}.iso
+        asset_content_type: application/octet-stream
+    - name: Upload devx
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/woof-output-dpupbullseye64-${{ github.event.inputs.version }}/devx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
+        asset_name: devx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
+        asset_content_type: application/octet-stream
+    - name: Upload kernel sources
+      if: github.event_name == 'workflow_dispatch'
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output/kernel_sources-5.10-dpupbullseye64.sfs
+        asset_name: kernel_sources-5.10-dpupbullseye64.sfs
+        asset_content_type: application/octet-stream
+    - name: Move cached directories
+      run: |
+        sudo mv ../woof-out_x86_64_x86_64_debian_bullseye64/petbuild-{sources,cache,output} .
+        sudo mv ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output kernel-kit-output

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Currently supported:
 
 - Slackware [![slacko64](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/slacko64.yml/badge.svg)](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/slacko64.yml) [![slacko-7](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/slacko-7.yml/badge.svg)](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/slacko-7.yml) [![slacko64-7](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/slacko64-7.yml/badge.svg)](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/slacko64-7.yml)
 - Ubuntu [![fossa64](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/fossa64.yml/badge.svg)](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/fossa64.yml)
-- Debian
+- Debian [![bullseye64](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/bullseye64.yml/badge.svg)](https://github.com/puppylinux-woof-CE/woof-CE/actions/workflows/bullseye64.yml)
 
 # Building a Puppy: using GitHub Actions
 

--- a/kernel-kit/bullseye64-build.conf
+++ b/kernel-kit/bullseye64-build.conf
@@ -1,0 +1,123 @@
+#--
+#             Configuration options
+#             =====================
+# 
+#  **NOTE**: check the original file every once in a while
+#            settings might be added or removed...
+#
+# see http://www.kernel.org/ for the latest kernel info..
+#--
+
+################################################################
+## add a Kernel .config file in one of the configs_* directories
+## It must follow this syntax:
+##           version  info
+## DOTconfig-3.14.73-i686-4g
+################################################################
+
+## speed up the process by specifing a DOTconfig file:
+#DOTconfig_file=DOTconfig
+DOTconfig_file=configs_x86_64/DOTconfig-5.10.17-x86_64
+
+# latest in series, LatestK 
+# this gets the latest kernel in relation to the DOTconfig_file
+# specified above and depends on that value. It must be a longterm
+# kernel
+LatestK=1
+
+## use this version string with the current ./DOTconfig
+## (in case it doesn't have usable version info inside)
+kernel_ver=
+
+## i386 specific stuff: force pae/nopae - i486/i686
+## note: the script will run 'make oldconfig' to ensure
+##       the new settings take effect..
+#x86_disable_pae=yes
+#x86_enable_pae=yes
+
+## this is the kernel suffix hack, you can leave it empty ie: uname -r
+## if you don't leave empty the leading "dash" is required
+## DO NOT change it between minor versions (i.e 3.14.1 and 3.14.2); otherwise,
+## third-party drivers will break and users won't be able to upgrade: kernel-kit
+## patches the kernel to ensure drivers built for the major version (say, 3.14)
+## continue to work with any future minor version (3.14.1, 3.14.2, etc') and
+## don't have to be rebuilt, but the suffix must not change for this to work
+## (this is particularly good if you wish to stick with a longterm kernel branch
+## without any maintenance and without frustrating users that need extra drivers)
+## example:
+#custom_suffix=-4G
+custom_suffix=
+
+## this is the name of the pet package suffix, and source sfs
+## name it whatever you like, usually put in a signifier for your distro
+## eg: "s" is for slacko
+## if you leave empty the script will determine a proper package suffix
+package_name_suffix=dpupbullseye64
+
+##-----------------------------------------------------------------------
+
+## remove kernel sublevel, or not : set yes or no
+remove_sublevel=yes
+
+## aufs version (git branch) - see README -> AUFS GIT BRANCHES
+## the script automatically detects the aufs version, but when it does not
+## you must specify it here:
+#aufsv=3.14.40+
+
+## JOBS ###
+## if you have a multicore processor you can set this var
+## don't set if you have a single core! >> cooked machine 
+## DO NOT set it to 0 (zero) >> cooked machine
+#JOBS=-j6
+
+### squashfs compression ###
+## unset this for the default of your mksquashfs binary
+#COMP="-comp gzip"
+#COMP="-comp xz"
+#COMP="-comp xz -b 512K"
+COMP='-comp zstd -Xcompression-level 19 -b 512K -no-exports -no-xattrs'
+
+## strip kernel modules?
+## warning: this might cause issues
+STRIP_KMODULES=no
+
+## Firmware tarballs repository
+#FW_URL=http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux/firmware
+
+## Firmware tarball or SFS (fdrv)
+## specify pkg url to automate the process
+#FW_PKG_URL="http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux/firmware/firmware-140621-big.tar.bz2"
+
+## Kernel download mirrors
+kernel_mirrors='https://www.kernel.org/pub/linux/kernel
+ftp://ftp.ntu.edu.tw/linux/kernel
+ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
+ftp://ftp.yandex.ru/pub/linux/kernel/
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
+ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
+ftp://www.mirrorservice.org/pub/linux/kernel
+ftp://ftp.be.debian.org/pub/linux/kernel'
+
+## This kit now gets firmware from kernel.org
+## The default is to produce a firmware package that is based on the running
+## kernel package and sent to main build or you can send it to the fdrv 
+## or you can opt to have no firmware
+## fware=b >> builtin (zdrv)
+## fware=f >> fdrv
+## fware=n >> no firmware - no download of large firmware repo
+## RECOMMENDATION: choose f!
+fware=f
+
+## -- AUTO --
+## Enforce automation of the process. Also triggered by: ./build.sh auto
+## Every error is fatal, so you must specify all the needed stuff in build.conf first..
+AUTO=yes
+
+## if no third party drivers will be built, the generation of a kernel sources
+## SFS can be skipped
+#CREATE_SOURCES_SFS=no
+
+## in some special cases, like some ARM platforms, one might wish to build the
+## kernel without aufs
+# warning: Puppy might not boot, or be partially broken without aufs
+#AUFS=no

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_COMPAT_REPOS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_COMPAT_REPOS-debian-bullseye
@@ -1,0 +1,49 @@
+#
+# DISTRO_COMPAT_REPOS
+#
+
+if [ "$DISTRO_COMPAT_VERSION" = "" ] ; then
+	[ -f ./DISTRO_SPECS ] && . ./DISTRO_SPECS
+fi
+
+case "$DISTRO_TARGETARCH" in
+	x86)    DBIN_ARCH=i386  ;;
+	x86_64) DBIN_ARCH=amd64 ;;
+	arm)    DBIN_ARCH=armhf ;;
+esac
+
+#----------------------
+#PKG_DOCS_DISTRO_COMPAT - where to download the compat-distro pkgs databases from
+#---------------------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the database file.
+#   3 - name of db file when local and after being processed into standard format
+
+PKG_DOCS_DISTRO_COMPAT="
+z|http://http.us.debian.org/debian/dists/${DISTRO_COMPAT_VERSION}/main/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-main
+z|http://http.us.debian.org/debian/dists/${DISTRO_COMPAT_VERSION}/non-free/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-non-free
+z|http://http.us.debian.org/debian/dists/${DISTRO_COMPAT_VERSION}/contrib/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-contrib
+"
+
+#-------------------
+#REPOS_DISTRO_COMPAT - hardcode the compat-distro repos in here...
+#-------------------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the repo
+#   3 - name of db-file(s) associated with that repo. it may have glob wildcards.
+
+REPOS_DISTRO_COMPAT="
+z|http://http.us.debian.org/debian|Packages-debian-${DISTRO_COMPAT_VERSION}-*
+z|http://mirrors.kernel.org/debian|Packages-debian-${DISTRO_COMPAT_VERSION}-*
+z|http://ftp.de.debian.org/debian|Packages-debian-${DISTRO_COMPAT_VERSION}-*
+"
+
+
+#---------------
+# fix variables
+#---------------
+PKG_DOCS_DISTRO_COMPAT="$(echo $PKG_DOCS_DISTRO_COMPAT)"
+REPOS_DISTRO_COMPAT="$(echo $REPOS_DISTRO_COMPAT)"
+

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PET_REPOS
@@ -1,0 +1,53 @@
+#------------------
+#PKG_DOCS_PET_REPOS - where to download the pet pkgs databases from.
+#------------------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the database file.
+#   3 - name of db file when local and after being processed into standard format
+#  (in the case of PET databases, the names are the same and no processing is required)
+
+if [ "${BUILD_FROM_WOOF//;/_}" != "$BUILD_FROM_WOOF" ] ; then
+	WCE_BRANCH="${BUILD_FROM_WOOF%%;*}" #cut -f 1 -d ';'
+else
+	WCE_BRANCH=testing
+fi
+# TODO: remove this when C201 support lands in testing
+WCE_BRANCH=testing
+
+PKG_DOCS_PET_REPOS="
+z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woof-distro/Packages-puppy-noarch-official|z
+"
+
+#---------
+#PET_REPOS - hardcode the pet repos in here...
+#---------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the repo
+#   3 - name of db-file(s) associated with that repo. it may have glob wildcards.
+#   ex: Packages-puppy-4-official (note, url paths are in the database)
+
+PET_REPOS="
+z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-noarch-official
+z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-noarch-official
+z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
+"
+
+#----------------------
+#PACKAGELISTS_PET_ORDER
+#----------------------
+#   this defines where Woof (and PPM) looks first and second
+#   (and third, etc.) for pet pkgs
+
+PACKAGELISTS_PET_ORDER="
+Packages-puppy-noarch-official
+"
+
+#---------------
+# fix variables
+#---------------
+PKG_DOCS_PET_REPOS="$(echo $PKG_DOCS_PET_REPOS)"
+PET_REPOS="$(echo $PET_REPOS)"
+PACKAGELISTS_PET_ORDER="$(echo $PACKAGELISTS_PET_ORDER)"
+

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -1,0 +1,673 @@
+#fallbacks when looking for pkgs (space-separated list)...
+FALLBACKS_COMPAT_VERSIONS=''
+
+#PKGS_SPECS_TABLE table format:
+#will pkg be in puppy-build.
+#    Generic name for pkg. Note: PET packages, if exist, use this name.
+#            Comma-separated list of compatible-distro pkg(s). '-' prefix, exclude.
+#            Must be exact name-only of pkg, else '*' on end is wildcard to search full name.
+#            Empty field, then use PET pkg.
+#                                    How the package will get split up in woof (optional redirection '>' operator).
+#                                    Missing field, it goes into exe. Can also redirect >null, means dump it.
+#yes|abiword|iceword,iceword-plugins|exe,dev,doc,nls
+
+#example showing wildcard. finds all full pkg names with 'gcc-4.3*',
+#but, exclude any 'gcc-4.3-doc*' matches...
+# yes|gcc|gcc,gcc-4.3*,-gcc-4.3-doc*|exe,dev,doc,nls
+
+#110817 Comments preferred to be on end of line, ex:
+# yes|abiword|iceword,iceword-plugins|exe,dev,doc,nls| #this is a comment.
+
+#110829 enhancements:
+#                                                     Force pkg is from compat-distro repo, specifically 'salix' repo.
+# yes|abiword|iceword,iceword-plugins|exe,dev,doc,nls|compat:salix
+#Generic format:
+# yes|genericpkgname|[pkgnames]|[splitup]|[pet:[repo]]
+# yes|genericpkgname|[pkgnames]|[splitup]|[compat:[repo]]
+#for a fuller explanation of the entries in PKGS_SPECS_TABLE, please see:
+# http://bkhome.org/blog/?viewDetailed=02414
+
+PKGS_SPECS_TABLE='
+no|a52dec|liba52-0.7.4,liba52-0.7.4-dev|exe,dev,doc>null,nls>null
+no|aalib|libaa1|exe,dev>null,doc>null,nls>null #ascii library, needed by mplayer, gphoto
+yes|acl|libacl1,libacl1-dev|exe,dev,doc>null,nls>null
+no|acpi|acpi|exe,dev,doc>null,nls>null
+no|acpid-busibox||exe
+yes|advancecomp|advancecomp|exe>dev,dev,doc>null,nls>null
+no|alsaequal|libasound2-plugin-equal,caps|exe,dev,doc,nls| #needed by pequalizer.
+yes|alsa-lib|libasound2,libasound2-data,alsa-topology-conf,alsa-ucm-conf,libasound2-dev,libasound2-plugins|exe,dev,doc>null,nls>null
+yes|alsa-utils|alsa-utils|exe,dev,doc>null,nls>null
+no|apulse||exe,dev,doc
+no|aspell|libaspell15,libaspell-dev|exe,dev,doc>null,nls>null #needed by abiword.
+yes|atk|libatk1.0-0,libatk1.0-dev|exe,dev,doc>null,nls>null
+yes|at-spi2-atk|libatspi2.0-0,libatk-bridge2.0-0,libatk-bridge2.0-dev,libatspi2.0-dev|exe,dev,doc>null,nls>null #needed by gtk+3.
+yes|attr|libattr1,libattr1-dev|exe,dev,doc>null,nls>null
+no|audiofile|libaudiofile1,libaudiofile-dev|exe,dev,doc>null,nls>null
+yes|audit|libaudit-common,libaudit1,libaudit-dev|exe,dev,doc>null,nls>null #needed by xorg.
+yes|autoconf|autoconf|exe>dev,dev,doc>null,nls>null
+yes|automake|automake,autotools-dev|exe>dev,dev,doc>null,nls>null
+yes|autopoint|autopoint|exe>dev,dev,doc>null,nls>null
+yes|avahi|avahi-daemon,libavahi-core7,libavahi-client3,libavahi-client-dev,libavahi-glib1,libavahi-glib-dev,libavahi-common3,libavahi-common-data,libavahi-common-dev,libavahi-compat-libdnssd1,libavahi-compat-libdnssd-dev|exe,dev,doc>null,nls>null #avahi-daemon and libavahi-core7 are required to prevent gdbus error messages when opening print dialogs
+no|axel|axel|exe,dev>null,doc>null,nls>null
+yes|bash|bash,bash-builtins|exe,dev,doc,nls
+yes|bash-completion|bash-completion|exe,dev>null,doc>null,nls>null
+yes|bbe|bbe|exe,dev,doc>null,nls>null #sed-like editor for binary files.
+yes|bc|bc|exe,dev,doc>null,nls>null
+no|bcrypt|bcrypt|exe,dev,doc>null,nls>null
+yes|bdb|libdb5.3,libdb-dev,libdb5.3-dev|exe,dev,doc>null,nls>null
+yes|bin86|bin86|exe>dev,dev,doc>null,nls>null
+yes|bison|bison|exe>dev,dev,doc>null,nls>null
+yes|boehm-gc|libgc1,libgc-dev|exe,dev,doc>null,nls>null
+no|busybox||exe
+yes|bzip2|bzip2,libbz2-1.0,libbz2-dev|exe,dev,doc>null,nls>null
+yes|ca-certificates|ca-certificates|exe,dev,doc>null,nls>null
+yes|cairo|libcairo2,libcairo2-dev,libcairo-gobject2,libcairo-gobject2,libcairo-script-interpreter2|exe,dev,doc>null,nls>null
+yes|ccache|ccache|exe>dev,dev,doc>null,nls>null
+no|cdparanoia|cdparanoia,libcdparanoia0,libcdparanoia-dev|exe,dev,doc>null,nls>null
+no|cifs-utils|cifs-utils|exe,dev,doc>null,nls>null
+no|copy-fast||exe,doc>null,nls>null
+yes|coreutils|coreutils|exe,doc>null,nls>null
+yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc>null,nls>null
+no|colord|libcolord2,libcolord-dev|exe,dev,doc>null,nls>null #needed by gtk+3.
+yes|cpio|cpio|exe,dev>null,doc>null,nls>null
+yes|crda|crda,wireless-regdb|exe,dev,doc,nls
+no|ctorrent|ctorrent|exe,dev>null,doc>null,nls>null
+no|cryptsetup||exe # must use wce static binary
+no|cups|cups-bsd,cups,cups-common,cups-core-drivers,cups-server-common,cups-client,cups-ppdc,libcups2,libcups2-dev,libcupsimage2,libcupsimage2-dev,cups-daemon|exe,dev,doc>null,nls>null
+no|cups-filters|cups-filters,cups-filters-core-drivers,libcupsfilters1,libcupsfilters-dev,libfontembed1,libfontembed-dev|exe,dev,doc>null,nls>null #extra cups filters, especially pdftops.
+yes|curl|curl,libcurl4,libcurl4-openssl-dev|exe,dev,doc>null,nls>null
+no|cvs|cvs|exe>dev,dev,doc>null,nls>null
+yes|cyrus-sasl2|libsasl2-2,libsasl2-dev|exe,dev,doc>null,nls>null
+yes|dash|dash|exe>dev,dev,doc>null,nls>null
+yes|dbus|dbus,dbus-x11,libdbus-1-3,libdbus-1-dev,libapparmor1|exe,dev,doc,nls
+yes|dbus-glib|libdbus-glib-1-2,libdbus-glib-1-dev|exe,dev,doc>null,nls>null
+yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1|exe,dev,doc>null,nls>null #needed by gsettings-desktop-settings
+#yes|deadbeef|deadbeef,deadbeef-waveform-seekbar,deadbeef-vu-meter,deadbeef-spectrogram,deadbeef-rating,deadbeef-musical-spectrum,deadbeef-infobar|exe|
+yes|debianutils|debianutils|exe,dev,doc>null,nls>null
+yes|dejavu_fonts|fonts-dejavu-core,fonts-dejavu-extra|exe,dev,doc,nls
+no|desk_icon_theme_uniform||exe
+no|desk_icon_theme_neon||exe
+yes|desktop-file-utils|desktop-file-utils|exe,dev,doc,nls
+no|devmapper|libdevmapper1.02.1,libdevmapper-dev,libdevmapper-event1.02.1|exe,dev,doc>null,nls>null
+yes|dhcpcd|dhcpcd5|exe,dev>null,doc>null,nls>null
+yes|dialog|dialog|exe,dev>null,doc>null,nls>null
+no|dictd||exe,dev>null,doc>null,nls>null
+no|dietlibc|dietlibc-dev|exe>dev,dev,doc>null,nls>null
+no|diffstat|diffstat|exe,dev>null,doc>null,nls>null
+yes|diffutils|diffutils|exe,dev>null,doc>null,nls>null
+no|directfb|lib++dfb-1.7-7,libdirectfb-*,libdirectfb-dev,libdirectfb-extra|exe,dev,doc>null,nls>null
+no|disktype||exe,dev>null,doc>null,nls>null
+yes|dmz-cursor-theme|dmz-cursor-theme|exe,dev>null,doc>null,nls>null
+yes|dmidecode|dmidecode|exe,dev>null,doc>null,nls>null
+yes|docbook|docbook|exe>dev,dev,doc>null,nls>null
+yes|dosfstools|dosfstools|exe,dev>null,doc>null,nls>null
+yes|dpkg-deb|dpkg|exe,dev>null,doc>null,nls>null
+no|dvdauthor|dvdauthor|exe,dev>null,doc>null,nls>null
+no|dvd+rwtools|dvd+rw-tools,growisofs|exe,dev>null,doc>null,nls>null
+yes|e2fsprogs|e2fsprogs,libext2fs2,libext2fs-dev,libblkid1,libblkid-dev,libcom-err2,comerr-dev,libext2fs2,libext2fs-dev,libss2,ss-dev,libuuid1,uuid-dev|exe,dev,doc>null,nls>null #note, strange ubuntu seems to have lost the dev component of libuuid.
+yes|edid|read-edid|exe,dev>null,doc>null,nls>null
+yes|eject|eject|exe,dev>null,doc>null,nls>null
+yes|elfutils|elfutils,libasm1,libasm-dev,libdw1,libdw-dev,libelf1,libelf-dev|exe,dev,doc>null,nls>null #note, libelf is a different pkg.
+no|enchant|libenchant1c2a,libenchant-dev|exe,dev,doc>null,nls>null
+yes|ethtool|ethtool|exe,dev>null,doc>null,nls>null
+no|exiv2|exiv2,libexiv2-14,libexiv2-dev|exe,dev,doc>null,nls>null
+no|exfat|exfat-fuse,exfat-utils|exe,dev,doc,nls #requires fuse
+yes|expat|libexpat1,libexpat1-dev|exe,dev,doc>null,nls>null
+no|f2fs-tools||exe,dev
+no|faac|libfaac0|exe,dev,doc>null,nls>null
+no|faad|faad,libfaad2,libfaad-dev|exe,dev,doc>null,nls>null
+no|ffconvert||exe,dev,doc>null,nls>null
+no|ffmpeg|ffmpeg,libaom0,libaom-dev,libavcodec58,libavcodec-extra58,libavcodec-dev,libavutil56,libavdevice58,libavdevice-dev,libswresample3,libswresample-dev,libavresample4,libavresample-dev,libavfilter-extra*,libpostproc55,libpostproc-dev,libavutil-dev,libavutil-dev,libavformat58,libavformat-dev,libavdevice-dev,libavfilter7,libavfilter-dev,libbs2b0,libbs2b-dev,libcodec2-0.8.1,libcodec2-dev,libflite1,libgme0,libiec61883-0,liblilv-0-0,liblilv-dev,libjack-jackd2-0,libjack-jackd2-dev,libnorm1,libnorm-dev,libnuma1,libnuma-dev,libopenal1,libopenal-data,libopenal-dev,libshine3,libshine-dev,libsnappy1v5,libsodium23,libsodium-dev,libsoxr0,libsoxr-dev,libssh-gcrypt-4,libssh-gcrypt-dev,libswscale5,libswscale-dev,libwavpack1,libwavpack-dev,libzmq5,libsndio7.0,libsndio-dev,libsdl2-2.0-0,libsdl2-dev,libavc1394-0,libtwolame0,libmodplug1,librubberband2,libebur128-1,libass9,libass-dev,libchromaprint1,libzvbi0,libzvbi-common,libwebpmux3,libwebp6,libcrystalhd3,libjson-c3,libjson-c-dev,libspeex1,libcaca0,libopenmpt0,libmpg123-0,libpgm-5.2-0,libmysofa0,libmysofa-dev,libvidstab1.1,libvidstab-dev|exe,dev,doc>null,nls>null
+yes|file|file,libmagic1,libmagic-mgc,libmagic-dev|exe,dev,doc>null,nls>null
+no|file_sharing-curlftpfs-mpscan||exe
+yes|findutils|findutils|exe,dev>null,doc>null,nls>null
+yes|firefox|firefox-esr|exe,dev>null,doc>null,nls
+no|firmware_linux_module_b43||exe| #120919 have taken these out of woof, now pets.
+no|firmware_linux_module_b43legacy||exe
+yes|flac|libflac8,libflac-dev|exe,dev,doc>null,nls>null
+yes|flex|flex|exe>dev,dev,doc>null,nls>null
+no|foomatic-db-engine|foomatic-db-engine|exe,dev,doc>null,nls>null
+no|foomatic-filters|foomatic-filters|exe,dev,doc>null,nls>null
+yes|fonts-liberation|fonts-liberation|exe,dev,doc>null,nls>null
+no|fpm2||exe,dev
+no|freeglut|freeglut3,freeglut3-dev|exe,dev,doc>null,nls>null
+no|freememapplet||exe
+yes|freetype|libfreetype6,libfreetype-dev|exe,dev,doc>null,nls>null
+yes|fribidi|libfribidi0,libfribidi-dev|exe,dev,doc>null,nls>null
+yes|fuse|fuse,libfuse2,libfuse-dev|exe,dev,doc>null,nls>null
+no|gadmin-rsync|gadmin-rsync|exe,dev>null,doc>null,nls>null
+no|gail|libgail18,libgail-common,libgail-dev|exe,dev,doc>null,nls>null
+yes|galculator|galculator|exe,dev>null,doc>null,nls>null
+no|gamin|gamin,libgamin0,libgamin-dev|exe,dev,doc>null,nls>null
+yes|gawk|gawk|exe,dev>null,doc>null,nls>null
+yes|gcc_dev|gcc-10-base,gcc,gcc-10,g++,g++-10,cpp,cpp-10|exe>dev,dev,doc>null,nls>null #cloog-isl removed
+yes|gconf|gconf2-common,gconf2,libgconf-2-4,libgconf2-dev,libgconf-2-4,gconf-service|exe,dev,doc>null,nls>null
+no|gdb|gdb,libdb5.3,libbabeltrace-ctf1,libbabeltrace1,libmpdec2,libpython3.5,libpython3.5-minimal,libpython3.5-stdlib,mime-support|exe>dev,dev,doc>null,nls>null
+yes|gdbm|libgdbm6,libgdbm-dev,libgdbm-compat4,libgdbm-compat-dev|exe,dev,doc>null,nls>null
+yes|gdk-pixbuf|libgdk-pixbuf-2.0-0,libgdk-pixbuf2.0-common,libgdk-pixbuf-2.0-dev|exe,dev,doc>null,nls>null
+no|gdmap|gdmap|exe,dev>null,doc>null,nls>null
+no|geany|geany,geany-common|exe,dev,doc>null,nls>null #this is gtk3 version, use gtk2 pet instead
+no|getflash||exe
+no|get_libreoffice||exe
+yes|gettext_devxonly|gettext-base,gettext|exe>dev,dev,doc>null,nls>null
+yes|gettext|gettext-base,gettext|exe,dev>null,doc>null,nls>null
+no|gexec|gexec|exe,dev>null,doc>null,nls>null
+no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc>null,nls>null
+no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc>null,nls>null
+no|gifsicle|gifsicle|exe,dev>null,doc>null,nls>null
+yes|git|git|exe>dev,dev,doc>null,nls>null
+no|glade2|glade,libgladeui-2-6,libgladeui-common,libgladeui-dev|exe>dev,dev,doc>null,nls>null
+yes|glib|libglib2.0-bin,libglib2.0-0,libglib2.0-data,libglib2.0-dev,libglib2.0-dev-bin|exe,dev,doc,nls
+no|glibc32|libc6-i386|exe,dev,doc,nls
+yes|glibc|libc-bin,libc6,libc6-dev,tzdata|exe,dev,doc>null,nls>null
+yes|glibc_locales|locales|exe,dev,doc>null,nls>exe
+no|gmeasures||exe,dev>null,doc>null,nls>null
+yes|gmp|libgmp10,libgmpxx4ldbl,libgmp-dev,libgmp3-dev|exe,dev,doc>null,nls>null #in precise, this was only in devx, but abiword needs it.
+no|gnome-doc-utils|gnome-doc-utils|exe>dev,dev,doc>null,nls>null|+python-libxml2
+no|gnome-keyring|gnome-keyring|exe,dev,doc>null,nls>null
+no|gnome-menus||exe,dev #use my pet, version 2.14.3, needed by xdg_puppy.
+no|gnome-mplayer||exe #needs libgmlib1
+no|gnome-vfs|libgnomevfs2-0,libgnomevfs2-dev,libgnomevfs2-common|exe,dev,doc>null,nls>null
+no|gnumeric||exe,dev,doc,nls
+yes|gnutls|gnutls-bin,libgnutls30,libgnutls28-dev,libgnutls-dane0,libopts25,libopts25-dev|exe,dev,doc>null,nls>null
+no|goffice||exe,dev,doc,nls
+no|gpart|gpart|exe,dev>null,doc>null,nls>null #gparted
+no|gparted|gparted,libglibmm-2.4-1v5,libglibmm-2.4-dev,libatkmm-1.6-1v5,libatkmm-1.6-dev,libcairomm-1.0-1v5,libcairomm-1.0-dev,libpangomm-1.4-1v5,libpangomm-1.4-dev,libgtkmm-2.4-1v5,libgtkmm-2.4-dev|exe,dev,doc>null,nls>null
+yes|gperf|gperf|exe>dev,dev>null,doc>null,nls>null
+no|gphoto2|gphoto2|exe,dev>null,doc>null,nls>null
+no|gphotofs|gphotofs|exe,dev>null,doc>null,nls>null
+no|gpm|libgpm2|exe,dev>null,doc>null,nls>null #needed by mplayer, gphoto2.
+no|gpptp||exe,dev>null,doc>null,nls>null
+no|gptfdisk||exe,doc,dev,nls
+yes|graphite2|libgraphite2-3,libgraphite2-dev|exe,dev,doc>null,nls>null #needed by harfbuzz.
+yes|grep|grep|exe,dev>null,doc>null,nls>null
+yes|groff|groff|exe>dev,dev,doc>null,nls>null
+no|grsync||exe,dev,doc,nls
+no|grub2_efi||exe
+no|grub4dos||exe,dev>null,doc>null,nls>null
+yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev #needs d-conf.
+no|gsm|libgsm1,libgsm1-dev|exe,dev,doc>null,nls>null
+no|gstreamer1|libgstreamer1.0-0,libgstreamer-plugins-base1.0-0|exe,dev,doc>null,nls>null
+yes|gtk+|libgtk2.0-0,libgtk2.0-dev|exe,dev,doc>null,nls>null
+yes|gtk2-engines-pixbuf|gtk2-engines-pixbuf|exe,dev,doc>null,nls>null
+yes|gtk+3|libgtk-3-0,libgtk-3-dev,libgtk-3-common,gtk-update-icon-cache,adwaita-icon-theme|exe,dev,doc>null,nls>null #have taken out all gtk3 apps. 140127 still have gnome-mplayer --no
+no|gtkam|gtkam|exe,dev>null,doc>null,nls>null
+no|gtk-chtheme|gtk-chtheme|exe,dev>null,doc>null,nls>null
+no|gtkdialog||exe,dev,doc>dev,nls
+no|gtkhash||exe,dev
+no|gtklp|gtklp|exe,dev,doc>null,nls>null
+no|gtk_theme_stark||exe
+no|gtk_theme_flatbluecontrast||exe
+no|gtk_theme_flat_grey_rounded||exe
+no|gtk_theme_gradient_grey||exe
+no|gtk_theme_polished_blue||exe
+no|gtk_theme_stark-blueish||exe
+no|gtksourceview|libgtksourceview2.0-0,libgtksourceview2.0-common,libgtksourceview2.0-dev|exe,dev,doc>null,nls>null
+no|gtkspell|libgtkspell0,libgtkspell-dev|exe,dev,doc>null,nls>null
+no|gutenprint|printer-driver-gutenprint,libgutenprint9,libgutenprint-dev,libgutenprintui2-2,libgutenprintui2-dev,printer-driver-gutenprint|exe,dev,doc>null,nls>null
+no|gview||exe,dev,dev>null,doc>null,nls>null
+no|gwhere||exe,dev,dev>null,doc>null,nls>null
+no|gxmessage||exe #use my pet, as has xmessage symlink to gxmessage.
+yes|gzip|gzip|exe,dev>null,doc>null,nls>null
+no|hardinfo|hardinfo|exe,dev #our pet is patched to recognise puppy linux distro.
+yes|harfbuzz|libharfbuzz0b|exe,dev,doc>null,nls>null #needed by pango. unfortunately, needs icu. no, maybe pango not need icu, take out libharfbuzz-icu0,libharfbuzz-dev
+yes|harfbuzz-dev|libharfbuzz-dev|exe>dev,dev,doc>null,nls>null #need harfbuzz.pc, for pkg-config --cflags gtk+-2.0. broken, leaving out libharfbuzz-icu0, libharfbuzz-gobject0
+yes|hdparm|hdparm|exe,dev>null,doc>null,nls>null
+yes|heimdal|heimdal-dev,heimdal-multidev,libasn1-8-heimdal,libsl0-heimdal,libgssapi3-heimdal,libhcrypto4-heimdal,libhdb9-heimdal,libheimbase1-heimdal,libhx509-5-heimdal,libkadm5clnt7-heimdal,libkadm5srv8-heimdal,libkafs0-heimdal,libkdc2-heimdal,libkrb5-26-heimdal,libwind0-heimdal,libroken18-heimdal,libheimntlm0-heimdal,|exe,dev,doc>null,nls>null #all this crap needed by cupsd.
+no|helpsurfer||exe| #simple html viewer, needs libgtkhtml.
+no|hexchat|hexchat,libproxy1v5|exe,dev,doc>null,nls>null
+yes|hicolor-icon-theme|hicolor-icon-theme|exe,dev>null,doc>null,nls>null
+no|htop|htop|exe,dev>null,doc>null,nls>null
+no|hunspell|hunspell,libhunspell-*,libhunspell-dev|exe,dev,doc>null,nls>null
+no|hunspell-en-us|hunspell-en-us|exe,dev,doc>null,nls>null
+no|icedtea-netx|icedtea-netx,default-jre,default-jre-headless,librhino-java,libtagsoup-java|exe,dev,doc,nls #java jnlp, needs openjdk-*-jre
+yes|icu|libicu67,libicu-dev|exe,dev,doc>null,nls>null #scribus needs this though it is not listed as a dep. note, it is big, 7MB pkg. crap, better put it into main f.s. NO have manually put this dep into main db. harfbuzz needs icu also.
+no|id3lib|libid3-3.8.3v5,libid3-3.8.3-dev|exe,dev,doc>null,nls>null
+no|ijs|libijs-0.35,libijs-dev|exe,dev,doc>null,nls>null
+yes|imake|xutils-dev|exe>dev,dev,doc>null,nls>null
+yes|initscripts|initscripts|exe,dev,doc>null,nls>null
+yes|init-system-helpers|init-system-helpers|exe>null,dev>null,doc>null,nls>null #to prevent it from being installed as dependency..
+no|inkscapelite||exe,dev,doc>null,nls>null
+yes|inotify-tools|inotify-tools,libinotifytools0|exe,dev,doc>null,nls>null
+yes|installwatch|checkinstall|exe>dev,dev,doc>null,nls>null
+yes|intltool|intltool|exe,dev,doc>null,nls>null #previously only in devx, but need in main f.s. to run momanager without devx.
+yes|iptables|iptables,libip4tc2,libip6tc2,libxtables12,libnftnl11,libnftnl-dev|exe,dev,doc>null,nls>null
+no|iso-codes|iso-codes|exe,dev,doc>null,nls>null #needed by gstreamer. very big. GSTREAMER1.0 GSTREAMER0.10
+no|isomaster|isomaster|exe,dev,doc>null,nls>null
+yes|iw|iw|exe,dev,doc,nls
+yes|jbig2dec|libjbig2dec0,libjbig2dec0-dev|exe,dev,doc>null,nls>null #needed by ghostscript.
+yes|jbigkit|libjbig0,libjbig-dev|exe,dev,doc>null,nls>null #needed by libtiff5.
+no|jwm|jwm|exe,dev,doc>null,nls>null
+yes|jq|jq,libjq1,libjq-dev|exe,dev,doc>null,nls>null
+no|JWMDesk||exe,dev,doc,nls
+yes|keyutils|libkeyutils1|exe,dev>null,doc>null,nls>null
+yes|kmod|kmod,libkmod2,libkmod-dev|exe,dev,doc>null,nls>null #er, no, looks like compiled without gzip support --but i think only need that in initrd, where already have old modprobe.
+yes|krb5|libkrb5-3,libkrb5-dev,libkrb5support0,libk5crypto3,libgssapi-krb5-2|exe,dev,doc>null,nls>null
+no|lame|lame,libmp3lame0,libmp3lame-dev|exe,dev,doc>null,nls>null
+no|lcms|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc>null,nls>null
+no|lcms2|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc>null,nls>null
+#yes|leafpad|leafpad|exe,dev>null,doc>null,nls>null
+yes|less|less|exe,dev>null,doc>null,nls>null
+no|libaacs|libaacs0,libaacs-dev|exe,dev,doc>null,nls>null #mplayer needs this.
+yes|libao|libao4,libao-common,libao-dev|exe,dev,doc>null,nls>null
+no|libappindicator|libappindicator3-1,libappindicator3-dev,libindicator3-7,libindicator3-dev|exe,dev,doc>null,nls>null #needs gtk3, needed by transmission. no, using my pet.
+yes|libarchive|libarchive13|exe>dev,dev,doc>null,nls>null #needed by cmake.
+no|libart|libart-2.0-2,libart-2.0-dev|exe,dev,doc>null,nls>null
+yes|libasyncns|libasyncns0,libasyncns-dev|exe,dev,doc>null,nls>null #needed by mplayer.
+no|libayatana|libayatana-appindicator3-1,libayatana-indicator3-7,libayatana-indicator7,libayatana-appindicator3-dev,libayatana-ido3-0.4-0,libayatana-ido3-dev|exe,dev,doc>null,nls>null
+no|libb2-1|libb2-1,libb2-dev|exe,dev,doc>null,nls>nul
+no|libbluray|libbluray2,libbluray-dev|exe,dev,doc>null,nls>null #needed by mplayer.
+no|libbonobo|libbonobo2-0,libbonobo2-dev,libbonoboui2-0,libbonoboui2-dev|exe,dev,doc>null,nls>null
+no|libboost-filesystem|libboost-filesystem1.67.0,libboost-filesystem1.67-dev|exe,dev,doc>null,nls>null
+no|libboost-system|libboost-system1.67.0,libboost-system1.67-dev|exe,dev,doc>null,nls>null
+yes|libbsd|libbsd0,libbsd-dev|exe,dev,doc>null,nls>null #needed by libedit.
+yes|libcanberra|libcanberra0,libcanberra-dev|exe,dev,doc>null,nls>null #libbonobui needs this.
+yes|libcap|libcap2,libcap-dev|exe,dev,doc>null,nls>null
+yes|libcap-ng|libcap-ng0,libcap-ng-dev|exe,dev,doc>null,nls>null
+no|libcddb|libcddb2,libcddb2-dev|exe,dev,doc>null,nls>null #debian/ubuntu pkg missing 'cddb_query', also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.
+no|libcdio|libcdio18,libcdio-dev,libcdio-cdda2,libcdio-cdda-dev,libcdio-paranoia2,libcdio-paranoia-dev,libcdio-utils,libiso9660-*,libiso9660-dev,libudf0,libudf-dev|exe,dev,doc>null,nls>null #not compatible with my libcddb pet, use my pet. 120907 yes.
+no|libcdk5|libcdk5nc6,libcdk5-dev|exe,dev,doc>null,nls>null
+no|libcroco|libcroco3,libcroco3-dev|exe,dev,doc>null,nls>null
+yes|libbrotli|libbrotli1,libbrotli-dev|exe,dev,doc>null,nls>null
+yes|libcrypt|libcrypt1,libcrypt-dev|exe,dev,doc>null,nls>null
+yes|libcurl3-gnutls|libcurl3-gnutls|exe,dev,doc>null,nls>null #this is needed by git in the devx sfs file. update: conky needs it in the main f.s.
+yes|libdaemon|libdaemon0,libdaemon-dev|exe,dev,doc>null,nls>null
+yes|libdatrie|libdatrie1,libdatrie-dev|exe,dev,doc>null,nls>null
+yes|libdb|libdb5.3,libdb5.3-dev|exe>dev,dev,doc>null,nls>null
+no|libdbusmenu|libdbusmenu-gtk3-4,libdbusmenu-glib4|exe,dev,doc>null,nls>null #needed by libappindicator. left off dev debs.
+no|libdc1394|libdc1394-22,libdc1394-22-dev|exe,dev,doc>null,nls>null #ffmpeg3 compiled in luci needs this
+no|libdca|libdca0,libdca-dev|exe,dev,doc>null,nls>null #mplayer needs this.
+yes|libdeflate|libdeflate0,libdeflate-dev|exe,dev,doc>null,nls>null
+yes|libdmx|libdmx1,libdmx-dev|exe,dev,doc>null,nls>null #this is actaully part of xorg.
+no|libdvdcss||exe,dev,doc>null,nls>null
+no|libdvdnav|libdvdnav4|exe,dev,doc>null,nls>null #needed by mplayer.
+no|libdvdread|libdvdread4,libdvdread-dev|exe,dev,doc>null,nls>null
+yes|libedit|libedit2,libedit-dev|exe,dev,doc>null,nls>null
+no|libenca|libenca0,libenca-dev|exe,dev,doc>null,nls>null
+yes|liberror-perl|liberror-perl|exe>dev,dev,doc>null,nls>null #needed by git.
+yes|libevdev|libevdev2,libevdev-dev|exe,dev,doc>null,nls>null
+yes|libevent|libevent-core-*,libevent-*,libevent-dev|exe,dev,doc>null,nls>null #needed by transmission.
+no|libexif|libexif12,libexif-dev|exe,dev,doc>null,nls>null
+no|libexif-gtk|libexif-gtk5,libexif-gtk-dev|exe,dev,doc>null,nls>null
+no|libf2fs|libf2fs5,libf2fs-dev|exe,dev,doc>null,nls>null
+yes|libffi|libffi7,libffi-dev|exe,dev,doc>null,nls>null
+no|libfftw3|libfftw3-3,libfftw3-bin,libfftw3-double3,libfftw3-long3,libfftw3-single3,libfftw3-quad3,libfftw3-dev|exe,dev,doc,nls
+no|libfs|libfs6,libfs-dev|exe,dev,doc>null,nls>null #120603 mavrothal reported need this for compiling xorg drivers.
+yes|libgcrypt|libgcrypt20,libgcrypt20-dev|exe,dev,doc>null,nls>null
+no|libgd2|libgd3,libgd-dev|exe,dev,doc>null,nls>null #needed by libgphoto2.
+no|libgee|libgee-0.8-2,libgee-0.8-dev|exe,dev,doc>null,nls>null
+no|libgeoip|libgeoip1,libgeoip-dev|exe,dev,doc>null,nls>null
+no|libgif|libgif7,libgif-dev|exe,dev,doc>null,nls>null
+no|libglade2|libglade2-0,libglade2-dev|exe,dev,doc>null,nls>null
+no|libglide3|libglide3,libglide3-dev|exe,dev,doc,nls
+no|libgnome|libgnome-2-0,libgnome2-dev|exe,dev,doc>null,nls>null
+no|libgnomecanvas2|libgnomecanvas2-0,libgnomecanvas2-dev|exe,dev,doc>null,nls>null
+no|libgnomeui|libgnomeui-0,libgnomeui-dev|exe,dev,doc>null,nls>null
+yes|libgpg-error|libgpg-error0,libgpg-error-dev|exe,dev,doc>null,nls>null
+no|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc>null,nls>null
+no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc>null,nls>null
+no|libgsf|libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc>null,nls>null
+no|libgtkhtml||exe,dev,doc>null,nls>null #needed by my osmo pet.
+yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc>null,nls>null
+no|libical|libical2,libical-dev|exe,dev,doc>null,nls>null
+no|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc>null,nls>null
+no|libidl|libidl-2-0,libidl-dev|exe,dev,doc>null,nls>null
+no|libidn|libidn11|exe,dev,doc>null,nls>null
+yes|libidn2|libidn2-0,libidn2-0-dev|exe,dev,doc>null,nls>null
+no|libieee1284|libieee1284-3|exe,dev,doc>null,nls>null
+no|libimlib|libimlib2,libimlib2-dev|exe,dev,doc>null,nls>null
+no|libindicator|libindicator7,libindicator-dev|exe,dev,doc>null,nls>null #needed by libappindicator.
+yes|libinput|libinput10,libinput-bin,libinput-dev,libwacom2,libwacom-dev|exe,dev,doc>null,nls>null
+yes|libjack|libjack0,libjack-dev|exe,dev,doc>null,nls>null
+no|libjansson4|libjansson4,libjansson-dev|exe,dev,doc>null,nls>null
+yes|libjpeg62|libjpeg62-turbo,libjpeg62-turbo-dev,libjpeg-dev|exe,dev,doc>null,nls>null
+no|libjsoncpp1|libjsoncpp1,libjsoncpp-dev|exe,dev,doc>null,nls>null
+no|libjson-glib|libjson-glib-1.0-0,libjson-glib-1.0-common,libjson-glib-dev|exe,dev,doc>null,nls>null
+no|libloudmouth|libloudmouth1-0,libloudmouth1-dev|exe,dev,doc>null,nls>null
+yes|libltdl|libltdl7,libltdl-dev|exe,dev,doc>null,nls>null #note, this is really part of libtool pkg, but libs needed at runtime.
+no|libmad|libmad0,libmad0-dev|exe,dev,doc>null,nls>null
+no|libmcrypt|libmcrypt4,libmcrypt-dev|exe,dev,doc>null,nls>null
+yes|libmd|libmd0,libmd-dev|exe,dev,doc>null,nls>null
+no|libmng|libmng1,libmng-dev|exe,dev,doc>null,nls>null
+yes|libmnl|libmnl0,libmnl-dev|exe,dev,doc>null,nls>null
+no|libmpcdec|libmpcdec6,libmpcdec-dev|exe,dev,doc>null,nls>null
+yes|libmpfr|libmpfr6|exe,doc>null,nls>null
+no|libmtp||exe,dev,doc,nls #pupmtp
+yes|libnatpmp|libnatpmp1,libnatpmp-dev|exe,dev,doc>null,nls>null #needed by transmission.
+yes|libnfnetlink|libnfnetlink0,libnfnetlink-dev|exe,devdoc>null,nls>null
+yes|libnetfilter-conntrack|libnetfilter-conntrack3,libnetfilter-conntrack-dev|exe,dev,doc>null,nls>null
+yes|libnghttp2|libnghttp2-14,libnghttp2-dev|exe,dev,doc>null,nls>null #stretch: needed by curl, cmake, etc...
+yes|libnl|libnl-3-200,libnl-3-dev|exe,dev,doc>null,nls>null #this was used in lucid, perhaps not needed now.
+yes|libnl3|libnl-3-200,libnl-3-dev,libnl-cli-3-200,libnl-cli-3-dev,libnl-genl-3-200,libnl-genl-3-dev,libnl-nf-3-200,libnl-nf-3-dev,libnl-route-3-200,libnl-route-3-dev|exe,dev,doc>null,nls>null
+no|libnotify|libnotify4,libnotify-dev|exe,dev,doc>null,nls>null
+yes|libnsl|libnsl2,libnsl-dev|exe,dev,doc>null,nls>null
+no|libopenjp2|libopenjp2-7,libopenjp2-7-dev|exe,dev,doc>null,nls>null
+no|libopencore|libopencore-amrnb0,libopencore-amrnb-dev,libopencore-amrwb0,libopencore-amrwb-dev|exe,dev,doc>null,nls>null #was libopencore dep for ffmpeg3 or mplayer2--can delete if mplayer2
+yes|libogg|libogg0,libogg-dev|exe,dev,doc>null,nls>null
+yes|libonig|libonig5,libonig-dev|exe,dev,doc>null,nls>null
+no|libpaper|libpaper1,libpaper-dev,libpaper-utils|exe,dev,doc>null,nls>null
+yes|libpcap|libpcap0.8,libpcap0.8-dev|exe,dev,doc>null,nls>null
+yes|libpciaccess|libpciaccess0,libpciaccess-dev|exe,dev,doc>null,nls>null
+yes|libpcsclite|libpcsclite1,libpcsclite-dev|exe,dev,doc>null,nls>null
+yes|libperl|libperl5.32,libperl-dev|exe,dev,doc>null,nls>null
+no|libpipeline|libpipeline1,libpipeline-dev|exe,dev,doc,nls| #needed by usb-modeswitch
+yes|libpng|libpng16-16,libpng-dev|exe,dev,doc>null,nls>null
+no|libpng12||exe,dev>null,doc>null,nls>null #from precise..
+yes|libpsl|libpsl5,libpsl-dev|exe,dev,doc>null,nls>null #stretch: wget dep
+yes|libpthread-stubs|libpthread-stubs0-dev|exe>dev,dev,doc>null,nls>null
+no|libraw1394|libraw1394-11,libraw1394-dev|exe,dev,doc>null,nls>null
+no|librest|librest-0.7-0,librest-dev|exe,dev,doc>null,nls>null
+no|librevenge|librevenge-0.0-0,librevenge-dev|exe,dev,doc>null,nls>null
+yes|librsvg|librsvg2-2,librsvg2-dev,librsvg2-bin,librsvg2-common|exe,dev,doc>null,nls>null #shows gtk3 as dep, but might work without.
+yes|librtmp|librtmp1,librtmp-dev|exe,dev,doc>null,nls>null
+yes|libsamplerate|libsamplerate0,libsamplerate0-dev|exe,dev,doc>null,nls>null
+yes|libselinux|libselinux1,libselinux1-dev|exe,dev,doc>null,nls>null
+yes|libsepol|libsepol1,libsepol1-dev|exe,dev,doc>null,nls>null
+no|libserd|libserd-0-0,libserd-dev|exe,dev,doc>null,nls>null
+no|libsigc++|libsigc++-2.0-0v5,libsigc++-2.0-dev|exe,dev,doc>null,nls>null
+yes|libsigsegv|libsigsegv2,libsigsegv-dev|exe,dev,doc>null,nls>null
+no|libslang|libslang2|exe,dev>null,doc>null,nls>null
+no|libsmartcols|libsmartcols1,libsmartcols-dev|exe,dev,doc>null,nls>null
+yes|libsndfile|libsndfile1,libsndfile1-dev|exe,dev,doc>null,nls>null
+no|libsord|libsord-0-0,libsord-dev|exe,dev,doc>null,nls>null
+no|libsoup|libsoup2.4-1,libsoup2.4-dev,libsoup-gnome2.4-1,libsoup-gnome2.4-dev|exe,dev,doc>null,nls>null
+yes|libsoxr|libsoxr0,libsoxr-dev|exe,dev,doc>null,nls>null
+yes|libspeexdsp1|libspeexdsp1,libspeexdsp-dev|exe,dev,doc>null,nls>null
+no|libsratom|libsratom-0-0,libsratom-dev|exe,dev,doc>null,nls>null
+yes|libssh2|libssh2-1,libssh2-1-dev|exe,dev,doc>null,nls>null #stretch: needed by curl, etc.
+yes|libstdc++6|libstdc++6|exe,dev,doc>null,nls>null
+yes|libstdc++10|libstdc++-10-dev|exe,dev,doc>null,nls>null
+yes|libsystemd|libsystemd0|exe,dev,doc>null,nls>null
+no|libtar|libtar0,libtar-dev|exe,dev,doc>null,nls>null #needed by osmo.
+yes|libtasn1|libtasn1-6,libtasn1-6-dev|exe,dev,doc>null,nls>null
+yes|libtext-unidecode-perl|libtext-unidecode-perl|exe>dev,dev,doc>null,nls>null
+yes|libthai|libthai0,libthai-data,libthai-dev|exe,dev,doc>null,nls>null
+no|libtheora|libtheora0,libtheora-dev|exe,dev,doc>null,nls>null
+yes|libtiff|libtiff5,libtiff-dev|exe,dev,doc>null,nls>null
+yes|libtool|libtool,autotools-dev|exe>dev,dev,doc>null,nls>null
+yes|libtirpc|libtirpc3,libtirpc-common,libtirpc-dev|exe,dev,doc>null,nls>null
+yes|libudev|libudev1,libudev-dev|exe,dev,doc>null,nls>null
+yes|libunbound|libunbound*,libunbound-dev|exe,dev,doc,nls
+yes|libunistring|libunistring2,libunistring-dev|exe,dev,doc>null,nls>null
+no|libusb|libusb-0.1-4,libusb-dev|exe,dev,doc>null,nls>null
+yes|libusb1|libusb-1.0-0,libusb-1.0-0-dev|exe,dev,doc>null,nls>null #libusb1 necesssary for ffmpeg3
+yes|libutf8proc|libutf8proc2,libutf8proc-dev|exe>dev,dev,doc>null,nls>null
+no|libv4l|libv4l-0,libv4l-dev,libv4lconvert0|exe,dev,doc>null,nls>null
+no|libva|libva2,libva-drm2,libva-dev,libva-glx2,libva-x11-2,libva-wayland2,vainfo|exe,dev,doc>null,nls>null #needed by mplayer.
+no|libvdpau|libvdpau1,mesa-vdpau-drivers,vdpau-va-driver,libvdpau-dev|exe,dev,doc>null,nls>null #needed by mplayer. no, this has another big dep: Failed to open VDPAU backend libvdpau_nvidia.so missing.
+yes|libvorbis|libvorbis0a,libvorbis-dev,libvorbisenc2|exe,dev,doc>null,nls>null
+yes|libvpx|libvpx6,libvpx-dev|exe,dev,doc>null,nls>null #needed by mplayer.
+yes|libvulkan|libvulkan1,libvulkan-dev|exe,dev,doc,nls
+no|libwmf|libwmf0.2-7,libwmf-dev|exe,dev,doc>null,nls>null
+no|libwpg|libwpg-0.3-3|exe,dev>null,doc>null,nls>null
+no|libwpd|libwpd-0.10-10,libwpd-dev|exe,dev,doc>null,nls>null
+no|libxatracker2|libxatracker2,libxatracker-dev|exe,dev,doc,nls
+yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri2-0-dev,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-image0,libxcb-image0-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-randr0,libxcb-randr0-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-xinerama0,libxcb-xinerama0-dev,libxcb-damage0,libxcb-damage0-dev|exe,dev,doc>null,nls>null
+yes|libz3|libz3-4,libz3-dev|exe,dev,doc>null,nls>null
+no|libzip|libzip4,libzip-dev|exe,dev,doc>null,nls>null
+yes|xcb-util|libxcb-util1,libxcb-util-dev|exe,dev,doc>null,nls>null
+no|libxdg-basedir|libxdg-basedir1,libxdg-basedir-dev|exe,dev,doc>null,nls>null
+yes|libxkbcommon|libxkbcommon0,libxkbcommon-dev,libxkbcommon-x11-0,libxkbcommon-x11-dev|exe,dev,doc>null,nls>null #needed by gtk+3. have taken out gtk3
+yes|libxml2|libxml2,libxml2-dev|exe,dev,doc>null,nls>null
+yes|libxml2-utils|libxml2-utils|exe>dev,dev,doc>null,nls>null
+yes|libxshmfence|libxshmfence1,libxshmfence-dev|exe,dev,doc>null,nls>null #xorg needs this.
+yes|libxslt|libxslt1.1,libxslt1-dev,xsltproc|exe>dev,dev,doc>null,nls>null
+yes|libxvmc|libxvmc1,libxvmc-dev|exe,dev,doc>null,nls>null #this is actually part of xorg.
+yes|libzstd|libzstd1,libzstd-dev|exe,dev,doc,nls
+no|linux_firmware_dvb||exe
+yes|linux-header|linux-libc-dev|exe>dev,dev,doc>null,nls>null
+no|lirc|liblircclient0,liblircclient-dev|exe,dev,doc>null,nls>null
+yes|llvm|libllvm11|exe,dev| #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
+yes|lsb-base|lsb-base|exe,dev,doc>null,nls>null
+no|lxrandr||exe,dev,doc,nls
+no|lxtask||exe,dev,doc,nls
+no|lxterminal||exe,dev,doc,nls
+no|lxde_apps|gpicview,lxinput|exe,dev,doc>null,nls>null
+no|gmrun||exe
+no|pcmanfm|pcmanfm,libfm4,libfm-data,libfm-extra4,libfm-gtk4,libfm-gtk-data,libmenu-cache3,libmenu-cache-bin,lxmenu-data
+no|pup-volume-monitor||exe
+yes|lzma|lzma,lzma-dev|exe,dev,doc>null,nls>null
+yes|lz4|liblz4-1,liblz4-dev|exe,dev,doc>null,nls>null
+yes|lzo2|liblzo2-2,liblzo2-dev|exe,dev,doc>null,nls>null
+no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc>null,nls>null
+yes|m4|m4|exe>dev,dev,doc>null,nls>null
+no|madplay|madplay|exe,dev,doc>null,nls>null
+yes|make|make|exe>dev,dev,doc>null,nls>null
+yes|man|man-db|exe>dev,dev,doc>null,nls>null
+yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,mesa-va-drivers,libglu1-mesa,libglu1-mesa-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc>null,nls>null #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
+no|mhash|libmhash2,libmhash-dev|exe,dev,doc>null,nls>null
+no|mhwaveedit|mhwaveedit|exe,dev>null,doc>null,nls>null
+no|miniupnpc|libminiupnpc*,libminiupnpc-dev|exe,dev,doc>null,nls>null #needed by transmission.
+no|mirdir||exe
+yes|mpclib3|libmpc3,libmpc-dev|exe>dev,dev,doc,nls| #needed by gcc.
+no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc>null,nls>null #needed by mplayer.
+yes|mpfr|libmpfr6|exe>dev,dev,doc>null,nls>null
+no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc>null,nls>null
+no|mpv|mpv,libguess1,libguess-dev,libuchardet0,libuchardet-dev|exe,dev,doc>null,nls>null
+no|mplayer_samba|libsmbclient,libldb1,liblmdb0,libtalloc2,libtevent0,libwbclient0,python-talloc,samba-libs|exe,dev,doc>null,nls>null
+no|ms-sys||exe
+yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc>null,nls>null #needed by synaptics_drv.so in xorg.
+no|mtpaint|mtpaint|exe,dev,doc>null,nls>null
+no|mtr|mtr|exe,dev,doc>null,nls>null
+no|musl|musl,musl-dev,musl-tools|exe>dev,dev,doc>null,nls>null
+yes|nano|nano|exe,dev,doc>null,nls>null
+no|nas|libaudio2,libaudio-dev|exe,dev,doc>null,nls>null #needed by mplayer, qupzilla
+yes|nasm|nasm|exe>dev,dev,doc>null,nls>null
+no|nbtscan|nbtscan|exe,dev
+yes|ncurses|ncurses-base,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc>null,nls>null
+no|nenscript||exe
+yes|net-tools|net-tools|exe,dev,doc>null,nls>null
+yes|nettle|libnettle8,nettle-dev,libhogweed6|exe,dev,doc>null,nls>null #needed by libarchive.
+no|netmon_wce||exe,dev
+no|network_roxapp_samba||exe
+no|normalize|normalize-audio|exe,dev,doc>null,nls>null
+no|notecase||exe,dev,doc>null,nls>null
+no|nrg2iso|nrg2iso|exe,dev,doc>null,nls>null #used by pburn.
+yes|nscd|unscd|exe
+yes|nspr|libnspr4,libnspr4-dev|exe,dev,doc>null,nls>null #using seamonkey pkg with these built-in. 120913 enabled.
+yes|nss|libnss3,libnss3-dev|exe,dev,doc>null,nls>null #using seamonkey pkg with these built-in. 120913 enabled.
+no|ntfs-3g|ntfs-3g,libntfs-*,ntfs-3g-dev|exe,dev,doc>null,nls>null #this seems to have taken over the full functionality of ntfsprogs.
+yes|ntpdate|ntpdate|exe,dev,doc,nls #used by psync to sync local time and date from the internet.
+no|numlockx||exe| #needed by shinobars firstrun.
+no|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc>null,nls>null #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
+no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected
+yes|openldap|libldap-2.4-2,libldap2-dev|exe,dev,doc>null,nls>null
+no|opensp|opensp,libosp-dev|exe>dev,dev,doc>null,nls>null|+sgml-base,+sgml-data,+xml-core
+yes|openssh_client|openssh-client|exe,dev,doc>null,nls>null
+yes|openssl|openssl,libssl1.1,libssl-dev|exe,dev,doc>null,nls>null #libssl1.0.2 = older libssl
+yes|optipng|optipng|exe>dev,dev,doc>null,nls>null
+yes|opus|libopus0,libopus-dev|exe,dev,doc>null,nls>null #needed by ffmpeg
+no|orbit2|liborbit2,liborbit-2-0,liborbit2-dev|exe,dev,doc>null,nls>null
+yes|orc|liborc-0.4-0,liborc-0.4-dev|exe,dev,doc>null,nls>null #needed by mplayer.
+#yes|osmo||exe,dev,doc,nls
+no|ots|libots0,libots-dev|exe,dev,doc>null,nls>null
+no|p7zip-full|p7zip-full|exe,dev,doc>null,nls>null
+yes|p11-kit|libp11-kit0,libp11-kit-dev|exe,dev,doc>null,nls>null #needed by cupsd (ubuntu cups pkg). 121210 need dev pkg for gnutls, refer forum t=82092&start=135
+no|PackIt||exe,dev
+no|pam|libpam0g|exe,dev,doc>null,nls>null
+yes|pango|libpango-1.0-0,libpango1.0-dev,libpangoft2-1.0-0,libpangocairo-1.0-0,libpangoxft-1.0-0,gir1.2-pango-1.0|exe,dev,doc>null,nls>null
+no|parted|parted,libparted2,libparted-fs-resize0,libparted-dev|exe,dev,doc>null,nls>null #gparted
+yes|patch|patch|exe>dev,dev,doc>null,nls>null
+yes|patchutils|patchutils|exe>dev,dev,doc>null,nls>null
+no|pbackup||exe
+no|pciutils|pciutils,libpci3,libpci-dev|exe,dev,doc>null,nls>null
+no|pcmciautils|pcmciautils|exe,dev,doc>null,nls>null
+yes|pcre|libpcre2-8-0,libpcre2-dev,libpcre3,libpcre3-dev,libpcre16-3,libpcrecpp0v5|exe,dev,doc>null,nls>null
+no|pdiag||exe| #diagnostic tool created by rerwin.
+no|pdvdrsab||exe
+no|peasydisc||exe
+no|peasyglue||exe,dev
+no|peasypdf||exe,dev
+no|peasyport||exe| #rcrsn51, alternative to superscan.
+no|peasyprint||exe,dev
+no|peasyscale||exe #rcrsn51, jpg image resizer.
+no|peasyscan_pdf_plugin||exe,dev
+yes|perl|perl,perl-base,perl-modules-5.32|exe>dev,dev
+yes|perl_tiny|perl,perl-base,perl-modules-5.32|exe,dev>null,doc>null,nls>null
+yes|perl-compress-zlib|libcompress-raw-zlib-perl|exe>dev,dev
+yes|perl-digest-sha1|libdigest-sha-perl|exe,dev
+yes|perl-extutils-depends|libextutils-depends-perl|exe>dev,dev
+yes|perl-extutils-pkgconfig|libextutils-pkgconfig-perl|exe>dev,dev
+yes|perl-html-parser|libhtml-parser-perl|exe,dev
+yes|perl-uri|liburi-perl|exe>dev,dev
+yes|perl-xml-parser|libxml-parser-perl|exe>dev,dev
+yes|perl-xml-simple|libxml-simple-perl|exe>dev,dev
+no|picocom|picocom|exe,dev
+yes|pixman|libpixman-1-0,libpixman-1-dev|exe,dev
+yes|pkgconfig|pkg-config|exe>dev,dev
+no|pmirrorget||exe
+no|pnethood||exe| #using network_roxapp and YASSM instead. leave it in, some users want it.
+no|pnscan||exe,dev,doc,nls #peasyport
+no|poppler|libpoppler102,libpoppler-dev,poppler-utils,libpoppler-glib8,libpoppler-glib-dev|exe,dev
+yes|popt|libpopt0,libpopt-dev|exe>dev,dev
+no|powerapplet_tray||exe
+no|ppp|ppp|exe,dev>null
+no|pptp|pptp-linux|exe,dev,doc>null,nls>null
+yes|procps|procps,libprocps8,libprocps-dev|exe,dev,doc>null,nls>null
+yes|psmisc|psmisc|exe,dev>null,doc>null,nls>null
+yes|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,libwebrtc-audio-processing-dev,pulseaudio-utils|exe,dev,doc>null,nls>null #needed by mplayer, gnome-mplayer and gmtk
+no|psynclient||exe
+no|pupmixer||exe
+no|Pup-Kview||exe
+no|Pup-SysInfo||exe
+no|puppy_icon_theme||exe #gtk theme
+no|puppy-podcast-grabber||exe
+no|pure-ftpd||exe
+no|pwsget||exe
+yes|python|python3,python3.9-minimal,python3.9,libpython3.9,libpython3.9-stdlib,libpython3.9-minimal|exe>dev,dev,doc>null,nls>null #121022 moved from devx to main f.s. /usr/include/python2.7 must also go into main f.s. so take out ,dev. see also libpython2.7 needed by gdb in devx. 130404 added libs.
+no|python-libxml2|python2-libxml2|exe,dev,doc>null,nls>null #121022 moved from devx to main f.s.
+yes|python-dev|libpython3-dev,libpython3.9-dev,python3-dev,python3.9-dev|exe,dev,doc>null,nls>null
+no|qpdf|libqpdf21,libqpdf-dev|exe,dev,doc>null,nls>null #needed by cups.
+no|qemu||exe>dev
+no|qtweb||exe
+no|radeon_firmware||exe,dev
+no|raptor2|libraptor2-0,libraptor2-dev|exe,dev,doc>null,nls>null #needed by redland.
+yes|readline|libreadline8,libreadline-dev,readline-common|exe,dev,doc>null,nls>null
+no|redland|librdf0,librasqal3|exe,dev,doc>null,nls>null #needed by abiword. left out -dev libs.
+no|redshift|redshift|exe,dev,doc,nls
+no|retrovol||exe
+yes|rman|rman|exe>dev,dev,doc>null,nls>null
+no|rox-filer||exe
+yes|rsync|rsync|exe>dev,dev
+no|rtmpdump|rtmpdump,librtmp1,librtmp-dev,flvstreamer|exe,dev,doc>null,nls>null
+no|rxvt-unicode||exe,dev>null,doc>null,nls>null
+no|sane-backends||exe,dev,doc>null,nls>null
+no|scale2x||exe
+no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc>null,nls>null
+yes|sed|sed|exe,dev>null,doc>null,nls>null
+yes|serf|libserf-1-1|exe>dev,dev,doc>null,nls>null #needed by svn.
+yes|setserial|setserial|exe,dev>null,doc>null,nls>null
+yes|sgml-base|sgml-base|exe>dev,dev,doc>null,nls>null
+yes|sgml-data|sgml-data|exe>dev,dev,doc>null,nls>null
+yes|shared-mime-info|shared-mime-info|exe,dev,doc,nls
+no|simple-mtpfs||exe,dev,doc,nls #pupmtp
+yes|sqlite|sqlite3,libsqlite3-0,libsqlite3-dev|exe,dev,doc>null,nls>null
+yes|squashfs-tools|squashfs-tools|exe,dev,doc>null,nls>null
+no|ssh_gui||exe
+no|startup-notification|libstartup-notification0,libstartup-notification0-dev|exe,dev,doc>null,nls>null
+yes|strace|strace|exe>dev,dev,doc>null,nls>null
+no|streamripper|streamripper|exe,dev
+yes|subversion|subversion,libsvn1,libdb5.3,libaprutil1,libapr1|exe>dev,dev,doc>null,nls>null
+no|sudo||exe,dev
+yes|sysfsutils|libsysfs2,libsysfs-dev,sysfsutils|exe,dev,doc>null,nls>null
+no|taglib|libtag1v5,libtag1-dev,libtag1v5-vanilla|exe,dev,doc>null,nls>null #needed by lots of media apps.
+yes|tar|tar|exe,dev>null,doc>null,nls>null
+no|tas||exe,nls
+no|tbb|libtbb2|exe,dev>null,doc>null,nls>null #needed by libopencv-core. have left off the dev.
+yes|tcp-wrappers|libwrap0,libwrap0-dev|exe,dev,doc>null,nls>null #needed by mplayer, skype
+yes|tdb|libtdb1,libtdb-dev|exe,dev,doc>null,nls>null #needed by mplayer and libcanberra.
+no|telepathy-glib|libtelepathy-glib0|exe,dev,doc>null,nls>null #needed by abiword. left out -dev lib.
+yes|texinfo|texinfo|exe>dev,dev,doc>null,nls>null
+no|tidy|libtidy5deb1,libtidy-dev|exe,dev,doc>null,nls>null #needed by abiword.
+yes|time|time|exe,dev>null,doc>null,nls>null
+no|transmission|transmission-gtk,transmission-common|exe,dev,doc>null,nls>null
+yes|tree|tree|exe,dev,doc>null,nls>null
+yes|udev|udev|exe>null,dev>null,doc>null,nls>null #fake install
+no|eudev||exe,dev #pet pkg: replaces udev and libudev
+no|uget|uget,aria2,libc-ares2,libc-ares-dev,libaria2,libaria2-0,libaria2-0-dev|exe,dev,doc>null,nls>null
+yes|unclutter|unclutter|exe,dev>null,doc>null,nls>null
+yes|unzip|unzip|exe,dev>null,doc>null,nls>null
+no|UrxvtControl||exe,dev
+no|usb-modeswitch|usb-modeswitch,libjim0.76|exe,dev,doc,nls
+no|usb-modeswitch||exe,dev,doc,nls
+no|usb-modeswitch-data||exe,dev,doc,nls
+yes|usbutils|usbutils|exe,dev,doc>null,nls>null
+yes|util-linux|util-linux,mount,uuid-runtime,bsdutils,libuuid1,libblkid1,libfdisk1,libmount1,libsmartcols1,libfdisk-dev,libmount-dev,libsmartcols-dev,uuid-dev,libblkid-dev,libmount-dev|exe,dev,doc>null,nls>null
+no|uextract||exe,dev
+no|vala|valac,libvala-*|exe>dev,dev,doc>dev,nls>null
+no|vamps|vamps|exe,dev,doc>null,nls>null
+no|vobcopy|vobcopy|exe,dev,doc>null,nls>null
+no|vorbis-tools|vorbis-tools|exe,dev,doc>null,nls>null
+yes|vte|libvte-2.91-0,libvte-2.91-common,libvte-2.91-dev|exe,dev,doc>null,nls>null
+yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0,libwayland-dev,wayland-protocols|exe,dev,doc>null,nls>null
+no|wcpufreq||exe,dev| #using this instead of cpu-scaling-ondemand.
+yes|wget|wget|exe,dev>null,doc>null,nls>null
+yes|wireless-tools|wireless-tools,libiw30,libiw-dev|exe,dev,doc>null,nls>null
+no|wmctrl|wmctrl|exe,dev,doc>null,nls>null
+yes|wpa_supplicant|wpasupplicant|exe,dev>null,doc>null,nls>null
+no|wv|wv,libwv-1.2-4,libwv-dev|exe,dev,doc>null,nls>null
+no|wvdial|wvdial,libuniconf4.6,libwvstreams4.6-base,libwvstreams4.6-extras,libwvstreams-dev|exe
+yes|x11proto|x11proto-dev|exe>dev,dev,doc>null,nls>null
+no|x264|libx264-*,libx264-dev|exe,dev,doc>null,nls>null
+no|x265|libx265-*,libx265-dev|exe,dev,doc>null,nls>null
+no|xarchive||exe
+yes|xclip|xclip|exe,dev,doc>null,nls>null
+no|xcur2png||exe #pcur needs this
+no|xdelta||exe
+no|xdg-puppy-jwm||exe
+yes|xdotool|xdotool,libxdo3|exe,dev,doc>null,nls>null
+no|Xdialog||exe
+no|xfdiff-cut||exe
+no|xlock_gui||exe
+no|xlockmore||exe
+yes|xml-core|xml-core|exe>dev,dev,doc>null,nls>null
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,libx11-xcb-dev,xfonts-utils,libxmu-headers,mesa-common-dev,libgl1,libgl1-mesa-dri,xinit,x11-xkb-utils,x11-xserver-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libglvnd-dev,libglu1-mesa,libglu1-mesa-dev,libice6,libice-dev,libsm6,libsm-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libx11-data,libxau6,libxau-dev,libxaw7,libxaw7-dev,libxcomposite1,libxcomposite-dev,libxcursor1,libxcursor-dev,libxdamage1,libxdamage-dev,libxdmcp6,libxdmcp-dev,libxext6,libxext-dev,libxfixes3,libxfixes-dev,libxfont2,libxfont-dev,libxft2,libxft-dev,libxi6,libxi-dev,libxinerama1,libxinerama-dev,libxkbfile1,libxkbfile-dev,libxmu6,libxmu-dev,libxmuu1,libxmuu-dev,libxpm4,libxpm-dev,libxrandr2,libxrandr-dev,libxrender1,libxrender-dev,libxres1,libxres-dev,libxss1,libxss-dev,libxt6,libxt-dev,libxtst6,libxtst-dev,libxv1,libxv-dev,libxxf86dga1,libxxf86dga-dev,libxxf86vm1,libxxf86vm-dev,xkb-data,xinput,xbitmaps,xauth|exe,dev,doc>null,nls
+yes|xorg_dri|libgl1-mesa-dri,mesa-utils,libglew2.1,libsensors5|exe,dev,doc>null,nls>null
+no|xsane||exe
+yes|xserver_xorg|xserver-xorg-dev,xserver-common,xserver-xorg,xserver-xorg-core,xserver-xorg-video-*,xserver-xorg-input-*,-xserver-xorg-video-*-dbg,-xserver-xorg-video-dummy,-xserver-xorg-video-glint,-xserver-xorg-video-ivtv,-xserver-xorg-video-nsc,-xserver-xorg-video-tga,-xserver-xorg-video-vga,-xserver-xorg-video-vmware|exe,dev
+no|xsoldier|xsoldier|exe,dev>null,doc>null,nls>null
+yes|xtrans|xtrans-dev|exe>dev,dev,doc>null,nls>null
+no|xvidcore|libxvidcore4,libxvidcore-dev|exe,dev,doc>null,nls>null
+yes|xz|xz-utils,liblzma5,liblzma-dev|exe,dev,doc>null,nls>null
+no|yad||exe
+no|yajl|libyajl2,libyajl-dev|exe,dev,doc>null,nls>null #needed by raptor2.
+yes|yasm|yasm|exe>dev,dev>null,doc>null,nls>null
+no|YASSM||exe,dev>null,doc>null,nls>null
+yes|zip|zip|exe,dev>null,doc>null,nls>null
+yes|zlib|zlib1g,zlib1g-dev|exe,dev,doc>null,nls>null
+no|zzznet||exe
+'
+
+if [ -f /etc/DISTRO_SPECS ]; then
+    . /etc/DISTRO_SPECS
+else
+    . ./DISTRO_SPECS
+fi
+
+case $DISTRO_TARGETARCH in
+x86)
+    PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|binutils|binutils,binutils-common,binutils-i686-linux-gnu,binutils-dev,libbinutils,libctf0,libctf-nobfd0|exe>dev,dev,doc>null,nls>null
+yes|gcc_lib|libasan6,libatomic1,libcc1-0,libgcc-s1,libgcc-10-dev,libgomp1,libisl23,libitm1,libquadmath0|exe,dev,doc>null,nls>null #libcloog-isl4 and libisl15 removed for Bullseye
+"
+    ;;
+x86_64)
+    PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|binutils|binutils,binutils-common,binutils-x86-64-linux-gnu,binutils-dev,libbinutils,libctf0,libctf-nobfd0|exe>dev,dev,doc>null,nls>null
+yes|gcc_lib|libasan6,libatomic1,libcc1-0,libgcc-s1,libgcc-10-dev,libgomp1,libisl23,libitm1,libquadmath0|exe,dev,doc>null,nls>null #libcloog-isl4 and libisl15 removed for Bullseye
+"
+    ;;
+arm)
+    PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|binutils|binutils,binutils-common,binutils-arm-linux-gnueabihf,binutils-dev,libbinutils,libctf0,libctf-nobfd0|exe>dev,dev,doc>null,nls>null
+yes|gcc_lib|libasan6,libatomic1,libcc1-0,libgcc-s1,libgcc-10-dev,libgomp1,libisl23|exe,dev,doc>null,nls>null #libcloog-isl4 and libisl15 removed for Bullseye
+yes|firmware-brcm80211|firmware-brcm80211|exe
+"
+    ;;
+aarch64)
+    PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|binutils|binutils,binutils-common,binutils-aarch64-linux-gnu,binutils-dev,libbinutils,libctf0,libctf-nobfd0|exe>dev,dev,doc>null,nls>null
+yes|gcc_lib|libasan6,libatomic1,libcc1-0,libgcc-s1,libgcc-10-dev,libgomp1,libisl23|exe,dev,doc>null,nls>null #libcloog-isl4 and libisl15 removed for Bullseye
+"
+    ;;
+esac

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_SPECS
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_SPECS
@@ -1,0 +1,18 @@
+#One or more words that identify this distribution:
+DISTRO_NAME='Dpup Bullseye64'
+#version number of this distribution:
+DISTRO_VERSION=9.0.0
+#The distro whose binary packages were used to build this distribution:
+DISTRO_BINARY_COMPAT='debian'
+#Prefix for some filenames: exs: bullseyesave.2fs, bullseye-8.0.sfs
+DISTRO_FILE_PREFIX='dpupbullseye64'
+#The version of the distro whose binary packages were used to build this distro:
+DISTRO_COMPAT_VERSION='bullseye'
+#the kernel pet package used:
+DISTRO_KERNEL_PET='Huge_Kernel'
+#read by /usr/bin to bypass Xorg Wizard at first boot:
+DISTRO_XORG_AUTO='yes'
+#subname for online PETs dir. Ex: "slacko14", dir "pet_packages-slacko14", db file "Packages-puppy-slacko14-official":
+#note: prior to existence of this variable, online subname was set to $DISTRO_COMPAT_VERSION or via some hack code.
+DISTRO_DB_SUBNAME='bullseye'
+DISTRO_TARGETARCH='x86_64'

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -17,7 +17,7 @@ UNIONFS=overlay
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ### Kernel tarball URL - avoid being asked questions about downloading/choosing a kernel
-KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-5.4-dpupbullseye64.tar.bz2
+KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-5.10-dpupbullseye64.tar.bz2
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -1,0 +1,127 @@
+#
+#  persistent configuration options
+#
+#  see also DISTRO_SPECS DISTRO_PET_REPOS DISTRO_COMPAT_REPOS-*
+#
+#  **NOTE**: check the original file every once in a while
+#            settings might be added or removed...
+#
+
+# 2createpackages
+STRIP_BINARIES=no
+
+## UnionFS: aufs or overlay
+UNIONFS=overlay
+
+## Kernel tarballs repo URL for choosing/downloading kernel
+KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
+
+### Kernel tarball URL - avoid being asked questions about downloading/choosing a kernel
+KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-5.4-dpupbullseye64.tar.bz2
+
+## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
+## ADRV_INC="abiword gnumeric goffice"
+ADRV_INC="firefox galculator"
+## YDRV_INC=""
+YDRV_INC=""
+## FDRV_INC="" #this one is very experimental and it's recommended to be left unset
+FDRV_INC=""
+
+## Include kernel-kit generated FDRIVE
+## set to yes or no or leave commented to be asked the question at build time
+#KFDRIVE=no
+
+## build devx? yes/no - any other value = ask
+BUILD_DEVX=yes
+
+## include devx SFS in ISO?
+DEVX_IN_ISO=no
+
+## build missing packages from source? yes/no
+PETBUILDS=yes
+
+## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
+LICK_IN_ISO=yes
+
+## compression method to be used (SFS files)
+#SFSCOMP='-comp xz -Xbcj x86 -b 512K'
+#SFSCOMP='-comp xz -Xbcj arm,armthumb -b 512K'
+#SFSCOMP='-comp gzip'
+#SFSCOMP='-noI -noD -noF -noX'
+SFSCOMP='-comp zstd -Xcompression-level 19 -b 512K -no-exports -no-xattrs'
+
+## if "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH"
+## This is usually not needed
+EXTRA_STRIPPING=no
+
+## -- pTheme -- applies only if ptheme pkg is being used
+##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
+## You can choose a ptheme here if you wish
+## otherwise 3builddistro will ask you to choose one
+#PTHEME="Dark Touch"
+#PTHEME="Dark Mouse"
+#PTHEME="Bright Touch"
+#PTHEME="Bright Mouse"
+#PTHEME="Dark_Blue"
+PTHEME="Dark Gray"
+
+## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
+## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
+## For testing builds XERRS_FLG=yes is recommended. If the target device is low RAM suggest to leave this unset, especially for release
+XERRS_FLG=yes
+
+## include Pkg in build (y/n). If commented then asked in 3builddistro
+INCLUDE_PKG=n
+
+## -- Default Apps --
+## Not all are implemented in the puppy scripts,
+##   but you can specify a default app if you wish...
+## If you specify a value it will override anything that previously
+##   set that value in the corresponding script...
+## These are the current default*apps (scripts) in /usr/local/bin
+DEFAULTAPPS="
+defaultconnect=sns
+"
+
+## -- NON-FREE firmware --
+## this downloads and installs to fdrive firmwares that
+## may be needed by the kernel drivers (wireless + dvb).
+## a yes or no val to NONFREE_FW is needed to automate build
+## Note 0: FDRV_INC= must be unset
+## Note 1: see the file support/fw.conf for configuration
+## Note 2: if you select b43* (any) in the fw.conf then b43-fwcutter
+## is downloaded, compiled and installed if you don't already have it
+## Note 3: if nouveau=true then a python script 'extract_firmware.py'
+## is downloaded along with the full nvidia driver. It may take a while.
+## Note 4: you can choose to keep downloaded binaries if you set the
+## 'save_dld=true' var in fw.conf. They'll be used next time instead
+## of downloading them again.
+NONFREE_FW=yes
+
+## -- EXTRA FLAG --
+## This allows some customisation for the iso name
+## eg: slacko64-6.9.9.1-uefi-k3.16.iso
+## where XTRA_FLG='-k3.16' (the dash is a requirement)
+#XTRA_FLG=''
+
+## - extra commands --
+## Here add custom commands to be executed inside sandbox3/rootfs-complete
+EXTRA_COMMANDS="
+chroot . /usr/sbin/firewall_ng enable
+sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i ../adrv/usr/share/applications/firefox-esr.desktop
+touch usr/bin/firefox-esr
+chroot . /usr/sbin/setup-spot firefox-esr=true
+mv -f ../adrv/usr/bin/firefox-esr{,.bin}
+mv -f usr/bin/firefox-esr ../adrv/usr/bin/
+rm -f usr/bin/firefox-esr.bin
+touch usr/bin/sylpheed
+chroot . /usr/sbin/setup-spot sylpheed=true
+mv -f ../adrv/usr/bin/sylpheed{,.bin}
+mv -f usr/bin/sylpheed ../adrv/usr/bin/
+rm -f usr/bin/sylpheed.bin
+touch usr/bin/transmission-gtk
+chroot . /usr/sbin/setup-spot transmission-gtk=true
+mv -f ../adrv/usr/bin/transmission-gtk{,.bin}
+mv -f usr/bin/transmission-gtk ../adrv/usr/bin/
+rm -f usr/bin/transmission-gtk.bin
+"

--- a/woof-distro/x86_64/debian/bullseye64/_00build_2.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build_2.conf
@@ -1,0 +1,9 @@
+#
+# use defaults (_00build.conf)
+#
+# but override these settings:
+
+## Download and include custom SFS (XDRV_INC= overrides this)
+#ADRV_SFS_URL=
+#YDRV_SFS_URL=
+#FDRV_SFS_URL=


### PR DESCRIPTION
This should be almost identical to what's produced by #1948, but a regular ISO with savefiles, etc'.

Once #2033 is fixed, the DISTRO_PKGS_SPECS files can become symlinks.

There **will** be many missing packages required for core functionality like the installers - for example, syslinux.
