### PR TITLE
Generate UEFI bootable x86_64 Chrome OS style images

### DIFF
--- a/woof-code/support/cros_image.sh
+++ b/woof-code/support/cros_image.sh
@@ -8,6 +8,7 @@ INSTALL_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-install.img
 
 SSD_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-16gb.img
 LEGACY_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-legacy.img
+UEFI_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-uefi.img
 
 echo "console=tty1 root=PARTUUID=%U/PARTNROFF=1 init=/init rootfstype=ext4 rootwait rw" > cmdline
 vmlinuz=build/vmlinuz
@@ -135,6 +136,38 @@ EOF
 	mv -f ${LEGACY_IMG_BASE} ../${WOOF_OUTPUT}/
 	;;
 esac
+
+if [ "$WOOF_TARGETARCH" = "x86_64" ]; then
+	dd if=/dev/zero of=${UEFI_IMG_BASE} bs=50M count=40 conv=sparse
+	parted --script ${UEFI_IMG_BASE} mklabel gpt
+	parted --script ${UEFI_IMG_BASE} mkpart "${DISTRO_FILE_PREFIX}_esp" fat32 1MiB 261MiB
+	parted --script ${UEFI_IMG_BASE} set 1 esp on
+	parted --script ${UEFI_IMG_BASE} mkpart "${DISTRO_FILE_PREFIX}_root" ext4 261MiB 100%
+	LOOP=`losetup -Pf --show ${UEFI_IMG_BASE}`
+	mkfs.fat -F 32 ${LOOP}p1
+	mkfs.ext4 -F -b 4096 -m 0 -O ^has_journal,encrypt ${LOOP}p2
+
+	mkdir -p /mnt/uefiimagep1 /mnt/uefiimagep2
+
+	unsquashfs -d kernel_sources ../kernel-kit/output/kernel_sources-*.sfs
+	cd kernel_sources/usr/src/linux
+	cat << EOF >> .config
+CONFIG_EFI_STUB=y
+CONFIG_CMDLINE_BOOL=y
+CONFIG_CMDLINE="root=PARTLABEL=${DISTRO_FILE_PREFIX}_root init=/init rootfstype=ext4 rootwait rw"
+EOF
+	make -j`nproc` bzImage
+	mount-FULL -o noatime ${LOOP}p1 /mnt/uefiimagep1
+	install -D -m 644 arch/x86/boot/bzImage /mnt/uefiimagep1/EFI/BOOT/BOOTX64.EFI
+	busybox umount /mnt/uefiimagep1 2>/dev/null
+	cd ../../../..
+
+	mount-FULL -o noatime ${LOOP}p2 /mnt/uefiimagep2
+	cp -a /mnt/ssdimagep2/* /mnt/uefiimagep2/
+	busybox umount /mnt/uefiimagep2 2>/dev/null
+
+	mv -f ${UEFI_IMG_BASE} ../${WOOF_OUTPUT}/
+fi
 
 busybox umount /mnt/sdimagep2 2>/dev/null
 busybox umount /mnt/ssdimagep2 2>/dev/null


### PR DESCRIPTION
These make it possible to test Chromebook builds of Puppy on recent, regular x86_64 machines that support only UEFI boot.

This special UEFI support uses the "EFI stub" feature of the kernel, which allows it to be used instead of a boot loader, but at the cost of having to hardcode the kernel command-line. To make these images able to auto-update in the future, but without using the same partition UUID all the time, the boot partition is identified by a special label.