### PR TITLE
Start PulseAudio only if not running already, and log to syslog

### DIFF
--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -48,7 +48,7 @@ export DBUS_SESSION_BUS_PID
 
 # start PulseAudio over the session bus and use it for both root and spot, so they see the same output devices
 if [ -e /usr/bin/pulseaudio ]; then
-    run-as-spot pulseaudio --start
+    run-as-spot sh -c "pidof -s pulseaudio > /dev/null || pulseaudio --start --log-target=syslog"
     export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
     export PULSE_COOKIE=/home/spot/.config/pulse/cookie
 fi


### PR DESCRIPTION
When I connect to my Bluetooth speakers and restart X, I have to reconnect because now everything talks to a new PulseAudio instance that doesn't know the Bluetooth output device.