### PR TITLE
Fall back to X.Org only if it's present

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -30,9 +30,11 @@ else
 fi
 
 startxwayland=
-# we want to use X.Org until NVIDIA drivers have proper Wayland support and
-# assume all nouveau users switch to the proprietary driver
-grep -q -e ^nouveau -e ^nvidia /proc/modules || startxwayland=`command -v startxwayland`
+# if X.Org is present, we want to use X.Org until NVIDIA drivers have proper
+# Wayland support and assume all nouveau users switch to the proprietary driver
+if [ -z "`grep -e ^nouveau -e ^nvidia /proc/modules`" -o ! -e /usr/bin/xinit ]; then
+	startxwayland=`command -v startxwayland`
+fi
 
 if [ -z "$startxwayland" ] && [ `id -u` -eq 0 ] && [ -h /usr/bin/X ] ; then
 	ln -snf Xorg /usr/bin/X


### PR DESCRIPTION
Current logic:
- If NVIDIA, use X.Org
- Otherwise, use Xwayland

New logic:
- If NVIDIA and X.Org is present, use X.Org
- Otherwise, use Xwayland

This change allows woof-CE to build a much smaller Puppy without X.Org, after #2303 made it mandatory even if Xwayland is present.