### PR TITLE
Make sure the kernel-kit exit code is 0 if 2barks.au exists

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -1089,6 +1089,6 @@ Output files:
 fi
 
 echo "Done!"
-[ ! -f /usr/share/sounds/2barks.au ] || aplay /usr/share/sounds/2barks.au
+[ -n "$GITHUB_ACTIONS" -o ! -f /usr/share/sounds/2barks.au ] || aplay /usr/share/sounds/2barks.au
 
 ### END ###


### PR DESCRIPTION
I'm currently working on building Puppy containers that can be used to run woof-CE in a Puppy-like environment, and found this bug: 2barks.au exists, so build.sh runs aplay and it fails. Because there's no `exit 0` or anything, build.sh returns a non-zero exit code.