### PR TITLE
Add scheduled builds of bionic64 to protect it against breakage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,10 @@ jobs:
             compat-distro: slackware
             compat-distro-version: "15.0"
             kernel: 5.4.x-x86
+          - arch: x86_64
+            compat-distro: ubuntu
+            compat-distro-version: bionic64
+            kernel: 4.19.x-x86_64
           - arch: arm
             compat-distro: debian
             compat-distro-version: bullseye-veyron-speedy

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -302,7 +302,7 @@ yes|jbigkit|libjbig0,libjbig-dev|exe,dev,doc,nls| #needed by libtiff5.
 yes|jimtcl||exe
 yes|json-c|libjson-c3,libjson-c-dev|exe,dev,doc,nls| #needed by mplayer.
 yes|jwm|jwm|exe,dev,doc,nls
-yes|jwmconfig3||exe
+no|jwmconfig3||exe
 yes|JWMDesk||exe,dev,doc,nls
 yes|jwm_theme_stark-blueish||exe|
 yes|keyutils|libkeyutils1,libkeyutils-dev|exe,dev>null,doc,nls

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -445,6 +445,7 @@ yes|libpng14||exe,dev>null,doc,nls|
 yes|libpolkit-gobject|libpolkit-gobject-1-0,libpolkit-gobject-1-dev|exe>dev,dev,doc,nls| #needed by sysprof
 yes|libproxy|libproxy1v5,libproxy-dev|exe,dev,doc,nls
 yes|libpthread-stubs|libpthread-stubs0-dev|exe>dev,dev,doc,nls
+yes|libpulse|libpulse-mainloop-glib0,libpulse0|exe,dev,doc,nls| #needed by mplayer, gnome-mplayer and gmtk
 yes|libraw1394|libraw1394-11,libraw1394-dev|exe,dev,doc,nls
 yes|librest|librest-0.7-0,librest-dev|exe,dev,doc,nls
 yes|librevenge|librevenge-0.0-0,librevenge-dev|exe,dev,doc,nls
@@ -629,7 +630,6 @@ yes|Primrose||exe,dev,doc,nls
 yes|procps|procps,libprocps*,libprocps-dev|exe,dev,doc,nls
 no|pschedule||exe
 yes|psmisc|psmisc|exe,dev>null,doc,nls
-yes|pulseaudio|libpulse-mainloop-glib0,libpulse0|exe,dev,doc,nls| #needed by mplayer, gnome-mplayer and gmtk
 yes|psynclient||exe
 yes|pupmixer||exe
 yes|PupClockset||exe|

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_SPECS
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='bionicpup64'
 #version number of this distribution:
-DISTRO_VERSION=8.0
+DISTRO_VERSION=8.1
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='ubuntu'
 #Prefix for some filenames: exs: bionicpup64save.2fs, bionicpup64-7.9.8.sfs

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build_2.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build_2.conf
@@ -3,5 +3,5 @@
 #
 # but override these settings:
 
-KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19.23-bionicpup64.tar.bz2
+#KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-4.19.23-bionicpup64.tar.bz2
 


### PR DESCRIPTION
Looks like people still like it in 2021, so let's do some super minimal effort to keep it working: without petbuilds, without updates from rootfs-packages, and without the cleanup it needs (zz_bionicfix64, I'm looking at you).