### PR TITLE
Alt-F2 does not work with the default jwmrc-personal (#2152)

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
@@ -59,7 +59,7 @@
 <Key mask="A" key="F6">minimize</Key>
 <Key mask="A" key="#">desktop#</Key>
 <Key mask="A" key="F1">root:9</Key>
-<Key mask="A" key="F2">window</Key>
+<Key mask="A" key="F3">window</Key>
 <Key mask="A" key="space">window</Key>
 
 <Key mask="CA" key="Delete">exec:defaultprocessmanager</Key>


### PR DESCRIPTION
This makes a7671c3601afe0782738899e9b1e2cd0ec6b0bb0 work even if jwmrc-personal is unchanged