### PR TITLE
Let the user select the petbuilds to use

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -254,7 +254,7 @@ case $BUILD_DEVX in #_00build.conf
 	*) BUILD_DEVX=yes ;;
 esac
 
-if [ "$BUILD_DEVX" = "yes" -o "$PETBUILDS" = "yes" ] ; then
+if [ "$BUILD_DEVX" = "yes" -o -n "$PETBUILDS" ] ; then
 	cd $WKGDIR
 	echo "Building sandbox3/devx ..."
 	echo "$PKGS_SPECS_TABLE" | grep '^yes' | cut -f 2 -d '|' | sed -e 's%$%_DEV%' > /tmp/ALLGENNAMESD
@@ -279,7 +279,7 @@ find sandbox3/rootfs-complete/ sandbox3/devx/ -type f -name "*.la" -delete # del
 QEMU=`command -v qemu-${WOOF_TARGETARCH}-static`
 [ -n "$QEMU" ] && install -D -m 755 $QEMU rootfs-complete/${QEMU}
 
-if [ "$PETBUILDS" = "yes" ]; then
+if [ -n "$PETBUILDS" ]; then
 	if [ "$WOOF_HOSTARCH" != "$WOOF_TARGETARCH" -a -z "$QEMU" ]; then
 		echo "petbuilds need qemu-user-static!"
 		exit 1

--- a/woof-code/_00build.conf
+++ b/woof-code/_00build.conf
@@ -40,8 +40,8 @@ FDRV_INC=""
 #YDRV_SFS_URL=
 #FDRV_SFS_URL=
 
-## NEW - build missing packages from source? yes/no
-PETBUILDS=no
+## packages to build from source
+PETBUILDS=
 
 ## build devx? yes/no - any other value = yes
 BUILD_DEVX=yes

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -41,62 +41,8 @@ HERE=`pwd`
 PKGS=
 
 # busybox must be first, so other petbuilds can use coreutils commands
-for i in ../rootfs-petbuilds/busybox ../rootfs-petbuilds/*; do
-    NAME=${i#../rootfs-petbuilds/}
-
-    if grep -iq "^yes|${NAME}|" ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}; then
-        echo "Skipping ${NAME}, using a package"
-        continue
-    fi
-
-    ALTNAME=`echo ${NAME} | tr - _`
-    if grep -iq "^yes|${ALTNAME}|" ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}; then
-        echo "Skipping ${NAME}, using alternate package ${ALTNAME}"
-        continue
-    fi
-
-    if [ "$NAME" = "pa-applet" ] && [ -z "`grep '^yes|pulseaudio|' ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}`" ]; then
-        echo "Skipping pa-applet, pulseaudio is not installed"
-        continue
-    fi
-
-    if [ "$NAME" = "pa-applet" ] && [ -n "`grep '^yes|apulse|' ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}`" ]; then
-        echo "Skipping pa-applet, apulse is installed"
-        continue
-    fi
-
-    if [ "$NAME" = "xarchiver" ] && [ -n "`grep '^yes|xarchive|' ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}`" ]; then
-        echo "Skipping xarchiver, using xarchive"
-        continue
-    fi
-
-    if [ "$NAME" = "l3afpad" -a $PETBUILD_GTK -eq 2 ]; then
-        echo "Skipping l3afpad, using leafpad"
-        continue
-    elif [ "$NAME" = "leafpad" -a $PETBUILD_GTK -eq 3 ]; then
-        echo "Skipping leafpad, using l3afpad"
-        continue
-    fi
-
-    if [ "$NAME" = "sylpheed" ] && [ -n "`grep '^yes|claws-mail|' ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}`" ]; then
-        echo "Skipping sylpheed, using claws-mail"
-        continue
-    fi
-
-    if [ "$NAME" = "gpicview" ] && [ -n "`grep '^yes|viewnior|' ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION}`" ]; then
-        echo "Skipping gpicview, using viewnior"
-        continue
-    fi
-
-    if [ "$NAME" = "cage" ] && [ "$XWAYLAND" != "yes" ]; then
-        echo "Skipping cage, XWAYLAND=$XWAYLAND"
-        continue
-    elif [ "$NAME" = "cage" ] && [ -z "$XWAYLAND" ] && [ "$DISTRO_TARGETARCH" = "x86" ]; then
-        echo "Skipping cage on x86"
-        continue
-    fi
-
-    HASH=`cat ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_COMPAT_REPOS ../DISTRO_COMPAT_REPOS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_PET_REPOS $i/petbuild 2>/dev/null | md5sum | awk '{print $1}'`
+for NAME in $PETBUILDS; do
+    HASH=`cat ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_COMPAT_REPOS ../DISTRO_COMPAT_REPOS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_PET_REPOS ../rootfs-petbuilds/${NAME}/petbuild 2>/dev/null | md5sum | awk '{print $1}'`
     if [ ! -d "../petbuild-output/${NAME}-${HASH}" ]; then
         if [ $HAVE_ROOTFS -eq 0 ]; then
             echo "Preparing build environment"
@@ -204,7 +150,7 @@ for i in ../rootfs-petbuilds/busybox ../rootfs-petbuilds/*; do
 
         cp -a ../petbuild-sources/${NAME}/* petbuild-rootfs-complete-${NAME}/tmp/
         cp -a ../rootfs-petbuilds/${NAME}/* petbuild-rootfs-complete-${NAME}/tmp/
-        CC="$WOOF_CC" CXX="$WOOF_CXX" CFLAGS="$WOOF_CFLAGS" CXXFLAGS="$WOOF_CXXFLAGS" LDFLAGS="$WOOF_LDFLAGS" MAKEFLAGS="$MAKEFLAGS" CCACHE_DIR=/root/.ccache CCACHE_NOHASHDIR=1 PKG_CONFIG_PATH="$PKG_CONFIG_PATH" PYTHONDONTWRITEBYTECODE=1 PETBUILD_GTK=$PETBUILD_GTK chroot petbuild-rootfs-complete-${NAME} sh -ec "cd /tmp && . ./petbuild && build"
+        CC="$WOOF_CC" CXX="$WOOF_CXX" CFLAGS="$WOOF_CFLAGS" CXXFLAGS="$WOOF_CXXFLAGS" LDFLAGS="$WOOF_LDFLAGS" MAKEFLAGS="$MAKEFLAGS" CCACHE_DIR=/root/.ccache CCACHE_NOHASHDIR=1 PKG_CONFIG_PATH="$PKG_CONFIG_PATH" PYTHONDONTWRITEBYTECODE=1 PETBUILD_GTK=$PETBUILD_GTK chroot petbuild-rootfs-complete-${NAME} bash -ec "cd /tmp && . ./petbuild && build"
         ret=$?
         umount -l petbuild-rootfs-complete-${NAME}/root/.ccache
         umount -l petbuild-rootfs-complete-${NAME}/tmp

--- a/woof-distro/x86/debian/bullseye/_00build_2.conf
+++ b/woof-distro/x86/debian/bullseye/_00build_2.conf
@@ -8,4 +8,4 @@
 #YDRV_SFS_URL=
 #FDRV_SFS_URL=
 
-XWAYLAND=no
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme eudev firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"

--- a/woof-distro/x86/slackware/14.2/_00build.conf
+++ b/woof-distro/x86/slackware/14.2/_00build.conf
@@ -46,8 +46,8 @@ BUILD_DEVX=yes
 BUILD_DOCX=no
 BUILD_NLSX=no
 
-## build missing packages from source? yes/no
-PETBUILDS=yes
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
 
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no

--- a/woof-distro/x86/slackware/14.2/_00build_2.conf
+++ b/woof-distro/x86/slackware/14.2/_00build_2.conf
@@ -11,6 +11,3 @@ INCLUDE_PKG=y
 PTHEME="The Beach Grey"
 
 XERRS_FLG=no
-
-## build missing packages from source? yes/no
-PETBUILDS=yes

--- a/woof-distro/x86/slackware/15.0/_00build.conf
+++ b/woof-distro/x86/slackware/15.0/_00build.conf
@@ -46,8 +46,8 @@ BUILD_DEVX=yes
 BUILD_DOCX=no
 BUILD_NLSX=no
 
-## build missing packages from source? yes/no
-PETBUILDS=yes
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
 
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -37,11 +37,8 @@ BUILD_DEVX=yes
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no
 
-## build missing packages from source? yes/no
-PETBUILDS=yes
-
-## build Xwayland and use it instead of X.Org by default? yes/no
-XWAYLAND=yes
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme eudev firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
 
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes

--- a/woof-distro/x86_64/slackware64/14.2/_00build.conf
+++ b/woof-distro/x86_64/slackware64/14.2/_00build.conf
@@ -46,8 +46,8 @@ BUILD_DEVX=yes
 BUILD_DOCX=no
 BUILD_NLSX=no
 
-## build missing packages from source? yes/no
-PETBUILDS=yes
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
 
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no

--- a/woof-distro/x86_64/slackware64/15.0/_00build.conf
+++ b/woof-distro/x86_64/slackware64/15.0/_00build.conf
@@ -46,8 +46,8 @@ BUILD_DEVX=yes
 BUILD_DOCX=no
 BUILD_NLSX=no
 
-## build missing packages from source? yes/no
-PETBUILDS=yes
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
 
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -49,8 +49,8 @@ BUILD_NLSX=no
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no
 
-## build missing packages from source? yes/no
-PETBUILDS=yes
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme eudev firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
 
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes


### PR DESCRIPTION
This PR makes `PETBUILDS` a list of packages to build, instead of an on/off toggle that selects all packages not included already.

The list can be tuned later (as requested by @mrfricks in https://github.com/puppylinux-woof-CE/woof-CE/issues/2418#issuecomment-890919569); for now, I set PETBUILDS= to the list of packages that previously got auto-selected.