### PR TITLE
Replace broken syslinux pet with Ubuntu 20.04 packages

### DIFF
--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
@@ -748,7 +748,8 @@ yes|subversion|subversion,libsvn1,libdb5.3,libutf8proc2,libneon27-gnutls,libapru
 yes|sudo||exe,dev,doc,nls
 no|sunfish_chess||exe,dev,doc,nls
 yes|sysfsutils|libsysfs2,libsysfs-dev,sysfsutils|exe,dev,doc,nls
-yes|syslinux||exe,dev,doc,nls| #must use pet syslinux pkg.
+no|syslinux||exe,dev,doc,nls| #must use pet syslinux pkg.
+yes|syslinux|extlinux,isolinux,syslinux,syslinux-common,syslinux-efi,syslinux-utils|exe,dev,doc,nls
 yes|sysvinit||exe
 yes|taglib|libtag1v5,libtag1-dev,libtag1v5-vanilla|exe,dev,doc,nls| #needed by lots of media apps.
 yes|tar|tar|exe,dev>null,doc,nls


### PR DESCRIPTION
For some reason, isolinux keeps complaining ldlinux.c32 is not found.