### PR TITLE
Revert commits referenced in #2450

### DIFF
--- a/woof-distro/x86/ubuntu/upupbb/_00build.conf
+++ b/woof-distro/x86/ubuntu/upupbb/_00build.conf
@@ -13,9 +13,6 @@ STRIP_BINARIES=yes
 ## UnionFS: aufs or overlay
 UNIONFS=aufs
 
-## replace /bin, /sbin, /lib* with symlinks to /usr? yes/no
-#USR_SYMLINKS=no
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -13,9 +13,6 @@ STRIP_BINARIES=yes
 ## UnionFS: aufs or overlay
 UNIONFS=aufs
 
-## replace /bin, /sbin, /lib* with symlinks to /usr? yes/no
-#USR_SYMLINKS=no
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -13,9 +13,6 @@ STRIP_BINARIES=yes
 ## UnionFS: aufs or overlay
 UNIONFS=aufs
 
-## replace /bin, /sbin, /lib* with symlinks to /usr? yes/no
-#USR_SYMLINKS=no
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=yes
 


### PR DESCRIPTION
The /usr feature (#2445) is not merged yet (and maybe won't be merged), it's off by default and it's disabled in legacy Puppy versions. These three lines, intended to protect woof-CE users against possibly problematic future woof-CE changes, don't do anything, and might mislead them into enabling this feature, which is not implemented.