### PR TITLE
Restore fallback to X.Org with NVIDIA GPUs, until full Xwayland support

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -29,7 +29,12 @@ else
 	LOGFILE_X='/tmp/xerrs.log'
 fi
 
-startxwayland=`command -v startxwayland`
+startxwayland=
+# if X.Org is present, we want to use X.Org until NVIDIA drivers have proper
+# Wayland support and assume all nouveau users switch to the proprietary driver
+if [ -z "`grep -e ^nouveau -e ^nvidia /proc/modules`" -o ! -e /usr/bin/xinit ]; then
+	startxwayland=`command -v startxwayland`
+fi
 
 if [ -z "$startxwayland" ] && [ `id -u` -eq 0 ] && [ -h /usr/bin/X ] ; then
 	ln -snf Xorg /usr/bin/X


### PR DESCRIPTION
Wayland is still problematic with the initial Wayland support in NVIDIA's driver, and it's too early to disable this fallback.