### PR TITLE
When building a PR, keep the output for 3 days

### DIFF
--- a/.github/workflows/bullseye.yml
+++ b/.github/workflows/bullseye.yml
@@ -1,13 +1,6 @@
 name: bullseye
 
 on:
-  push:
-    branches:
-      - ci
-      - testing
-    paths:
-      - 'woof-distro/x86/debian/bullseye/**'
-      - 'woof-distro/x86_64/debian/bullseye64/**' # bullseye/* are symlinks to bullseye64/8
   pull_request:
     branches:
       - testing
@@ -20,18 +13,10 @@ on:
     branches:
       - ci
       - testing
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
-        default: '9.0.0'
-      suffix:
-        description: 'Release name suffix, with leading -'
-        required: false
-        default: '-prepreprealpha1'
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -57,25 +42,17 @@ jobs:
         sudo ln -s bash /bin/ash
     - name: merge2out
       run: yes "" | sudo -E linux32 ./merge2out woof-distro/x86/debian/bullseye
-    - name: Set version
-      if: github.event_name == 'workflow_dispatch'
-      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_x86_debian_bullseye/DISTRO_SPECS
-    - name: Set compression algorithm
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        echo | sudo tee -a ../woof-out_x86_x86_debian_bullseye/_00build.conf
-        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_x86_debian_bullseye/_00build.conf
     - name: 0setup
       run: |
-        cd ../woof-out_x86_x86_debian_bullseye
+        cd ../woof-out_*
         sudo -E linux32 ./0setup
     - name: 1download
       run: |
-        cd ../woof-out_x86_x86_debian_bullseye
+        cd ../woof-out_*
         sudo -E linux32 ./1download
     - name: 2createpackages
       run: |
-        cd ../woof-out_x86_x86_debian_bullseye
+        cd ../woof-out_*
         echo | sudo -E linux32 ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
@@ -85,9 +62,9 @@ jobs:
         workflow: kernel-kit.yml
         workflow_conclusion: success
         name: kernel-kit-output-4.19.x-x86
-        path: kernel-kit-output
+        path: output
     - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_x86_debian_bullseye/kernel-kit/output
+      run: sudo mv output ../woof-out_*/kernel-kit/
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -123,69 +100,16 @@ jobs:
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output
-        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_x86_debian_bullseye/
-        cd ../woof-out_x86_x86_debian_bullseye
+        sudo mv petbuild-{sources,cache,output} ../woof-out_*/
+        cd ../woof-out_*
         sudo -E HOME=/root linux32 ./3builddistro release
-    - name: Create Release
-      if: github.event_name == 'workflow_dispatch'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        sudo mv -f woof-output-*/*.{sfs,iso} $GITHUB_WORKSPACE/
+        sudo mv -f kernel-kit/output/kernel_sources-*.sfs $GITHUB_WORKSPACE/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: dpupbullseye-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        release_name: dpupbullseye-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        draft: false
-        prerelease: true
-    - name: Upload ISO
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_debian_bullseye/woof-output-dpupbullseye-${{ github.event.inputs.version }}/dpupbullseye-${{ github.event.inputs.version }}.iso
-        asset_name: dpupbullseye-${{ github.event.inputs.version }}.iso
-        asset_content_type: application/octet-stream
-    - name: Upload devx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_debian_bullseye/woof-output-dpupbullseye-${{ github.event.inputs.version }}/devx_dpupbullseye_${{ github.event.inputs.version }}.sfs
-        asset_name: devx_dpupbullseye_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload docx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_debian_bullseye/woof-output-dpupbullseye-${{ github.event.inputs.version }}/docx_dpupbullseye_${{ github.event.inputs.version }}.sfs
-        asset_name: docx_dpupbullseye_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload nlsx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_debian_bullseye/woof-output-dpupbullseye-${{ github.event.inputs.version }}/nlsx_dpupbullseye_${{ github.event.inputs.version }}.sfs
-        asset_name: nlsx_dpupbullseye_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload kernel sources
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_debian_bullseye/kernel-kit/output/kernel_sources-4.19-kernel-kit.sfs
-        asset_name: kernel_sources-4.19-kernel-kit.sfs
-        asset_content_type: application/octet-stream
-    - name: Move cached directories
-      run: sudo mv ../woof-out_x86_x86_debian_bullseye/petbuild-{sources,cache,output} .
+        name: ${{ github.workflow }}-${{ github.run_number }}
+        path: |
+          *.iso
+          *.sfs
+        retention-days: 3

--- a/.github/workflows/bullseye.yml
+++ b/.github/workflows/bullseye.yml
@@ -6,7 +6,7 @@ on:
       - testing
     paths:
       - 'woof-distro/x86/debian/bullseye/**'
-      - 'woof-distro/x86_64/debian/bullseye64/**' # bullseye/* are symlinks to bullseye64/8
+      - 'woof-distro/x86_64/debian/bullseye64/**' # bullseye/* are symlinks to bullseye64/*
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:

--- a/.github/workflows/bullseye.yml
+++ b/.github/workflows/bullseye.yml
@@ -10,9 +10,6 @@ on:
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
-    branches:
-      - ci
-      - testing
 
 jobs:
   build:

--- a/.github/workflows/bullseye64.yml
+++ b/.github/workflows/bullseye64.yml
@@ -1,12 +1,6 @@
 name: bullseye64
 
 on:
-  push:
-    branches:
-      - ci
-      - testing
-    paths:
-      - 'woof-distro/x86_64/debian/bullseye64/**'
   pull_request:
     branches:
       - testing
@@ -18,18 +12,10 @@ on:
     branches:
       - ci
       - testing
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
-        default: '9.0.0'
-      suffix:
-        description: 'Release name suffix, with leading -'
-        required: false
-        default: '-prepreprealpha1'
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -55,25 +41,22 @@ jobs:
         sudo ln -s bash /bin/ash
     - name: merge2out
       run: yes "" | sudo -E ./merge2out woof-distro/x86_64/debian/bullseye64
-    - name: Set version
-      if: github.event_name == 'workflow_dispatch'
-      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_debian_bullseye64/DISTRO_SPECS
     - name: Set compression algorithm
-      if: github.event_name != 'workflow_dispatch'
+      if: github.event_name != 'schedule'
       run: |
-        echo | sudo tee -a ../woof-out_x86_64_x86_64_debian_bullseye64/_00build.conf
-        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_64_x86_64_debian_bullseye64/_00build.conf
+        echo | sudo tee -a ../woof-out_*/_00build.conf
+        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_*/_00build.conf
     - name: 0setup
       run: |
-        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        cd ../woof-out_*
         sudo -E ./0setup
     - name: 1download
       run: |
-        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        cd ../woof-out_*
         sudo -E ./1download
     - name: 2createpackages
       run: |
-        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        cd ../woof-out_*
         echo | sudo -E ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
@@ -83,9 +66,9 @@ jobs:
         workflow: kernel-kit.yml
         workflow_conclusion: success
         name: kernel-kit-output-5.10.x-x86_64
-        path: kernel-kit-output
+        path: output
     - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output
+      run: sudo mv output ../woof-out_*/kernel-kit/
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -116,69 +99,16 @@ jobs:
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output
-        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_64_x86_64_debian_bullseye64/
-        cd ../woof-out_x86_64_x86_64_debian_bullseye64
+        sudo mv petbuild-{sources,cache,output} ../woof-out_*/
+        cd ../woof-out_*
         sudo -E HOME=/root ./3builddistro release
-    - name: Create Release
-      if: github.event_name == 'workflow_dispatch'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        sudo mv -f woof-output-*/*.{sfs,iso} $GITHUB_WORKSPACE/
+        sudo mv -f kernel-kit/output/kernel_sources-*.sfs $GITHUB_WORKSPACE/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: dpupbullseye64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        release_name: dpupbullseye64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        draft: false
-        prerelease: true
-    - name: Upload ISO
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/woof-output-dpupbullseye64-${{ github.event.inputs.version }}/dpupbullseye64-${{ github.event.inputs.version }}.iso
-        asset_name: dpupbullseye64-${{ github.event.inputs.version }}.iso
-        asset_content_type: application/octet-stream
-    - name: Upload devx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/woof-output-dpupbullseye64-${{ github.event.inputs.version }}/devx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
-        asset_name: devx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload docx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/woof-output-dpupbullseye64-${{ github.event.inputs.version }}/docx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
-        asset_name: docx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload nlsx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/woof-output-dpupbullseye64-${{ github.event.inputs.version }}/nlsx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
-        asset_name: nlsx_dpupbullseye64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload kernel sources
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_debian_bullseye64/kernel-kit/output/kernel_sources-5.10-kernel-kit.sfs
-        asset_name: kernel_sources-5.10-kernel-kit.sfs
-        asset_content_type: application/octet-stream
-    - name: Move cached directories
-      run: sudo mv ../woof-out_x86_64_x86_64_debian_bullseye64/petbuild-{sources,cache,output} .
+        name: ${{ github.workflow }}-${{ github.run_number }}
+        path: |
+          *.iso
+          *.sfs
+        retention-days: 3

--- a/.github/workflows/bullseye64.yml
+++ b/.github/workflows/bullseye64.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
-    branches:
-      - ci
-      - testing
 
 jobs:
   build:

--- a/.github/workflows/fossa64.yml
+++ b/.github/workflows/fossa64.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 0 1,14 * *'
   workflow_dispatch:
-    branches:
-      - ci
-      - testing
 
 jobs:
   build:

--- a/.github/workflows/fossa64.yml
+++ b/.github/workflows/fossa64.yml
@@ -1,12 +1,6 @@
 name: fossa64
 
 on:
-  push:
-    branches:
-      - ci
-      - testing
-    paths:
-      - 'woof-distro/x86_64/ubuntu/focal64/**'
   pull_request:
     branches:
       - testing
@@ -18,18 +12,10 @@ on:
     branches:
       - ci
       - testing
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
-        default: '9.5'
-      suffix:
-        description: 'Release name suffix, with leading -'
-        required: false
-        default: '-prepreprealpha1'
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -55,25 +41,17 @@ jobs:
         sudo ln -s bash /bin/ash
     - name: merge2out
       run: yes "" | sudo -E ./merge2out woof-distro/x86_64/ubuntu/focal64
-    - name: Set version
-      if: github.event_name == 'workflow_dispatch'
-      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_ubuntu_focal64/DISTRO_SPECS
-    - name: Set compression algorithm
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        echo | sudo tee -a ../woof-out_x86_64_x86_64_ubuntu_focal64/_00build.conf
-        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_64_x86_64_ubuntu_focal64/_00build.conf
     - name: 0setup
       run: |
-        cd ../woof-out_x86_64_x86_64_ubuntu_focal64
+        cd ../woof-out_*
         sudo -E ./0setup
     - name: 1download
       run: |
-        cd ../woof-out_x86_64_x86_64_ubuntu_focal64
+        cd ../woof-out_*
         sudo -E ./1download
     - name: 2createpackages
       run: |
-        cd ../woof-out_x86_64_x86_64_ubuntu_focal64
+        cd ../woof-out_*
         echo | sudo -E ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
@@ -83,9 +61,9 @@ jobs:
         workflow: kernel-kit.yml
         workflow_conclusion: success
         name: kernel-kit-output-5.4.x-x86_64
-        path: kernel-kit-output
+        path: output
     - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output
+      run: sudo mv output ../woof-out_*/kernel-kit/
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -116,69 +94,16 @@ jobs:
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output
-        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_64_x86_64_ubuntu_focal64/
-        cd ../woof-out_x86_64_x86_64_ubuntu_focal64
+        sudo mv petbuild-{sources,cache,output} ../woof-out_*/
+        cd ../woof-out_*
         sudo -E HOME=/root ./3builddistro release
-    - name: Create Release
-      if: github.event_name == 'workflow_dispatch'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        sudo mv -f woof-output-*/*.{sfs,iso} $GITHUB_WORKSPACE/
+        sudo mv -f kernel-kit/output/kernel_sources-*.sfs $GITHUB_WORKSPACE/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: fossa64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        release_name: fossa64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        draft: false
-        prerelease: true
-    - name: Upload ISO
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/woof-output-fossapup64-${{ github.event.inputs.version }}/fossapup64-${{ github.event.inputs.version }}.iso
-        asset_name: fossapup64-${{ github.event.inputs.version }}.iso
-        asset_content_type: application/octet-stream
-    - name: Upload devx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/woof-output-fossapup64-${{ github.event.inputs.version }}/devx_fossapup64_${{ github.event.inputs.version }}.sfs
-        asset_name: devx_fossapup64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload docx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/woof-output-fossapup64-${{ github.event.inputs.version }}/docx_fossapup64_${{ github.event.inputs.version }}.sfs
-        asset_name: docx_fossapup64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload nlsx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/woof-output-fossapup64-${{ github.event.inputs.version }}/nlsx_fossapup64_${{ github.event.inputs.version }}.sfs
-        asset_name: nlsx_fossapup64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload kernel sources
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_ubuntu_focal64/kernel-kit/output/kernel_sources-5.4-kernel-kit.sfs
-        asset_name: kernel_sources-5.4-kernel-kit.sfs
-        asset_content_type: application/octet-stream
-    - name: Move cached directories
-      run: sudo mv ../woof-out_x86_64_x86_64_ubuntu_focal64/petbuild-{sources,cache,output} .
+        name: ${{ github.workflow }}-${{ github.run_number }}
+        path: |
+          *.iso
+          *.sfs
+        retention-days: 3

--- a/.github/workflows/slacko-7.yml
+++ b/.github/workflows/slacko-7.yml
@@ -1,12 +1,6 @@
 name: slacko-7
 
 on:
-  push:
-    branches:
-      - ci
-      - testing
-    paths:
-      - 'woof-distro/x86/slackware/14.2/**'
   pull_request:
     branches:
       - testing
@@ -18,18 +12,10 @@ on:
     branches:
       - ci
       - testing
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
-        default: '7.1'
-      suffix:
-        description: 'Release name suffix, with leading -'
-        required: false
-        default: ''
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -55,25 +41,17 @@ jobs:
         sudo ln -s bash /bin/ash
     - name: merge2out
       run: yes "" | sudo -E linux32 ./merge2out woof-distro/x86/slackware/14.2
-    - name: Set version
-      if: github.event_name == 'workflow_dispatch'
-      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_x86_slackware_14.2/DISTRO_SPECS
-    - name: Set compression algorithm
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        echo | sudo tee -a ../woof-out_x86_x86_slackware_14.2/_00build.conf
-        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_x86_slackware_14.2/_00build.conf
     - name: 0setup
       run: |
-        cd ../woof-out_x86_x86_slackware_14.2
+        cd ../woof-out_*
         sudo -E linux32 ./0setup
     - name: 1download
       run: |
-        cd ../woof-out_x86_x86_slackware_14.2
+        cd ../woof-out_*
         sudo -E linux32 ./1download
     - name: 2createpackages
       run: |
-        cd ../woof-out_x86_x86_slackware_14.2
+        cd ../woof-out_*
         echo | sudo -E linux32 ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
@@ -83,9 +61,9 @@ jobs:
         workflow: kernel-kit.yml
         workflow_conclusion: success
         name: kernel-kit-output-4.19.x-x86
-        path: kernel-kit-output
+        path: output
     - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_x86_slackware_14.2/kernel-kit/output
+      run: sudo mv output ../woof-out_*/kernel-kit/
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -121,69 +99,16 @@ jobs:
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output
-        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_x86_slackware_14.2/
-        cd ../woof-out_x86_x86_slackware_14.2
+        sudo mv petbuild-{sources,cache,output} ../woof-out_*/
+        cd ../woof-out_*
         sudo -E HOME=/root linux32 ./3builddistro release
-    - name: Create Release
-      if: github.event_name == 'workflow_dispatch'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        sudo mv -f woof-output-*/*.{sfs,iso} $GITHUB_WORKSPACE/
+        sudo mv -f kernel-kit/output/kernel_sources-*.sfs $GITHUB_WORKSPACE/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: slacko-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        release_name: slacko-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        draft: false
-        prerelease: false
-    - name: Upload ISO
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_slackware_14.2/woof-output-slacko-${{ github.event.inputs.version }}/slacko-${{ github.event.inputs.version }}.iso
-        asset_name: slacko-${{ github.event.inputs.version }}.iso
-        asset_content_type: application/octet-stream
-    - name: Upload devx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_slackware_14.2/woof-output-slacko-${{ github.event.inputs.version }}/devx_slacko_${{ github.event.inputs.version }}.sfs
-        asset_name: devx_slacko_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload docx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_slackware_14.2/woof-output-slacko-${{ github.event.inputs.version }}/docx_slacko_${{ github.event.inputs.version }}.sfs
-        asset_name: docx_slacko_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload nlsx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_slackware_14.2/woof-output-slacko-${{ github.event.inputs.version }}/nlsx_slacko_${{ github.event.inputs.version }}.sfs
-        asset_name: nlsx_slacko_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload kernel sources
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_x86_slackware_14.2/kernel-kit/output/kernel_sources-4.19-kernel-kit.sfs
-        asset_name: kernel_sources-4.19-kernel-kit.sfs
-        asset_content_type: application/octet-stream
-    - name: Move cached directories
-      run: sudo mv ../woof-out_x86_x86_slackware_14.2/petbuild-{sources,cache,output} .
+        name: ${{ github.workflow }}-${{ github.run_number }}
+        path: |
+          *.iso
+          *.sfs
+        retention-days: 3

--- a/.github/workflows/slacko-7.yml
+++ b/.github/workflows/slacko-7.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 0 1,14 * *'
   workflow_dispatch:
-    branches:
-      - ci
-      - testing
 
 jobs:
   build:

--- a/.github/workflows/slacko64-7.yml
+++ b/.github/workflows/slacko64-7.yml
@@ -1,12 +1,6 @@
 name: slacko64-7
 
 on:
-  push:
-    branches:
-      - ci
-      - testing
-    paths:
-      - 'woof-distro/x86_64/slackware64/14.2/**'
   pull_request:
     branches:
       - testing
@@ -18,18 +12,10 @@ on:
     branches:
       - ci
       - testing
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
-        default: '7.1'
-      suffix:
-        description: 'Release name suffix, with leading -'
-        required: false
-        default: ''
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -55,25 +41,17 @@ jobs:
         sudo ln -s bash /bin/ash
     - name: merge2out
       run: yes "" | sudo -E ./merge2out woof-distro/x86_64/slackware64/14.2
-    - name: Set version
-      if: github.event_name == 'workflow_dispatch'
-      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_slackware64_14.2/DISTRO_SPECS
-    - name: Set compression algorithm
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        echo | sudo tee -a ../woof-out_x86_64_x86_64_slackware64_14.2/_00build.conf
-        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_64_x86_64_slackware64_14.2/_00build.conf
     - name: 0setup
       run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_14.2
+        cd ../woof-out_*
         sudo -E ./0setup
     - name: 1download
       run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_14.2
+        cd ../woof-out_*
         sudo -E ./1download
     - name: 2createpackages
       run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_14.2
+        cd ../woof-out_*
         echo | sudo -E ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
@@ -83,9 +61,9 @@ jobs:
         workflow: kernel-kit.yml
         workflow_conclusion: success
         name: kernel-kit-output-4.19.x-x86_64
-        path: kernel-kit-output
+        path: output
     - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output
+      run: sudo mv output ../woof-out_*/kernel-kit/
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -116,69 +94,16 @@ jobs:
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output
-        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_64_x86_64_slackware64_14.2/
-        cd ../woof-out_x86_64_x86_64_slackware64_14.2
+        sudo mv petbuild-{sources,cache,output} ../woof-out_*/
+        cd ../woof-out_*
         sudo -E HOME=/root ./3builddistro release
-    - name: Create Release
-      if: github.event_name == 'workflow_dispatch'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        sudo mv -f woof-output-*/*.{sfs,iso} $GITHUB_WORKSPACE/
+        sudo mv -f kernel-kit/output/kernel_sources-*.sfs $GITHUB_WORKSPACE/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: slacko64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        release_name: slacko64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        draft: false
-        prerelease: false
-    - name: Upload ISO
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/woof-output-slacko64-${{ github.event.inputs.version }}/slacko64-${{ github.event.inputs.version }}.iso
-        asset_name: slacko64-${{ github.event.inputs.version }}.iso
-        asset_content_type: application/octet-stream
-    - name: Upload devx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/woof-output-slacko64-${{ github.event.inputs.version }}/devx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_name: devx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload docx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/woof-output-slacko64-${{ github.event.inputs.version }}/docx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_name: docx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload nlsx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/woof-output-slacko64-${{ github.event.inputs.version }}/nlsx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_name: nlsx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload kernel sources
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_14.2/kernel-kit/output/kernel_sources-4.19-kernel-kit.sfs
-        asset_name: kernel_sources-4.19-kernel-kit.sfs
-        asset_content_type: application/octet-stream
-    - name: Move cached directories
-      run: sudo mv ../woof-out_x86_64_x86_64_slackware64_14.2/petbuild-{sources,cache,output} .
+        name: ${{ github.workflow }}-${{ github.run_number }}
+        path: |
+          *.iso
+          *.sfs
+        retention-days: 3

--- a/.github/workflows/slacko64-7.yml
+++ b/.github/workflows/slacko64-7.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 0 1,14 * *'
   workflow_dispatch:
-    branches:
-      - ci
-      - testing
 
 jobs:
   build:

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -1,12 +1,6 @@
 name: slacko64
 
 on:
-  push:
-    branches:
-      - ci
-      - testing
-    paths:
-      - 'woof-distro/x86_64/slackware64/15.0/**'
   pull_request:
     branches:
       - testing
@@ -18,18 +12,10 @@ on:
     branches:
       - ci
       - testing
-    inputs:
-      version:
-        description: 'Version number'
-        required: true
-        default: '8.0'
-      suffix:
-        description: 'Release name suffix, with leading -'
-        required: false
-        default: '-prepreprealpha1'
 
 jobs:
   build:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
     runs-on: ubuntu-20.04
     steps:
     - name: Checkout code
@@ -55,25 +41,17 @@ jobs:
         sudo ln -s bash /bin/ash
     - name: merge2out
       run: yes "" | sudo -E ./merge2out woof-distro/x86_64/slackware64/15.0
-    - name: Set version
-      if: github.event_name == 'workflow_dispatch'
-      run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_x86_64_x86_64_slackware64_15.0/DISTRO_SPECS
-    - name: Set compression algorithm
-      if: github.event_name != 'workflow_dispatch'
-      run: |
-        echo | sudo tee -a ../woof-out_x86_64_x86_64_slackware64_15.0/_00build.conf
-        echo 'SFSCOMP="-comp lzo -Xalgorithm lzo1x_1"' | sudo tee -a ../woof-out_x86_64_x86_64_slackware64_15.0/_00build.conf
     - name: 0setup
       run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_15.0
+        cd ../woof-out_*
         sudo -E ./0setup
     - name: 1download
       run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_15.0
+        cd ../woof-out_*
         sudo -E ./1download
     - name: 2createpackages
       run: |
-        cd ../woof-out_x86_64_x86_64_slackware64_15.0
+        cd ../woof-out_*
         echo | sudo -E ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
@@ -83,9 +61,9 @@ jobs:
         workflow: kernel-kit.yml
         workflow_conclusion: success
         name: kernel-kit-output-5.10.x-x86_64
-        path: kernel-kit-output
+        path: output
     - name: Move cached kernel-kit output
-      run: sudo mv kernel-kit-output ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output
+      run: sudo mv output ../woof-out_*/kernel-kit/
     - name: Get cached petbuild-sources
       uses: actions/cache@v2
       with:
@@ -116,69 +94,16 @@ jobs:
     - name: 3builddistro
       run: |
         sudo chown -R root:root petbuild-output
-        sudo mv petbuild-{sources,cache,output} ../woof-out_x86_64_x86_64_slackware64_15.0/
-        cd ../woof-out_x86_64_x86_64_slackware64_15.0
+        sudo mv petbuild-{sources,cache,output} ../woof-out_*/
+        cd ../woof-out_*
         sudo -E HOME=/root ./3builddistro release
-    - name: Create Release
-      if: github.event_name == 'workflow_dispatch'
-      id: create_release
-      uses: actions/create-release@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        sudo mv -f woof-output-*/*.{sfs,iso} $GITHUB_WORKSPACE/
+        sudo mv -f kernel-kit/output/kernel_sources-*.sfs $GITHUB_WORKSPACE/
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v2
       with:
-        tag_name: slacko64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        release_name: slacko64-${{ github.event.inputs.version }}${{ github.event.inputs.suffix }}
-        draft: false
-        prerelease: true
-    - name: Upload ISO
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/woof-output-slacko64-${{ github.event.inputs.version }}/slacko64-${{ github.event.inputs.version }}.iso
-        asset_name: slacko64-${{ github.event.inputs.version }}.iso
-        asset_content_type: application/octet-stream
-    - name: Upload devx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/woof-output-slacko64-${{ github.event.inputs.version }}/devx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_name: devx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload docx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/woof-output-slacko64-${{ github.event.inputs.version }}/docx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_name: docx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload nlsx
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/woof-output-slacko64-${{ github.event.inputs.version }}/nlsx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_name: nlsx_slacko64_${{ github.event.inputs.version }}.sfs
-        asset_content_type: application/octet-stream
-    - name: Upload kernel sources
-      if: github.event_name == 'workflow_dispatch'
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ../woof-out_x86_64_x86_64_slackware64_15.0/kernel-kit/output/kernel_sources-5.10-kernel-kit.sfs
-        asset_name: kernel_sources-5.10-kernel-kit.sfs
-        asset_content_type: application/octet-stream
-    - name: Move cached directories
-      run: sudo mv ../woof-out_x86_64_x86_64_slackware64_15.0/petbuild-{sources,cache,output} .
+        name: ${{ github.workflow }}-${{ github.run_number }}
+        path: |
+          *.iso
+          *.sfs
+        retention-days: 3

--- a/.github/workflows/slacko64.yml
+++ b/.github/workflows/slacko64.yml
@@ -9,9 +9,6 @@ on:
   schedule:
     - cron: '0 0 * * 4'
   workflow_dispatch:
-    branches:
-      - ci
-      - testing
 
 jobs:
   build:


### PR DESCRIPTION
@01micko This will make it easier to test powerapplet_tray, and make you less hesitant to publish alpha builds.

Now, every build puts the woof-CE output in a build artifact and it's deleted after 3 days:

![image](https://user-images.githubusercontent.com/1471149/113540076-fed09a80-95e7-11eb-90fa-f4d5a5794257.png)

(It's a zip file containing the files that previously, went into the release, and it's uploaded even when it's a PR build, so the PR can be tested easily without having to build locally first)
(All CI workflows are exactly the same now, except the kernel package name!)

Because now publishing a release is not fun, in addition, I'm working on this (will be a separate PR I think, I'm still testing it):

![image](https://user-images.githubusercontent.com/1471149/113541250-83241d00-95ea-11eb-9128-2189d5dcdb5b.png)

This job does the same, but without caching, and creates a release **draft** at the end (so it can be tested before it's published, or discarded if it's not good).