### PR TITLE
Change workspace switch keyboard shortcut to Ctrl-Alt-direction

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -189,7 +189,10 @@
 
 <Key mask="A" key="Tab">next</Key>
 <Key mask="A" key="F4">close</Key>
-<Key mask="A" key="#">desktop#</Key>
+<Key mask="CA" key="Right">rdesktop</Key>
+<Key mask="CA" key="Left">ldesktop</Key>
+<Key mask="CA" key="Up">udesktop</Key>
+<Key mask="CA" key="Down">ddesktop</Key>
 <Key mask="A" key="F1">root:9</Key>
 <Key mask="A" key="F2">exec:gexec</Key>
 <Key mask="A" key="F3">window</Key>


### PR DESCRIPTION
Two reasons for this change:
- The current Alt-number keyboard shortcut collides with the GTK tab switching keyboard shortcuts (i.e. if you have two tabs in Geany or the terminal, you can't switch between them with Alt-1 and Alt-2)
- Ctrl-Alt-direction is consistent with other distros and DEs like MATE