### PR TITLE
Do x86_64 to x86 builds without qemu-user-static

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,11 +75,9 @@ jobs:
         echo "dash dash/sh boolean false" | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
-        [ "${{ matrix.arch }}" = "x86" ] && echo -e '#!/bin/sh\nexec linux32 "$@"' | sudo tee /usr/local/bin/linuxn || echo -e '#!/bin/sh\nexec "$@"' | sudo tee /usr/local/bin/linuxn
-        sudo chmod 755 /usr/local/bin/linuxn
     - name: merge2out
       timeout-minutes: 5
-      run: yes "" | sudo -E linuxn ./merge2out woof-distro/${{ matrix.arch }}/${{ matrix.compat-distro }}/${{ matrix.compat-distro-version }}
+      run: yes "" | sudo -E ./merge2out woof-distro/${{ matrix.arch }}/${{ matrix.compat-distro }}/${{ matrix.compat-distro-version }}
     - name: Set distro version
       run: |
         . ../woof-out_*/DISTRO_SPECS
@@ -89,17 +87,17 @@ jobs:
       timeout-minutes: 10
       run: |
         cd ../woof-out_*
-        sudo -E linuxn ./0setup
+        sudo -E ./0setup
     - name: 1download
       timeout-minutes: 120
       run: |
         cd ../woof-out_*
-        sudo -E linuxn ./1download
+        sudo -E ./1download
     - name: 2createpackages
       timeout-minutes: 30
       run: |
         cd ../woof-out_*
-        echo | sudo -E linuxn ./2createpackages
+        echo | sudo -E ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
       with:
@@ -157,7 +155,7 @@ jobs:
         sudo chown -R root:root petbuild-output
         sudo mv petbuild-{sources,cache,output} ../woof-out_*/
         cd ../woof-out_*
-        sudo -E HOME=/root linuxn ./3builddistro
+        sudo -E HOME=/root ./3builddistro
         sudo mv petbuild-{sources,cache,output} $GITHUB_WORKSPACE/
     - name: Move build output
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,10 +59,8 @@ jobs:
         echo "dash dash/sh boolean false" | sudo debconf-set-selections
         sudo DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
         sudo ln -s bash /bin/ash
-        [ "${{ github.event.inputs.arch }}" = "x86" ] && echo -e '#!/bin/sh\nexec linux32 "$@"' | sudo tee /usr/local/bin/linuxn || echo -e '#!/bin/sh\nexec "$@"' | sudo tee /usr/local/bin/linuxn
-        sudo chmod 755 /usr/local/bin/linuxn
     - name: merge2out
-      run: yes "" | sudo -E linuxn ./merge2out woof-distro/${{ github.event.inputs.arch }}/${{ github.event.inputs.compat_distro }}/${{ github.event.inputs.compat_version }}
+      run: yes "" | sudo -E ./merge2out woof-distro/${{ github.event.inputs.arch }}/${{ github.event.inputs.compat_distro }}/${{ github.event.inputs.compat_version }}
     - name: Set version
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_*/DISTRO_SPECS
     - name: Set file name prefix
@@ -70,15 +68,15 @@ jobs:
     - name: 0setup
       run: |
         cd ../woof-out_*
-        sudo -E linuxn ./0setup
+        sudo -E ./0setup
     - name: 1download
       run: |
         cd ../woof-out_*
-        sudo -E linuxn ./1download
+        sudo -E ./1download
     - name: 2createpackages
       run: |
         cd ../woof-out_*
-        echo | sudo -E linuxn ./2createpackages
+        echo | sudo -E ./2createpackages
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
       with:
@@ -111,7 +109,7 @@ jobs:
       run: |
         sudo mv petbuild-sources ../woof-out_*/
         cd ../woof-out_*
-        sudo -E HOME=/root linuxn ./3builddistro release
+        sudo -E HOME=/root ./3builddistro release
         sudo mv -f woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}.iso $GITHUB_WORKSPACE/
         sudo mv -f woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/devx_${{ github.event.inputs.prefix }}_${{ github.event.inputs.version }}.sfs $GITHUB_WORKSPACE/
         sudo mv -f woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/docx_${{ github.event.inputs.prefix }}_${{ github.event.inputs.version }}.sfs $GITHUB_WORKSPACE/

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -276,12 +276,12 @@ fi
 echo "removing obsolete libtool *.la files"
 find sandbox3/rootfs-complete/ sandbox3/devx/ -type f -name "*.la" -delete # delete old libtool files
 
-NEEDQEMU=0
+CROSSBUILD=0
 QEMU=
 if [ "$WOOF_HOSTARCH" != "$WOOF_TARGETARCH" ]; then
 	# exception: qemu-user-static is not needed if it's a x86_64 to x86 cross-build
 	if [ "$WOOF_HOSTARCH" != "x86_64" -o "$WOOF_TARGETARCH" != "x86" ]; then
-		NEEDQEMU=1
+		CROSSBUILD=1
 		if [ "$WOOF_TARGETARCH" = "x86" ]; then
 			QEMU=`command -v qemu-i386-static`
 		else
@@ -292,10 +292,10 @@ fi
 [ -n "$QEMU" ] && install -D -m 755 $QEMU rootfs-complete/${QEMU}
 
 if [ -n "$PETBUILDS" ]; then
-	if [ $NEEDQEMU -eq 1 -a -z "$QEMU" ]; then
+	if [ $CROSSBUILD -eq 1 -a -z "$QEMU" ]; then
 		echo "petbuilds need qemu-user-static!"
 		exit 1
-	elif [ $NEEDQEMU -eq 0 ]; then
+	elif [ $CROSSBUILD -eq 0 ]; then
 		echo "Building without qemu-user-static"
 	fi
 
@@ -606,7 +606,7 @@ rm -f rootfs-complete/etc/profile.d/*.csh* 2>/dev/null # slackware 13.1
 #sanity check...
 echo
 
-if [ "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH" -o -n "$QEMU" ];then #111123
+if [ $CROSSBUILD -eq 0 -o -n "$QEMU" ];then #111123
 	chroot rootfs-complete echo 'testing chroot'
 	if [ $? -ne 0 ];then
 		echo "ERROR: could not 'chroot' into sandbox3/rootfs-complete"
@@ -740,7 +740,7 @@ mkdir -p rootfs-complete/etc/ld.so.conf.d/ # may not be there
 
 echo "Updating system config.."
 mkdir -p rootfs-complete/var/cache/fontconfig
-if [ "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH" -o -n "$QEMU" ];then
+if [ $CROSSBUILD -eq 0 -o -n "$QEMU" ];then
 	chroot rootfs-complete /etc/rc.d/rc.update w
 	# create a table for dialog/Xdialog: /usr/share/i18n/dialog_table
 	# 'chooselocale' is called from /etc/rc.d/rc.country at first boot and
@@ -769,7 +769,7 @@ if [ "${GTKTHEME}" ] && [ -d rootfs-complete/usr/share/themes/${GTKTHEME} ] ; th
 	pathGTK3THEME="`find rootfs-complete/usr/share/themes/${GTKTHEME} -type d -name gtk-3.0`"
 	[ "$pathGTK3THEME" ] && ln -snf "$pathGTK3THEME" rootfs-complete/root/.config/gtk-3.0
 fi
-if [ "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH" -o -n "$QEMU" ]; then
+if [ $CROSSBUILD -eq 0 -o -n "$QEMU" ]; then
 	chroot rootfs-complete /usr/sbin/icon_switcher -a ${DESKICONS} #see above
 else
 	(
@@ -909,7 +909,7 @@ echo
 #before building puppy.sfs from rootfs-complete, check for any invalid symlinks
 #and move them to the devx...
 echo
-if [ "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH" -o -n "$QEMU" ] ; then
+if [ $CROSSBUILD -eq 0 -o -n "$QEMU" ] ; then
 	echo "Finding invalid symlinks..."
 	dirs=$(ls -d rootfs-complete/* | sed -e 's|^rootfs-complete||' | grep -vE '/dev/|/proc/|/sys/') #|/initrd/|/tmp/|/var/|/run/|/mnt/
 	chroot rootfs-complete find $dirs -type l ! -exec test -e {} \; -print > /tmp/invalidsymlinks
@@ -972,7 +972,7 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 	echo "Building ${DEVXSFS}..."
 	cd $WKGDIR
 
-	if [ "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH" -o -n "$QEMU" ] ; then
+	if [ $CROSSBUILD -eq 0 -o -n "$QEMU" ] ; then
 		#earlier above i moved all invalid symlinks into the devx module, yeah but i
 		#think should delete them if they really point nowhere...
 		echo " Deleting really invalid symlinks in devx..."

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -276,13 +276,27 @@ fi
 echo "removing obsolete libtool *.la files"
 find sandbox3/rootfs-complete/ sandbox3/devx/ -type f -name "*.la" -delete # delete old libtool files
 
-QEMU=`command -v qemu-${WOOF_TARGETARCH}-static`
+NEEDQEMU=0
+QEMU=
+if [ "$WOOF_HOSTARCH" != "$WOOF_TARGETARCH" ]; then
+	# exception: qemu-user-static is not needed if it's a x86_64 to x86 cross-build
+	if [ "$WOOF_HOSTARCH" != "x86_64" -o "$WOOF_TARGETARCH" != "x86" ]; then
+		NEEDQEMU=1
+		if [ "$WOOF_TARGETARCH" = "x86" ]; then
+			QEMU=`command -v qemu-i386-static`
+		else
+			QEMU=`command -v qemu-${WOOF_TARGETARCH}-static`
+		fi
+	fi
+fi
 [ -n "$QEMU" ] && install -D -m 755 $QEMU rootfs-complete/${QEMU}
 
 if [ -n "$PETBUILDS" ]; then
-	if [ "$WOOF_HOSTARCH" != "$WOOF_TARGETARCH" -a -z "$QEMU" ]; then
+	if [ $NEEDQEMU -eq 1 -a -z "$QEMU" ]; then
 		echo "petbuilds need qemu-user-static!"
 		exit 1
+	elif [ $NEEDQEMU -eq 0 ]; then
+		echo "Building without qemu-user-static"
 	fi
 
 	cd sandbox3

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -19,6 +19,13 @@ MAKEFLAGS=-j`nproc`
 
 HAVE_ROOTFS=0
 HAVE_BUSYBOX=0
+
+CHROOT_PFIX=
+if [ "$WOOF_HOSTARCH" = "x86_64" -a "$WOOF_TARGETARCH" = "x86" ]; then
+    echo "Simulating a 32-bit kernel"
+    CHROOT_PFIX=linux32
+fi
+
 PETBUILD_GTK=2
 if [ "$DISTRO_TARGETARCH" = "x86" ]; then
     echo "Using GTK+ 2 for x86 petbuilds"
@@ -37,6 +44,7 @@ else
         echo "Using GTK+ 2 for petbuilds, GTK+ 3 is missing"
     fi
 fi
+
 HERE=`pwd`
 PKGS=
 
@@ -150,7 +158,7 @@ for NAME in $PETBUILDS; do
 
         cp -a ../petbuild-sources/${NAME}/* petbuild-rootfs-complete-${NAME}/tmp/
         cp -a ../rootfs-petbuilds/${NAME}/* petbuild-rootfs-complete-${NAME}/tmp/
-        CC="$WOOF_CC" CXX="$WOOF_CXX" CFLAGS="$WOOF_CFLAGS" CXXFLAGS="$WOOF_CXXFLAGS" LDFLAGS="$WOOF_LDFLAGS" MAKEFLAGS="$MAKEFLAGS" CCACHE_DIR=/root/.ccache CCACHE_NOHASHDIR=1 PKG_CONFIG_PATH="$PKG_CONFIG_PATH" PYTHONDONTWRITEBYTECODE=1 PETBUILD_GTK=$PETBUILD_GTK chroot petbuild-rootfs-complete-${NAME} bash -ec "cd /tmp && . ./petbuild && build"
+        CC="$WOOF_CC" CXX="$WOOF_CXX" CFLAGS="$WOOF_CFLAGS" CXXFLAGS="$WOOF_CXXFLAGS" LDFLAGS="$WOOF_LDFLAGS" MAKEFLAGS="$MAKEFLAGS" CCACHE_DIR=/root/.ccache CCACHE_NOHASHDIR=1 PKG_CONFIG_PATH="$PKG_CONFIG_PATH" PYTHONDONTWRITEBYTECODE=1 PETBUILD_GTK=$PETBUILD_GTK $CHROOT_PFIX chroot petbuild-rootfs-complete-${NAME} bash -ec "cd /tmp && . ./petbuild && build"
         ret=$?
         umount -l petbuild-rootfs-complete-${NAME}/root/.ccache
         umount -l petbuild-rootfs-complete-${NAME}/tmp


### PR DESCRIPTION
There's no point in copying the qemu-user executable into rootfs-complete.

Also, it is possible to chroot into rootfs-complete, if it's a build for x from x, a build for x from y but qemu-user-static is present, **or if it's a build for x86 from x86_64**. This means more work can be done using tools like rsvg2-convert from the built Puppy, making it possible to run woof-CE without all these tools on the host, and without fear of version inconsistencies.