### PR TITLE
Bluetooth audio support in focal64

### DIFF
--- a/woof-code/packages-templates/bluez_FIXUPHACK
+++ b/woof-code/packages-templates/bluez_FIXUPHACK
@@ -1,0 +1,5 @@
+# hack for fossa64: /etc/init.d/bluetooth looks for /etc/default/bluetooth
+if [ "$DISTRO_BINARY_COMPAT" = "ubuntu" -a ! -e etc/default/bluetooth ]; then
+    mkdir -p etc/default
+    echo BLUETOOTH_ENABLED=1 > etc/default/bluetooth
+fi

--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
@@ -36,11 +36,13 @@ yes|abiword||exe,dev>null,doc,nls|
 yes|acl|acl,libacl1,libacl1-dev|exe,dev,doc,nls
 yes|acpi|acpi|exe,dev,doc,nls
 yes|acpid-busibox||exe
+yes|adduser|adduser|exe>null,dev>null,doc>null,nls>null
 yes|advancecomp|advancecomp|exe>dev,dev,doc,nls
 yes|alsa-base|alsa-base|exe,dev,doc,nls
 yes|alsa-driver|linux-sound-base|exe,dev,doc,nls|
 no|alsaequal|libasound2-plugin-equal,caps|exe,dev,doc,nls| #needed by pequalizer.
-yes|alsa-lib|libasound2,libasound2-data,alsa-topology-conf,alsa-ucm-conf,libasound2-dev,libasound2-plugins|exe,dev,doc,nls
+yes|alsa-lib|libasound2,libasound2-data,alsa-topology-conf,alsa-ucm-conf,libasound2-dev|exe,dev,doc,nls
+yes|libasound2-plugins-pulseonly|libasound2-plugins|exe,dev,doc,nls
 yes|alsa-utils|alsa-utils|exe,dev,doc,nls
 no|alsa_zzBTfix||exe,dev,doc,nls| #alsa recompiled with --disable-thread-safety for bluez-alsa
 no|alsaequal||exe| #needed by pequalizer.
@@ -74,8 +76,8 @@ yes|beediff||exe,dev,doc,nls
 yes|bin86|bin86|exe>dev,dev,doc,nls
 yes|binutils|binutils,libbinutils,binutils-common,binutils-x86-64-linux-gnu,binutils-dev,libctf0,libctf-nobfd0|exe>dev,dev,doc,nls
 yes|bison|bison|exe>dev,dev,doc,nls
-yes|bluez||exe,dev,doc,nls
-yes|bluez-alsa||exe,dev,doc,nls
+yes|bluez|bluez,bluez-obexd|exe,dev,doc,nls||deps:yes
+yes|blueman|blueman|exe,dev,doc,nls||deps:yes
 yes|boehm-gc|libgc1c2,libgc-dev|exe,dev,doc,nls
 no|bones||exe
 yes|breeze-cursor-theme|breeze-cursor-theme|exe,dev,doc,nls
@@ -117,6 +119,7 @@ yes|dbus-glib|libdbus-glib-1-2,libdbus-glib-1-dev-bin,libdbus-glib-1-dev|exe,dev
 yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1,libdconf-dev|exe,dev,doc,nls
 yes|ddcprobe||exe,dev>null,doc,nls
 yes|deadbeef||exe,dev,doc,nls
+yes|debconf|debconf|exe>null,dev>null,doc>null,nls>null
 yes|debianutils|debianutils|exe,dev,doc,nls
 yes|dejavu_fonts|fonts-dejavu-core,fonts-dejavu-extra|exe,dev,doc,nls
 yes|desk_icon_theme_ardis||exe
@@ -141,6 +144,7 @@ no|disktype||exe,dev,doc,nls|
 yes|dmidecode|dmidecode|exe,dev>null,doc,nls
 yes|dosfstools|dosfstools|exe,dev>null,doc,nls
 yes|dpkg|dpkg,libzstd1,dpkg-dev,libdpkg-dev|exe,dev>null,doc,nls|
+yes|dpkg-dev|dpkg-dev|exe>null,dev>null,doc>null,nls>null
 yes|dunst||exe,dev,doc,nls|
 yes|Dunst-config||exe,dev,doc,nls|
 yes|dvdauthor|dvdauthor|exe,dev,doc,nls|
@@ -226,6 +230,7 @@ no|gmic||exe,dev,doc,nls
 yes|gmp|libgmp10,libgmpxx4ldbl,libgmp-dev,libgmp3-dev|exe,dev,doc,nls| #in precise, this was only in devx, but abiword needs it.
 yes|gnet||exe,dev,doc,nls
 no|gnome-doc-utils|gnome-doc-utils|exe>dev,dev,doc,nls|+python-libxml2
+yes|gnome-icon-theme|gnome-icon-theme|exe>null,dev>null,doc>null,nls>null
 no|gnome-keyring|libgnome-keyring0,libgnome-keyring-dev|exe,dev,doc,nls
 no|gnome-menus||exe,dev,doc,nls| #use my pet, version 2.14.3, needed by xdg_puppy.
 no|gnome-vfs|libgnomevfs2-0,libgnomevfs2-dev,libgnomevfs2-common|exe,dev,doc,nls
@@ -315,7 +320,7 @@ yes|iqpuzzle||exe|
 yes|iso-codes|iso-codes|exe,dev,doc,nls| #needed by gstreamer. very big. GSTREAMER1.0 GSTREAMER0.10
 yes|isomaster|isomaster|exe,dev,doc,nls|
 yes|iw|iw|exe,dev,doc,nls
-yes|janky_BT||exe,dev,doc,nls
+no|janky_BT||exe,dev,doc,nls
 yes|jbig2dec|libjbig2dec0,libjbig2dec0-dev|exe,dev,doc,nls| #needed by ghostscript.
 yes|jbigkit|libjbig0,libjbig-dev|exe,dev,doc,nls| #needed by libtiff5.
 yes|jimtcl||exe
@@ -479,7 +484,7 @@ yes|librhash|librhash0,librhash-dev|exe>dev,dev,doc,nls
 no|libreoffice|dirmngr,fonts-opensymbol,gnupg2,gnupg1-l10n,gnupg-utils,gpg,gpg-agent,gpgconf,gpgsm,gpgv,gpg-wks-client,gpg-wks-server,libabw-0.1-1,libabw-dev,libassuan0,libasyncns-dev,libcdr-0.1-1,libcdr-dev,libclucene-contribs1v5,libclucene-core1v5,libclucene-dev,libcmis-0.5-5v5,libcmis-dev,libcolamd2,libe-book-0.1-1,libe-book-dev,libeot0,libeot-dev,libepubgen-0.1-1,libepubgen-dev,libetonyek-0.1-1,libetonyek-dev,libexttextcat-2.0-0,libexttextcat-data,libexttextcat-dev,libfreehand-0.1-1,libfreehand-dev,libqgpgme7,libgpgme11,libgpgme-dev,libgpgmepp6,libgpgmepp-dev,libhyphen0,libhyphen-dev,libksba8,libksba-dev,liblangtag1,liblangtag-common,liblangtag-gobject0,liblangtag-dev,libmspub-0.1-1,libmspub-dev,libmwaw-0.3-3,libmwaw-dev,libmythes-1.2-0,libmythes-dev,libneon27-gnutls,libneon27-gnutls-dev,libnpth0,libnpth0-dev,libodfgen-0.1-1,libodfgen-dev,liborcus-0.15-0,liborcus-dev,liborcus-spreadsheet-model-0.15-0,liborcus-dev,libpagemaker-0.0-0,libpagemaker-dev,libreoffice-avmedia-backend-gstreamer,libreoffice-base-core,libreoffice-calc,libreoffice-common,libreoffice-core,libreoffice-draw,libreoffice-gtk3,libreoffice-impress,libreoffice-pdfimport,libreoffice-style-elementary,libreoffice-systray,libreoffice-writer,libuno-cppu3,libuno-cppuhelpergcc3-3,libuno-purpenvhelpergcc3-3,libuno-sal3,libuno-salhelpergcc3-3,libvisio-0.1-1,libvisio-dev,libwps-0.4-4,libwps-dev,libixion-0.15-0,libixion-dev,libxmlsec1,libxmlsec1-dev,libxmlsec1-gcrypt,libxmlsec1-openssl,libxmlsec1-gnutls,libxmlsec1-nss,lp-solve,pinentry-curses,uno-libs-private,ure|exe,dev,doc,nls
 yes|librsvg|librsvg2-bin,librsvg2-2,librsvg2-common,librsvg2-dev|exe,dev,doc,nls| #MERGED 20150717-08. 20151204 removed ,librsvg2-bin GTK3 --RESTORED 20160402. need rsvg-convert
 yes|libsamplerate|libsamplerate0,libsamplerate0-dev|exe,dev,doc,nls
-yes|libsbc|libsbc1,libsbc-dev|exe,dev,doc,nls| #needed for bluez-alsa
+no|libsbc|libsbc1,libsbc-dev|exe,dev,doc,nls| #needed for bluez-alsa
 yes|libseccomp|libseccomp2,libseccomp-dev|exe,dev,doc,nls
 yes|libsecret|libsecret-1-0,libsecret-common,libsecret-1-dev|exe,dev,doc,nls| #needed for skype4linux
 yes|libselinux|libselinux1,libselinux1-dev|exe,dev,doc,nls
@@ -617,6 +622,7 @@ yes|pam|libpam0g,libpam0g-dev,libpam-modules|exe,dev,doc,nls|
 yes|pango|libpango-1.0-0,libpango1.0-dev,libpangoft2-1.0-0,libpangocairo-1.0-0,libpangox-1.0-0,libpangoxft-1.0-0,gir1.2-pango-1.0|exe,dev,doc,nls
 yes|pangomm|libpangomm-1.4-1v5,libpangomm-1.4-dev|exe,dev,doc,nls
 yes|parted|parted,libparted2,libparted-dev,libparted-fs-resize0|exe,dev,doc,nls|
+yes|passwd|passwd|exe>null,dev>null,doc>null,nls>null
 yes|patch|patch|exe>dev,dev,doc,nls
 yes|patchutils|patchutils|exe>dev,dev,doc,nls
 yes|pavucontrol|pavucontrol|exe,dev,doc,nls
@@ -671,7 +677,7 @@ no|programchooser||exe
 no|pschedule||exe
 yes|psip||exe,dev,doc,nls
 yes|psmisc|psmisc|exe,dev>null,doc,nls
-yes|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,libwebrtc-audio-processing-dev,pulseaudio-utils|exe,dev,doc,nls #needed by mplayer, gnome-mplayer and gmtk
+yes|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,libwebrtc-audio-processing-dev,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
 yes|PupClockset||exe|
 yes|Pup-SysInfo||exe|
 yes|puppyinputdetect||exe


### PR DESCRIPTION
This is https://github.com/puppylinux-woof-CE/woof-CE/pull/2349, but for focal64. Now, PulseAudio works for both root and spot, with Bluetooth audio support.