### PR TITLE
Restart acpid on every X restart

### DIFF
--- a/woof-code/rootfs-packages/acpid_busybox/etc/xdg/autostart/acpid.desktop
+++ b/woof-code/rootfs-packages/acpid_busybox/etc/xdg/autostart/acpid.desktop
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Version=1.0
-Name=acpid
+Name=startacpid
 Comment=ACPI daemon
 Exec=startacpid
 Terminal=false


### PR DESCRIPTION
For xlock to work, acpid must run with the correct value of DISPLAY.

But xdg_autostart.sh takes `acpid` from `Name=acpid`, calls `pidof acpid` and decides not to run `startacpid`, which takes care of restarting acpid.