### PR TITLE
If DISTRO_* files are symlinks, follow the links (#2033)

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -187,10 +187,10 @@ for ONETOP in \
 `find woof-distro -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '` \
 `find woof-distro/${TARGETARCH} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '` \
 `find woof-distro/${TARGETARCH}/${COMPATDISTRO} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '` \
-`find ${COMPATVERSION_DIR} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '`
+`find -L ${COMPATVERSION_DIR} -mindepth 1 -maxdepth 1 -type f | tr '\n' ' '`
 do
 	echo "    $ONETOP" >> ${WOOF_OUT}/merge2out.log
-	cp -a -f --remove-destination $ONETOP ${WOOF_OUT}/ 2>&1 | tee -a ${WOOF_OUT}/merge2out.log
+	cp -a -f -L --remove-destination $ONETOP ${WOOF_OUT}/ 2>&1 | tee -a ${WOOF_OUT}/merge2out.log
 done
 echo | tee -a ${WOOF_OUT}/merge2out.log
 


### PR DESCRIPTION
This allows dpup to use the same DISTRO_PKGS_SPECS for x86, x86_64 and ARM. I'd like to add a 32-bit dpup configuration template once this is merged, because it looks like there is demand for 32 bit Puppies and someone in the forums will probably take ownership of a 32-bit dpup.