### PR TITLE
Get rid of the second startxwayland process

### DIFF
--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -62,7 +62,7 @@ while ! xdpyinfo >/dev/null 2>&1; do
     fi
 done
 
-[ -n "$XWAYLAND_SCREENSAVER_DELAY" ] && swayidle -w timeout "$XWAYLAND_SCREENSAVER_DELAY" 'sh -c "exec xlock -nolock `cat ~/.config/Xlock/xlockscreenparams 2>/dev/null`"' > /dev/null 2>&1 &
+[ -n "$XWAYLAND_SCREENSAVER_DELAY" ] && exec swayidle -w timeout "$XWAYLAND_SCREENSAVER_DELAY" 'sh -c "exec xlock -nolock `cat ~/.config/Xlock/xlockscreenparams 2>/dev/null`"' > /dev/null 2>&1 &
 
 export WAYLAND_DISPLAY=null
 export GDK_BACKEND=x11


### PR DESCRIPTION
It's confusing to see not one, but two `startxwayland` lines in `ps`!