### PR TITLE
use the same toolbar style for GTK+ 2 and 3

### DIFF
--- a/woof-code/rootfs-packages/ptheme/pinstall.sh
+++ b/woof-code/rootfs-packages/ptheme/pinstall.sh
@@ -97,12 +97,16 @@ include "/root/.gtkrc-2.0.mine"
 
 # -- THEME AUTO-WRITTEN BY gtk-theme-switch2 DO NOT EDIT
 gtk-theme-name = "${PTHEME_GTK}"
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 if [ -d usr/share/themes/${PTHEME_GTK}/gtk-3.0 ]; then
 	mkdir -p root/.config/gtk-3.0
 	cat > root/.config/gtk-3.0/settings.ini << _EOF
 [Settings]
 gtk-theme-name = ${PTHEME_GTK}
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 fi
 

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -36,6 +36,8 @@ set_gtk3_theme() {
 			cat > $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini << _EOF
 [Settings]
 gtk-theme-name = ${PTHEME_GTK3}
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 		fi
 	fi
@@ -77,6 +79,8 @@ include "/root/.gtkrc-2.0.mine"
 
 # -- THEME AUTO-WRITTEN BY gtk-theme-switch2 DO NOT EDIT
 gtk-theme-name = "${PTHEME_GTK}"
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 
 			set_gtk3_theme "$THEME"


### PR DESCRIPTION
Inspired by @mrfricks's imppup64.

I really liked this - existing Puppy users won't see this big change under the hood.

32-bit dpup, GTK+ 2:

![gtk2](https://user-images.githubusercontent.com/1471149/135537063-830c62de-c760-4b70-b495-1a7ca9083e5c.png)

64-bit dpup, GTK+ 3

![gtk3](https://user-images.githubusercontent.com/1471149/135540041-dedfd6bd-0fba-4a4f-9945-0a965c02189e.png)
:
