### PR TITLE
Use the session bus only for spot (#2363)

### DIFF
--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -42,9 +42,7 @@ fi
 xhost +local: 2>/dev/null
 
 # start a D-Bus session bus for both root and spot, for PulseAudio and applications that don't work without it
-eval `run-as-spot dbus-launch --exit-with-x11`
-export DBUS_SESSION_BUS_ADDRESS
-export DBUS_SESSION_BUS_PID
+run-as-spot dbus-launch --exit-with-x11 > /tmp/.spot-session-bus
 
 # start PulseAudio over the session bus and use it for both root and spot, so they see the same output devices
 if [ -e /usr/bin/pulseaudio ]; then

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -46,7 +46,7 @@ run-as-spot dbus-launch --exit-with-x11 > /tmp/.spot-session-bus
 
 # start PulseAudio over the session bus and use it for both root and spot, so they see the same output devices
 if [ -e /usr/bin/pulseaudio ]; then
-    run-as-spot sh -c "pidof -s pulseaudio > /dev/null || pulseaudio --start --log-target=syslog"
+    run-as-spot sh -c "pulseaudio --kill > /dev/null 2>&1; pulseaudio --start --log-target=syslog"
     export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
     export PULSE_COOKIE=/home/spot/.config/pulse/cookie
 fi

--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -59,6 +59,12 @@ if [ $(id -u) -eq 0 ]; then
 		fi
 	fi
 
+	if [ -s /tmp/.spot-session-bus ]; then
+		. /tmp/.spot-session-bus
+		export DBUS_SESSION_BUS_ADDRESS
+		export DBUS_SESSION_BUS_PID
+	fi
+
 	exec su ${XUSER} -s /bin/ash -c '
 # try to switch to original directory, unless it is /root
 ! [ "'"$CURDIR"'" = /root ] && cd "'"$CURDIR"'"


### PR DESCRIPTION
- [x] Test Bluetooth audio on dpup, when Blueman runs as spot
- [x] Test Bluetooth audio on dpup, when Blueman runs as root (should fail)
- [x] Check if dbus-monitor runs as root 
- [x] Check if gvfd-trash runs as root