### PR TITLE
Default to the 431 global theme in dpup

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -63,7 +63,7 @@ EXTRA_STRIPPING=no
 #PTHEME="Bright Touch"
 #PTHEME="Bright Mouse"
 #PTHEME="Dark_Blue"
-PTHEME="Dark Gray"
+PTHEME="431"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'


### PR DESCRIPTION
This will make screenshots distinguishable from Slacko 8.x screenshots, and give the GTK+ 3 port of Polished-Blue extra testing. 