### PR TITLE
Free up space during CI builds

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -953,6 +953,7 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 			sync
 			rm -f build/${TYPE_SYS_SFS} 2>/dev/null
 			mksquashfs $SYS_SFS build/${TYPE_SYS_SFS} ${SFSCOMP} #170330
+			[ -n "$GITHUB_ACTIONS" ] && rm -rf $SYS_SFS
 			sync
 		done
 	fi
@@ -964,7 +965,7 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 		"fdrv|${FDRV_SFS_URL}|${FDRVSFS}"
 	do
 		IFS="|" read XDRV XDRV_URL XDRV_SFS <<< "$i"
-		if [ -d "$XDRV" ] ; then
+		if [ -f build/${XDRV_SFS} ] ; then
 			continue # $XDRV is created using the PKGS_SPECS
 		fi
 		if ! [ "$XDRV_URL" ] ; then
@@ -1040,6 +1041,7 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 
 	echo "Now creating ${DEVXSFS} ..."
 	mksquashfs sandbox3/devx ./sandbox3/${DEVXSFS} ${SFSCOMP} #100911 110713
+	[ -n "$GITHUB_ACTIONS" ] && rm -rf sandbox3/devx
 	sync
 	chmod 644 ./sandbox3/${DEVXSFS}
 	echo "...done"
@@ -1146,7 +1148,11 @@ elif [ "$SDFLAG" ]; then #120506 sd image
 
 fi
 
-[ -n "$GITHUB_ACTIONS" ] || (beep ; beep ; beep)
+if [ -n "$GITHUB_ACTIONS" ]; then
+	rm -rf rootfs-complete
+else
+	beep ; beep ; beep
+fi
 echo -e "\nScript finished."
 
 ###END###

--- a/woof-code/support/cros_image.sh
+++ b/woof-code/support/cros_image.sh
@@ -161,6 +161,7 @@ EOF
 	install -D -m 644 arch/x86/boot/bzImage /mnt/uefiimagep1/EFI/BOOT/BOOTX64.EFI
 	busybox umount /mnt/uefiimagep1 2>/dev/null
 	cd ../../../..
+	[ -n "$GITHUB_ACTIONS" ] && rm -rf kernel_sources
 
 	mount-FULL -o noatime ${LOOP}p2 /mnt/uefiimagep2
 	cp -a /mnt/ssdimagep2/* /mnt/uefiimagep2/


### PR DESCRIPTION
sandbox3 is huge and we're almost filling all free space. It's good to have everything when woof-CE fails, but in CI, some directories can be deleted (i.e. devx, after SFS is ready).