### PR TITLE
Make kernel-kit build artifacts smaller

### DIFF
--- a/.github/workflows/kernel-kit.yml
+++ b/.github/workflows/kernel-kit.yml
@@ -47,7 +47,7 @@ jobs:
           sudo cp -f ${{ matrix.kernel-kit-config }}-build.conf build.conf
           sudo -E ./build.sh
           sudo mkdir small-output
-          sudo mv output/*.{sfs,tar}* small-output/
+          sudo mv `ls output/kernel_sources-*.sfs* output/*.tar* 2>/dev/null` small-output
       - name: Upload kernel
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
There's a second copy of fdrv and zdrv outside of the tarball, and 3builddistro doesn't need it.