### PR TITLE
Switch to GTK+ 2 petbuilds on dpup ARM, but keep Cage and ConnMan

### DIFF
--- a/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
+++ b/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
@@ -10,4 +10,6 @@
 
 ADRV_INC=
 BUILD_CROS_IMAGE=yes
+PETBUILD_GTK=2
+PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver connman-ui"
 BOOT_BOARD='veyron-speedy'


### PR DESCRIPTION
My Asus C201 is the 2 GB model, and that's not much.

Everything is smoother and faster with Cage, so it's a keeper. ConnMan and Blueman are user friendly, so we keep them despite the RAM cost.

Everything else can use GTK+ 2.