### PR TITLE
Stop non-interactive merge2out on invalid input

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -33,6 +33,9 @@ if [ "$1" != "" ]; then
 		COMPATDISTRO=${DISTRO_BINARY_COMPAT}
 		COMPATVERSION=${DISTRO_COMPAT_VERSION}
 		ALTERNATE_BUILD=$COMPATVERSION_DIR
+	else
+		echo "Missing configuration directory: $1"
+		exit 1
 	fi
 fi
 


### PR DESCRIPTION
Otherwise, it loops forever without logging that explains what happened, as in #2345.