### PR TITLE
Disable GTK+ 3 animations and smooth scrolling

### DIFF
--- a/woof-code/rootfs-packages/ptheme/pinstall.sh
+++ b/woof-code/rootfs-packages/ptheme/pinstall.sh
@@ -126,6 +126,7 @@ if [ -d "usr/share/icons/$USE_ICON_THEME" ];then
 		cat >> root/.config/gtk-3.0/settings.ini <<EOF
 gtk-menu-images = 1
 gtk-button-images = 1				
+gtk-enable-animations = 0
 EOF
 	fi
 	# then ROX

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -43,6 +43,7 @@ _EOF
 		cat >> $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini << EOF
 gtk-menu-images = 1
 gtk-button-images = 1		
+gtk-enable-animations = 0
 EOF
 	fi
 	install -D -m 644 $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini /etc/gtk-3.0/settings.ini


### PR DESCRIPTION
This should make GTK+ 3 applications behave more like GTK+ 2 ones, and make the faster to render.