### PR TITLE
Remove automatic redirection of petbuilds to adrv (#2492)

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -284,11 +284,16 @@ for NAME in $PKGS; do
     cat ../packages-${DISTRO_FILE_PREFIX}/${NAME}/pet.specs >> /tmp/petbuild-output.specs
 
     # redirect packages with menu entries to adrv, with exceptions
-    if [ -n "$ADRV_INC" ] && [ "$NAME" != "rox-filer" ] && [ "$NAME" != "lxterminal" ] && [ "$NAME" != "leafpad" ] && [ "$NAME" != "l3afpad" ] && [ "$NAME" != "gexec" ] && [ -n "`ls ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/applications/*.desktop 2>/dev/null`" ]; then
-        ADRV_INC="$ADRV_INC $NAME"
-    elif [ -n "$MAINPKGS" ]; then
+    COPY=1
+    for DRVPKG in $ADRV_INC $YDRV_INC $FDRV_INC; do
+        [ "$DRVPKG" != "$NAME" ] && continue
+        COPY=0
+        break
+    done
+
+    if [ $COPY -eq 1 -a -n "$MAINPKGS" ]; then
         MAINPKGS="$MAINPKGS $NAME"
-    else
+    elif [ $COPY -eq 1 ]; then
         MAINPKGS="$NAME"
     fi
 done

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -21,7 +21,7 @@ KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"
-ADRV_INC="firefox-esr galculator libavcodec libva"
+ADRV_INC="firefox-esr galculator libavcodec libva geany gpicview lxtask mtpaint sylpheed transmission xarchiver"
 ## YDRV_INC=""
 YDRV_INC=""
 ## FDRV_INC="" #this one is very experimental and it's recommended to be left unset

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -25,7 +25,7 @@ KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"
-ADRV_INC="abiword asunder claws-mail clipit conky conky-gtk deadbeef Dunst-config easytag eboardchess findnrun fpm2 galculator gatotray gdmap get_libreoffice gexec gftp gmeasures gnumeric goffice gogglesmm gplanarity gtkhash guvcview gview gwaveedit haiku hardinfo hexalate hexchat hiawatha homebank htop inkscapelite iqpuzzle isomaster ListDDF lxrandr notecase osmo PackIt palemoon pdvdrsab peasyport picpuz pmirrorget pnethood pplog psip PupClockset Pup-SysInfo qpdfview QtNote rubix simplegtkradio simplescreenrecorder simsu uextract uget UrxvtControl xvkbd yahtzeez"
+ADRV_INC="abiword asunder claws-mail clipit conky conky-gtk deadbeef Dunst-config easytag eboardchess findnrun fpm2 galculator gatotray gdmap get_libreoffice gexec gftp gmeasures gnumeric goffice gogglesmm gplanarity gtkhash guvcview gview gwaveedit haiku hardinfo hexalate hexchat hiawatha homebank htop inkscapelite iqpuzzle isomaster ListDDF lxrandr notecase osmo PackIt palemoon pdvdrsab peasyport picpuz pmirrorget pnethood pplog psip PupClockset Pup-SysInfo qpdfview QtNote rubix simplegtkradio simplescreenrecorder simsu uextract uget UrxvtControl xvkbd yahtzeez geany gpicview lxtask mtpaint transmission xarchiver"
 ## YDRV_INC=""
 YDRV_INC=""
 ## FDRV_INC="" #this one is very experimental and it's recommended to be left unset


### PR DESCRIPTION
Instead of redirecting all petbuilds with a .desktop file (with exceptions) to adrv if ADRV_INC is non-empty, this PR makes petbuilds.sh respect ADRV_INC.