### PR TITLE
Allow the display settings wizard to run on Xwayland

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
@@ -57,7 +57,6 @@ export WizardWizard='
       </button>
       '$BUTTON_22'
       <button image-position="2">
-        <sensitive>'$([ -z "$WAYLAND_DISPLAY" ] && echo true || echo false)'</sensitive>
         <label>'$(gettext 'Graphics / Screen')'</label>
         '"`/usr/lib/gtkdialog/xml_button-icon graphics.svg huge`"'
         <action>/usr/sbin/xserverwizard &</action>

--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
@@ -488,6 +488,12 @@ if which nvidia-settings >/dev/null 2>&1 && NRATE=$(nvidia-settings -q RefreshRa
 	USING_NVIDIA=1
 fi
 
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	USING_XORG=false
+else
+	USING_XORG=true
+fi
+
 #--------------------
 function setscreenres_gui() {
 	if [ "$USING_NVIDIA" ] ; then
@@ -663,6 +669,7 @@ function gui_opt() { #exit icon msg
             <button>
               '"`/usr/lib/gtkdialog/xml_button-icon $2 big`"'
               <action>'"$1"'</action>
+              <sensitive>'"$4"'</sensitive>
             </button>
           </vbox>
         </hbox>'
@@ -678,10 +685,10 @@ if [ "$(which xscreensaver)" != "" ]; then
  fi 
 
  xSCREENSAVER="$(gui_opt "$binexec" graphics.svg "$(gettext '<b>Sreensaver</b>
-Configure screensaver..')")"
+Configure screensaver..')" true)"
 else
  xSCREENSAVER="$(gui_opt "pupx screensaver" graphics.svg "$(gettext '<b>Sreensaver</b>
-Configure screensaver..')")"
+Configure screensaver..')" true)"
 fi
 
 
@@ -694,10 +701,10 @@ export MAIN1='
       <frame '$(gettext 'Screen tuning')'>
       '"`/usr/lib/gtkdialog/xml_info fixed graphics.svg 60 "$(gettext '<b>Screen tuning</b> depends on the loaded video/graphics driver, so if correct resolution is not there, check the advanced tab...')"`"'
         '$(gui_opt "xorgwizard setscreenres" graphics_xorg.svg "$(gettext '<b>Screen resolution / Color depth (xorg.conf)</b>
-Guarantees a proper X startup..')")'
+Guarantees a proper X startup..')" $USING_XORG)'
         <hseparator></hseparator>
         '$(gui_opt "xrandr_x" screen_resolution.svg "$(gettext '<b>Screen resolution (xrandr)</b>
-How many vertical and horizontal pixels fits your screen..')")'
+How many vertical and horizontal pixels fits your screen..')" $USING_XORG)'
         <hseparator></hseparator>
         '$xSCREENSAVER'
        </frame>
@@ -706,13 +713,13 @@ How many vertical and horizontal pixels fits your screen..')")'
     <vbox space-expand="true" space-fill="true" margin="8">
       <frame '$(gettext 'Manage xorg.conf')'>
         '"`/usr/lib/gtkdialog/xml_info fixed graphics.svg 60 "$(gettext 'The behaviour of Xorg is controlled by a configuration file, /etc/X11/xorg.conf. This was generated automatically at the first boot, you may edit it manually.')"`"'
-        '$(gui_opt "defaulttexteditor /etc/X11/xorg.conf" edit.svg "$(gettext 'You can <b>manually edit</b> /etc/X11/xorg.conf, but you will need to <b>restart X</b> (see Shutdown menu).')")'
+        '$(gui_opt "defaulttexteditor /etc/X11/xorg.conf" edit.svg "$(gettext 'You can <b>manually edit</b> /etc/X11/xorg.conf, but you will need to <b>restart X</b> (see Shutdown menu).')" $USING_XORG)'
         <hseparator></hseparator>
         '$(gui_opt "xgamma-gui" screen_calibration.svg "$(gettext '<b>Monitor gamma calibration</b>
-Adjust monitor colors including screen brightness..')")'
+Adjust monitor colors including screen brightness..')" $USING_XORG)'
         <hseparator></hseparator>
         '$(gui_opt "xvidtune_x" screen_xy.svg "$(gettext '<b>X/Y correction</b>
-If the screen is displaced or the width/height are wrong. This will modify xorg.conf. <b>Use with caution!</b>')")'
+If the screen is displaced or the width/height are wrong. This will modify xorg.conf. <b>Use with caution!</b>')" $USING_XORG)'
       </frame>
     </vbox>
 


### PR DESCRIPTION
Right now, the button in wizardwizard is grayed out, but it's still possible to run the display settings wizard directly from the menu and nothing works. Instead, every feature that doesn't work on Xwayland should be grayed out, while the wizard itself is still accessible.