### PR TITLE
Make the Cage monitor layout configurable (Hjdskes/cage#212)

### DIFF
--- a/woof-code/rootfs-petbuilds/cage/placement.patch
+++ b/woof-code/rootfs-petbuilds/cage/placement.patch
@@ -1,24 +1,131 @@
-diff -rupN --exclude .git cage-clean/output.c cage/output.c
---- cage-clean/output.c	2021-09-30 19:51:28.904027424 +0800
-+++ cage/output.c	2021-09-30 19:51:02.636026799 +0800
-@@ -246,7 +246,19 @@ output_enable(struct cg_output *output)
+diff -rupN --exclude .git cage-orig/cage.1.scd cage/cage.1.scd
+--- cage-orig/cage.1.scd	2021-09-30 19:51:28.900027424 +0800
++++ cage/cage.1.scd	2021-10-01 11:44:22.352148643 +0800
+@@ -27,6 +27,11 @@ activities outside the scope of the runn
+ 	*last* Cage uses only the last connected monitor.
+ 	*extend* Cage extends the display across all connected monitors.
+ 
++*-e* <mode>
++	Set the monitor addition mode, if display is extended across all connected monitors.
++	*auto* Cage places monitors automatically.
++	*right* Cage places each newly-connected monitor on the right of the rightmost connected monitor.
++
+ *-r*
+ 	Rotate the output 90 degrees clockwise. This can be specified up to three
+ 	times, each resulting in an additional 90 degrees clockwise rotation.
+diff -rupN --exclude .git cage-orig/cage.c cage/cage.c
+--- cage-orig/cage.c	2021-09-30 19:51:28.900027424 +0800
++++ cage/cage.c	2021-10-01 12:01:08.576172558 +0800
+@@ -191,6 +191,8 @@ usage(FILE *file, const char *cage)
+ 		" -h\t Display this help message\n"
+ 		" -m extend Extend the display across all connected outputs (default)\n"
+ 		" -m last Use only the last connected output\n"
++		" -e auto Automatically place newly connected outputs (default)\n"
++		" -e right Place newly connected outputs on the right\n"
+ 		" -r\t Rotate the output 90 degrees clockwise, specify up to three times\n"
+ 		" -s\t Allow VT switching\n"
+ 		" -v\t Show the version number and exit\n"
+@@ -204,9 +206,9 @@ parse_args(struct cg_server *server, int
+ {
+ 	int c;
+ #ifdef DEBUG
+-	while ((c = getopt(argc, argv, "dDhm:rsv")) != -1) {
++	while ((c = getopt(argc, argv, "dDhm:e:rsv")) != -1) {
+ #else
+-	while ((c = getopt(argc, argv, "dhm:rsv")) != -1) {
++	while ((c = getopt(argc, argv, "dhm:e:rsv")) != -1) {
+ #endif
+ 		switch (c) {
+ 		case 'd':
+@@ -227,6 +229,13 @@ parse_args(struct cg_server *server, int
+ 				server->output_mode = CAGE_MULTI_OUTPUT_MODE_EXTEND;
+ 			}
+ 			break;
++		case 'e':
++			if (strcmp(optarg, "right") == 0) {
++				server->output_extend_mode = CAGE_OUTPUT_EXTEND_MODE_RIGHT;
++			} else if (strcmp(optarg, "auto") == 0) {
++				server->output_extend_mode = CAGE_OUTPUT_EXTEND_MODE_AUTO;
++			}
++			break;
+ 		case 'r':
+ 			server->output_transform++;
+ 			if (server->output_transform > WL_OUTPUT_TRANSFORM_270) {
+diff -rupN --exclude .git cage-orig/output.c cage/output.c
+--- cage-orig/output.c	2021-09-30 19:51:28.904027424 +0800
++++ cage/output.c	2021-10-01 12:04:23.032177179 +0800
+@@ -237,7 +237,7 @@ scan_out_primary_view(struct cg_output *
+ }
+ 
+ static void
+-output_enable(struct cg_output *output)
++output_enable(struct cg_server *server, struct cg_output *output)
+ {
+ 	struct wlr_output *wlr_output = output->wlr_output;
+ 
+@@ -246,7 +246,23 @@ output_enable(struct cg_output *output)
  	 * duplicate the enabled property in cg_output. */
  	wlr_log(WLR_DEBUG, "Enabling output %s", wlr_output->name);
  
 -	wlr_output_layout_add_auto(output->server->output_layout, wlr_output);
-+	/* Add the new output to the right of the rightmost display */
-+	int max_x = 0, max_x_y = 0;
-+	struct wlr_output_layout_output *l_output;
-+	wl_list_for_each(l_output, &output->server->output_layout->outputs, link) {
-+		int width, height;
-+		wlr_output_effective_resolution(l_output->output, &width, &height);
-+		if (l_output->x + width > max_x) {
-+			max_x = l_output->x + width;
-+			max_x_y = l_output->y;
++	if (server->output_extend_mode == CAGE_OUTPUT_EXTEND_MODE_RIGHT) {
++		int max_x = 0, max_x_y = 0;
++		struct wlr_output_layout_output *l_output;
++		wl_list_for_each(l_output, &output->server->output_layout->outputs, link) {
++			int width, height;
++			wlr_output_effective_resolution(l_output->output, &width, &height);
++			if (l_output->x + width > max_x) {
++				max_x = l_output->x + width;
++				max_x_y = l_output->y;
++			}
 +		}
++
++		wlr_output_layout_add(output->server->output_layout, wlr_output, max_x, max_x_y);
++	} else {
++		wlr_output_layout_add_auto(output->server->output_layout, wlr_output);
 +	}
 +
-+	wlr_output_layout_add(output->server->output_layout, wlr_output, max_x, max_x_y);
  	wlr_output_enable(wlr_output, true);
  	wlr_output_commit(wlr_output);
  }
+@@ -411,7 +427,7 @@ output_destroy(struct cg_output *output)
+ 	} else if (server->output_mode == CAGE_MULTI_OUTPUT_MODE_LAST) {
+ 		struct cg_output *prev = wl_container_of(server->outputs.next, prev, link);
+ 		if (prev) {
+-			output_enable(prev);
++			output_enable(server, prev);
+ 
+ 			struct cg_view *view;
+ 			wl_list_for_each (view, &server->views, link) {
+@@ -482,7 +498,7 @@ handle_new_output(struct wl_listener *li
+ 			wlr_output->scale);
+ 	}
+ 
+-	output_enable(output);
++	output_enable(server, output);
+ 
+ 	struct cg_view *view;
+ 	wl_list_for_each (view, &output->server->views, link) {
+diff -rupN --exclude .git cage-orig/server.h cage/server.h
+--- cage-orig/server.h	2021-09-30 19:51:28.904027424 +0800
++++ cage/server.h	2021-10-01 11:30:56.996129503 +0800
+@@ -21,6 +21,11 @@ enum cg_multi_output_mode {
+ 	CAGE_MULTI_OUTPUT_MODE_LAST,
+ };
+ 
++enum cg_output_extend_mode {
++	CAGE_OUTPUT_EXTEND_MODE_AUTO,
++	CAGE_OUTPUT_EXTEND_MODE_RIGHT,
++};
++
+ struct cg_server {
+ 	struct wl_display *wl_display;
+ 	struct wl_list views;
+@@ -33,6 +38,7 @@ struct cg_server {
+ 	struct wl_list inhibitors;
+ 
+ 	enum cg_multi_output_mode output_mode;
++	enum cg_output_extend_mode output_extend_mode;
+ 	struct wlr_output_layout *output_layout;
+ 	/* Includes disabled outputs; depending on the output_mode
+ 	 * some outputs may be disabled. */

--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -46,7 +46,7 @@ if [ -f ~/.Xresources ]; then
 	[ -n "$dpi" ] && args="$args -dpi $dpi"
 fi
 
-WLR_RENDERER_ALLOW_SOFTWARE=1 cage -ds -- Xwayland $DISPLAY -auth "$XAUTHORITY" $args &
+WLR_RENDERER_ALLOW_SOFTWARE=1 cage -ds -e right -- Xwayland $DISPLAY -auth "$XAUTHORITY" $args &
 pid=$!
 
 export DISPLAY


### PR DESCRIPTION
Instead of forcing placement on the right, https://github.com/Hjdskes/cage/pull/212 makes it possible to specify the layout via `-e right` and `-e auto`. In the future, we'll be able to add more modes (i.e. `grid`, `vertical`) if needed.