### PR TITLE
Lock the screen only if not locked already

### DIFF
--- a/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
+++ b/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
@@ -42,7 +42,7 @@ rmmod ehci_hcd
 case "$DISABLE_LOCK" in
 y*|Y*|true|True|TRUE|1) echo -n mem > /sys/power/state ;;
 *)
-  if [ -n "$DISPLAY" ]; then
+  if [ -n "$DISPLAY" -a -z "`pidof xlock`" ]; then
     xlock -startCmd "echo mem > /sys/power/state"
   else
     echo -n mem > /sys/power/state

--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -62,7 +62,7 @@ while ! xdpyinfo >/dev/null 2>&1; do
     fi
 done
 
-[ -n "$XWAYLAND_SCREENSAVER_DELAY" ] && exec swayidle -w timeout "$XWAYLAND_SCREENSAVER_DELAY" 'sh -c "exec xlock -nolock `cat ~/.config/Xlock/xlockscreenparams 2>/dev/null`"' > /dev/null 2>&1 &
+[ -n "$XWAYLAND_SCREENSAVER_DELAY" ] && exec swayidle -w timeout "$XWAYLAND_SCREENSAVER_DELAY" 'sh -c "pidof xlock || exec xlock -nolock `cat ~/.config/Xlock/xlockscreenparams 2>/dev/null`"' > /dev/null 2>&1 &
 
 export WAYLAND_DISPLAY=null
 export GDK_BACKEND=x11


### PR DESCRIPTION
This should fix issues like two xlock instances, if closing the laptop lid while the screen is locked.