### PR TITLE
Disable the Bluman tray applet on x86 to save RAM if Bluetooth is unused

### DIFF
--- a/woof-code/packages-templates/blueman_FIXUPHACK
+++ b/woof-code/packages-templates/blueman_FIXUPHACK
@@ -6,3 +6,6 @@ chroot . /usr/sbin/setup-spot blueman-applet=true
 chroot . /usr/sbin/setup-spot blueman-manager=true
 [ -f root/.spot-status.orig ] && mv -f root/.spot-status.orig root/.spot-status || rm -f root/.spot-status
 EOF
+
+# the tray applet is written in Python and eats up precious RAM
+[ "$DISTRO_TARGETARCH" = "x86" ] && rm -vf etc/xdg/autostart/blueman.desktop


### PR DESCRIPTION
It's super expensive!

![python3](https://user-images.githubusercontent.com/1471149/132364485-32dc9af7-7f4f-42c1-bf15-ffd1deefe7d7.png)
