### PR TITLE
Avoid triggering a rerun of petbuilds on every resolvedeps.sh invocation

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -292,7 +292,9 @@ echo "Copying petbuilds to rootfs-complete"
 MAINPKGS=
 
 for NAME in $PKGS; do
-    mkdir -p ../packages-${DISTRO_FILE_PREFIX}/${NAME}
+    rm -rf ../packages-${DISTRO_FILE_PREFIX}/${NAME} ../packages-${DISTRO_FILE_PREFIX}/${NAME}_NLS ../packages-${DISTRO_FILE_PREFIX}/${NAME}_DOC
+
+    mkdir ../packages-${DISTRO_FILE_PREFIX}/${NAME}
     cp -a ../petbuild-output/${NAME}-latest/* ../packages-${DISTRO_FILE_PREFIX}/${NAME}/
 
     if [ -d ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/locale ]; then

--- a/woof-code/support/resolvedeps.sh
+++ b/woof-code/support/resolvedeps.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
+PKGS_SPECS_TABLE_RESOLVED=0
 . $1
+[ $PKGS_SPECS_TABLE_RESOLVED -eq 1 ] && exit 0
 
 INSTALLED_PKGS=
 NEW_PKGS_SPECS_TABLE=
@@ -93,6 +95,8 @@ if [ $AUTOCNT -gt 0 ]; then
 PKGS_SPECS_TABLE='
 $NEW_PKGS_SPECS_TABLE
 '
+
+PKGS_SPECS_TABLE_RESOLVED=1
 EOF
 else
     echo "Skipped dependency resolution"


### PR DESCRIPTION
3builddistro re-runs resolvedeps.sh, which changes DISTRO_PKGS_SPECS, and that causes petbuilds.sh to rebuild all packages.

In addition, on rebuild, we should remove the split packages to remove extra files from the previous petbuild version.