### PR TITLE
bugfix for new line and missing field

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -318,7 +318,7 @@ for NAME in $PKGS; do
     rmdir ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share 2>/dev/null
     rmdir ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr 2>/dev/null
 
-    (echo ":${NAME}:|pet|"; cat ../rootfs-petbuilds/${NAME}/pet.specs) >> ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}
+    (echo -n ":${NAME}:|pet|local|"; cat ../rootfs-petbuilds/${NAME}/pet.specs) >> ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}
 
     # redirect packages with menu entries to adrv, with exceptions
     if [ -n "$ADRV_INC" ] && [ "$NAME" != "rox-filer" ] && [ "$NAME" != "lxterminal" ] && [ "$NAME" != "leafpad" ] && [ "$NAME" != "l3afpad" ] && [ "$NAME" != "gexec" ] && [ -n "`ls ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/applications/*.desktop 2>/dev/null`" ]; then


### PR DESCRIPTION
- formerly looked like this:

:xlockmore:|pet|
xlockmore-5.66|xlockmore|5.66||BuildingBlock|256||xlockmore-5.66.pet||Lock the screen|puppy|||

- now

:xlockmore:|pet|local|xlockmore-5.66|xlockmore|5.66||BuildingBlock|256||xlockmore-5.66.pet||Lock the screen|puppy|||

Since not from a repo I put 'local'

I did similar with 894a62e