### PR TITLE
Always take the up-to-date debdb2pupdb from woof-CE

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -32,7 +32,7 @@ if [ -d ./support -a -f ./DISTRO_SPECS -a -d ./rootfs-skeleton ] ;then
   . ./PKGS_MANAGEMENT
   . ./DISTRO_PET_REPOS
   RUNNINGPUP='no'
-  [ ! -f /usr/local/petget/debdb2pupdb ] && DEBDB2PUPDB="$(pwd)/support/debdb2pupdb"
+  DEBDB2PUPDB="$(pwd)/support/debdb2pupdb"
   FIND_CAT="$(pwd)/support/find_cat"
   #note, 3builddistro copies it into rootfs-complete/usr/local/petget when building a pup.
 else


### PR DESCRIPTION
dpup is broken when building it using a previous dpup, because the old debdb2pupdb doesn't understand Pre-Depends.