### PR TITLE
rc.shutdown: Unmount timeshift mountpoints

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -111,6 +111,13 @@ sync
 umount-FULL -a -t cifs,smbfs,nfs,sshfs
 ###
 
+#Unmount timeshift backup mountpoints
+for tmshift in $(mount | grep "/timeshift" | awk  '{ print $3 }')
+do
+ sync
+ umount -l "$tmshift"
+done
+
 #100902 rerwin: log the cumulative bytes transmitted on dialup...
 which modemdisconnect >/dev/null && modemdisconnect #(if connected)
 


### PR DESCRIPTION
Timeshift is a system restore utility for linux. Sometimes it mounts on /run/timeshift/. For safety reason, it must be unmounted upon shutdown

More info
[https://github.com/teejee2008/timeshift](https://github.com/teejee2008/timeshift)