### PR TITLE
Allow woof-CE to run on dpup

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -651,10 +651,11 @@ yes|zlib|zlib1g,zlib1g-dev|exe,dev,doc,nls||deps:yes
 no|zzznet||exe
 '
 
-if [ -f /etc/DISTRO_SPECS ]; then
-    . /etc/DISTRO_SPECS
-else
+# hack: we need DISTRO_TARGETARCH but PPM needs to be able to source this file
+if [ -f DISTRO_SPECS ]; then
     . ./DISTRO_SPECS
+else
+    . /etc/DISTRO_SPECS
 fi
 
 case $DISTRO_TARGETARCH in


### PR DESCRIPTION
If we always take the host DISTRO_SPECS, then we can only build for x86_64.