### PR TITLE
Use square window borders in 412

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes/Gradient_grey-jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/usr/share/jwm/themes/Gradient_grey-jwmrc
@@ -4,6 +4,7 @@
 	<WindowStyle> 
 		<Font>DejaVu Sans-10</Font> 
 		<Width>3</Width> 
+		<Corner>0</Corner>
 		<Height>22</Height>      
 		<Active> 
 			<Foreground>black</Foreground>


### PR DESCRIPTION
This is more historically accurate, and makes JWM more consistent with GTK+ 3 applications with CSD:

![before](https://user-images.githubusercontent.com/1471149/131245481-8cdceafd-ec36-4ab5-b321-98d9057dc17b.png)

![after](https://user-images.githubusercontent.com/1471149/131245519-11b0267b-31c7-43e8-8eeb-e4bfe9d92d4e.png)
