### PR TITLE
Add squashfs-tools petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/squashfs-tools/pet.specs
+++ b/woof-code/rootfs-petbuilds/squashfs-tools/pet.specs
@@ -1,0 +1,1 @@
+squashfs-tools-4.5|squashfs-tools|4.5||BuildingBlock|1K||squashfs-tools-4.5.pet||Squashfs file system tools|puppy|||

--- a/woof-code/rootfs-petbuilds/squashfs-tools/petbuild
+++ b/woof-code/rootfs-petbuilds/squashfs-tools/petbuild
@@ -5,5 +5,5 @@ download() {
 build() {
     tar -xzf squashfs-tools-4.5.tar.gz
     cd squashfs-tools-4.5/squashfs-tools
-    make XZ_SUPPORT=1 ZSTD_SUPPORT=1 LZO_SUPPORT=1 install
+    make XZ_SUPPORT=1 ZSTD_SUPPORT=1 LZO_SUPPORT=1 INSTALL_DIR=/usr/bin install
 }

--- a/woof-code/rootfs-petbuilds/squashfs-tools/petbuild
+++ b/woof-code/rootfs-petbuilds/squashfs-tools/petbuild
@@ -1,0 +1,9 @@
+download() {
+    [ -f squashfs-tools-4.5.tar.gz ] || wget -t 1 -T 15 -O squashfs-tools-4.5.tar.gz https://github.com/plougher/squashfs-tools/archive/refs/tags/4.5.tar.gz
+}
+
+build() {
+    tar -xzf squashfs-tools-4.5.tar.gz
+    cd squashfs-tools-4.5/squashfs-tools
+    make XZ_SUPPORT=1 ZSTD_SUPPORT=1 LZO_SUPPORT=1 install
+}

--- a/woof-code/rootfs-petbuilds/squashfs-tools/sha256.sum
+++ b/woof-code/rootfs-petbuilds/squashfs-tools/sha256.sum
@@ -1,0 +1,1 @@
+b9e16188e6dc1857fe312633920f7d71cc36b0162eb50f3ecb1f0040f02edddd  squashfs-tools-4.5.tar.gz

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -440,7 +440,7 @@ no|pcmanfm|pcmanfm,libfm4,libfm-data,libfm-extra4,libfm-gtk4,libfm-gtk-data,libm
 no|pup-volume-monitor||exe
 yes|lzma|lzma|exe,dev,doc,nls||deps:yes
 yes|lz4|liblz4-1|exe,dev,doc,nls||deps:yes
-yes|lzo2|liblzo2-2|exe,dev,doc,nls||deps:yes
+yes|lzo2|liblzo2-2,liblzo2-dev|exe,dev,doc,nls||deps:yes
 no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
@@ -582,7 +582,7 @@ yes|sgml-data|sgml-data|exe>dev,dev,doc,nls||deps:yes
 yes|shared-mime-info|shared-mime-info|exe,dev,doc,nls||deps:yes
 no|simple-mtpfs||exe,dev,doc,nls #pupmtp
 yes|sqlite|libsqlite3-0|exe,dev,doc,nls||deps:yes
-yes|squashfs-tools|squashfs-tools|exe,dev,doc,nls||deps:yes
+yes|squashfs-tools-null|squashfs-tools|exe>null,dev>null,doc>null,nls>null
 no|ssh_gui||exe
 no|startup-notification|libstartup-notification0,libstartup-notification0-dev|exe,dev,doc,nls
 yes|strace|strace|exe>dev,dev,doc,nls||deps:yes
@@ -658,7 +658,7 @@ no|yasm|yasm|exe>dev,dev>null,doc,nls
 no|YASSM||exe,dev>null,doc,nls
 yes|zip|zip|exe,dev>null,doc,nls||deps:yes
 yes|zlib|zlib1g,zlib1g-dev|exe,dev,doc,nls||deps:yes
-yes|zstd|zstd|exe,dev,doc,nls||deps:yes
+yes|zstd|zstd,libzstd-dev|exe,dev,doc,nls||deps:yes
 no|zzznet||exe
 '
 

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -38,7 +38,7 @@ BUILD_DEVX=yes
 DEVX_IN_ISO=no
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme eudev firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad"
+PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme eudev firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad squashfs-tools"
 
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes


### PR DESCRIPTION
This allows us to upgrade squashfs-tools to a newer version.

I want to use the new "actions" feature in squashfs-tools 4.5 to achieve a better compression ratio for the main SFS, in a separate PR.