### PR TITLE
If remove_sublevel=yes, change the bugfix version to 999

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -606,7 +606,7 @@ fi
 cp Makefile Makefile-orig
 if [ "$remove_sublevel" = "yes" ] ; then
 	log_msg "Resetting the minor version number" #!
-	sed -i "s/^SUBLEVEL =.*/#&\nSUBLEVEL = 0/" Makefile
+	sed -i "s/^SUBLEVEL =.*/#&\nSUBLEVEL = 999/" Makefile
 fi
 ## custom suffix
 if [ -n "${custom_suffix}" ] ; then


### PR DESCRIPTION
.0 is confusing or scary for users, who might think they have zero bug and security fixes. .999 looks weird, but at least it's not scary.