### PR TITLE
Remove the mixer menu entry if PulseAudio is present

### DIFF
--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -1,5 +1,6 @@
 echo '
 echo "Configuring Pulseaudio"
+rm -f usr/share/applications/defaultaudiomixer.desktop
 chroot . addgroup pulse
 chroot . addgroup pulse-access
 chroot . adduser -D -s /bin/false -g 'PulseAudio' -G audio -h /var/run/pulse pulse 2>/dev/null

--- a/woof-code/rootfs-skeleton/usr/share/applications/defaultaudiomixer.desktop
+++ b/woof-code/rootfs-skeleton/usr/share/applications/defaultaudiomixer.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=Mixer generic sound mixer
+Name=Mixer
 Icon=/usr/share/pixmaps/puppy/sound_mixer.svg
-Comment=Mixer generic sound mixer
+Comment=Generic sound mixer
 Exec=defaultaudiomixer
 Terminal=false
 Type=Application
 Categories=Mixer
-GenericName=Mixer generic sound mixer
+GenericName=Generic sound mixer


### PR DESCRIPTION
Assumption: this menu entry runs retrovol or alsamixer on legacy Puppies that use ALSA, and in new ones that use PulseAudio, the generic mixer menu entry is useless.