### PR TITLE
Check if the package directory exists before running _PRE

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -114,6 +114,8 @@ STRIP_BIN="`which strip`"
 rm -f ERROR-2CREATEPACKAGES 2>/dev/null
 
 pre_process_pkg() {
+	[ ! -d ${PKG_DIR} ] && return
+
 	# before processing the whole package, check if there is a _PRE file
 	# which contains code to fix/trim dowm stuff to speed up processing...
 	if [ -f ${MWD}/packages-templates/${GENERICNAME}/_PRE ] ; then


### PR DESCRIPTION
```
2021-08-16T01:43:35.8326341Z 
2021-08-16T01:43:35.8327610Z Processing ncurses
2021-08-16T01:43:35.8352862Z  processing libncurses-dev_6.2+20201114-2_amd64.deb
2021-08-16T01:43:35.8827506Z  executing packages-templates/ncurses_PRE
2021-08-16T01:43:35.8831449Z ./2createpackages: line 124: cd: /home/runner/work/woof-CE/woof-out_x86_64_x86_64_debian_bullseye64/packages-dpupbullseye64/ncurses: No such file or directory
2021-08-16T01:43:35.8853727Z  processing libncurses6_6.2+20201114-2_amd64.deb
2021-08-16T01:43:35.8994005Z  executing packages-templates/ncurses_PRE
2021-08-16T01:43:35.9018862Z  processing libncursesw6_6.2+20201114-2_amd64.deb
2021-08-16T01:43:35.9182647Z  executing packages-templates/ncurses_PRE
2021-08-16T01:43:35.9211348Z  processing libtinfo6_6.2+20201114-2_amd64.deb
2021-08-16T01:43:35.9557014Z  executing packages-templates/ncurses_PRE
2021-08-16T01:43:35.9558835Z  processing ncurses-base_6.2+20201114-2_all.deb
2021-08-16T01:43:35.9676718Z  executing packages-templates/ncurses_PRE
2021-08-16T01:43:35.9704639Z  processing ncurses-bin_6.2+20201114-2_amd64.deb
2021-08-16T01:43:35.9986552Z  executing packages-templates/ncurses_PRE
```