### PR TITLE
Offer ext4 without a journal, not ext3, as an alternative to ext4

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -397,16 +397,22 @@ choosefs(){
  T_fstitle="$(gettext 'First shutdown: choose filesystem')"
  T_fsmenu="$(gettext 'Previously, Puppy has only used 'ext2', now there is a choice. Regarding power-failure, note that Puppy will do a f.s. check at next boot so ext2 can recover, however journalled filesystems can recover even without a f.s. check. If in doubt, choose 'ext2'. After making the choice, click OK button...')"
  T_ext2="$(gettext 'Maximum storage space, encrypted save-file must use ext2')"
- T_ext3="$(gettext 'Journalled f.s., safest if power failure etc.')"
+ T_ext4="$(gettext 'Non-journaled f.s., may extend drive lifespan.')"
  #120427 01micko: support ext4...
- T_ext4="$(gettext 'Journalled f.s., safest if power failure etc.')"
+ T_journaled_ext4="$(gettext 'Journalled f.s., safest if power failure etc.')"
  if [ "`grep 'ext4$' /proc/filesystems`" != "" ];then #120428 technosaurus: simplify test. 
-  ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fstitle" --no-cancel --default-item ext4 --menu "$T_fsmenu" 0 0 0 ext2 "$T_ext2" ext3 "$T_ext3"  ext4 "$T_ext4" 2>/tmp/rc.shutdown_pupsave_fs #120425 01micko
+  ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fstitle" --no-cancel --default-item "Journaled ext4" --menu "$T_fsmenu" 0 0 0 ext2 "$T_ext2" ext4 "$T_ext4" "Journaled ext4" "$T_journaled_ext4" 2>/tmp/rc.shutdown_pupsave_fs #120425 01micko
  else
   ${DIALOGEXE} ${BACKGROUNDYELLOW} ${TITLEPARAM} "$T_fstitle" --no-cancel --default-item ext3 --menu "$T_fsmenu" 0 0 0 ext2 "$T_ext2" ext3 "$T_ext3"  2>/tmp/rc.shutdown_pupsave_fs #110926
  fi
  SFFS="`cat /tmp/rc.shutdown_pupsave_fs`"
  [ "$SFFS" = "" ] && SFFS='ext2'
+ SFFSOPTS=''
+ if [ "$SFFS" = "Journaled ext4" ]; then
+   SFFS='ext4'
+ elif [ "$SFFS" = "ext4" ]; then
+   SFFSOPTS='-O ^has_journal'
+ fi
  SFEXTNUM="`echo -n "$SFFS" | cut -c 4`"
  SFEXT="${SFEXTNUM}fs" #ex: 2fs
 }
@@ -591,7 +597,7 @@ If anything looks wrong, choose \Zb\\\${T_notsave}\ZB...\"`"
  sync
  echo "`eval_gettext \"Creating a \\\${SFFS} filesystem in \\\${NAMEONLY}...\"`"
  if [ "$CRYPTO" = "" ];then
-  mkfs.${SFFS} -q -m 0 -F ${SMNTPT}$SAVEFILE
+  mkfs.${SFFS} -q -m 0 -F ${SFFSOPTS} ${SMNTPT}$SAVEFILE
   #...default is f.s. auto checked every 26 mounts or 180 days. tune2fs to change.
   pupkill $w1PID #130525 moved down.
  else


### PR DESCRIPTION
ext4 should be faster, and a better file system overall. There's no reason to choose ext3 over ext4, because Puppy supports ext4 since 4.3. However, there is a case for ext4 without journaling - it may be a more flash memory friendly option.