### PR TITLE
fix broken extra firmware

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -880,7 +880,7 @@ fi
 echo
 echo
 if [ "$BUILD_SFS" = 'yes' ];then
-	if [ -z "$NONFREE_FW" -a "$KFDRIVE" = no ];then
+	if [ -z "$NONFREE_FW" ];then
 		echo "You now have the opportunity to grab some non-free firmware
 to include in ${FDRVSFS}. There is a file in
  'support/fw.conf' 
@@ -898,7 +898,7 @@ Do you want to grab extra non-free firmware?
 			cd - ;;
 		esac
 	else
-		if [ "$NONFREE_FW" = 'yes' -a "$KFDRIVE" = no ];then
+		if [ "$NONFREE_FW" = 'yes' ];then
 			cd $WKGDIR
 			echo
 			echo "grabbing extra non-free firmware..."

--- a/woof-code/support/get_fw
+++ b/woof-code/support/get_fw
@@ -10,7 +10,7 @@ FKVER=${KERNEL_VERSION%%-*} # to cross reference firmware in kernel config
 DOTCONFIGVER=
 TMP=/tmp/fw$$
 mkdir -p $TMP
-OUT=${SANDBOX}/fdrv/lib/firmware
+OUT=${SANDBOX}/ydrv/lib/firmware
 #rm -rf $OUT
 mkdir -p $OUT
 export FIRMWARE_INSTALL_DIR="${OUT}"  #/lib/firmware for b43-fwcutter
@@ -76,8 +76,8 @@ return_msg() {
 }
 
 success_msg() {
-	echo "$1: successfully installed to fdrv"
-	echo "$1: successfully installed to fdrv" >> $LOG
+	echo "$1: successfully installed to ydrv"
+	echo "$1: successfully installed to ydrv" >> $LOG
 }
 
 download_func() {
@@ -184,11 +184,11 @@ atmel_func() {
 	tar xvf ${TMP}/atmel-firmware-1.3.tar.gz -C ${TMP} || return 1
 	cp -af ${TMP}/atmel-firmware-1.3/images/* ${OUT}
 	cp -af ${TMP}/atmel-firmware-1.3/images.usb/* ${OUT}
-	mkdir -p ${WKGDIR}/${SANDBOX}/fdrv/usr/sbin
-	mkdir -p ${WKGDIR}/${SANDBOX}/fdrv/etc/pcmcia
-	cp -af ${TMP}/atmel-firmware-1.3/atmel.conf ${WKGDIR}/${SANDBOX}/fdrv/etc/pcmcia
-	cp -af ${TMP}/atmel-firmware-1.3/atmel_fwl.pl ${WKGDIR}/${SANDBOX}/fdrv/usr/sbin/atmel_fwl
-	chmod 755 ${WKGDIR}/${SANDBOX}/fdrv/usr/sbin/atmel_fwl
+	mkdir -p ${WKGDIR}/${SANDBOX}/ydrv/usr/sbin
+	mkdir -p ${WKGDIR}/${SANDBOX}/ydrv/etc/pcmcia
+	cp -af ${TMP}/atmel-firmware-1.3/atmel.conf ${WKGDIR}/${SANDBOX}/ydrv/etc/pcmcia
+	cp -af ${TMP}/atmel-firmware-1.3/atmel_fwl.pl ${WKGDIR}/${SANDBOX}/ydrv/usr/sbin/atmel_fwl
+	chmod 755 ${WKGDIR}/${SANDBOX}/ydrv/usr/sbin/atmel_fwl
 	clear_tmp
 }
 
@@ -318,7 +318,7 @@ if [ "$nouveau" = 'true' -a "$nouveau_cut" = 'true' ];then
 fi
 
 cat ${WKGDIR}/support/fw.conf >> $LOG
-# download and build fdrv
+# download and build ydrv
 build_func $b43_all b43_func b43_all all
 build_func $b43_new b43_func b43_new new
 build_func $b43_old b43_func b43_old old

--- a/woof-distro/x86/slackware/14.2/_00build.conf
+++ b/woof-distro/x86/slackware/14.2/_00build.conf
@@ -132,7 +132,7 @@ defaultwordprocessor=
 ## Note 4: you can choose to keep downloaded binaries if you set the
 ## 'save_dld=true' var in fw.conf. They'll be used next time instead
 ## of downloading them again.
-#NONFREE_FW=yes
+NONFREE_FW=no
 
 ## -- EXTRA FLAG --
 ## This allows some customisation for the iso name

--- a/woof-distro/x86_64/debian/buster64/_00build.conf
+++ b/woof-distro/x86_64/debian/buster64/_00build.conf
@@ -64,6 +64,21 @@ XERRS_FLG=yes
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
+## -- NON-FREE firmware --
+## this downloads and installs to fdrive firmwares that
+## may be needed by the kernel drivers (wireless + dvb).
+## a yes or no val to NONFREE_FW is needed to automate build
+## Note 0: FDRV_INC= must be unset
+## Note 1: see the file support/fw.conf for configuration
+## Note 2: if you select b43* (any) in the fw.conf then b43-fwcutter
+## is downloaded, compiled and installed if you don't already have it
+## Note 3: if nouveau=true then a python script 'extract_firmware.py'
+## is downloaded along with the full nvidia driver. It may take a while.
+## Note 4: you can choose to keep downloaded binaries if you set the
+## 'save_dld=true' var in fw.conf. They'll be used next time instead
+## of downloading them again.
+NONFREE_FW=no
+
 ## -- Default Apps --
 ## Not all are implemented in the puppy scripts,
 ##   but you can specify a default app if you wish...

--- a/woof-distro/x86_64/slackware64/14.2/_00build.conf
+++ b/woof-distro/x86_64/slackware64/14.2/_00build.conf
@@ -132,7 +132,7 @@ defaultwordprocessor=
 ## Note 4: you can choose to keep downloaded binaries if you set the
 ## 'save_dld=true' var in fw.conf. They'll be used next time instead
 ## of downloading them again.
-#NONFREE_FW=yes
+NONFREE_FW=no
 
 ## -- EXTRA FLAG --
 ## This allows some customisation for the iso name

--- a/woof-distro/x86_64/slackware64/15.0/_00build.conf
+++ b/woof-distro/x86_64/slackware64/15.0/_00build.conf
@@ -133,7 +133,7 @@ defaultwordprocessor=
 ## Note 4: you can choose to keep downloaded binaries if you set the
 ## 'save_dld=true' var in fw.conf. They'll be used next time instead
 ## of downloading them again.
-#NONFREE_FW=yes
+NONFREE_FW=yes
 
 ## -- EXTRA FLAG --
 ## This allows some customisation for the iso name

--- a/woof-distro/x86_64/slackware64/15.0/support/fw.conf
+++ b/woof-distro/x86_64/slackware64/15.0/support/fw.conf
@@ -1,0 +1,35 @@
+# config for non-free firmwares
+# special for b43 wireless
+# these are broadcom non-free firmware
+# extracted with b43-fwcutter
+b43_all=true
+b43_new=false
+b43_old=false
+# wireless - these are old and probably safe to omit
+zd1201=false
+atmel=false
+# should always be false unless module is compiled out of tree
+acx=false
+# intel pro wireless - maybe less useful on 64 bit
+ipw=false
+# DVB - TV tuner cards mostly
+af9005=false
+af9013=false
+af9015=false
+af9035=false
+xc5000=false
+bluebird=false
+dib0700=false
+dibusb5=false
+dibusb6=false
+dtt200u=false
+umt=false
+vp702x=false
+vp7045=false
+wt220u01=false
+wt220u02=false
+# nouveau - needed only some cards for acceleration - optional
+nouveau=false
+nouveau_cut=true
+# save downloaded tarballs/firmwares?
+save_dld=true

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -64,6 +64,21 @@ XERRS_FLG=yes
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
+## -- NON-FREE firmware --
+## this downloads and installs to fdrive firmwares that
+## may be needed by the kernel drivers (wireless + dvb).
+## a yes or no val to NONFREE_FW is needed to automate build
+## Note 0: FDRV_INC= must be unset
+## Note 1: see the file support/fw.conf for configuration
+## Note 2: if you select b43* (any) in the fw.conf then b43-fwcutter
+## is downloaded, compiled and installed if you don't already have it
+## Note 3: if nouveau=true then a python script 'extract_firmware.py'
+## is downloaded along with the full nvidia driver. It may take a while.
+## Note 4: you can choose to keep downloaded binaries if you set the
+## 'save_dld=true' var in fw.conf. They'll be used next time instead
+## of downloading them again.
+NONFREE_FW=no
+
 ## -- Default Apps --
 ## Not all are implemented in the puppy scripts,
 ##   but you can specify a default app if you wish...

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -133,7 +133,7 @@ defaultwordprocessor=
 ## Note 4: you can choose to keep downloaded binaries if you set the
 ## 'save_dld=true' var in fw.conf. They'll be used next time instead
 ## of downloading them again.
-#NONFREE_FW=yes
+NONFREE_FW=no
 
 ## PROMPT - change the CLI prompt to whatever you like. Default is unset
 #PROMPT='PS1="\w\$ "'


### PR DESCRIPTION
re #2278

Adding this to a `ydrv` as this routine was written when we used an `fdrv` optionally. It (fdrv) was actually only loaded with a boot parameter,