### PR TITLE
disable xerrs.log in dpup

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -68,7 +68,7 @@ PTHEME="431"
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
 ## For testing builds XERRS_FLG=yes is recommended. If the target device is low RAM suggest to leave this unset, especially for release
-XERRS_FLG=yes
+#XERRS_FLG=yes
 
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=y


### PR DESCRIPTION
There's an endless stream of wlroots errors under QEMU with `-vga cirrus`, and this eats up RAM:

![cirrus](https://user-images.githubusercontent.com/1471149/130395818-db2b8484-9f80-40e2-ad98-d004710633a3.png)
