### PR TITLE
xorgwizard: Added video mode detection

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
@@ -87,6 +87,9 @@ function xorg_screen_res_dlg_stuff() {
 	else
 		DEFAULT_RES=$(report-video res)
 	fi
+if [ -e /var/local/xorg-detect-screen-size ]; then
+  RESOLUTIONS=`xrandr --screen 0 | grep -E '*[0-9]x[0-9].*[0-9]\.' | awk '{ print $1 }' | sed '/640x480/q'`
+else
 	#- screen resolutions (edit this)
 	RESOLUTIONS="1024x768
 800x600
@@ -109,6 +112,8 @@ function xorg_screen_res_dlg_stuff() {
 4096x2160
 5120x2880
 8192x4320"
+
+fi
 	#- messages
 	export SCREEN_RES_TITLE=$(gettext 'Screen resolution')
 	export SCREEN_RES_MSG1=$(gettext "Choose a reasonable resolution for your hardware. 


### PR DESCRIPTION
Instead of  predefined screen resolution. It just read the supported screen resolutions of a monitor. To enable this feature just create xorg-detect-screen-size file in /var/local before running the xorgwizard.