### PR TITLE
Add a placeholder for missing default applications (#2180)

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -827,8 +827,6 @@ done
 echo "Checking for missing default apps ..."
 for default in rootfs-complete/usr/local/bin/default* ; do
     app=${default##*/}
-    [ -e adrv/usr/local/bin/${app} ] && continue
-
     app=${app/default/}
     dexec=`grep '^exec' $default | cut -f 2 -d " "`
     chroot rootfs-complete sh -c "command -v $dexec >/dev/null 2>&1" && continue

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -834,8 +834,10 @@ for default in rootfs-complete/usr/local/bin/default* ; do
     chroot rootfs-complete sh -c "command -v $dexec >/dev/null 2>&1" && continue
 
     echo -n "$dexec "
-    rm -f rootfs-complete/usr/local/bin/default${app}
-    ln -s missingdefaultapp rootfs-complete/usr/local/bin/default${app}
+    cat << EOF > $default
+#!/bin/sh
+exec missingdefaultapp $app
+EOF
 done
 echo
 

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -805,7 +805,6 @@ fi
 )
 
 rm -rf rootfs-complete/tmp/* #121123 some above chroot operations may have left something behind in here.
-[ -n "$QEMU" ] && rm -f rootfs-complete/${QEMU}
 
 ## $DEFAULTAPPS - build.conf
 echo "Setting default apps specified in build.conf ..."
@@ -824,6 +823,23 @@ do
 exec $value \"\$@\"" > ${DRV_TGT}/usr/local/bin/$field
 	chmod 755 ${DRV_TGT}/usr/local/bin/$field
 done
+
+echo "Checking for missing default apps ..."
+for default in rootfs-complete/usr/local/bin/default* ; do
+    app=${default##*/}
+    [ -e adrv/usr/local/bin/${app} ] && continue
+
+    app=${app/default/}
+    dexec=`grep '^exec' $default | cut -f 2 -d " "`
+    chroot rootfs-complete sh -c "command -v $dexec >/dev/null 2>&1" && continue
+
+    echo -n "$dexec "
+    rm -f rootfs-complete/usr/local/bin/default${app}
+    ln -s missingdefaultapp rootfs-complete/usr/local/bin/default${app}
+done
+echo
+
+[ -n "$QEMU" ] && rm -f rootfs-complete/${QEMU}
 
 if [ "$SDFLAG" != "" -a "$SDFLAG" != "zip" ]; then
 	BUILD_SFS='no'

--- a/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
+++ b/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
@@ -8,7 +8,7 @@
 --yes-icon package_pet.svg \
 --no-icon puppy_config.svg \
 "Configure default apps" \
-"Configure your default ${0##*/} by either installing one from PPM or openning Puppy Apps
+"Configure your default $1 by either installing one from PPM or openning Puppy Apps
 if an appropriate application is on your system." \
 "Click Open PPM to start Puppy Package Manager or Open Puppy Apps to configure."
 EXITCODE=$?

--- a/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
+++ b/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+/usr/lib/gtkdialog/box_yesno \
+--info \
+--image-icon info.svg \
+--yes-label "Open PPM" \
+--no-label "Open Puppy Apps" \
+--yes-icon package_pet.svg \
+--no-icon puppy_config.svg \
+"Configure default apps" \
+"Configure your default ${0##*/} by either installing one from PPM or openning Puppy Apps
+if an appropriate application is on your system." \
+"Click Open PPM to start Puppy Package Manager or Open Puppy Apps to configure."
+EXITCODE=$?
+echo $EXITCODE
+case $EXITCODE in
+	0)exec ppm;;
+	1)exec puppyapps;;
+esac

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -63,7 +63,7 @@ EXTRA_STRIPPING=no
 #PTHEME="Bright Touch"
 #PTHEME="Bright Mouse"
 #PTHEME="Dark_Blue"
-PTHEME="Dark Gray"
+PTHEME="431"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'


### PR DESCRIPTION
~**Not tested yet,** building dpup with these changes in https://github.com/dimkr/woof-CE/actions/runs/692401164.~

https://github.com/dimkr/woof-CE/releases/tag/dpupbullseye64-9.0.0-placeholder

The missing applications are stopping me from making 431 the default theme of dpup, so it's distinguishable from Slacko 8 and the Chromebook port of Puppy that uses Dark Gray. Therefore, 16e84aa.