### PR TITLE
Force man-db to use less instead of pager or cat (#2313)

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile
+++ b/woof-code/rootfs-skeleton/etc/profile
@@ -37,11 +37,12 @@ elif [ -f /usr/bin/nano ] ; then
 else
 	EDITOR=vi
 fi
+PAGER=less
 INPUTRC=/etc/inputrc
 TERM=xterm
 [ -d /usr/share/terminfo ] && export TERMINFO=/usr/share/terminfo
 
-export PS1 USER LOGNAME HISTSIZE INPUTRC EDITOR TERM
+export PS1 USER LOGNAME HISTSIZE INPUTRC EDITOR PAGER TERM
 XFINANSDIR="/root/.xfinans"
 export XFINANSDIR
 export XLIB_SKIP_ARGB_VISUALS=1 #rox crashes with DRI modules. solution:


### PR DESCRIPTION
In Debian and derivatives, pager is a symlink to less, but Puppy doesn't have it and that makes man-db fall back to using cat, so there's no search and no scrolling.