### PR TITLE
Keep tray icon right-click menus after the mouse key is released

### DIFF
--- a/woof-code/rootfs-petbuilds/firewallstatus/firewallstatus-0.7/firewallstatus.c
+++ b/woof-code/rootfs-petbuilds/firewallstatus/firewallstatus-0.7/firewallstatus.c
@@ -158,7 +158,7 @@ void tray_icon_on_menu(GtkStatusIcon *status_icon,
 	}
     
 	gtk_widget_show_all(menu);
-	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, gdk_event_get_time(NULL));
+	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, gtk_get_current_event_time());
 }
 
 /* -create icon and 'click' properties */

--- a/woof-code/rootfs-petbuilds/freememapplet/grab.patch
+++ b/woof-code/rootfs-petbuilds/freememapplet/grab.patch
@@ -1,0 +1,12 @@
+diff -rupN freememapplet-2.8.6-org/freememapplet_tray.c freememapplet-2.8.6/freememapplet_tray.c
+--- freememapplet-2.8.6-org/freememapplet_tray.c	2021-09-25 11:12:28.819925060 +0300
++++ freememapplet-2.8.6/freememapplet_tray.c	2021-09-25 11:12:37.351907749 +0300
+@@ -162,7 +162,7 @@ void tray_icon_on_menu(GtkStatusIcon *st
+ 	gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
+ 	
+ 	gtk_widget_show_all(menu);
+-	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, gdk_event_get_time(NULL));
++	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, gtk_get_current_event_time());
+ }
+ 
+ static GtkStatusIcon *create_tray_icon() {

--- a/woof-code/rootfs-petbuilds/freememapplet/petbuild
+++ b/woof-code/rootfs-petbuilds/freememapplet/petbuild
@@ -5,6 +5,7 @@ download() {
 build() {
     tar -xjf freememapplet-2.8.6.tar.bz2
     cd freememapplet-2.8.6
+    patch -p1 < ../grab.patch
     if [ $PETBUILD_GTK -eq 3 ]; then
         patch -p1 < ../gtk3.patch
         $CC $CFLAGS `pkg-config --cflags gtk+-3.0` freememapplet_tray.c $LDFLAGS `pkg-config --libs gtk+-3.0` -o /usr/bin/freememapplet_tray

--- a/woof-code/rootfs-petbuilds/netmon_wce/netmon_wce-3.3/netmon_wce.c
+++ b/woof-code/rootfs-petbuilds/netmon_wce/netmon_wce-3.3/netmon_wce.c
@@ -510,7 +510,7 @@ void tray_icon_on_menu(GtkStatusIcon *status_icon, guint button, guint activate_
 		gtk_menu_shell_append(GTK_MENU_SHELL(menu), menuitem);
 	}
 	gtk_widget_show_all(menu);
-	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, gdk_event_get_time(NULL));
+	gtk_menu_popup(GTK_MENU(menu), NULL, NULL, NULL, NULL, button, gtk_get_current_event_time());
 }
 
 //left click callback


### PR DESCRIPTION
https://docs.gtk.org/gtk3/method.Menu.popup.html says:

```
The activate_time parameter is used to conflict-resolve initiation of concurrent requests for mouse/keyboard grab requests. To function properly, this needs to be the timestamp of the user event (such as a mouse click or key press) that caused the initiation of the popup. Only if no such event is available, gtk_get_current_event_time() can be used instead.
```

I found this bug in the Puppy tray applets when I checked if the connman-ui bug fixed in https://github.com/puppylinux-woof-CE/woof-CE/pull/2514/commits/e4cb2c2827538d081b27619b20230e537a429a8f (see grab.patch) happens with them too. It does.