### PR TITLE
Ensure /usr/local/bin/default* are executable when inside adrv

### DIFF
--- a/woof-code/rootfs-petbuilds/geany/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/geany/pinstall.sh
@@ -1,5 +1,7 @@
 echo '#!/bin/sh
 exec geany "$@"' > usr/local/bin/defaulttexteditor
+chmod 755 usr/local/bin/defaulttexteditor
 
 echo '#!/bin/sh
 exec geany "$@"' > usr/local/bin/defaulthtmleditor
+chmod 755 usr/local/bin/defaulthtmleditor

--- a/woof-code/rootfs-petbuilds/gpicview/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/gpicview/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec gpicview "$@"' > usr/local/bin/defaultimageviewer
+chmod 755 usr/local/bin/defaultimageviewer

--- a/woof-code/rootfs-petbuilds/l3afpad/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/l3afpad/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec l3afpad "$@"' > usr/local/bin/defaulttextviewer
+chmod 755 usr/local/bin/defaulttextviewer

--- a/woof-code/rootfs-petbuilds/leafpad/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/leafpad/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec leafpad "$@"' > usr/local/bin/defaulttextviewer
+chmod 755 usr/local/bin/defaulttextviewer

--- a/woof-code/rootfs-petbuilds/lxtask/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/lxtask/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec lxtask "$@"' > usr/local/bin/defaultprocessmanager
+chmod 755 usr/local/bin/defaultprocessmanager

--- a/woof-code/rootfs-petbuilds/lxterminal/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/lxterminal/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec lxterminal "$@"' > usr/local/bin/defaultterminal
+chmod 755 usr/local/bin/defaultterminal

--- a/woof-code/rootfs-petbuilds/mtpaint/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/mtpaint/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec mtpaint "$@"' > usr/local/bin/defaultimageeditor
+chmod 755 usr/local/bin/defaultimageeditor

--- a/woof-code/rootfs-petbuilds/rox-filer/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/rox-filer/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec roxfiler "$@"' > usr/local/bin/defaultfilemanager
+chmod 755 usr/local/bin/defaultfilemanager

--- a/woof-code/rootfs-petbuilds/sylpheed/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/sylpheed/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec sylpheed "$@"' > usr/local/bin/defaultemail
+chmod 755 usr/local/bin/defaultemail

--- a/woof-code/rootfs-petbuilds/transmission/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/transmission/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec transmission-gtk "$@"' > usr/local/bin/defaulttorrent
+chmod 755 usr/local/bin/defaulttorrent

--- a/woof-code/rootfs-petbuilds/xarchiver/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/xarchiver/pinstall.sh
@@ -1,2 +1,3 @@
 echo '#!/bin/sh
 exec xarchiver "$@"' > usr/local/bin/defaultarchiver
+chmod 755 usr/local/bin/defaultarchiver


### PR DESCRIPTION
Good bug.

rootfs-skeleton has these wrappers and they're executable, so there's no need to `chmod` them. But when petbuilds are in adrv, there's no chmod.