### PR TITLE
xorg-autoconf: Improve Xorg detection

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -2,6 +2,17 @@
 #written by mistfire
 #automatically generate xorg configuration
 
+#Look for Xorg executable
+if [ "$(which Xorg)" != "" ]; then
+ XEXEC="$(which Xorg)" 
+elif [ "$(which X)" != "" ]; then
+ XEXEC="$(which X)"
+else
+ #Xorg not installed. It might be running Wayland
+ echo "# Xorg not found. Unable to generate xorg configuration."
+ exit
+fi
+
 XORG_PATHS="/usr/lib/xorg /usr/lib64/xorg /usr/lib/X11 /usr/lib64/X11"
 
 MODLIST="$(busybox lsmod 2>/dev/null)"
@@ -26,13 +37,6 @@ if [ "$UDEVD" == "" ] && [ -e /usr/lib/systemd/systemd-udevd ]; then
 elif [ "$UDEVD" == "" ] && [ -e /lib/systemd/systemd-udevd ]; then
  UDEVD="/lib/systemd/systemd-udevd"  
 fi 
-
-#Look for Xorg executable
-if [ "$(which Xorg)" != "" ]; then
- XEXEC="$(which Xorg)" 
-else
- XEXEC="$(which X)"
-fi
 
 #Look for xorg version
 XORG_VERSION="$($XEXEC -version 2>&1 | grep -oE "X Server.*" | grep -oE "[0-9]\..*\.[0-9]")"


### PR DESCRIPTION
If Xorg was not installed. Stop generating configuration file