### PR TITLE
Put libramsaver.so.1 alongside libc.so.6

### DIFF
--- a/woof-code/rootfs-petbuilds/ram-saver/petbuild
+++ b/woof-code/rootfs-petbuilds/ram-saver/petbuild
@@ -3,5 +3,5 @@ download() {
 }
 
 build() {
-    $CC $CFLAGS ramsaver.c $LDFLAGS -shared -o `dirname $(ldd /bin/bash | grep libc.so.6 | cut -f 3 -d ' ')`/libramsaver.so.1
+    $CC $CFLAGS ramsaver.c $LDFLAGS -shared -o `dirname $(ldd /usr/bin/gcc | grep libc.so.6 | cut -f 3 -d ' ')`/libramsaver.so.1
 }

--- a/woof-code/rootfs-petbuilds/ram-saver/petbuild
+++ b/woof-code/rootfs-petbuilds/ram-saver/petbuild
@@ -3,6 +3,5 @@ download() {
 }
 
 build() {
-    mkdir -p /usr/libexec/ram-saver
-    $CC $CFLAGS ramsaver.c $LDFLAGS -shared -o /usr/libexec/ram-saver/libramsaver.so.1
+    $CC $CFLAGS ramsaver.c $LDFLAGS -shared -o `dirname $(ldd /bin/bash | grep libc.so.6 | cut -f 3 -d ' ')`/libramsaver.so.1
 }

--- a/woof-code/rootfs-petbuilds/ram-saver/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/ram-saver/pinstall.sh
@@ -1,1 +1,1 @@
-patchelf --add-needed /usr/libexec/ram-saver/libramsaver.so.1 ./`chroot . ldd /bin/bash | grep libc.so.6 | cut -f 3 -d ' '` || exit 1
+patchelf --add-needed libramsaver.so.1 ./`chroot . ldd /bin/bash | grep libc.so.6 | cut -f 3 -d ' '` || exit 1


### PR DESCRIPTION
Without this, it's impossible to take /usr/lib from 32-bit dpup and load it in 64-bit dpup, to run 32-bit applications like wine or Steam.