### PR TITLE
Add wlroots dependencies and Meson to dpup

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -403,7 +403,7 @@ no|libwmf|libwmf0.2-7,libwmf-dev|exe,dev,doc,nls
 no|libwpg|libwpg-0.3-3|exe,dev>null,doc,nls
 no|libwpd|libwpd-0.10-10,libwpd-dev|exe,dev,doc,nls
 no|libxatracker2|libxatracker2,libxatracker-dev|exe,dev,doc,nls
-yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri2-0-dev,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-image0,libxcb-image0-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-randr0,libxcb-randr0-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-xinerama0,libxcb-xinerama0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-xinput0,libxcb-xinput-dev|exe,dev,doc,nls
+yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri2-0-dev,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-image0,libxcb-image0-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-randr0,libxcb-randr0-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-xinerama0,libxcb-xinerama0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-xinput0,libxcb-xinput-dev,libxcb-res0,libxcb-res0-dev|exe,dev,doc,nls
 yes|libz3|libz3-4,libz3-dev|exe,dev,doc,nls
 no|libzip|libzip4,libzip-dev|exe,dev,doc,nls
 yes|xcb-util|libxcb-util1,libxcb-util-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -378,7 +378,7 @@ no|libsratom|libsratom-0-0,libsratom-dev|exe,dev,doc,nls
 yes|libssh2|libssh2-1,libssh2-1-dev|exe,dev,doc,nls #stretch: needed by curl, etc.
 yes|libstdc++6|libstdc++6|exe,dev,doc,nls
 yes|libstdc++10|libstdc++-10-dev|exe,dev,doc,nls
-yes|libsystemd|libsystemd0|exe,dev,doc,nls
+yes|libsystemd|libsystemd0,libsystemd-dev|exe,dev,doc,nls
 no|libtar|libtar0,libtar-dev|exe,dev,doc,nls #needed by osmo.
 yes|libtasn1|libtasn1-6,libtasn1-6-dev|exe,dev,doc,nls
 yes|libtext-unidecode-perl|libtext-unidecode-perl|exe>dev,dev,doc,nls
@@ -403,7 +403,7 @@ no|libwmf|libwmf0.2-7,libwmf-dev|exe,dev,doc,nls
 no|libwpg|libwpg-0.3-3|exe,dev>null,doc,nls
 no|libwpd|libwpd-0.10-10,libwpd-dev|exe,dev,doc,nls
 no|libxatracker2|libxatracker2,libxatracker-dev|exe,dev,doc,nls
-yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri2-0-dev,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-image0,libxcb-image0-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-randr0,libxcb-randr0-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-xinerama0,libxcb-xinerama0-dev,libxcb-damage0,libxcb-damage0-dev|exe,dev,doc,nls
+yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri2-0-dev,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-image0,libxcb-image0-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-randr0,libxcb-randr0-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-xinerama0,libxcb-xinerama0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-xinput0,libxcb-xinput-dev|exe,dev,doc,nls
 yes|libz3|libz3-4,libz3-dev|exe,dev,doc,nls
 no|libzip|libzip4,libzip-dev|exe,dev,doc,nls
 yes|xcb-util|libxcb-util1,libxcb-util-dev|exe,dev,doc,nls
@@ -435,7 +435,8 @@ yes|m4|m4|exe>dev,dev,doc,nls
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls
 yes|man|man-db|exe>dev,dev,doc,nls
-yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,mesa-va-drivers,libglu1-mesa,libglu1-mesa-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
+yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles2-mesa-dev,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,mesa-va-drivers,libglu1-mesa,libglu1-mesa-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
+yes|meson|meson|exe>dev,dev,doc,nls
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls
 no|mhwaveedit|mhwaveedit|exe,dev>null,doc,nls
 no|miniupnpc|libminiupnpc*,libminiupnpc-dev|exe,dev,doc,nls #needed by transmission.
@@ -461,6 +462,7 @@ yes|net-tools|net-tools|exe,dev,doc,nls
 yes|nettle|libnettle8,nettle-dev,libhogweed6|exe,dev,doc,nls #needed by libarchive.
 no|netmon_wce||exe,dev
 no|network_roxapp_samba||exe
+yes|ninja|ninja-build|exe>dev,dev,doc,nls
 no|normalize|normalize-audio|exe,dev,doc,nls
 no|notecase||exe,dev,doc,nls
 no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
@@ -535,7 +537,7 @@ no|puppy_icon_theme||exe #gtk theme
 no|puppy-podcast-grabber||exe
 no|pure-ftpd||exe
 no|pwsget||exe
-yes|python|python3,python3.9-minimal,python3.9,libpython3.9,libpython3.9-stdlib,libpython3.9-minimal|exe>dev,dev,doc,nls #121022 moved from devx to main f.s. /usr/include/python2.7 must also go into main f.s. so take out ,dev. see also libpython2.7 needed by gdb in devx. 130404 added libs.
+yes|python|python3,python3-minimal,python3.9-minimal,python3.9,libpython3.9,libpython3.9-stdlib,libpython3.9-minimal,python3-pip,python3-setuptools,python3-wheel,python3-pkg-resources,python-pip-whl|exe>dev,dev,doc,nls #121022 moved from devx to main f.s. /usr/include/python2.7 must also go into main f.s. so take out ,dev. see also libpython2.7 needed by gdb in devx. 130404 added libs.
 no|python-libxml2|python2-libxml2|exe,dev,doc,nls #121022 moved from devx to main f.s.
 yes|python-dev|libpython3-dev,libpython3.9-dev,python3-dev,python3.9-dev|exe,dev,doc,nls
 no|qpdf|libqpdf21,libqpdf-dev|exe,dev,doc,nls #needed by cups.
@@ -600,7 +602,7 @@ no|vamps|vamps|exe,dev,doc,nls
 no|vobcopy|vobcopy|exe,dev,doc,nls
 no|vorbis-tools|vorbis-tools|exe,dev,doc,nls
 yes|vte|libvte-2.91-0,libvte-2.91-common,libvte-2.91-dev|exe,dev,doc,nls
-yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0,libwayland-dev,wayland-protocols|exe,dev,doc,nls
+yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0,libwayland-dev,wayland-protocols,libwayland-bin|exe,dev,doc,nls
 no|wcpufreq||exe,dev| #using this instead of cpu-scaling-ondemand.
 yes|wget|wget|exe,dev>null,doc,nls
 yes|wireless-tools|wireless-tools,libiw30,libiw-dev|exe,dev,doc,nls
@@ -629,6 +631,7 @@ yes|xserver_xorg|xserver-xorg-dev,xserver-common,xserver-xorg,xserver-xorg-core,
 no|xsoldier|xsoldier|exe,dev>null,doc,nls
 yes|xtrans|xtrans-dev|exe>dev,dev,doc,nls
 no|xvidcore|libxvidcore4,libxvidcore-dev|exe,dev,doc,nls
+yes|xwayland|xwayland|exe,dev,doc,nls
 yes|xz|xz-utils,liblzma5,liblzma-dev|exe,dev,doc,nls
 no|yad||exe
 no|yajl|libyajl2,libyajl-dev|exe,dev,doc,nls #needed by raptor2.


### PR DESCRIPTION
Meson is required to build many modern GTK+ 3 applications (including the latest versions of Puppy applications like Viewnior and HexChat).

In addition, Meson is needed to build many Wayland compositors and wlroots, so this is a very small first step towards #2252.

I've been able to build https://github.com/Hjdskes/cage, run it in a window and run GTK+ 3 applications like Geany inside it.

EDIT: got the Puppy desktop (JWM+pinboard+everything else) running on top of a fullscreen Xwayland, on top of Cage! It's pretty cool because all applications seem to work, and there's no tearing when moving windows. The X keyboard wizard doesn't work, though, because it writes to Xorg.conf and Xwayland doesn't read it. I used something very similar to https://source.mnt.re/reform/reform-system-image/-/blob/mmdebstrap/reform2-imx8mq/template-skel/bin/reform-windowmaker, but had to build xwayland+seatd+wlroots+cage because the wlroots+xwayland versions in Bullseye didn't work for some reason. I'm writing a petbuild for this package combo and hope to produce a cage executable statically-linked against wlroots and libseat, to prevent collision against compat distro packages. This petbuild will be a separate PR. Then, I'll see how to start cage instead of Xorg, in a third PR.