### PR TITLE
Use 5.10.x for 32-bit Slacko 8.x CI builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
           - arch: x86
             compat-distro: slackware
             compat-distro-version: "15.0"
-            kernel: 5.4.x-x86
+            kernel: 5.10.x-x86
           - arch: x86_64
             compat-distro: ubuntu
             compat-distro-version: bionic64


### PR DESCRIPTION
The 32-bit dpup already uses it, and it seems to work just fine.

More users means more bug fixes that benefit all users of this kernel package.