### PR TITLE
Make Alt-Tab more consistent with other distros

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -187,7 +187,7 @@
 <Key mask="A" key="bracketleft">maxleft</Key>
 <Key mask="A" key="bracketright">maxright</Key>
 
-<Key mask="A" key="Tab">next</Key>
+<Key mask="A" key="Tab">nextstacked</Key>
 <Key mask="A" key="F4">close</Key>
 <Key mask="CA" key="Right">rdesktop</Key>
 <Key mask="CA" key="Left">ldesktop</Key>

--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -188,6 +188,7 @@
 <Key mask="A" key="bracketright">maxright</Key>
 
 <Key mask="A" key="Tab">nextstacked</Key>
+<Key mask="AS" key="Tab">prevstacked</Key>
 <Key mask="A" key="F4">close</Key>
 <Key mask="CA" key="Right">rdesktop</Key>
 <Key mask="CA" key="Left">ldesktop</Key>


### PR DESCRIPTION
This makes JWM behave more like MATE, GNOME and Windows. Not 100% there, but a huge improvement IMHO.

`next` makes JWM iterate over taskbar items, while `nextstacked` makes it iterate over windows in the stacking order. When using `nextstacked`, pressing Alt-Tab makes JWM focus window B, and another Alt-Tab makes JWM focus window A once again. With `next`, the second Alt-Tab makes JWM proceed to the next window in the taskbar, and that's 1) inconsistent with the Alt-Tab behavior outside of the Puppy world and 2) annoying, because you have to cycle through all open windows to return to the previously focused window. 