### PR TITLE
Put the real kernel version in /proc/version

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -607,6 +607,7 @@ cp Makefile Makefile-orig
 if [ "$remove_sublevel" = "yes" ] ; then
 	log_msg "Resetting the minor version number" #!
 	sed -i "s/^SUBLEVEL =.*/#&\nSUBLEVEL = 0/" Makefile
+	export KBUILD_BUILD_USER="$kernel_version"
 fi
 ## custom suffix
 if [ -n "${custom_suffix}" ] ; then


### PR DESCRIPTION
The username is always root, so it's the best field to replace with the kernel version.

![image](https://user-images.githubusercontent.com/1471149/112721743-c01b5000-8f16-11eb-8f3a-7fb570cb46b7.png)
