### PR TITLE
For consistency with X.Org, run Xwayland as :0, not :1

### DIFF
--- a/woof-code/rootfs-petbuilds/cage/no-xwin.patch
+++ b/woof-code/rootfs-petbuilds/cage/no-xwin.patch
@@ -1,0 +1,65 @@
+diff -rupN cage-0.1.4-orig/cage.c cage-0.1.4/cage.c
+--- cage-0.1.4-orig/cage.c	2021-07-27 08:44:36.995423489 +0300
++++ cage-0.1.4/cage.c	2021-07-27 08:45:30.183909757 +0300
+@@ -29,14 +29,14 @@
+ #include <wlr/types/wlr_output_layout.h>
+ #include <wlr/types/wlr_screencopy_v1.h>
+ #include <wlr/types/wlr_server_decoration.h>
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ #include <wlr/types/wlr_xcursor_manager.h>
+ #endif
+ #include <wlr/types/wlr_xdg_decoration_v1.h>
+ #include <wlr/types/wlr_xdg_output_v1.h>
+ #include <wlr/types/wlr_xdg_shell.h>
+ #include <wlr/util/log.h>
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ #include <wlr/xwayland.h>
+ #endif
+ 
+@@ -46,7 +46,7 @@
+ #include "server.h"
+ #include "view.h"
+ #include "xdg_shell.h"
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ #include "xwayland.h"
+ #endif
+ 
+@@ -271,7 +271,7 @@ main(int argc, char *argv[])
+ 	struct wlr_xdg_output_manager_v1 *output_manager = NULL;
+ 	struct wlr_gamma_control_manager_v1 *gamma_control_manager = NULL;
+ 	struct wlr_xdg_shell *xdg_shell = NULL;
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ 	struct wlr_xwayland *xwayland = NULL;
+ 	struct wlr_xcursor_manager *xcursor_manager = NULL;
+ #endif
+@@ -429,7 +429,7 @@ main(int argc, char *argv[])
+ 		goto end;
+ 	}
+ 
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ 	xwayland = wlr_xwayland_create(server.wl_display, compositor, true);
+ 	if (!xwayland) {
+ 		wlr_log(WLR_ERROR, "Cannot create XWayland server");
+@@ -482,7 +482,7 @@ main(int argc, char *argv[])
+ 		wlr_log(WLR_DEBUG, "Cage " CAGE_VERSION " is running on Wayland display %s", socket);
+ 	}
+ 
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ 	wlr_xwayland_set_seat(xwayland, server.seat->seat);
+ #endif
+ 
+@@ -497,7 +497,7 @@ main(int argc, char *argv[])
+ 
+ 	wl_display_run(server.wl_display);
+ 
+-#if CAGE_HAS_XWAYLAND
++#if 0
+ 	wlr_xwayland_destroy(xwayland);
+ 	wlr_xcursor_manager_destroy(xcursor_manager);
+ #endif

--- a/woof-code/rootfs-petbuilds/cage/petbuild
+++ b/woof-code/rootfs-petbuilds/cage/petbuild
@@ -30,6 +30,7 @@ build() {
     cd cage-0.1.4
     patch -p1 < ../root.patch
     patch -p1 < ../libinput-conf.patch
+    patch -p1 < ../no-xwin.patch
     meson --buildtype=minsize --prefix=/usr -Dxwayland=true build
     ninja -C build install
     cd ..

--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -29,7 +29,7 @@ EOF
 [ -n "$LIBINPUT_DEFAULT_ACCELERATION" ] && export LIBINPUT_DEFAULT_ACCELERATION
 [ -n "$LIBINPUT_DEFAULT_SCROLL_METHOD" ] && export LIBINPUT_DEFAULT_SCROLL_METHOD
 
-DISPLAY=:1
+DISPLAY=:0
 XAUTHORITY=~/.Xauthority
 
 auth=`mktemp`
@@ -45,7 +45,7 @@ if [ -f ~/.Xresources ]; then
 	[ -n "$dpi" ] && args="$args -dpi $dpi"
 fi
 
-WLR_RENDERER_ALLOW_SOFTWARE=1 cage -ds -- Xwayland :1 -auth "$XAUTHORITY" $args &
+WLR_RENDERER_ALLOW_SOFTWARE=1 cage -ds -- Xwayland $DISPLAY -auth "$XAUTHORITY" $args &
 pid=$!
 
 export DISPLAY


### PR DESCRIPTION
Like other compositors, Cage uses "lazy" start of Xwayland: DISPLAY=:0 is set, and Xwayland is started when a legacy X11 application is started.

But we don't need that in our particular use case of Cage. We want to run Xwayland right from the start and want this instance to use :0, because that's the usual value of DISPLAY, and some scripts rely on this.