### PR TITLE
Fix build failure of native busybox in ARM builds and fail next time this happens

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -116,12 +116,12 @@ for i in ../rootfs-petbuilds/busybox ../rootfs-petbuilds/*; do
 
                 if [ ! -f ../petbuild-cache/busybox ]; then
                     mkdir -p ../petbuild-cache/busybox
-                    wget -t 1 -T 15 https://busybox.net/downloads/busybox-1.32.1.tar.bz2
-                    tar -xjf busybox-1.32.1.tar.bz2
-                    cp -f ../rootfs-petbuilds/busybox/DOTconfig busybox-1.32.1/.config
-                    cd busybox-1.32.1
+                    wget -t 1 -T 15 https://busybox.net/downloads/busybox-1.33.1.tar.bz2
+                    tar -xjf busybox-1.33.1.tar.bz2
+                    cp -f ../rootfs-petbuilds/busybox/DOTconfig busybox-1.33.1/.config
+                    cd busybox-1.33.1
                     make CONFIG_STATIC=y
-                    install -D -m 755 busybox ../../petbuild-cache/busybox
+                    install -D -m 755 busybox ../../petbuild-cache/busybox || exit 1
                     cd ..
                 fi
 

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -115,7 +115,6 @@ for i in ../rootfs-petbuilds/busybox ../rootfs-petbuilds/*; do
                 ln -s bash petbuild-rootfs-complete/bin/sh
 
                 if [ ! -f ../petbuild-cache/busybox ]; then
-                    mkdir -p ../petbuild-cache/busybox
                     wget -t 1 -T 15 https://busybox.net/downloads/busybox-1.33.1.tar.bz2
                     tar -xjf busybox-1.33.1.tar.bz2
                     cp -f ../rootfs-petbuilds/busybox/DOTconfig busybox-1.33.1/.config


### PR DESCRIPTION
We build a native, static busybox and put it in rootfs-complete to make petbuilds, which run under QEMU user emulation, much faster. But I broke this functionality when I upgrade busybox and this breakage is ignored, so the build is painfully slow.