### PR TITLE
Support file:// URLs in download_file.sh

### DIFF
--- a/woof-code/support/download_file.sh
+++ b/woof-code/support/download_file.sh
@@ -22,11 +22,20 @@ if [ ! -f ${DOWNLOAD_DIR}"${FILE}" ] ; then
 	if [ -f "$URL" ] ; then # full path
 		cp -a "$URL" "${FILE}"
 	else
-		wget -P ${DOWNLOAD_DIR} --no-check-certificate "${URL}"
-		if [ $? -ne 0 ] ; then
-			rm -fv ${DOWNLOAD_DIR}"${FILE}"
-			exit 1
-		fi
+		case "$URL" in
+		file://*)
+			FPATH="${URL#file://}"
+			cp -f "${FPATH}" ${DOWNLOAD_DIR}/ || exit 1
+			;;
+
+		*)
+			wget -P ${DOWNLOAD_DIR} --no-check-certificate "${URL}"
+			if [ $? -ne 0 ] ; then
+				rm -fv ${DOWNLOAD_DIR}"${FILE}"
+				exit 1
+			fi
+			;;
+		esac
 	fi
 fi
 


### PR DESCRIPTION
This allows things like, `YDRV_SFS_URL=file:///path/to/ydrv.sfs`, so ydrv doesn't have to be downloaded.

See https://github.com/dpupos/woof-CE/runs/3638996058 for an example: ydrv is built locally, YDRV_SFS_URL is changed, then woof-CE runs and uses the pre-existing file.