### PR TITLE
Make Firefox 78 ESR draw tabs in the title bar by default and maximize it

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -8,6 +8,7 @@ cat << EOF > ${FFDIR}/puppy.cfg
 
 // use less vertical space
 defaultPref("browser.compactmode.show", true);
+defaultPref("browser.tabs.drawInTitlebar", true);
 defaultPref("browser.uidensity", 1);
 
 // render website text while fetching images

--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
@@ -35,6 +35,13 @@
 <!-- <Option>aerosnap</Option> -->
 </Group>
 
+<!-- Start Firefox maximized, to save vertical space -->
+<Group>
+    <Name>Navigator</Name>
+    <Name>Firefox</Name>
+    <Option>maximized</Option>
+</Group>
+
 <!-- Key bindings -->
 <Key key="Up">up</Key>
 <Key key="Down">down</Key>


### PR DESCRIPTION
This makes Firefox 78 behave more like Firefox 89, after #2301.

![1](https://user-images.githubusercontent.com/1471149/120932823-15869100-c700-11eb-8fff-c0c518e871e1.png)
