### PR TITLE
Make rc.sysinit compatible with udev from systemd >= 246

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -370,6 +370,16 @@ if [ ! -e /bin/udevd ] && [ ! -e /sbin/udevd ] ; then
 	fi
 fi
 
+if [ -f /lib/systemd/systemd-udevd ] ; then
+  # since systemd 246 (https://github.com/systemd/systemd/commit/6b2229c6c60d0486f5eb9ed3088f9c780d7c0233), udev doesn't create these
+  rm -f /dev/core /dev/fd /dev/stdin /dev/stdout /dev/stderr
+  ln -s /proc/kcore /dev/core
+  ln -s /proc/self/fd /dev/fd
+  ln -s /proc/self/fd/0 /dev/stdin
+  ln -s /proc/self/fd/1 /dev/stdout
+  ln -s /proc/self/fd/2 /dev/stderr
+fi
+
 #110502 change 'never' to 'early', fixes device nodes created with correct owner:group...
 if [ "$BOOT_UDEVDCHILDREN" ];then #120709
    udevd --daemon --resolve-names=early --children-max=${BOOT_UDEVDCHILDREN} #BOOT_UDEVDCHILDREN=1 good idea?

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -370,7 +370,7 @@ if [ ! -e /bin/udevd ] && [ ! -e /sbin/udevd ] ; then
 	fi
 fi
 
-if [ -f /lib/systemd/systemd-udevd ] ; then
+if [ -e /lib/systemd/systemd-udevd ] ; then
   # since systemd 246 (https://github.com/systemd/systemd/commit/6b2229c6c60d0486f5eb9ed3088f9c780d7c0233), udev doesn't create these
   rm -f /dev/core /dev/fd /dev/stdin /dev/stdout /dev/stderr
   ln -s /proc/kcore /dev/core


### PR DESCRIPTION
pupdialog uses /dev/stderr, and if it's missing or broken, its output is empty and shutdownconfig doesn't do anything.