### PR TITLE
Move PETBUILD_GTK to _00build.conf

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -28,6 +28,7 @@ fi
 
 if [ -z "$PETBUILD_GTK" ]; then
     echo "WARNING: PETBUILD_GTK is empty, this may be a hard error in the future"
+    [ -n "$GITHUB_ACTIONS" ] && exit 1
 
     PETBUILD_GTK=2
     if [ "$DISTRO_TARGETARCH" = "x86" ]; then

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -26,22 +26,26 @@ if [ "$WOOF_HOSTARCH" = "x86_64" -a "$WOOF_TARGETARCH" = "x86" ]; then
     CHROOT_PFIX=linux32
 fi
 
-PETBUILD_GTK=2
-if [ "$DISTRO_TARGETARCH" = "x86" ]; then
-    echo "Using GTK+ 2 for x86 petbuilds"
-else
-    GTK3_PC=`find ../packages-${DISTRO_FILE_PREFIX} -name gtk+-3.0.pc | head -n 1`
-    if [ -n "$GTK3_PC" ]; then
-        GTK3_VER=`awk '/Version:/{print $2}' "${GTK3_PC}"`
-        vercmp "$GTK3_VER" ge 3.24.18
-        if [ $? -eq 0 ]; then
-            echo "Using GTK+ 3 for petbuilds"
-            PETBUILD_GTK=3
-        else
-            echo "Using GTK+ 2 for petbuilds, GTK+ 3 is too old"
-        fi
+if [ -z "$PETBUILD_GTK" ]; then
+    echo "WARNING: PETBUILD_GTK is empty, this may be a hard error in the future"
+
+    PETBUILD_GTK=2
+    if [ "$DISTRO_TARGETARCH" = "x86" ]; then
+        echo "Using GTK+ 2 for x86 petbuilds"
     else
-        echo "Using GTK+ 2 for petbuilds, GTK+ 3 is missing"
+        GTK3_PC=`find ../packages-${DISTRO_FILE_PREFIX} -name gtk+-3.0.pc | head -n 1`
+        if [ -n "$GTK3_PC" ]; then
+            GTK3_VER=`awk '/Version:/{print $2}' "${GTK3_PC}"`
+            vercmp "$GTK3_VER" ge 3.24.18
+            if [ $? -eq 0 ]; then
+                echo "Using GTK+ 3 for petbuilds"
+                PETBUILD_GTK=3
+            else
+                echo "Using GTK+ 2 for petbuilds, GTK+ 3 is too old"
+            fi
+        else
+            echo "Using GTK+ 2 for petbuilds, GTK+ 3 is missing"
+        fi
     fi
 fi
 

--- a/woof-distro/x86/debian/bullseye/_00build_2.conf
+++ b/woof-distro/x86/debian/bullseye/_00build_2.conf
@@ -11,4 +11,5 @@
 DEFAULTAPPS="
 defaultconnect=sns
 "
+PETBUILD_GTK=2
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons ram-saver"

--- a/woof-distro/x86/slackware/14.2/_00build.conf
+++ b/woof-distro/x86/slackware/14.2/_00build.conf
@@ -52,6 +52,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=2
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 

--- a/woof-distro/x86/slackware/15.0/_00build.conf
+++ b/woof-distro/x86/slackware/15.0/_00build.conf
@@ -52,6 +52,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons ram-saver"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=2
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -40,6 +40,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons ram-saver connman-ui"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=3
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 

--- a/woof-distro/x86_64/slackware64/14.2/_00build.conf
+++ b/woof-distro/x86_64/slackware64/14.2/_00build.conf
@@ -52,6 +52,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=2
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 

--- a/woof-distro/x86_64/slackware64/15.0/_00build.conf
+++ b/woof-distro/x86_64/slackware64/15.0/_00build.conf
@@ -52,6 +52,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons ram-saver"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=3
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -41,6 +41,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="pmaterial_icons puppy_flat_icons puppy_standard_icons"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=2
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -52,6 +52,9 @@ DEVX_IN_ISO=no
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons"
 
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=3
+
 ## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
 LICK_IN_ISO=yes
 


### PR DESCRIPTION
This will be useful if:
1. @mrfricks decides to use GTK+ 2 to make his next Puppy closer to FossaPup 9.5 (https://forum.puppylinux.com/viewtopic.php?f=40&t=4138)
2. @peabee wants to use GTK+ 2 in a 64-bit build not based on an old distro like Ubuntu 18.04; the automatic PETBUILD_GTK choice logic in petbuilds.sh (what we have today) will pick GTK+ 3
3. @01micko decides to stick with GTK+ 2 for Slacko 8.x, and deal with GTK+ 3 related issues later, possibly in a point release
3.  I want to build a "lite" or "barebones" 64-bit flavor of dpup that uses the lighter GTK+ 2