### PR TITLE
Build longterm kernels once a week and disable PR builds (#2194)

### DIFF
--- a/.github/workflows/bullseye.yml
+++ b/.github/workflows/bullseye.yml
@@ -7,37 +7,11 @@ on:
       - testing
     paths:
       - 'woof-distro/x86/debian/bullseye/**'
-      - 'kernel-kit/**'
-      - 'woof-code/**'
-      - '!woof-code/support/arm_**'
-      - 'woof-arch/x86/**'
-      - 'merge2out'
-      - '!**.svg'
-      - '!**.png'
-      - '!**.htm'
-      - '!**.html'
-      - '!**.desktop'
-      - '!**.po'
-      - '!**.mo'
-      - '!**/README*'
   pull_request:
     branches:
       - testing
     paths:
       - 'woof-distro/x86/debian/bullseye/**'
-      - 'kernel-kit/**'
-      - 'woof-code/**'
-      - '!woof-code/support/arm_**'
-      - 'woof-arch/x86/**'
-      - 'merge2out'
-      - '!**.svg'
-      - '!**.png'
-      - '!**.htm'
-      - '!**.html'
-      - '!**.desktop'
-      - '!**.po'
-      - '!**.mo'
-      - '!**/README*'
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
@@ -62,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Create cache directories
       run: |
-        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2
@@ -80,8 +54,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
     - name: merge2out
-      run: |
-        (echo 2; echo 1; echo 1; echo; echo) | sudo -E linux32 ./merge2out
+      run: yes "" | sudo -E linux32 ./merge2out woof-distro/x86/debian/bullseye
     - name: Set version
       if: github.event_name == 'workflow_dispatch'
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_x86_debian_bullseye/DISTRO_SPECS
@@ -98,37 +71,21 @@ jobs:
       run: |
         cd ../woof-out_x86_x86_debian_bullseye
         sudo -E linux32 ./1download
-    - name: Get cached kernel-kit output
-      if: github.event_name != 'workflow_dispatch'
-      id: get_kernel_kit_output_cache
-      uses: actions/cache@v2
-      with:
-        path: kernel-kit-output
-        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-    - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_x86_debian_bullseye/kernel-kit/output
-    - name: Install kernel-kit dependencies
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
-        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
-    - name: Get cached ~/.ccache
-      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
-    - name: kernel-kit
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        cd ../woof-out_x86_x86_debian_bullseye/kernel-kit
-        sed 's/^package_name_suffix=.*/package_name_suffix=dpupbullseye/' 4.19.x-x86-build.conf | sudo tee build.conf
-        sudo -E ./build.sh
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_x86_debian_bullseye
         echo | sudo -E linux32 ./2createpackages
+    - name: Get cached kernel-kit output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: puppylinux-woof-CE/woof-CE
+        branch: testing
+        workflow: kernel-kit.yml
+        workflow_conclusion: success
+        name: kernel-kit-output-4.19.x-x86
+        path: kernel-kit-output
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_x86_debian_bullseye/kernel-kit/output
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -205,10 +162,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_debian_bullseye/kernel-kit/output/kernel_sources-4.19-dpupbullseye.sfs
-        asset_name: kernel_sources-4.19-dpupbullseye.sfs
+        asset_path: ../woof-out_x86_x86_debian_bullseye/kernel-kit/output/kernel_sources-4.19-kernel-kit.sfs
+        asset_name: kernel_sources-4.19-kernel-kit.sfs
         asset_content_type: application/octet-stream
     - name: Move cached directories
-      run: |
-        sudo mv ../woof-out_x86_x86_debian_bullseye/petbuild-{sources,cache,output} .
-        sudo mv ../woof-out_x86_x86_debian_bullseye/kernel-kit/output kernel-kit-output
+      run: sudo mv ../woof-out_x86_x86_debian_bullseye/petbuild-{sources,cache,output} .

--- a/.github/workflows/bullseye64.yml
+++ b/.github/workflows/bullseye64.yml
@@ -7,17 +7,11 @@ on:
       - testing
     paths:
       - 'woof-distro/x86_64/debian/bullseye64/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   pull_request:
     branches:
       - testing
     paths:
       - 'woof-distro/x86_64/debian/bullseye64/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
@@ -42,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Create cache directories
       run: |
-        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2
@@ -60,8 +54,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
     - name: merge2out
-      run: |
-        (echo 3; echo 1; echo 1; echo; echo) | sudo -E ./merge2out
+      run: yes "" | sudo -E ./merge2out woof-distro/x86_64/debian/bullseye64
     - name: Set version
       if: github.event_name == 'workflow_dispatch'
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_debian_bullseye64/DISTRO_SPECS
@@ -78,37 +71,21 @@ jobs:
       run: |
         cd ../woof-out_x86_64_x86_64_debian_bullseye64
         sudo -E ./1download
-    - name: Get cached kernel-kit output
-      if: github.event_name != 'workflow_dispatch'
-      id: get_kernel_kit_output_cache
-      uses: actions/cache@v2
-      with:
-        path: kernel-kit-output
-        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-    - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output
-    - name: Install kernel-kit dependencies
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
-        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
-    - name: Get cached ~/.ccache
-      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
-    - name: kernel-kit
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        cd ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit
-        sed 's/^package_name_suffix=.*/package_name_suffix=dpupbullseye64/' 5.10.x-x86_64-build.conf | sudo tee build.conf
-        sudo -E ./build.sh
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_64_x86_64_debian_bullseye64
         echo | sudo -E ./2createpackages
+    - name: Get cached kernel-kit output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: puppylinux-woof-CE/woof-CE
+        branch: testing
+        workflow: kernel-kit.yml
+        workflow_conclusion: success
+        name: kernel-kit-output-5.10.x-x86_64
+        path: kernel-kit-output
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -180,10 +157,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output/kernel_sources-5.10-dpupbullseye64.sfs
-        asset_name: kernel_sources-5.10-dpupbullseye64.sfs
+        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output/kernel_sources-5.10-kernel-kit.sfs
+        asset_name: kernel_sources-5.10-kernel-kit.sfs
         asset_content_type: application/octet-stream
     - name: Move cached directories
-      run: |
-        sudo mv ../woof-out_x86_64_x86_64_debian_bullseye64/petbuild-{sources,cache,output} .
-        sudo mv ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output kernel-kit-output
+      run: sudo mv ../woof-out_x86_64_x86_64_debian_bullseye64/petbuild-{sources,cache,output} .

--- a/.github/workflows/fossa64.yml
+++ b/.github/workflows/fossa64.yml
@@ -7,17 +7,11 @@ on:
       - testing
     paths:
       - 'woof-distro/x86_64/ubuntu/focal64/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   pull_request:
     branches:
       - testing
     paths:
       - 'woof-distro/x86_64/ubuntu/focal64/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
@@ -42,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Create cache directories
       run: |
-        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2
@@ -60,8 +54,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
     - name: merge2out
-      run: |
-        (echo 3; echo 3; echo 2; echo; echo) | sudo -E ./merge2out
+      run: yes "" | sudo -E ./merge2out woof-distro/x86_64/ubuntu/focal64
     - name: Set version
       if: github.event_name == 'workflow_dispatch'
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_ubuntu_focal64/DISTRO_SPECS
@@ -78,37 +71,21 @@ jobs:
       run: |
         cd ../woof-out_x86_64_x86_64_ubuntu_focal64
         sudo -E ./1download
-    - name: Get cached kernel-kit output
-      if: github.event_name != 'workflow_dispatch'
-      id: get_kernel_kit_output_cache
-      uses: actions/cache@v2
-      with:
-        path: kernel-kit-output
-        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-    - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output
-    - name: Install kernel-kit dependencies
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
-        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
-    - name: Get cached ~/.ccache
-      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
-    - name: kernel-kit
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        cd ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit
-        sed 's/^package_name_suffix=.*/package_name_suffix=fossa64/' 5.4.x-x86_64-build.conf | sudo tee build.conf
-        sudo -E ./build.sh
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_64_x86_64_ubuntu_focal64
         echo | sudo -E ./2createpackages
+    - name: Get cached kernel-kit output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: puppylinux-woof-CE/woof-CE
+        branch: testing
+        workflow: kernel-kit.yml
+        workflow_conclusion: success
+        name: kernel-kit-output-5.4.x-x86_64
+        path: kernel-kit-output
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -180,10 +157,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output/kernel_sources-5.4-fossa64.sfs
-        asset_name: kernel_sources-5.4-fossa64.sfs
+        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output/kernel_sources-5.4-kernel-kit.sfs
+        asset_name: kernel_sources-5.4-kernel-kit.sfs
         asset_content_type: application/octet-stream
     - name: Move cached directories
-      run: |
-        sudo mv ../woof-out_x86_64_x86_64_ubuntu_focal64/petbuild-{sources,cache,output} .
-        sudo mv ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output kernel-kit-output
+      run: sudo mv ../woof-out_x86_64_x86_64_ubuntu_focal64/petbuild-{sources,cache,output} .

--- a/.github/workflows/fossa64.yml
+++ b/.github/workflows/fossa64.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - 'woof-distro/x86_64/ubuntu/focal64/**'
   schedule:
-    - cron: '0 0 * * 4'
+    - cron: '0 0 1,14 * *'
   workflow_dispatch:
     branches:
       - ci

--- a/.github/workflows/kernel-kit.yml
+++ b/.github/workflows/kernel-kit.yml
@@ -1,0 +1,42 @@
+name: kernel-kit
+
+on:
+  push:
+    branches:
+      - testing
+    paths:
+      - 'kernel-kit/**'
+      - '!kernel-kit/patches/**'
+      - '!kernel-kit/README'
+      - '!kernel-kit/ZNOTES'
+  schedule:
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  build:
+    if: github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing'
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        kernel-kit-config: [4.19.x-x86, 4.19.x-x86_64, 5.4.x-x86_64, 5.10.x-x86_64]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends libelf-dev libssl-dev
+          curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | sudo gcc -x c -o /usr/local/bin/vercmp -
+      - name: Build kernel
+        run: |
+          cd kernel-kit
+          sudo cp -f ${{ matrix.kernel-kit-config }}-build.conf build.conf
+          sudo -E ./build.sh
+          sudo mkdir small-output
+          sudo mv output/*.{sfs,tar.bz2}* small-output/
+      - name: Upload kernel
+        uses: actions/upload-artifact@v2
+        with:
+          name: kernel-kit-output-${{ matrix.kernel-kit-config }}
+          path: kernel-kit/small-output
+          retention-days: 14

--- a/.github/workflows/slacko-7.yml
+++ b/.github/workflows/slacko-7.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - 'woof-distro/x86/slackware/14.2/**'
   schedule:
-    - cron: '0 0 * * 4'
+    - cron: '0 0 1,14 * *'
   workflow_dispatch:
     branches:
       - ci

--- a/.github/workflows/slacko-7.yml
+++ b/.github/workflows/slacko-7.yml
@@ -7,17 +7,11 @@ on:
       - testing
     paths:
       - 'woof-distro/x86/slackware/14.2/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   pull_request:
     branches:
       - testing
     paths:
       - 'woof-distro/x86/slackware/14.2/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
@@ -42,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Create cache directories
       run: |
-        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2
@@ -60,8 +54,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
     - name: merge2out
-      run: |
-        (echo 2; echo 2; echo 3; echo; echo) | sudo -E linux32 ./merge2out
+      run: yes "" | sudo -E linux32 ./merge2out woof-distro/x86/slackware/14.2
     - name: Set version
       if: github.event_name == 'workflow_dispatch'
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_x86_slackware_14.2/DISTRO_SPECS
@@ -78,37 +71,21 @@ jobs:
       run: |
         cd ../woof-out_x86_x86_slackware_14.2
         sudo -E linux32 ./1download
-    - name: Get cached kernel-kit output
-      if: github.event_name != 'workflow_dispatch'
-      id: get_kernel_kit_output_cache
-      uses: actions/cache@v2
-      with:
-        path: kernel-kit-output
-        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-    - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_x86_slackware_14.2/kernel-kit/output
-    - name: Install kernel-kit dependencies
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
-        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
-    - name: Get cached ~/.ccache
-      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
-    - name: kernel-kit
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        cd ../woof-out_x86_x86_slackware_14.2/kernel-kit
-        sed 's/^package_name_suffix=.*/package_name_suffix=slacko/' 4.19.x-x86-build.conf | sudo tee build.conf
-        sudo -E ./build.sh
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_x86_slackware_14.2
         echo | sudo -E linux32 ./2createpackages
+    - name: Get cached kernel-kit output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: puppylinux-woof-CE/woof-CE
+        branch: testing
+        workflow: kernel-kit.yml
+        workflow_conclusion: success
+        name: kernel-kit-output-4.19.x-x86
+        path: kernel-kit-output
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_x86_slackware_14.2/kernel-kit/output
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -185,10 +162,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_slackware_14.2/kernel-kit/output/kernel_sources-4.19-slacko.sfs
-        asset_name: kernel_sources-4.19-slacko.sfs
+        asset_path: ../woof-out_x86_x86_slackware_14.2/kernel-kit/output/kernel_sources-4.19-kernel-kit.sfs
+        asset_name: kernel_sources-4.19-kernel-kit.sfs
         asset_content_type: application/octet-stream
     - name: Move cached directories
-      run: |
-        sudo mv ../woof-out_x86_x86_slackware_14.2/petbuild-{sources,cache,output} .
-        sudo mv ../woof-out_x86_x86_slackware_14.2/kernel-kit/output kernel-kit-output
+      run: sudo mv ../woof-out_x86_x86_slackware_14.2/petbuild-{sources,cache,output} .

--- a/.github/workflows/slacko64-7.yml
+++ b/.github/workflows/slacko64-7.yml
@@ -7,17 +7,11 @@ on:
       - testing
     paths:
       - 'woof-distro/x86_64/slackware64/14.2/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   pull_request:
     branches:
       - testing
     paths:
       - 'woof-distro/x86_64/slackware64/14.2/**'
-      - 'kernel-kit/**'
-      - 'merge2out'
-      - '!**/README*'
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
@@ -42,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Create cache directories
       run: |
-        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2
@@ -60,8 +54,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
     - name: merge2out
-      run: |
-        (echo 3; echo 2; echo 3; echo; echo) | sudo -E ./merge2out
+      run: yes "" | sudo -E ./merge2out woof-distro/x86_64/slackware64/14.2
     - name: Set version
       if: github.event_name == 'workflow_dispatch'
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_slackware64_14.2/DISTRO_SPECS
@@ -78,37 +71,21 @@ jobs:
       run: |
         cd ../woof-out_x86_64_x86_64_slackware64_14.2
         sudo -E ./1download
-    - name: Get cached kernel-kit output
-      if: github.event_name != 'workflow_dispatch'
-      id: get_kernel_kit_output_cache
-      uses: actions/cache@v2
-      with:
-        path: kernel-kit-output
-        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-    - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output
-    - name: Install kernel-kit dependencies
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
-        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
-    - name: Get cached ~/.ccache
-      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
-    - name: kernel-kit
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit
-        sed 's/^package_name_suffix=.*/package_name_suffix=slacko64/' 4.19.x-x86_64-build.conf | sudo tee build.conf
-        sudo -E ./build.sh
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_64_x86_64_slackware64_14.2
         echo | sudo -E ./2createpackages
+    - name: Get cached kernel-kit output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: puppylinux-woof-CE/woof-CE
+        branch: testing
+        workflow: kernel-kit.yml
+        workflow_conclusion: success
+        name: kernel-kit-output-4.19.x-x86_64
+        path: kernel-kit-output
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -180,10 +157,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output/kernel_sources-4.19-slacko64.sfs
-        asset_name: kernel_sources-4.19-slacko64.sfs
+        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output/kernel_sources-4.19-kernel-kit.sfs
+        asset_name: kernel_sources-4.19-kernel-kit.sfs
         asset_content_type: application/octet-stream
     - name: Move cached directories
-      run: |
-        sudo mv ../woof-out_x86_64_x86_64_slackware64_14.2/petbuild-{sources,cache,output} .
-        sudo mv ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output kernel-kit-output
+      run: sudo mv ../woof-out_x86_64_x86_64_slackware64_14.2/petbuild-{sources,cache,output} .

--- a/.github/workflows/slacko64-7.yml
+++ b/.github/workflows/slacko64-7.yml
@@ -13,7 +13,7 @@ on:
     paths:
       - 'woof-distro/x86_64/slackware64/14.2/**'
   schedule:
-    - cron: '0 0 * * 4'
+    - cron: '0 0 1,14 * *'
   workflow_dispatch:
     branches:
       - ci

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -7,37 +7,11 @@ on:
       - testing
     paths:
       - 'woof-distro/x86_64/slackware64/15.0/**'
-      - 'kernel-kit/**'
-      - 'woof-code/**'
-      - '!woof-code/support/arm_**'
-      - 'woof-arch/x86_64/**'
-      - 'merge2out'
-      - '!**.svg'
-      - '!**.png'
-      - '!**.htm'
-      - '!**.html'
-      - '!**.desktop'
-      - '!**.po'
-      - '!**.mo'
-      - '!**/README*'
   pull_request:
     branches:
       - testing
     paths:
       - 'woof-distro/x86_64/slackware64/15.0/**'
-      - 'kernel-kit/**'
-      - 'woof-code/**'
-      - '!woof-code/support/arm_**'
-      - 'woof-arch/x86_64/**'
-      - 'merge2out'
-      - '!**.svg'
-      - '!**.png'
-      - '!**.htm'
-      - '!**.html'
-      - '!**.desktop'
-      - '!**.po'
-      - '!**.mo'
-      - '!**/README*'
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
@@ -62,7 +36,7 @@ jobs:
       uses: actions/checkout@v2
     - name: Create cache directories
       run: |
-        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output kernel-kit-output
+        mkdir -p local-repositories petbuild-sources petbuild-cache petbuild-output
         ln -s `pwd`/local-repositories ../local-repositories
     - name: Get cached local-repositories
       uses: actions/cache@v2
@@ -80,8 +54,7 @@ jobs:
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
     - name: merge2out
-      run: |
-        (echo 3; echo 2; echo 4; echo; echo) | sudo -E ./merge2out
+      run: yes "" | sudo -E ./merge2out woof-distro/x86_64/slackware64/15.0
     - name: Set version
       if: github.event_name == 'workflow_dispatch'
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_slackware64_15.0/DISTRO_SPECS
@@ -98,37 +71,21 @@ jobs:
       run: |
         cd ../woof-out_x86_64_x86_64_slackware64_15.0
         sudo -E ./1download
-    - name: Get cached kernel-kit output
-      if: github.event_name != 'workflow_dispatch'
-      id: get_kernel_kit_output_cache
-      uses: actions/cache@v2
-      with:
-        path: kernel-kit-output
-        key: ${{ github.workflow }}-kernel-kit-output-${{ hashFiles('kernel-kit/**') }}
-    - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output
-    - name: Install kernel-kit dependencies
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends ccache libelf-dev libssl-dev
-        ccache --set-config=hash_dir=false --set-config=max_size=2.0G
-    - name: Get cached ~/.ccache
-      if: github.event_name != 'workflow_dispatch' && steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      uses: actions/cache@v2
-      with:
-        path: ~/.ccache
-        key: ${{ github.workflow }}-ccache-${{ hashFiles('kernel-kit/**') }}
-    - name: kernel-kit
-      if: steps.get_kernel_kit_output_cache.outputs.cache-hit != 'true'
-      run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit
-        sed 's/^package_name_suffix=.*/package_name_suffix=slacko64/' 5.10.x-x86_64-build.conf | sudo tee build.conf
-        sudo -E ./build.sh
     - name: 2createpackages
       run: |
         cd ../woof-out_x86_64_x86_64_slackware64_15.0
         echo | sudo -E ./2createpackages
+    - name: Get cached kernel-kit output
+      uses: dawidd6/action-download-artifact@v2
+      with:
+        repo: puppylinux-woof-CE/woof-CE
+        branch: testing
+        workflow: kernel-kit.yml
+        workflow_conclusion: success
+        name: kernel-kit-output-5.10.x-x86_64
+        path: kernel-kit-output
+    - name: Move cached kernel-kit output
+      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -200,10 +157,8 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output/kernel_sources-5.10-slacko64.sfs
-        asset_name: kernel_sources-5.10-slacko64.sfs
+        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output/kernel_sources-5.10-kernel-kit.sfs
+        asset_name: kernel_sources-5.10-kernel-kit.sfs
         asset_content_type: application/octet-stream
     - name: Move cached directories
-      run: |
-        sudo mv ../woof-out_x86_64_x86_64_slackware64_15.0/petbuild-{sources,cache,output} .
-        sudo mv ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output kernel-kit-output
+      run: sudo mv ../woof-out_x86_64_x86_64_slackware64_15.0/petbuild-{sources,cache,output} .

--- a/kernel-kit/4.19.x-x86-build.conf
+++ b/kernel-kit/4.19.x-x86-build.conf
@@ -52,7 +52,7 @@ custom_suffix=
 ## name it whatever you like, usually put in a signifier for your distro
 ## eg: "s" is for slacko
 ## if you leave empty the script will determine a proper package suffix
-package_name_suffix=
+package_name_suffix=kernel-kit
 
 ##-----------------------------------------------------------------------
 
@@ -73,8 +73,9 @@ remove_sublevel=yes
 ### squashfs compression ###
 ## unset this for the default of your mksquashfs binary
 #COMP="-comp gzip"
-COMP="-comp xz"
+#COMP="-comp xz"
 #COMP="-comp xz -b 512K"
+COMP='-comp zstd -Xcompression-level 19 -b 512K'
 
 ## strip kernel modules?
 ## warning: this might cause issues

--- a/kernel-kit/4.19.x-x86_64-build.conf
+++ b/kernel-kit/4.19.x-x86_64-build.conf
@@ -52,7 +52,7 @@ custom_suffix=
 ## name it whatever you like, usually put in a signifier for your distro
 ## eg: "s" is for slacko
 ## if you leave empty the script will determine a proper package suffix
-package_name_suffix=
+package_name_suffix=kernel-kit
 
 ##-----------------------------------------------------------------------
 
@@ -73,8 +73,9 @@ remove_sublevel=yes
 ### squashfs compression ###
 ## unset this for the default of your mksquashfs binary
 #COMP="-comp gzip"
-COMP="-comp xz"
+#COMP="-comp xz"
 #COMP="-comp xz -b 512K"
+COMP='-comp zstd -Xcompression-level 19 -b 512K'
 
 ## strip kernel modules?
 ## warning: this might cause issues

--- a/kernel-kit/5.10.x-x86_64-build.conf
+++ b/kernel-kit/5.10.x-x86_64-build.conf
@@ -52,7 +52,7 @@ custom_suffix=
 ## name it whatever you like, usually put in a signifier for your distro
 ## eg: "s" is for slacko
 ## if you leave empty the script will determine a proper package suffix
-package_name_suffix=
+package_name_suffix=kernel-kit
 
 ##-----------------------------------------------------------------------
 

--- a/kernel-kit/5.4.x-x86_64-build.conf
+++ b/kernel-kit/5.4.x-x86_64-build.conf
@@ -52,7 +52,7 @@ custom_suffix=
 ## name it whatever you like, usually put in a signifier for your distro
 ## eg: "s" is for slacko
 ## if you leave empty the script will determine a proper package suffix
-package_name_suffix=
+package_name_suffix=kernel-kit
 
 ##-----------------------------------------------------------------------
 
@@ -75,7 +75,7 @@ remove_sublevel=yes
 #COMP="-comp gzip"
 #COMP="-comp xz"
 #COMP="-comp xz -b 512K"
-COMP='-comp xz -Xbcj x86 -b 512K'
+COMP='-comp zstd -Xcompression-level 19 -b 512K'
 
 ## strip kernel modules?
 ## warning: this might cause issues

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -607,7 +607,7 @@ cp Makefile Makefile-orig
 if [ "$remove_sublevel" = "yes" ] ; then
 	log_msg "Resetting the minor version number" #!
 	sed -i "s/^SUBLEVEL =.*/#&\nSUBLEVEL = 0/" Makefile
-	export KBUILD_BUILD_USER="$kernel_version"
+	export KBUILD_BUILD_USER="${kernel_version}-${package_name_suffix}"
 fi
 ## custom suffix
 if [ -n "${custom_suffix}" ] ; then

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -699,11 +699,6 @@ function do_kernel_config() {
 	fi
 }
 
-# in CI, we want to speed up kernel building using ccache
-if [ -n "$GITHUB_ACTIONS" ] ; then
-	sed s~'$(CROSS_COMPILE)gcc'~'ccache &'~ -i Makefile
-fi
-
 if [ "$AUTO" = "yes" ] ; then
 	log_msg "$MAKE olddefconfig"
 	$MAKE olddefconfig

--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # GPL-V2 or later at your discretion
 # (c) Mick Amadio, 2020 01micko@gmail.com, Gold Coast QLD, Australia

--- a/woof-distro/x86/debian/bullseye/_00build.conf
+++ b/woof-distro/x86/debian/bullseye/_00build.conf
@@ -17,7 +17,7 @@ UNIONFS=overlay
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ### Kernel tarball URL - avoid being asked questions about downloading/choosing a kernel
-KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19-dpupbullseye.tar.bz2
+KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19-kernel-kit.tar.bz2
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"

--- a/woof-distro/x86/slackware/14.2/_00build_2.conf
+++ b/woof-distro/x86/slackware/14.2/_00build_2.conf
@@ -6,7 +6,7 @@
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=y
 
-KERNEL_TARBALL_URL=https://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19-slacko.tar.bz2
+KERNEL_TARBALL_URL=https://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19-kernel-kit.tar.bz2
 
 PTHEME="The Beach Grey"
 

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -17,7 +17,7 @@ UNIONFS=overlay
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ### Kernel tarball URL - avoid being asked questions about downloading/choosing a kernel
-KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-5.10-dpupbullseye64.tar.bz2
+KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-5.10-kernel-kit.tar.bz2
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"

--- a/woof-distro/x86_64/slackware64/14.2/_00build_2.conf
+++ b/woof-distro/x86_64/slackware64/14.2/_00build_2.conf
@@ -3,6 +3,6 @@
 #
 # but override these settings:
 
-KERNEL_TARBALL_URL=https://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19-slacko64.tar.bz2
+KERNEL_TARBALL_URL=https://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19-kernel-kit.tar.bz2
 
 PTHEME="The Beach Color"


### PR DESCRIPTION
This will reduce build times and make woof-CE's CI more scalable (need to make room for the next Ubuntu-based Puppy).

This PR will never pass CI because now Puppy builds try to pull kernel-kit output that's built once a week on the testing branch, so this PR must be merged before I can debug any issues. (Tested in a fork).

Because now slacko/fossa/dpup all use the same kernel packages (so fdrv and zdrv are renamed before inclusion in ISO), I added the package name suffix to /proc/version.