### PR TITLE
Move libicudata to nlsx and replace it with a tiny stub

### DIFF
--- a/woof-code/packages-templates/icu_FIXUPHACK
+++ b/woof-code/packages-templates/icu_FIXUPHACK
@@ -2,3 +2,7 @@
 
 # remove ICU static libs (huge)
 find ../icu_DEV -type f -name '*.a' -delete 2>/dev/null
+
+# copy libicudata to NLS so libicudata_stub petbuild can replace it in EXE
+SO=`find . -name 'libicudata.so.*' -type f`
+[ -n "$SO" ] && install -D -v -m 644 "${SO}" "../icu_NLS/${SO}"

--- a/woof-code/rootfs-petbuilds/libicudata_stub/pet.specs
+++ b/woof-code/rootfs-petbuilds/libicudata_stub/pet.specs
@@ -1,0 +1,1 @@
+libicudata_stub-69.1|libicudata_stub|69.1||BuildingBlock|348||libicudata_stub-69.1.pet||libicudata stub|puppy|||

--- a/woof-code/rootfs-petbuilds/libicudata_stub/petbuild
+++ b/woof-code/rootfs-petbuilds/libicudata_stub/petbuild
@@ -1,0 +1,8 @@
+download() {
+    [ -f stubdata-0e7b4428866f3133b4abba2d932ee3faa708db1d.cpp ] || wget -t 1 -T 15 -O stubdata-0e7b4428866f3133b4abba2d932ee3faa708db1d.cpp https://raw.githubusercontent.com/unicode-org/icu/0e7b4428866f3133b4abba2d932ee3faa708db1d/icu4c/source/stubdata/stubdata.cpp
+}
+
+build() {
+    SO=`find /usr -name 'libicudata.so.*' -type f`
+    g++ $CXXFLAGS stubdata-0e7b4428866f3133b4abba2d932ee3faa708db1d.cpp $LDFLAGS -shared -Wl,-soname=libicudata.so.`basename "$SO" | cut -f 3 -d .` -o "$SO"
+}

--- a/woof-code/rootfs-petbuilds/libicudata_stub/sha256.sum
+++ b/woof-code/rootfs-petbuilds/libicudata_stub/sha256.sum
@@ -1,0 +1,1 @@
+2ba463a3903611b86958e9a4194564ce2e2acfd4f978bffbeec5d4f78fcb8cfc  stubdata-0e7b4428866f3133b4abba2d932ee3faa708db1d.cpp


### PR DESCRIPTION
It's a huge library (27 MB on bullseye64), and I don't know if it's needed in an English-only system, like Puppy by default (i.e. without nlsx loaded).

This library exports only one symbol and there's a stub library included in the icu source code, which hasn't changed for a very long time.