### PR TITLE
Build dpup with 5.10.x kernel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
           - arch: x86_64
             compat-distro: debian
             compat-distro-version: bullseye64
-            kernel: 5.4.x-x86_64
+            kernel: 5.10.x-x86_64
           - arch: x86_64
             compat-distro: ubuntu
             compat-distro-version: focal64


### PR DESCRIPTION
EOL has been extended to 2026, making 5.10.x exceed the shelf life of 5.4.x: https://www.kernel.org/category/releases.html.