### PR TITLE
Bluetooth audio support in dpup

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -398,7 +398,7 @@ do
 			continue
 			;;
 		#-- DEV -- development
-		*"X11/config"|*"/include"|*"/pkgconfig"|*"/aclocal"|*"/cvs"*|*"/svn"*|*"/src"*|*"/gcc"|*"/girepository-1.0"*|*"/gir-1.0"*|*"/share/cmake"*)
+		*"X11/config"|*"/include"|*"/pkgconfig"|*"/aclocal"|*"/cvs"*|*"/svn"*|*"/src"*|*"/gcc"|*"/gir-1.0"*|*"/share/cmake"*)
 			if [ "$DEV" = "_NULL" ] ; then
 				rm -rf ${ONEDIR}
 				continue

--- a/woof-code/packages-templates/blueman_FIXUPHACK
+++ b/woof-code/packages-templates/blueman_FIXUPHACK
@@ -1,0 +1,1 @@
+sed 's/^Categories=.*/Categories=X-System;/' -i usr/share/applications/blueman-manager.desktop

--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -63,17 +63,5 @@ case $DISTRO_BINARY_COMPAT in
 	;;
 esac
 
-if [ -f usr/bin/start-pulseaudio-x11 ]; then
-	mv -f usr/bin/start-pulseaudio-x11 usr/bin/start-pulseaudio-x11.real
-	cat << EOF > usr/bin/start-pulseaudio-x11
-#!/bin/sh -e
-# hack: we don't have a user session bus or systemd for service activation
-pulseaudio --start
-grep -q =true ~/.spot-status 2>/dev/null && run-as-spot pulseaudio --start
-exec start-pulseaudio-x11.real
-EOF
-	chmod 755 usr/bin/start-pulseaudio-x11
-fi
-
 # because pulseaudio is not bus-activated, it must not exit when idle
 echo "exit-idle-time = -1" >> etc/pulse/daemon.conf

--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
@@ -75,7 +75,7 @@
 <Key mask="CA" key="Delete">exec:defaultprocessmanager</Key>
 
 <!-- http://wiki.linuxquestions.org/wiki/XF86_keyboard_symbols -->
-<Key key="XF86AudioMute">exec:amixer sset Master toggle</Key>
+<Key key="XF86AudioMute">exec:pactl set-sink-mute @DEFAULT_SINK@ toggle || amixer sset Master toggle</Key>
 <Key key="XF86AudioRaiseVolume">exec:pactl set-sink-volume @DEFAULT_SINK@ +1% || amixer sset Master 1+,1+</Key>
 <Key key="XF86AudioLowerVolume">exec:pactl set-sink-volume @DEFAULT_SINK@ -1% || amixer sset Master 1-,1-</Key>
 <Key key="XF86WWW">exec:defaultbrowser</Key>

--- a/woof-code/rootfs-skeleton/etc/group
+++ b/woof-code/rootfs-skeleton/etc/group
@@ -27,3 +27,4 @@ cdrom::107:root,spot
 tape::108:root
 tty::109:root,spot
 plugdev::110:root,spot
+bluetooth::111:root,spot

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -41,12 +41,12 @@ fi
 
 xhost +local: 2>/dev/null
 
-# start a D-Bus session bus, for applications that don't work without it
+# start a D-Bus session bus for both root and spot, for PulseAudio and applications that don't work without it
 eval `run-as-spot dbus-launch --exit-with-x11`
 export DBUS_SESSION_BUS_ADDRESS
 export DBUS_SESSION_BUS_PID
 
-# start PulseAudio over the session bus, and use it for both root and spot
+# start PulseAudio over the session bus and use it for both root and spot, so they see the same output devices
 if [ -e /usr/bin/pulseaudio ]; then
     run-as-spot pulseaudio --start
     export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -41,6 +41,9 @@ fi
 
 xhost +local: 2>/dev/null
 
+# start a D-Bus user session, for applications that don't work without it
+eval `dbus-launch --exit-with-x11`
+
 CURRENTWM="`cat /etc/windowmanager`"
 if [ "$CURRENTWM" = "startkde" ];then
  /sbin/pup_event_frontend_d & #130525

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -41,8 +41,17 @@ fi
 
 xhost +local: 2>/dev/null
 
-# start a D-Bus user session, for applications that don't work without it
-eval `dbus-launch --exit-with-x11`
+# start a D-Bus session bus, for applications that don't work without it
+eval `run-as-spot dbus-launch --exit-with-x11`
+export DBUS_SESSION_BUS_ADDRESS
+export DBUS_SESSION_BUS_PID
+
+# start PulseAudio over the session bus, and use it for both root and spot
+if [ -e /usr/bin/pulseaudio ]; then
+    run-as-spot pulseaudio --start
+    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
+    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
+fi
 
 CURRENTWM="`cat /etc/windowmanager`"
 if [ "$CURRENTWM" = "startkde" ];then

--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -58,7 +58,6 @@ if [ $(id -u) -eq 0 ]; then
 			chown ${XUSER} ${XDG_RUNTIME_DIR}
 		fi
 	fi
-	export DBUS_SESSION_BUS_ADDRESS=""
 
 	exec su ${XUSER} -s /bin/ash -c '
 # try to switch to original directory, unless it is /root

--- a/woof-code/support/release_extras/dpupbullseye.htm
+++ b/woof-code/support/release_extras/dpupbullseye.htm
@@ -32,5 +32,6 @@
   <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2151" target="_blank">gexec on Alt+F2</a></li>
   <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2155" target="_blank">vi as the default editor</a></li>
   <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2265" target="_blank">Tear-free rendering and faster startup using Cage and Xwayland</a></li>
+  <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2349" target="_blank">Support for Bluetooth audio</a></li>
   <li>And much more!</li>
 </ul>

--- a/woof-code/support/release_extras/dpupbullseye64.htm
+++ b/woof-code/support/release_extras/dpupbullseye64.htm
@@ -32,5 +32,6 @@
   <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2151" target="_blank">gexec on Alt+F2</a></li>
   <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2155" target="_blank">vi as the default editor</a></li>
   <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2265" target="_blank">Tear-free rendering and faster startup using Cage and Xwayland</a></li>
+  <li><a href="https://github.com/puppylinux-woof-CE/woof-CE/pull/2349" target="_blank">Support for Bluetooth audio</a></li>
   <li>And much more!</li>
 </ul>

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -62,7 +62,7 @@ no|bin86|bin86|exe>dev,dev,doc,nls
 yes|binutils|binutils|exe>dev,dev,doc,nls||deps:yes
 yes|bison|bison|exe>dev,dev,doc,nls||deps:yes
 yes|blueman|blueman|exe,dev,doc,nls||deps:yes
-yes|bluez|bluez|exe,dev,doc,nls||deps:yes
+yes|bluez|bluez,bluez-obexd|exe,dev,doc,nls||deps:yes
 no|boehm-gc|libgc1,libgc-dev|exe,dev,doc,nls||deps:yes
 no|busybox||exe
 yes|bzip2|bzip2,libbz2-1.0|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -61,6 +61,8 @@ yes|bdb|libdb5.3|exe,dev,doc,nls||deps:yes
 no|bin86|bin86|exe>dev,dev,doc,nls
 yes|binutils|binutils|exe>dev,dev,doc,nls||deps:yes
 yes|bison|bison|exe>dev,dev,doc,nls||deps:yes
+yes|blueman|blueman|exe,dev,doc,nls||deps:yes
+yes|bluez|bluez|exe,dev,doc,nls||deps:yes
 no|boehm-gc|libgc1,libgc-dev|exe,dev,doc,nls||deps:yes
 no|busybox||exe
 yes|bzip2|bzip2,libbz2-1.0|exe,dev,doc,nls||deps:yes
@@ -86,6 +88,7 @@ yes|cyrus-sasl2|libsasl2-2|exe,dev,doc,nls||deps:yes
 yes|dash|dash|exe>dev,dev,doc,nls||deps:yes
 yes|dbus|dbus,dbus-x11,libdbus-1-3,libdbus-1-dev,libapparmor1|exe,dev,doc,nls||deps:yes
 yes|dbus-glib|libdbus-glib-1-2|exe,dev,doc,nls||deps:yes
+yes|dbus-user-session|dbus-user-session|exe>null,dev>null,doc>null,nls>null
 yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1|exe,dev,doc,nls||deps:yes #needed by gsettings-desktop-settings
 #yes|deadbeef|deadbeef,deadbeef-waveform-seekbar,deadbeef-vu-meter,deadbeef-spectrogram,deadbeef-rating,deadbeef-musical-spectrum,deadbeef-infobar|exe|
 yes|debconf|debconf|exe>null,dev>null,doc>null,nls>null
@@ -172,6 +175,7 @@ yes|glibc_l10n|libc-l10n|exe,dev,doc,nls||deps:yes
 no|gmeasures||exe,dev>null,doc,nls
 yes|gmp|libgmp10,libgmpxx4ldbl,libgmp-dev|exe,dev,doc,nls||deps:yes #in precise, this was only in devx, but abiword needs it.
 no|gnome-doc-utils|gnome-doc-utils|exe>dev,dev,doc,nls|+python-libxml2
+yes|gnome-icon-theme|gnome-icon-theme|exe>null,dev>null,doc>null,nls>null
 no|gnome-keyring|gnome-keyring|exe,dev,doc,nls
 no|gnome-menus||exe,dev #use my pet, version 2.14.3, needed by xdg_puppy.
 no|gnome-mplayer||exe #needs libgmlib1
@@ -540,7 +544,7 @@ no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls
 yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
 yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
-yes|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
+yes|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
 no|psynclient||exe
 no|pupmixer||exe
 no|Pup-Kview||exe
@@ -549,7 +553,8 @@ no|puppy_icon_theme||exe #gtk theme
 no|puppy-podcast-grabber||exe
 no|pure-ftpd||exe
 no|pwsget||exe
-yes|python|python3,python3-minimal,python3.9-minimal,python3.9,libpython3.9,libpython3.9-stdlib,libpython3.9-minimal,python3-pip,python3-setuptools,python3-wheel,python3-pkg-resources,python-pip-whl,python3-distutils,python3-lib2to3|exe>dev,dev,doc,nls||deps:yes #121022 moved from devx to main f.s. /usr/include/python2.7 must also go into main f.s. so take out ,dev. see also libpython2.7 needed by gdb in devx. 130404 added libs.
+yes|python|python3,python3-minimal,python3.9-minimal,python3.9,libpython3.9,libpython3.9-stdlib,libpython3.9-minimal,python3-setuptools,python3-wheel,python3-pkg-resources,python3-distutils,python3-lib2to3|exe,dev,doc,nls||deps:yes
+yes|python3-pip|python3-pip|exe>dev,dev,doc,nls||deps:yes
 no|python-libxml2|python2-libxml2|exe,dev,doc,nls #121022 moved from devx to main f.s.
 no|python-dev|libpython3-dev,libpython3.9-dev,python3-dev,python3.9-dev|exe,dev,doc,nls||deps:yes
 no|qpdf|libqpdf21,libqpdf-dev|exe,dev,doc,nls #needed by cups.

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -100,6 +100,10 @@ PROMPT='PS1="\w\$ "'
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
 [ -d ../adrv ] && sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i ../adrv/usr/share/applications/firefox-esr.desktop || sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i usr/share/applications/firefox-esr.desktop
+chroot . /usr/sbin/setup-spot blueman-applet=true
+chroot . /usr/sbin/setup-spot blueman-manager=true
+chroot . /usr/sbin/setup-spot pa-applet=true
+rm -f root/.spot-status
 [ -d ../adrv ] && touch usr/bin/firefox-esr
 chroot . /usr/sbin/setup-spot firefox-esr=true
 [ -d ../adrv ] && mv -f ../adrv/usr/bin/firefox-esr{,.bin}
@@ -115,9 +119,6 @@ chroot . /usr/sbin/setup-spot transmission-gtk=true
 [ -d ../adrv ] && mv -f ../adrv/usr/bin/transmission-gtk{,.bin}
 [ -d ../adrv ] && mv -f usr/bin/transmission-gtk ../adrv/usr/bin/
 [ -d ../adrv ] && rm -f usr/bin/transmission-gtk.bin
-chroot . /usr/sbin/setup-spot blueman-applet=true
-chroot . /usr/sbin/setup-spot blueman-manager=true
-chroot . /usr/sbin/setup-spot pa-applet=true
 ./usr/sbin/pup-advert-blocker start ./etc/hosts
 mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -115,6 +115,7 @@ chroot . /usr/sbin/setup-spot transmission-gtk=true
 [ -d ../adrv ] && mv -f ../adrv/usr/bin/transmission-gtk{,.bin}
 [ -d ../adrv ] && mv -f usr/bin/transmission-gtk ../adrv/usr/bin/
 [ -d ../adrv ] && rm -f usr/bin/transmission-gtk.bin
+chroot . /usr/sbin/setup-spot blueman-applet=true
 ./usr/sbin/pup-advert-blocker start ./etc/hosts
 mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -117,6 +117,7 @@ chroot . /usr/sbin/setup-spot transmission-gtk=true
 [ -d ../adrv ] && rm -f usr/bin/transmission-gtk.bin
 chroot . /usr/sbin/setup-spot blueman-applet=true
 chroot . /usr/sbin/setup-spot blueman-manager=true
+chroot . /usr/sbin/setup-spot pa-applet=true
 ./usr/sbin/pup-advert-blocker start ./etc/hosts
 mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -116,6 +116,7 @@ chroot . /usr/sbin/setup-spot transmission-gtk=true
 [ -d ../adrv ] && mv -f usr/bin/transmission-gtk ../adrv/usr/bin/
 [ -d ../adrv ] && rm -f usr/bin/transmission-gtk.bin
 chroot . /usr/sbin/setup-spot blueman-applet=true
+chroot . /usr/sbin/setup-spot blueman-manager=true
 ./usr/sbin/pup-advert-blocker start ./etc/hosts
 mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads


### PR DESCRIPTION
- [x] Test on x86_64
- [ ] ~Test on ARM~ Will test later
- [ ] ~Test with headphones~ Will test later, forgot the headphones at the office 😨 
- [x] Test with speakers
- [x] Test in Firefox running as root
- [x] Test in Firefox running as spot
- [x] Fix audio in Firefox running as spot

---

This PR changes how D-Bus and PulseAudio work in Puppy.

Some applications, like Blueman, consist of an unprivileged daemon that runs through a "session" instance of D-Bus, and a separate GUI process. Traditionally, Puppy has only a "system" D-Bus instance and these applications just don't work. Therefore, this had to be fixed.

Secondly, because root and spot see different PulseAudio output devices when they use different instances of PulseAudio, and spot can't use a privileged PulseAudio instance, we must switch to a single PulseAudio instance to allow both users to use the same list of output devices. By making the "session bus" used by PulseAudio exit when the X server exits, we make sure PuleseAudio is stopped or restarted with the X server.

Third, because normally, the "session bus" uses the logged in user's credentials (so the daemon and the GUI components of applications like Blueman can talk to each other), we have to make the "session bus" that runs as spot the "session bus" of root too, otherwise processes running as root can't talk to PulseAudio running as spot.

And finally, this PR makes pa-applet run as spot in dpup, for no reason other than consistency with Blueman. Volume and mute keys work fine, and there's no reason to run it as root.