### PR TITLE
Speed up woof-CE and PPM by running sync less often

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -286,7 +286,6 @@ do
 			rm -f packages-${DISTRO_FILE_PREFIX}/${PETPKG}.tar
 			continue
 		fi
-		sync
 		rm -f packages-${DISTRO_FILE_PREFIX}/${PETPKG}.tar
 		if [ -d ${TARGET_DIR}/usr/share/applications/ ] ; then
 			sed -i 's| %u|| ; s| %U|| ; s| %f|| ; s| %F||' ${TARGET_DIR}/usr/share/applications/*.desktop
@@ -311,7 +310,6 @@ do
 			if [ ! "$DISABLE_POST_INSTALL_SCRIPT" ] ; then
 				echo " executing (Slackware) install script"
 				( cd ${TARGET_DIR} ; sh ./install/doinst.sh )
-				sync
 				rm -rf ${TARGET_DIR}/install
 			fi
 		fi

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -64,7 +64,6 @@ rm -rf sandbox3/rootfs-complete
 rm -rf sandbox3/devx
 rm -rf sandbox3/docx ${DOCXSFS}
 rm -rf sandbox3/nlsx ${NLSXSFS}
-sync
 mkdir -p sandbox3/rootfs-complete/etc
 mkdir -p sandbox3/devx
 cp DISTRO_SPECS sandbox3/rootfs-complete/etc/
@@ -216,7 +215,6 @@ function copy_pkgs_to_build() {
 	esac
 	echo -n " ${ONEPKG}"
 	cp -a --remove-destination packages-${DISTRO_FILE_PREFIX}/${ONEPKG}/* sandbox3/${SFS_DIR}/ 2> /tmp/3builddistro-cp-errlog
-	sync
 	if [ -f sandbox3/${SFS_DIR}/pinstall.sh ];then
 		#note, do not filter #! /bin/sh (with a space)...
 		(
@@ -269,11 +267,9 @@ if [ "$BUILD_DEVX" = "yes" -o "$PETBUILDS" = "yes" ] ; then
 		if grep -q -m1 "^$ONEDEV" /tmp/ALLGENNAMESD ;then
 			echo -n " ${ONEDEV}"
 			cp -a --remove-destination packages-${DISTRO_FILE_PREFIX}/${ONEDEV}/* sandbox3/devx/
-			sync
 		fi
 	done
 	rm -f /tmp/ALLGENNAMESD
-	sync
 	echo
 fi
 
@@ -495,7 +491,6 @@ cd $WKGDIR
 cd sandbox3
 #==========
 
-sync
 #now do the kernel...
 echo
 rm -rf build 2>/dev/null
@@ -533,7 +528,6 @@ elif [ -f ${rootfs}/boot/vmlinuz-*-rpi2 ];then #raspberry pi2, Raspbian kernel
 	REALKERNAME='kernel.img'
 fi
 [ -f ${rootfs}/boot/System.map ] && cp ${rootfs}/boot/System.map ./
-sync
 
 cp ../DISTRO_SPECS rootfs-complete/etc/DISTRO_SPECS
 
@@ -902,16 +896,12 @@ if [ "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH" -o -n "$QEMU" ] ; then
 	done
 fi
 
-sync
-
 if [ "$BUILD_SFS" = 'yes' ]; then
 	sh $MWD/support/files2delete.sh rootfs-complete
 	#build the rootfs-complete sfs...
 	echo -e "\nNow building the main f.s., ${PUPPYSFS}..."
-	sync
 	rm -f build/${PUPPYSFS} 2>/dev/null
 	mksquashfs rootfs-complete build/${PUPPYSFS} ${SFSCOMP} #100911 110713
-	sync
 	###########
 	if [ -d adrv -o -d fdrv -o -d ydrv ];then
 		#build the {a,f,y}drive sfs...
@@ -924,11 +914,9 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 				ydrv) TYPE_SYS_SFS="${YDRVSFS}";;
 			esac
 			echo -e "\nNow building the $SYS_SFS f.s., $TYPE_SYS_SFS ..."
-			sync
 			rm -f build/${TYPE_SYS_SFS} 2>/dev/null
 			mksquashfs $SYS_SFS build/${TYPE_SYS_SFS} ${SFSCOMP} #170330
 			[ -n "$GITHUB_ACTIONS" ] && rm -rf $SYS_SFS
-			sync
 		done
 	fi
 	#############
@@ -971,7 +959,6 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 		#--
 		dirs=$(ls -d layer_top/* | sed 's|layer_top||' | grep -vE '/dev/|/proc/|/sys/') #|/initrd/|/tmp/|/var/|/run/|/mnt/
 		chroot layer_top find -L $dirs -type l -delete
-		sync
 		umount layer_top  ;  rmdir layer_top
 	fi
 
@@ -985,7 +972,6 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 
 	#maybe stray /install dir from slackware pkgs...
 	rm -rf sandbox3/devx/install sandbox3/devx/pet.specs 2>/dev/null
-	sync
 
 	# 151019 - delete duplicate symlinks
 	echo "deleting duplicate symlinks"
@@ -995,7 +981,6 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 		ESYMLINK=${ONESYMLINK//devx/rootfs-complete}
 		[ -h "$ESYMLINK" ] && echo -n "$ONESYMLINK " && rm -f "$ONESYMLINK"
 	done
-	sync
 	# do same for duplicates in /etc
 	echo -e "\ndeleting duplicate entries in /etc"
 	find sandbox3/devx/etc -type f | \
@@ -1003,7 +988,6 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 		EDUPE=${ONEDUPE//devx/rootfs-complete}
 		[ -f "$EDUPE" ] && echo -n "$ONEDUPE " && rm -f "$ONEDUPE"
 	done
-	sync
 
 	echo -e "\ncleaning out whiteouts"
 	clean_out_whiteouts $sandbox3/devx # _00func
@@ -1016,7 +1000,6 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 	echo "Now creating ${DEVXSFS} ..."
 	mksquashfs sandbox3/devx ./sandbox3/${DEVXSFS} ${SFSCOMP} #100911 110713
 	[ -n "$GITHUB_ACTIONS" ] && rm -rf sandbox3/devx
-	sync
 	chmod 644 ./sandbox3/${DEVXSFS}
 	echo "...done"
 

--- a/woof-code/rootfs-skeleton/usr/local/petget/downloadpkgs.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/downloadpkgs.sh
@@ -277,7 +277,6 @@ do
    fi
    unset DL_F_CALLED_FROM
   fi
-  sync
   DLPKG="`basename $ONEFILE`"
   if [ -f "${DL_PATH}"/$DLPKG -a "$DLPKG" != "" ];then
    if [ "$PASSEDPARAM" = "DOWNLOADONLY" ];then

--- a/woof-code/rootfs-skeleton/usr/local/petget/installed_size_preview.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installed_size_preview.sh
@@ -60,7 +60,6 @@ if [ "$MISSINGDEPS_PATTERNS" = "" -a "$(do_grep $DB_ENTRY /tmp/petget_proc/overa
   *) SIZEVAL=$(($SIZEVAL / 1024 )) ;;
  esac
  echo $SIZEVAL >> /tmp/petget_proc/overall_pkg_size
- sync
  /usr/local/petget/installmodes.sh check_total_size &
  exit 0
 fi
@@ -131,5 +130,4 @@ cat /tmp/petget_proc/petget_missing_dbentries-* | cut -f1 -d '|' >> /tmp/petget_
 cat /tmp/petget_proc/dependecies_list | sort | uniq  >> /tmp/petget_proc/overall_dependencies
 rm -f /tmp/petget_proc/dependecies_list
 
-sync
 /usr/local/petget/installmodes.sh check_total_size &

--- a/woof-code/rootfs-skeleton/usr/local/petget/installmodes.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installmodes.sh
@@ -444,7 +444,6 @@ install_package () {
    /usr/local/petget/finduserinstalledpkgs.sh
    sed -i "/$TREE1/d" /tmp/petget_proc/pkgs_left_to_install
  done < /tmp/petget_proc/pkgs_to_install
- sync
  report_results
  clean_up
 }

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -400,8 +400,6 @@ else #-- anything other than PUPMODE 2 (full install) --
 	 #now re-evaluate all the layers...
 	 busybox mount -t aufs -o remount,udba=reval unionfs / #remount with faster evaluation mode.
 	 [ $? -ne 0 ] && logger -s -t "installpkg.sh" "Failed to remount aufs / with udba=reval"
-
-	 sync
 	fi
 
 fi
@@ -418,7 +416,6 @@ do
 	[ ! -e "$DIRECTSAVEPATH/$i" ] && continue
 	cd $DIRECTSAVEPATH/
 	LANG=$LANG_USER sh ${i}
-	sync
 	rm -f ${i}
 done
 rm -rf $DIRECTSAVEPATH/install

--- a/woof-code/support/arm_sd_image.sh
+++ b/woof-code/support/arm_sd_image.sh
@@ -34,8 +34,6 @@ if [ "$CREATE" ] ; then
 	fi
 	LOOPDEV=$(losetup -f)
 	losetup ${LOOPDEV} ${OUT_IMG}
-	sync
-	sleep 1
 
 	parted --script -- \
 		${LOOPDEV} \
@@ -44,8 +42,6 @@ if [ "$CREATE" ] ; then
 		mkpart primary ext2 100MiB 100% \
 		set 1 boot on
 
-	sync
-	sleep 1
 	losetup -d ${LOOPDEV}
 fi
 
@@ -87,18 +83,14 @@ if [ "$CREATE" ] ; then
 	LOOPDEV=$(losetup -f)
 	if losetup -o ${P1STARTBYTES} ${LOOPDEV} ${OUT_IMG} ; then
 		mkdosfs -v -I -F 32 ${LOOPDEV}
-		sync ; sleep 1
 		losetup -d ${LOOPDEV}
 	fi
 
 	LOOPDEV=$(losetup -f)
 	if losetup -o ${P2STARTBYTES} ${LOOPDEV} ${OUT_IMG} ; then
 		mkfs.ext4 -F ${LOOPDEV}
-		sync ; sleep 1
 		tune2fs -O ^has_journal ${LOOPDEV}
-		sync
 		e2fsck -y ${LOOPDEV}
-		sync ; sleep 1
 		losetup -d ${LOOPDEV}
 	fi
 fi
@@ -131,7 +123,6 @@ case $REALKERNAME in
 esac
 
 echo -n "$REALKERNAME" > /mnt/sdimagep1/REALKERNAME #just in case need to know, in a running puppy.
-sync
 busybox umount /mnt/sdimagep1 2>/dev/null
 echo "...done"
  
@@ -143,13 +134,11 @@ if [ $? -ne 0 ];then
 	exit 1
 fi
 cp -a rootfs-complete/* /mnt/sdimagep2/
-sync
 
 # add to /etc/fstab...
 #not sure if the root partition is referred to as /dev/root or /dev/mmcblk0p2 on the raspi
 echo "/dev/mmcblk0p2     /       ${SDFS2}     defaults,noatime      0 1" >> /mnt/sdimagep2/etc/fstab
 echo "/dev/mmcblk0p1     /boot   vfat     defaults,noatime      0 2" >> /mnt/sdimagep2/etc/fstab
-sync
 echo "...done"
 busybox umount /mnt/sdimagep2 2>/dev/null
  
@@ -170,7 +159,6 @@ case "$SD_IMG_OUTPUT_COMP" in xz|gz) #build.conf
 	elif [ "$COMP" = 'gz' ]; then
 		gzip --stdout ${OUT_IMG} > ${OUT_IMG}.gz
 	fi
-	sync
 	echo " ${OUT_IMG}.${COMP} created."
 	COMPRIMGBYTES=`stat -c %s ${OUT_IMG}.${COMP}`
 	echo

--- a/woof-code/support/builtin_files.sh
+++ b/woof-code/support/builtin_files.sh
@@ -27,7 +27,6 @@ do
 			find -H ../packages-${DISTRO_FILE_PREFIX}/$i -type f -o -type l | \
 				sed -e "s%^\\.\\./packages-${DISTRO_FILE_PREFIX}/${i}/%/%" | \
 				sort > /tmp/0builtin_files_${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}/${i}.files
-			sync
 			(
 			while read ONELINE ; do
 				[ -e "rootfs-complete${ONELINE}" ] && echo "${ONELINE}" #only files that are in rootfs-complete
@@ -46,7 +45,6 @@ if [ -f /tmp/rootfs-packages.specs ];then
 		find -H ../rootfs-packages/$PKGL -type f -o -type l | \
 			sed -e "s%^\\.\\./rootfs-packages/${PKGL}/%/%" | \
 			sort > /tmp/0builtin_files_${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}/${PKGL}.files
-		sync
 		while read ONELINE ; do
 			if [ -e "rootfs-complete${ONELINE}" ];then
 				echo "${ONELINE}" >> 0builtin_files_${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}${PACKAGES_DIR}/builtin_files/${PKGL}

--- a/woof-code/support/docx_nlsx.sh
+++ b/woof-code/support/docx_nlsx.sh
@@ -31,7 +31,6 @@ if [ "$BUILD_DOCX" = "yes" ] ; then
 		fi
 	done
 	echo
-	sync
 	rm -f docx/pet.specs
 	echo "Creating $DOCXSFS..."
 	mksquashfs docx ${DOCXSFS} ${SFSCOMP}
@@ -50,7 +49,6 @@ if [ "$BUILD_NLSX" = "yes" ] ; then
 		fi
 	done
 	echo
-	sync
 	rm -f nlsx/pet.specs
 	echo "Creating $NLSXSFS..."
 	mksquashfs nlsx ${NLSXSFS} ${SFSCOMP}

--- a/woof-code/support/findpkgs
+++ b/woof-code/support/findpkgs
@@ -409,7 +409,6 @@ if [ -f support/findpkgs-search-helper ] ; then
 else
   search_func 1 #first search.
 fi
-sync
 
 #=====================================================================
 
@@ -434,7 +433,6 @@ cat /tmp/findpkgs_tmp/fnd_ok_apps >> /tmp/findpkgs_tmp/PREFERRED_PKGS
 
 sort --key=3,3 --field-separator="|" -u /tmp/findpkgs_tmp/PREFERRED_PKGS > /tmp/findpkgs_tmp/PREFERRED_PKGS2
 cp -f /tmp/findpkgs_tmp/PREFERRED_PKGS ${STATUSDIR}/findpkgs_PREFERRED_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} #so retained between boots.
-sync
 
 [ -s /tmp/findpkgs_tmp/PREFERRED_PKGS ] && PREFERRED_PKGS=1 #second search
 
@@ -464,9 +462,7 @@ fi
 grep '^:' /tmp/findpkgs_tmp/FINAL_PKGS > /tmp/findpkgs_tmp/FINAL_PKGSx
 mv -f /tmp/findpkgs_tmp/FINAL_PKGSx /tmp/findpkgs_tmp/FINAL_PKGS
 
-sync
 sort --key=4,4 --field-separator="|" /tmp/findpkgs_tmp/FINAL_PKGS > ${STATUSDIR}/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} #so retained between boots.
-sync
 echo
 
 echo

--- a/woof-code/support/findwoofinstalledpkgs
+++ b/woof-code/support/findwoofinstalledpkgs
@@ -36,7 +36,6 @@ do
 	done
 done
 ) >> /tmp/woof-installed-packages-tmp
-sync
 
 # added for rootfs-packages
 if [ -f /tmp/rootfs-packages.specs ] ; then

--- a/woof-code/support/huge_kernel.sh
+++ b/woof-code/support/huge_kernel.sh
@@ -63,7 +63,6 @@ if [ -d '../kernel-kit/output' ];then
 			mkdir -p fdrv #we're in sandbox3
 			echo "copying files..."
 			cp -a -u --remove-destination /mnt/fdrv/* fdrv/
-			sync
 			umount /mnt/fdrv
 			rm -rf /mnt/fdrv
 			losetup -a | grep -o -q "${FREEDEV##*/}" && losetup -d $FREEDEV

--- a/woof-code/support/mk_iso.sh
+++ b/woof-code/support/mk_iso.sh
@@ -147,9 +147,7 @@ sed -i -e "s% /splash.png% /boot/splash.png%" ${GRUB_CFG} ${BUILD}/boot/grub/men
 #======================================================
 
 # build the iso
-sync
 mk_iso $BUILD $OUT
-sync
 
 (
 	cd $WOOF_OUTPUT


### PR DESCRIPTION
sync between two package downloads is pointless, because it's not a disaster if the battery dies during package download. It only slows down PPM, especially if the user is doing I/O intensive things while waiting for PPM to finish installation. PPM is super slow when booting from a slow flash drive, and these sync calls are one of the main reasons for that.