### PR TITLE
Move libicudata in aaa_libraries to nlsx

### DIFF
--- a/woof-code/packages-templates/aaa_libraries_FIXUPHACK
+++ b/woof-code/packages-templates/aaa_libraries_FIXUPHACK
@@ -1,0 +1,3 @@
+# hack for 15.0: there's a second libicudata in aaa_libraries
+SO=`find . -name 'libicudata.so.*' -type f`
+[ -n "$SO" ] && install -D -v -m 644 "${SO}" "../aaa_libraries_NLS/${SO}"


### PR DESCRIPTION
~~Testing it now~~

```
Processing aaa_libraries
 processing aaa_libraries-15.0-x86_64-7.txz
 executing packages-templates/aaa_libraries_FIXUPHACK
install: creating directory '../aaa_libraries_NLS'
install: creating directory '../aaa_libraries_NLS/./usr'
install: creating directory '../aaa_libraries_NLS/./usr/lib64'
'./usr/lib64/libicudata.so.68.2' -> '../aaa_libraries_NLS/./usr/lib64/libicudata.so.68.2'
```