### PR TITLE
Avoid many sleep calls during init and X startup on x86_64 and ARM

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -376,7 +376,7 @@ if [ "$BOOT_UDEVDCHILDREN" ];then #120709
 else
    udevd --daemon --resolve-names=early
 fi
-sleep 0.3
+[ "$WOOF_TARGETARCH" = "x86" ] && sleep 0.3
 
 # kernel polling - https://lwn.net/Articles/423619/
 echo 5000 > /sys/module/block/parameters/events_dfl_poll_msecs
@@ -387,7 +387,7 @@ do
  ONEPATH="`dirname $ONEMODALIAS`"
  if [ -e ${ONEPATH}/uevent ];then
   echo add > ${ONEPATH}/uevent #generates an 'add' uevent.
-  sleep 0.02
+  [ "$WOOF_TARGETARCH" = "x86" ] && sleep 0.02
  fi
 done
 

--- a/woof-code/rootfs-skeleton/usr/sbin/delayedrun
+++ b/woof-code/rootfs-skeleton/usr/sbin/delayedrun
@@ -40,14 +40,14 @@ if [ ! -f /var/local/delayedrun_firstboot_flag ];then
   else
    welcome1stboot
   fi
-  sleep 3 # problem as tray applets only got launched after welcome msg exited.
+  [ "$WOOF_TARGETARCH" = "x86" ] && sleep 3 # problem as tray applets only got launched after welcome msg exited.
   touch /var/local/delayedrun_firstboot_flag
 fi
 
 if [ -d /root/Startup ];then
  for A in /root/Startup/* ; do
   $A 2>/dev/null & 
-  sleep 0.2
+  [ "$WOOF_TARGETARCH" = "x86" ] && sleep 0.2
  done
 fi
 


### PR DESCRIPTION
They're still there on 32-bit x86, to avoid breaking Puppy on ancient hardware.

I don't understand the comment in `delayedrun` ... it's a problem that tray icons start after `welcome1stboot`, but we make the problem even worse by adding that `sleep 3`.

With this PR, rc.syinit takes 7 seconds in a VM on my not-very-new laptop.