### PR TITLE
SNS 3.2: reorganized, deprecate-free, enhanced upgrade

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
+++ b/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
@@ -1,5 +1,7 @@
-# Accumulate list of modules to be loaded, for use by rc.network.
+# Accumulate names of modules to be loaded, for use by rc.network -- if pup_event_backend_modprobe installed.
 
-ENV{MODALIAS}=="?*", ACTION=="add", SUBSYSTEM=="?*", \
-  PROGRAM="/usr/bin/test -s /etc/simple_network_setup/connections", \
-  RUN+="/usr/local/simple_network_setup/build_udevmodulelist"
+PROGRAM=="/usr/bin/test -x /sbin/pup_event_backend_modprobe", \
+  PROGRAM=="/usr/bin/test -s /etc/simple_network_setup/connections", \
+  SUBSYSTEM=="?*", SUBSYSTEM!="acpi|input|platform", \
+  ENV{MODALIAS}=="?*", ACTION=="add", \
+  RUN+="/usr/local/simple_network_setup/build_udevmodulelist $env{MODALIAS}"

--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-2.4.1|simple_network_setup|2.4.1||Network|144K||simple_network_setup-2.4.1.pet|+gtkdialog|Barry's simple network manager||||
+simple_network_setup-3.2|simple_network_setup|3.2||Network|160K||simple_network_setup-3.2.pet|+gtkdialog,+iw|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/pinstall.sh
+++ b/woof-code/rootfs-packages/simple_network_setup/pinstall.sh
@@ -1,3 +1,24 @@
 #!/bin/sh
+
+# Replace placeholder for link to sns.
 ln -snf /usr/local/simple_network_setup/sns usr/local/bin/
-rm -f usr/sbin/sns #old link
+
+#Version 3.0:
+if [ "$(pwd)" = '/' ]; then
+    if [ -e usr/sbin/sns ];then
+        if [ ! -L usr/sbin/sns ] \
+          || [ "$(readlink usr/sbin/sns)" != "/usr/local/simple_network_setup/sns" ];then
+             mv usr/sbin/sns usr/sbin/sns-old.bak
+             ln -snf /usr/local/simple_network_setup/sns usr/sbin/
+        fi
+    fi
+
+    grep '^..[^:]' etc/simple_network_setup/connections \
+      && [ ! -f etc/simple_network_setup/connections-oldformat ] \
+      && mv etc/simple_network_setup/connections etc/simple_network_setup/connections-oldformat
+
+    if ! which iw >/dev/null 2>&1; then
+        BACK_TITLE="This version of simple-network-setup cannot manage wireless connections, due to the absence of the 'iw' command in this installation, but can control wired ethernet connections."
+        Xdialog --wmclass pgitprep --title "SNS - Barry's Simple Network Setup" --backtitle "$BACK_TITLE" --left --wrap --msgbox "If you need wireless support, either install 'iw' if available or uninstall this package and install or use a 2.4.x version of simple-network-setup." 0 70
+    fi
+fi

--- a/woof-code/rootfs-packages/simple_network_setup/puninstall.sh
+++ b/woof-code/rootfs-packages/simple_network_setup/puninstall.sh
@@ -1,4 +1,10 @@
 #!/bin/sh
 # Restore old link to sns, if needed.
-[ -x /usr/local/bin/sns ] \
- || ln -s /usr/local/simple_network_setup/sns /usr/sbin/
+if [ -e /usr/sbin/sns-old.bak ];then
+    mv -f /usr/sbin/sns-old.bak /usr/sbin/sns
+    chmod +x
+fi
+
+#Version 3.0:
+[ -f /etc/simple_network_setup/connections-oldformat ] \
+  && mv -f /etc/simple_network_setup/connections-oldformat /etc/simple_network_setup/connections

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/build_udevmodulelist
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/build_udevmodulelist
@@ -4,33 +4,36 @@
 # The name may be different from the file name if a networking device is aliased to multiple driver modules or if a driver is blacklisted. 
 # Invoked by udev rule file 51-simple_network_setup.rules
 #201017 v2.4: Rewritten to save module names expected to be loaded, accessed by connection driver name (from /sys/class/net/*/device/driver link). 
+#210703 v3.1 Accept modalias as argument, to avoid depending on MODALIAS environment variable.
 
-[ -z "$MODALIAS" ] && exit
+[ -z "$1" ] && exit
+MODALIAS="$1"
 usleep 1000 #precaution for multiple cores
 MODULES="$(/sbin/modprobe -i --config /dev/null \
-  --show-depends $MODALIAS 2>/dev/null | \
+  --show-depends "$MODALIAS" 2>/dev/null | \
   grep -E '/kernel/drivers/net/|/kernel/drivers/staging/' | \
   grep -o '[^/]*\.ko' | cut -f 1 -d '.')"
 if [ -n "$MODULES" ]; then
-    MODULE="$(/sbin/modprobe -i --show-depends $MODALIAS 2>/dev/null | \
+    MODULE="$(/sbin/modprobe -i --show-depends "$MODALIAS" 2>/dev/null | \
       grep -E '/kernel/drivers/net/|/kernel/drivers/staging/' | \
       grep -o '[^/]*\.ko' | cut -f 1 -d '.' | tail -n 1)"
+    PREFLIST=''
     if [ -f /etc/rc.d/MODULESCONFIG-backend_modprobe ]; then
+# shellcheck disable=SC1091
         . /etc/rc.d/MODULESCONFIG-backend_modprobe #get PREFLIST
     elif [ -f /etc/rc.d/MODULESCONFIG ]; then
+# shellcheck disable=SC1091
         . /etc/rc.d/MODULESCONFIG #get PREFLIST
-    else
-        PREFLIST=''
     fi
     if [ -n "$PREFLIST" ]; then
         PREFHIT="$(echo -n "$PREFLIST" | tr ' ' '\n' | grep "^${MODULE}:" | head -n 1)"
-        if [ -n "$PREFHIT" ];then
+        if [ -n "$PREFHIT" ]; then
             grep -hso '^blacklist  *[^ ]*' /etc/modprobe.d/* | tr -s ' ' > /tmp/sns_blacklist.conf
             PREFMODS="$(echo -n "$PREFHIT" | cut -f 2-9 -d ':' | tr ':' ' ')"
             for PREFMOD in $PREFMODS; do #format can have multiple ':', ex: 8139cp:8139too:8139xx (last is most preferred).
                 echo "blacklist $MODULE" >> /tmp/sns_blacklist.conf
                 xMODULE="$(/sbin/modprobe -i --config /tmp/sns_blacklist.conf \
-                  --show-depends $MODALIAS 2>/dev/null | \
+                  --show-depends "$MODALIAS" 2>/dev/null | \
                   tail -n 1 | grep -o '[^/]*\.ko' | cut -f 1 -d '.')"
                 [ "$xMODULE" = "$PREFMOD" ] && MODULE="$xMODULE"
             done
@@ -39,6 +42,6 @@ if [ -n "$MODULES" ]; then
     fi
     mkdir -p /tmp/simple_network_setup/udevmodulelist
     for ONEMODULE in $MODULES; do
-        echo "$MODULE" > /tmp/simple_network_setup/udevmodulelist/${ONEMODULE//-/_}
+        echo "$MODULE" > /tmp/simple_network_setup/udevmodulelist/"${ONEMODULE//-/_}"
     done
 fi

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/help_profiles
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/help_profiles
@@ -2,14 +2,14 @@
 #120204 BK: internationalized.
 #131228 zigbert: gui (gtkdialog) improvements.
 
-export TEXTDOMAIN=sns___help_profiles
+export TEXTDOMAIN=simple_network_setup
 export OUTPUT_CHARSET=UTF-8
 
 echo "<b>$(gettext "Creating a profile")</b>
 When you click on a button in the <b>Interfaces</b> section in the main window, you will be creating a connection to the Internet. The setup parameters for the connection will be saved as a 'profile'. Technical note: each profile is saved as one line in file /etc/simple_network_setup/connections, that can be opened and viewed with a text editor if you wish to see the inner details.
 
 <b>Automatic connection</b>
-At bootup, if SNS has been set as the default network handler, the connection profiles are used to automatically connect to the internet. Each of the profiles is tried, the wireless ones first, then wired, and the first successful connection is used.
+At bootup, the connection profiles are used to automatically connect to the internet. Each of the profiles is tried in order by interface, and all wireless networks profiled for each interface.  The first successful connection is used.
 
 If for some reason this auto-connection does not happen at bootup, for example a USB modem was not plugged in, you can click the <b>Connect Now</b> button in the main SNS window to perform a connection whenever you want. Alternatively, the 'connect' icon on the desktop has a right-click menu with an entry that does the same thing.
 

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/help_security
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/help_security
@@ -1,22 +1,44 @@
 #!/bin/sh
 #120204 BK: internationalized.
 #131228 zigbert: gui (gtkdialog) improvements.
+#210425 v3.0 Update to match 'iw' output and modified Setup dialog.
 
-export TEXTDOMAIN=sns___help_security
+export TEXTDOMAIN=simple_network_setup
 export OUTPUT_CHARSET=UTF-8
 
-echo "<b>$(gettext "No security")</b>
-The wireless network is not encrypted, so anybody can access it. Some wireless routers are setup for MAC Address filtering, restricting which clients can access, so this is a form of security for an un-encrypted network.
-There is no need to type any 'Key' as it is not used.
+echo "<b>$(gettext 'Open - No security')</b>
+$(gettext "The wireless network is not encrypted, so anybody can access it. Some wireless routers are setup for MAC Address filtering, restricting which clients can access, so this is a form of security for an un-encrypted network.")
 
 <b>WEP</b>
-This is an 'older' method of encryption that is less secure than WPA. Basically, it is a case of 'the weakest link in the chain' -- if any client on the network supports only WEP then all clients must use WEP (and the wireless router must be set to WEP).
+$(gettext "This is an 'older' method of encryption that is less secure than WPA. Basically, it is a case of 'the weakest link in the chain' -- if any client on the network supports only WEP then all clients must use WEP (and the wireless router must be set to WEP).")
 
-The 'Key' must be a hexadecimal number (composed of the digits 0-9 and a-f) and either 13 or 26 digits long.
+$(gettext "The 'Key' must be a hexadecimal number (composed of the digits 0-9 and a-f) and either 13 or 26 digits long.")
 
 <b>WPA</b>
-This is more secure than WEP and is the recommended choice if your router and Linux driver supports it. There are actually two types WPA and WPA2, but ticking the 'WPA' radiobutton will use whichever of these is available. Also, there are two encryption management schemes, known as 'TKIP' and 'AES' -- again, whichever is available will be automatically used.
+$(gettext "This is more secure than WEP but was only an interim upgrade until RSN was finalized. It uses the 'TKIP' encryption management scheme and PSK authentication.")
 
-The 'Key' (sometimes known as the 'passphrase' or 'password') can be composed of any numerical or alphanumeric characters, from 8 to 63 characters long (even spaces are allowed)" > /tmp/box_help
+<b>RSN$(gettext ' (WPA2 and WPA3)')</b>
+$(gettext "This is significantly more secure than WPA.  WPA2 uses the CCMS (AES) encryption management scheme and PSK authentication; WPA3 uses the CCMS (AES) encryption management scheme and SAE authentication.")
+
+$(gettext "The 'Key' (sometimes known as the 'passphrase' or 'password') can be composed of any numerical or alphanumeric characters, from 8 to 63 characters long (even spaces are allowed)")
+
+<b>$(gettext 'Security Strength Indications')</b>
+$(gettext "The levels of wifi security supported by each network, from best to worst, are:")
+ RSN-CCMS-I$(gettext ':  WPA2/WPA3, AES encryption, EAP authentication')
+ RSN-CCMS-S$(gettext ':  WPA3, AES encryption, SAE authentication')
+ RSN-CCMS-P$(gettext ':  WPA2/WPA3, AES encryption, PSK authentication')
+ WPA-CCMS-P$(gettext ':  WPA1, AES encryption, PSK authentication')
+ WPA-TKIP-P$(gettext ':  WPA1, TKIP encryption, PSK authentication')
+ WEP$(gettext ':  Weak encryption (deprecated)')
+ $(gettext 'Open')$(gettext ':  Insecure')
+
+$(gettext 'Networks supporting multiple security levels are shown as:')
+ R/W-... $(gettext 'or') W/R-...
+ ...-C/T $(gettext 'or') ...-T/C
+
+$(gettext 'Finally, the authentication indications are:')
+ -I (IEEE 802.1x)$(gettext ': A highly secure method for protecting the authentication process -- not supported by SNS.')
+ -P (PSK)$(gettext ': Pre-Shared Key')
+ -S (SAE)$(gettext ': Simultaneous Authentication of Equals')" > /tmp/box_help
 
 /usr/lib/gtkdialog/box_help "Wireless network security" &

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/bin/bash
+# shellcheck disable=SC1091,2089,2090
 #(c) Copyright Barry Kauler 2010, bkhome.org
 #2010 Lesser GPL licence v2 (file:///usr/share/doc/legal/lgpl-2.1.txt)
 #/etc/simple_network_setup/connections is created by SNS, /usr/local/simple_network_setup/sns
@@ -36,355 +37,436 @@
 #190525 v2.3: Allow for udev list updates; correct module loading & connection checks; add/restore wait for interfaces to configure.
 #200412 v2.3.1: Increase wait for ethtool link detected, to 15 secs.
 #201017 v2.4: Change module detection to handle multiple aliases for a device and driver preferences; ignore driver names when gathering connection MAC addresses; remove use of devpaths, which are no longer created; wait for link up 1 second as well as 3 & 5. 
+#210201 Reorganized code into segments.
+#210202 Replace deprecated ifconfig and route with busybox-compatable subset of ip (assuming nonfunctional -oneline); replace iwconfig with iw; replace pidof with 'ps -C'; replace iwlist scan with iw scan.
+#210205 Shorten delays after bringing link up and initially.
+#210207 Change WEP support to use wpa_supplicant.
+#210209 If already running, ignore extra starts/stops; ensure wpa_supplicant killed.
+#210211 Try another interface if wpa_supplicant fails.
+#210212 BK: /tmp/sns_interface_success no longer used (derived from easyos 190215); extend wait before testing resolv.conf (derived from easyos 180924).
+#210226 Resolve shellcheck issues.
+#210623 v3.0 (not annotated) Support hidden networks; use 'read' to extract fields from one-line entries; retry dhcpcd (once) if it fails to set nameserver (gets IP 254.169...); replace temp files with redirected string variables (<<<); check for already running; add 'Attempting to reconnect' splash message.
+#210703 v3.1 Accommodate EasyOS which does not use pup_event_backend_modprobe for module loading; change yaf-splash to gtkdialog-splash.
+#210915 Retry wired dhcpcd if nameserver not set; skip country regulation check for wired networks; change wired log to /tmp/simple_network_setup/rc_network_wired_connection_log, supporting multiple attempts.
+#211002 v3.2 Try interfaces in connection (list) order, but only once per interface.
 
+#set -x; exec >&2 #DEBUG
 #If version is changed, ensure that new VERSION is set in the sns script. #190525
 
-export TEXTDOMAIN=sns___rc.network
+export TEXTDOMAIN=simple_network_setup
 export OUTPUT_CHARSET=UTF-8
+. gettext.sh
 LANGORIG=$LANG
 
-#each line of /etc/simple_network_setup/connections has everything known about a connection:
+#Running?...
+ps --no-headers -fC rc.network | grep '/usr/local/simple_network_setup' | grep -qvw "$$" \
+  && sleep 5 \
+  && ps --no-headers -fC rc.network | grep '/usr/local/simple_network_setup' | grep -qvw "$$" \
+  && exit 1 #210209
+
+#each line of /etc/simple_network_setup/connections has everything needed about a connection:
 #(please ignore spaces, put here for readability only)
-#Wireless:
-#        1         2          3         4       5                                   6                 7           8                 9            10           11                 12         13                         14       15         16          17
-#format: INTERFACE|IF_INTTYPE|IF_DRIVER|IF_BUS |IF_INFO                            |MACADDRESS       |CELL_NUMBER|CELL_ADDRESS     |CELL_CHANNEL|CELL_QUALITY|CELL_ENCRYPTIONKEY|CELL_ESSID|SEC_KEY                   |SEC_MGMT|ENCODEPROTO|WPA_DRIVER|DHCPCDFIX|
-#ex:     wlan1    |Wireless  |rt73usb  |usb    |Ralink RT73 USB Wireless LAN driver|00:26:19:F5:AC:3D|01         |00:17:3F:68:33:7E|11          |70/70       |off               |belkin54g |000102030405060708090a0b0c|WEP     |           |wext      |         |
-#Wired:
-#        1         2          3         4       5                                       6                 7
-#format: INTERFACE|IF_INTTYPE|IF_DRIVER|IF_BUS |IF_INFO                                |MACADDRESS       |DHCPCDFIX|
-#ex:     eth0     |Wired     |sky2     |pci    |Marvell Yukon 2 Gigabit Ethernet driver|00:17:36:84:E5:1A|         |
 
-#IMPORTANT: the INTERFACE field may be different at boot time, due to different plugged in network devices.
-
-# $1: interface
-interface_is_wireless() {
-	if [ ! "$1" ] ; then
-		return 1 #error
-	fi
-	if grep -q "${1}:" /proc/net/wireless ; then
-		return 0 #yes
-	fi
-	if [ -d /sys/class/net/${1}/wireless ] ; then
-		return 0 #yes
-	fi
-	# k3.2.x: my problematic wireless pci adapter is only recognized by iwconfig..
-	# hmm with 2 pci wireless adapters only iwconfig does the trick
-	if iwconfig ${1} 2>&1 | grep -q 'no wireless' ; then
-		return 1 #no
-	fi
-	return 0 #yes
-}
+#        1                 2          3         4       5                                       6         7          8                 9        10                         11
+#format: MACADDRESS       |IF_INTTYPE|IF_DRIVER|IF_BUS |IF_INFO                                |DHCPCDFIX|CELL_ESSID|CELL_ADDRESS     |SEC_MGMT|SEC_KEY                   |WPA_DRIVER|
+#ex:     00:17:36:84:E5:1A|Wired     |sky2     |pci    |Marvell Yukon 2 Gigabit Ethernet driver|         |belkin54g |00:17:3F:68:33:7E|WPA-PSK |000102030405060708090a0b0c|nl80211   |
+MACADDRESS_FIELD=1
+IF_DRIVER_FIELD=3
+DHCPCDFIX_FIELD=6
+CELL_ESSID_FIELD=7
+CELL_ADDRESS_FIELD=8
 
 cancel_splash_and_exit() { #170505...
-	if [ -f /tmp/sns_splash_pid ];then
-	 SPLASHPID="$(cat /tmp/sns_splash_pid)"
-	 rm -f /tmp/sns_splash_pid
-	 [ -n "$SPLASHPID" ] \
-	  && ps -fC yaf-splash | grep -wq "$SPLASHPID" \
-	  && kill $SPLASHPID
-	fi
-	exit 0
+    if [ -f /tmp/sns_splash_pid ]; then
+        local SPLASHPID
+        SPLASHPID="$(cat /tmp/sns_splash_pid)"
+        rm -f /tmp/sns_splash_pid
+# shellcheck disable=SC2009
+        [ -n "$SPLASHPID" ] \
+          && ps -C gtkdialog-splash -C yaf-splash | grep -wq "^ *$SPLASHPID" \
+          && kill "$SPLASHPID" 2>/dev/null
+    fi
+    exit 0
 } #170505 end
 
-export LANG='C'
-rm -f /tmp/sns_rc.network_exit 2>/dev/null #100703
+stop_interface() {
+    if ps -C wpa_supplicant >/dev/null 2>&1; then #210209...
+        wpa_cli terminate >/dev/null \
+          || killall wpa_supplicant #kill wpa_supplicant.
+    fi
+    INTERFACES="$(ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ':' | tr -d '\n')" #210202
+    for INTERFACE in $INTERFACES; do
+# shellcheck disable=SC2009
+        if ps -fC dhcpcd | grep -qw "$INTERFACE" \
+          || ip link show "$INTERFACE" | grep -qw 'UP' \
+          || iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid'; then #slacko puts : after command
+            iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid' \
+              && iw dev "$INTERFACE" disconnect #210202
+            ip link set "$INTERFACE" down #210202
+# shellcheck disable=SC2009
+            ps -fC dhcpcd | grep -qw "$INTERFACE" \
+              && dhcpcd --release "$INTERFACE" 2>/dev/null
+            ip route flush dev "$INTERFACE" #100703
+            #in situation bring down interface from desktop icon...
+            [ -n "$DISPLAY" ] \
+              && LANG=$LANGORIG gtkdialog-splash -placement bottom -bg pink -timeout 5 -text "$(eval_gettext "Network interface '\$INTERFACE' has been disabled")" >/dev/null &
+        fi
+    done
+    exit
+} #stop_interface
 
-if [ $1 ];then #100325
- case $1 in
-  stop)
-   INTERFACE="`cat /tmp/sns_interface_success`"
-   #170522 ...file written by 'sns' and 'rc.network', but in case not...
-   INTERFACES="$INTERFACE"
-   [ ! "$INTERFACES" ] && INTERFACES="$(ifconfig | grep -oE '^[^ ]+' | grep -v '^lo' | tr '\n' ' ')"
-   for INTERFACE in $INTERFACES
-   do
-    rm -f /tmp/sns_interface_success
-    [ "`pidof wpa_supplicant`" != "" ] && wpa_cli terminate #kill wpa_supplicant.
-    ifconfig $INTERFACE down
-    [ "`iwconfig $INTERFACE | grep "$INTERFACE" | grep "ESSID"`" != "" ] && iwconfig $INTERFACE essid off
-    dhcpcd --release $INTERFACE 2>/dev/null
-    ip route flush dev $INTERFACE #100703
-   done
-    #in situation bring down interface from desktop icon...
-   [ "$INTERFACES" ] && [ "$DISPLAY" ] && LANG=$LANGORIG yaf-splash -placement bottom -bg pink -timeout 5 -text "$(gettext 'Network interface') ${INTERFACE} $(gettext 'has been disabled')" &
-   exit
-  ;;
- esac
+find_available_drivers() {
+    #181109 Collect driver names from saved connection profiles & make grep patterns...
+    local CONNECTION_DRIVER_LIST CONNECTION_DRIVER_COUNT
+    local PREFERRED_DRIVER PREFERRED_MODULE
+    CONNECTION_DRIVER_LIST="$(cut -f "$IF_DRIVER_FIELD" -d '|' /etc/simple_network_setup/connections | sort -u)"
+    [ -z "$CONNECTION_DRIVER_LIST" ] && exit
+    PREFERRED_DRIVER="$(head -n 1 /etc/simple_network_setup/connections | cut -f "$IF_DRIVER_FIELD" -d '|')"
+    PREFERRED_MODULE="$(cat /tmp/simple_network_setup/udevmodulelist/"$PREFERRED_DRIVER" 2>/dev/null)"
+    PREFERRED_MODULE="${PREFERRED_MODULE:-$PREFERRED_DRIVER}"
+    CONNECTION_DRIVER_COUNT="$(grep -vEc '^$' <<< "$CONNECTION_DRIVER_LIST")" #190525
+    local CONNECTION_DRIVER_PATTERNS CONNECTION_BUILTIN_DRIVERS
+# shellcheck disable=SC2001
+    CONNECTION_DRIVER_PATTERNS="$(sed 's%.*%/&.ko%' <<< "$CONNECTION_DRIVER_LIST")"
+    CONNECTION_BUILTIN_DRIVERS="$(grep -soF "${CONNECTION_DRIVER_PATTERNS}" /lib/modules/"$(uname -r)"/modules.builtin | sed 's%.*/\([^/]*\)\.ko%\1%')" #201017...
+    if [ -n "$CONNECTION_BUILTIN_DRIVERS" ]; then
+        local CONNECTION_MODULE_LIST
+        CONNECTION_MODULE_LIST="$(grep -vF "$CONNECTION_BUILTIN_DRIVERS" <<< "$CONNECTION_DRIVER_LIST")"
+    else
+        local CONNECTION_MODULE_LIST="$CONNECTION_DRIVER_LIST"
+    fi
+    if [ -n "$CONNECTION_MODULE_LIST" ]; then #201017
+        [ "$ARGUMENT" != 'start' ] && sleep 2 # Unless started by sns, allow time for all module loading to be initiated. #190525 210205
+        WAITCNT=0 ; WAITMAX=12 ; local WAITDRVRS=8 #180108 190525
+        #wait for interfaces to become available...
+        #note, do not test for wlan0 or wlan1 (etc) to become available, as these can change depending on plugged-in devices.
+        local ACTIVE_MODULE_LIST ACTIVE_MODULE_COUNT ACTIVE_MODULE_STRING
+        local ACTIVE_MODULE_STRING ONEDRIVER SUBSTITUTEDRIVER
+        local ACTIVE_CONNECTION_MODULE_LOAD_LIST
+        local ACTIVE_CONNECTION_MODULE_COUNT LOADED_CONNECTION_MODULE_PATTERNS LOADED_CONNECTION_MODULE_COUNT
+        local NETDRIVER SUBSTITUTEMODULE LOADMODULE
+        while true; do #190525
+            ACTIVE_MACADDRESSES="$(ip link show | sed -n '/link\/ether/ s/.*ether \([^ ]*\).*/\1/p')"
+            ACTIVE_DRIVER_LIST="$(grep -F "${ACTIVE_MACADDRESSES}" < /etc/simple_network_setup/connections | cut -f "$IF_DRIVER_FIELD" -d '|')"
+            ACTIVE_DRIVER_COUNT="$(sort -u <<< "$ACTIVE_DRIVER_LIST" | wc -l)"
+            if [ -n "$ACTIVE_DRIVER_LIST" ]; then
+                if grep -qw "$PREFERRED_DRIVER" <<< "$ACTIVE_DRIVER_LIST" \
+                  || [ "$ACTIVE_DRIVER_COUNT" -ge "$CONNECTION_DRIVER_COUNT" ] \
+                  || [ $WAITCNT -ge $WAITDRVRS ]; then
+                    ACTIVE_MODULE_STRING=''
+                    for ONEPATH in /sys/class/net/*; do
+                        [ "$(basename $ONEPATH)" = 'lo' ] && continue
+                        NETDRIVER="$(sed -n '/DRIVERS=="[^"]/ {s/[^"]*"\([^"]*\).*/\1/p ; q}' <<< "$(udevadm info -a -p "$ONEPATH")" | grep -xF "${CONNECTION_MODULE_LIST}")"
+                        if [ -n "$NETDRIVER" ]; then
+                            SUBSTITUTEMODULE="$(cat /tmp/simple_network_setup/udevmodulelist/"$NETDRIVER" 2>/dev/null)"
+                            LOADMODULE="${SUBSTITUTEMODULE:-"$NETDRIVER"}"
+                            grep -qxF "$ACTIVE_DRIVER_LIST" <<< "$NETDRIVER" && ACTIVE_MODULE_STRING="${ACTIVE_MODULE_STRING}${LOADMODULE}|"
+                        fi
+                    done
+                    ACTIVE_CONNECTION_MODULE_LOAD_LIST="$(tr '|' '\n' <<< "${ACTIVE_MODULE_STRING}")"
+                    if [ -n "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" ]; then #201017
+                        ACTIVE_CONNECTION_MODULE_COUNT="$(wc -l <<< "$ACTIVE_CONNECTION_MODULE_LOAD_LIST")" #201017
+                        if grep -qw "$PREFERRED_MODULE" <<< "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" \
+                          || [ "$ACTIVE_CONNECTION_MODULE_COUNT" -ge "$CONNECTION_DRIVER_COUNT" ] \
+                          || [ $WAITCNT -ge $WAITDRVRS ]; then #190525
+                            LOADED_CONNECTION_MODULE_PATTERNS="$(lsmod | cut -f 1 -d ' ' | \
+                              grep -xF "${ACTIVE_CONNECTION_MODULE_LOAD_LIST}" | sed 's%^.*%|&|%')" #201017
+                            grep -qw "$PREFERRED_MODULE" <<< "$LOADED_CONNECTION_MODULE_PATTERNS" && break #preferred i/f present
+                            LOADED_CONNECTION_MODULE_COUNT="$(grep -vEc '^$' <<< "$LOADED_CONNECTION_MODULE_PATTERNS")"
+                            [ "$LOADED_CONNECTION_MODULE_COUNT" -ge "$ACTIVE_CONNECTION_MODULE_COUNT" ] && break
+                        fi
+                    fi
+                fi #190525
+            fi #201017
+            [ $WAITCNT -ge $WAITDRVRS ] && break #all modules may not be loaded or an i/f not present.
+            sleep 1
+            ((++WAITCNT))
+        done
+    fi
+    [ -n "$LOADED_CONNECTION_MODULE_PATTERNS" ] || [ -n "$CONNECTION_BUILTIN_DRIVERS" ] #set rc 0 = driver available 201017
+} #find_available_drivers
+
+find_available_interfaces() {
+    AVAILABLE_CONNECTIONS='' #190525...
+    local CONNECTION_MACADDRESS_COUNT
+    CONNECTION_MACADDRESS_COUNT="$(wc -l <<< "$ACTIVE_CONNECTION_MACADDRESSES")"
+    while true; do
+        local ACTIVE_MACADDRESS_PATTERNS
+# shellcheck disable=SC2060
+        ACTIVE_MACADDRESS_PATTERNS="$(sed 's%^.*%&|%' <<< "$ACTIVE_MACADDRESSES")"
+        AVAILABLE_CONNECTIONS="$(grep -iF "${ACTIVE_MACADDRESS_PATTERNS}" /etc/simple_network_setup/connections | grep '^..:')" #210202 201017
+        local AVAILABLE_CONNECTION_COUNT
+        AVAILABLE_CONNECTION_COUNT="$(wc -l <<< "$AVAILABLE_CONNECTIONS")"
+        [ "$AVAILABLE_CONNECTION_COUNT" -ge "$CONNECTION_MACADDRESS_COUNT" ] && break
+        [ $WAITCNT -ge $WAITMAX ] && break 
+        sleep 1
+        ((++WAITCNT))
+    done
+    [ $WAITCNT -gt 0 ] && echo "SNS rc.network: waited for ethernet interfaces: seconds=${WAITCNT}" #180115
+    [ -z "$AVAILABLE_CONNECTIONS" ] && cancel_splash_and_exit #181109 end
+    local AVAILABLE_CONNECTION_MACADDRESSES
+    AVAILABLE_CONNECTION_MACADDRESSES="$(cut -f "$MACADDRESS_FIELD" -d '|' <<< "$AVAILABLE_CONNECTIONS")"
+    local INTERFACE_MACADDRESSES
+    INTERFACE_MACADDRESSES="$(ip link show | \
+      grep -B 1 'link/ether' | \
+      grep -B 1 -iF "$AVAILABLE_CONNECTION_MACADDRESSES" | \
+      sed -n '/^[0-9]/ {N;s%^[0-9]\+: \([^:]*\).*link/ether\( [^ ]*\).*%\1\2%p}')" #ex. wlan0 xx:xx:xx:xx:xx:xx, avoid using busybox 'ip -online' #210202 210208
+    PRIORITIZED_INTERFACES='' #211002...
+    for MACADDR in $AVAILABLE_CONNECTION_MACADDRESSES; do
+        PRIORITIZED_INTERFACES="$PRIORITIZED_INTERFACES$(grep -w "$MACADDR" <<< "$INTERFACE_MACADDRESSES" | cut -f 1 -d ' ') " #190525 end 210205
+    done
+} #find_available_interfaces
+
+initiate_wireless_connection() { #Exits from start_wireless_connection if successful
+    [ -x /usr/sbin/connectwizard_crd ] \
+      && connectwizard_crd >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170612 #210915
+    # For each interface beginning with that in the first profile, search for a network in profile order.
+    EBSSIDS_WANT="$(grep '|Wireless|' /etc/simple_network_setup/connections | \
+      cut -f "$CELL_ESSID_FIELD,$CELL_ADDRESS_FIELD" -d '|')"
+    EBSSID_PATTERNS="$(sed -e 's/^[^|]*/SSID: &/' -e 's/[^|]*$/BSS &/' -e 's/|/\n/' <<< "$EBSSIDS_WANT")" #210202
+    which iw >/dev/null 2>&1 || return 1 #skip wireless if 'iw' not installed #####
+    rfkill unblock wlan #180125
+# shellcheck disable=SC2060
+    MACADDRESS="$(ip link show "$INTERFACE" | grep 'link/ether' | tr -s ' ' | cut -f 3 -d ' ')" #210202
+    find_available_networks
+    echo " EXECUTING: ip link set $INTERFACE down" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #110203 210202
+    ip link set "$INTERFACE" down #210202
+    [ -z "$SCANRESULT" ] && return 1 #210202
+    #convert each found network into a single line... 110203
+    SRLINES="$(tr '|' ' ' <<< "$SCANRESULT" | \
+      tr '\n' '|' | tr -d '\t' | \
+      sed -e 's%BSS \([0-9a-f:]\+\)[^\|]*%\n\1%g' \
+        -e 's%freq: \([0-9]\+\)[^\|]*%\1%g' \
+        -e 's%signal: \([/0-9-]\+\)[^\|]*%\1%g' \
+        -e 's%SSID: \([^\|]*\|\)%\1%g' | \
+      sort -g -r -t '|' -k 3)" #170619 210202
+    while IFS='|' read -r WANTSSID WANTBSS; do
+        while IFS='|' read -r CELL_ADDRESS CELL_FREQUENCY _ CELL_ESSID _; do
+            [ -z "$CELL_ESSID" ] && CELL_ESSID="$WANTSSID"
+            if [ "$CELL_ADDRESS" = "$WANTBSS" ] \
+              && [ "$CELL_ESSID" = "$WANTSSID" ]; then
+                find_connection_profile_and_extract_content || continue #210201
+                RUNWPASUPP='no'
+                case "${SEC_MGMT:0:3}" in #210207...
+                  WPA) RUNWPASUPP='yes' ;;
+                  NON) [ -n "$SEC_KEY" ] && RUNWPASUPP='yes' ;; #WEP
+                esac 
+                ip link set "$INTERFACE" up #hmmm, it seems need to bring up after all the iwconfig operations! #210202
+                local RC=$? #170301
+                echo "     RESULT=$RC FOR: ip link set $INTERFACE up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170301 210202
+                if [ $RC -eq 0 ]; then #170301
+                    sleep "${SECS}".1 #210205
+                    local wCNT=0
+                    if [ "$RUNWPASUPP" = "yes" ]; then
+                        run_wpa_supplicant || continue 2 #210211
+                    elif [ -z "$SEC_MGMT" ]; then
+                        iw dev "$INTERFACE" connect "${CELL_ESSID}" "$CELL_FREQUENCY" "$CELL_ADDRESS" #210202
+                    fi
+                    start_wireless_connection #exits if connection successful
+                fi 
+            fi 
+        done <<< "$SRLINES"
+    done <<< "$EBSSIDS_WANT"
+} #initiate_wireless_connection
+
+find_available_networks() {
+    # Input: INTERFACE, EBSSID_PATTERNS Output: SCANRESULT
+    echo -e "\n ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+    ip link set "$INTERFACE" up || return 1 #continue #210202 210201
+    echo " SUCCESS: ip link set ${INTERFACE} up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #210202
+    sleep 0.1 #210205
+    SECS=0 #210205
+    echo " EXECUTING SCAN: iw dev ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706 210202
+    for I in 1 2 3 4 5; do #210205
+        SCANRESULT="$(iw dev "$INTERFACE" scan | \
+          grep -E '^BSS |freq:|signal:|SSID:' | \
+          grep -F -C 3 --no-group-separator "${EBSSID_PATTERNS}" | \
+          grep -A 3 --no-group-separator '^BSS' | \
+          grep -B 3 --no-group-separator 'SSID:' | \
+          sed '/SSID:/ s/\\x00//g')" ###SCANNING### 110203 180706 210202 210205
+        echo " SCANRESULT=${SCANRESULT}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+        #note, possible to get: 'wlan0     No scan results' so delay then try again...
+        [ -n "$SCANRESULT" ] || [ $I -ge 5 ] && break #210205
+        sleep 1 #210205
+        ((++SECS))  #210205
+        echo " EXECUTING SCAN AGAIN: iw dev ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706 210202
+    done
+    return 0 #210201
+} #find_available_networks
+
+find_connection_profile_and_extract_content() {
+    [ -z "$CELL_ADDRESS" ] && return 1 #210201
+    #Get profile that matches interface MAC address, SSID & AP address.
+    local essidPATTERN
+    essidPATTERN='|'"${CELL_ESSID}"'|' #null or \x00... = hidden SSID
+    local maPATTERN
+    maPATTERN="^$MACADDRESS|.*|$CELL_ADDRESS|" #interface & AP MAC addresses
+    local CONNECTDATA
+    CONNECTDATA="$(grep -i "$maPATTERN" <<< "$AVAILABLE_CONNECTIONS" | grep "$essidPATTERN")" #211002
+    if [ -n "$CONNECTDATA" ]; then
+        echo "   MACADDRESS=$MACADDRESS CONNECTDATA=$CONNECTDATA" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+# shellcheck disable=SC2034
+        IFS='|' read -r _ _ _ _ _ DHCPCDFIX _ _ SEC_MGMT SEC_KEY WPA_DRIVER _ <<< "$CONNECTDATA"
+            #SEC_MGMT - ex: NONE, WPA-PSK
+            #SEC_KEY - to distinguish WEP from open
+            #WPA_DRIVER - ex: nl80211,wext, hostap, ralink
+            #DHCPCDFIX - ex: -I ''
+    else
+        return 1 #connection not found 210201
+    fi
+    return 0 #210201
+} #find_connection_profile_and_extract_content
+
+run_wpa_supplicant() {
+    local WPACONF
+    WPACONF="/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
+    [ -f "$WPACONF" ] || return 1 #210211
+    wpa_supplicant -B -D"${WPA_DRIVER}" -i"${INTERFACE}" -c"$WPACONF"
+    local RC=$? #210211
+    echo "       RESULT=$RC FOR: wpa_supplicant -B -D${WPA_DRIVER} -i${INTERFACE} -c\"$WPACONF\"" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+    [ "$RC" -eq 0 ] || return 1 #210211
+    while [ $((++wCNT)) -le 20 ]; do #100314 wait until wpa_supplicant has "connected".
+        sleep 1
+        {
+          echo "        TEST: wpa_cli -i $INTERFACE status"
+          wpa_cli -i "$INTERFACE" status
+          echo "        RESULT=$? wCNT=$wCNT"
+        } >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+        wpa_cli -i "$INTERFACE" status | grep -q '^bssid=[0-9a-f]' && return 0
+    done
+    wpa_cli terminate >/dev/null #kill
+    return 1 #210211
+} #run_wpa_supplicant
+
+start_wireless_connection() {
+    if [ "$wCNT" -le 20 ]; then #170402
+        for ATTEMPT in 1 2 ; do
+            sleep 0.1 #timing precaution
+            echo "        EXECUTING: dhcpcd ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924
+# shellcheck disable=SC2086 #word-split $DHCPCDFIX
+            dhcpcd $DHCPCDFIX "$INTERFACE"
+            local RC=$? #170402
+            echo "        dhcpcd return value: ${RC}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924
+            #need to wait awhile #210212...
+            if [ $RC -eq 0 ]; then
+                for ONESLEEP in 0.2 1 2; do
+                    sleep $ONESLEEP
+                    grep -q '^nameserver' /etc/resolv.conf && break
+                done
+            fi
+            if [ $RC -eq 0 ] \
+              && grep -q '^nameserver' /etc/resolv.conf; then #210212 end
+                echo "     SUCCESS" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+                #in situation bring up interface from desktop icon...
+                [ "$DISPLAY" ] \
+                  &&  gtkdialog-splash -placement bottom -bg lightgreen -timeout 5 -text "$(eval_gettext "Network interface '\${INTERFACE}' has been activated")" >/dev/null &
+                cancel_splash_and_exit #one internet connection is enough! #170505
+            else
+                echo "     FAIL" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+                dhcpcd --release "$INTERFACE" 2>/dev/null
+                [ "$ATTEMPT" -eq 1 ] && continue
+                ps -C wpa_supplicant >/dev/null 2>&1 && wpa_cli terminate >/dev/null #kill wpa_supplicant.     #210202
+                ip link set "$INTERFACE" down #210202
+                iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid' && iw dev "$INTERFACE" disconnect #210202
+                ip route flush dev "$INTERFACE" #100703
+            fi #170402 #rerwin - moved
+        done
+    fi
+} #start_wireless_connection
+
+initiate_wired_connection() {
+    ip link set "$INTERFACE" up >> /tmp/simple_network_setup/rc_network_wired_connection_log 2>&1 || return 1 #210202
+
+    LINK_DETECTED=no
+    TIMEOUT=15 #200412
+    while [ $TIMEOUT -ge 0 ]; do #200412
+        if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
+            LINK_DETECTED="yes"
+            break
+        fi
+        [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190212 200412
+    done
+    if [ "$LINK_DETECTED" = "no" ] ; then
+        ip link set "$INTERFACE" down #210202
+        return 1 #no network
+    fi
+
+# shellcheck disable=SC2060
+    MACADDRESS="$(ip link show "$INTERFACE" | grep 'link/ether' | tr -s ' ' | cut -f 3 -d ' ')" #210202
+    maPATTERN='|'"$MACADDRESS"'|'
+    DHCPCDFIX="$(grep -i "$maPATTERN" <<< "$AVAILABLE_CONNECTIONS" | \
+      head -n 1 | cut -f "$DHCPCDFIX_FIELD" -d '|')" #100325 ex: -I '' #210202 #211002
+
+    sleep 0.1 #timing precaution #210915
+    for ATTEMPT in 1 2 3 ; do #210915
+        echo "EXECUTING: dhcpcd ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wired_connection_log #170924
+# shellcheck disable=SC2086
+        dhcpcd $DHCPCDFIX "$INTERFACE" >> /tmp/simple_network_setup/rc_network_wired_connection_log 2>&1
+        local RC=$? #170402
+        echo "dhcpcd return value: ${RC}" >> /tmp/simple_network_setup/rc_network_wired_connection_log #170924
+        #need to wait awhile #210212...
+        if [ $RC -eq 0 ]; then
+            for ONESLEEP in 0.2 1 2; do
+                sleep $ONESLEEP
+                grep -q '^nameserver' /etc/resolv.conf && break
+            done
+        fi
+        if grep -q '^nameserver' /etc/resolv.conf; then #210212 end
+            [ "$DISPLAY" ] \
+              &&  gtkdialog-splash -placement bottom -bg lightgreen -timeout 5 -text "$(eval_gettext "Network interface '\${INTERFACE}' has been activated")" >/dev/null &
+            cancel_splash_and_exit #success. #170505
+        else
+            ip link set "$INTERFACE" down #210202
+            dhcpcd --release "$INTERFACE" 2>/dev/null
+            ip route flush dev "$INTERFACE" #100703
+            [ "$ATTEMPT" = '3' ] || sleep 5 #210915
+        fi
+    done #210915
+} #initiate_wired_connection
+
+
+################# MAIN ####################
+
+export LANG='C'
+if [ "$1" ]; then #100325
+    case $1 in
+      stop) stop_interface ;;
+    esac
 fi
 [ ! -s /etc/simple_network_setup/connections ] && cancel_splash_and_exit #170505 171222
 
-ARGUMENT="$1" #'start' from sns or null from network_default_connect
-rm -f /tmp/sns_interface_success 2>/dev/null
+if [ -z "$1" ] && [ -n "$DISPLAY" ]; then
+    gtkdialog-splash -bg orange -close never -fontsize large -text "$(gettext 'Attempting to reconnect to a network...')" >/dev/null &
+    echo $! >/tmp/sns_splash_pid
+fi
+
+ARGUMENT="$1" #'start' from sns or null from network_default_connect or Connect/AppRun
 [ -f /root/.connectwizardrc ] \
- || echo 'CURRENT_EXEC=sns' > /root/.connectwizardrc #170309
+  || echo 'CURRENT_EXEC=sns' > /root/.connectwizardrc #170309
 
-if [ "`grep '|ndiswrapper|' /etc/simple_network_setup/connections`" != "" ];then #100314...
- modprobe ndiswrapper \
-  && touch /tmp/simple_network_setup/udevmodulelist/ndiswrapper
+if grep -q '|ndiswrapper|' /etc/simple_network_setup/connections; then #100314...
+    modprobe ndiswrapper \
+      && touch /tmp/simple_network_setup/udevmodulelist/ndiswrapper
 fi
 
-#181109 Collect driver names from saved connection profiles & make grep patterns...
-CONNECTION_DRIVER_LIST="$(cut -f 3 -d '|' /etc/simple_network_setup/connections | sort -u)"
-[ -z "$CONNECTION_DRIVER_LIST" ] && exit
-CONNECTION_DRIVER_COUNT="$(echo "$CONNECTION_DRIVER_LIST" | grep -vE '^$' | wc -l)" #190525
-CONNECTION_DRIVER_PATTERNS="$(echo "$CONNECTION_DRIVER_LIST" | sed 's%.*%/&.ko%')"
-CONNECTION_BUILTIN_DRIVERS="$(grep -soF "${CONNECTION_DRIVER_PATTERNS}" /lib/modules/$(uname -r)/modules.builtin | sed 's%.*/\([^/]*\)\.ko%\1%')" #201017...
-if [ -n "$CONNECTION_BUILTIN_DRIVERS" ];then
- CONNECTION_MODULE_LIST="$(echo -n "$CONNECTION_DRIVER_LIST" | grep -vF "$CONNECTION_BUILTIN_DRIVERS")"
-else
- CONNECTION_MODULE_LIST="$CONNECTION_DRIVER_LIST"
-fi
-if [ -n "$CONNECTION_MODULE_LIST" ];then #201017
- WAITCNT=0 ; WAITDRVRS=8 ; WAITMAX=12 #180108 190525
- #wait for interfaces to become available...
- #note, do not test for wlan0 or wlan1 (etc) to become available, as these can change depending on plugged-in devices.
- [ "$ARGUMENT" != 'start' ] && sleep 1 # Unless started by sns, allow time for all module loading to be initiated. #190525
- while [ 1 ];do #190525
-  # Collect names of modules identified by udev events...
-  UDEV_RULE_LIST="$(ls -1 /tmp/simple_network_setup/udevmodulelist/ 2>/dev/null)"
-  # Collect names of any modules substituted by backend_modprobe...
-  #201017 udevmodulelist may include files for multiple drivers for same device; they identify the module expected to be loaded, based on default (last alias listed), blacklisting and preference.
-  LOADED_CONNECTION_MODULE_PATTERNS=''
-  if [ -n "$UDEV_RULE_LIST" ];then #190525 201017
-   # Get names of connection modules being loaded & the number of them (except substitutes)...
-   ACTIVE_CONNECTION_MODULE_NAME_PATH_LIST="$(echo "$CONNECTION_MODULE_LIST" | \
-     grep -xF "${UDEV_RULE_LIST}" | \
-     sed 's%^.*%/tmp/simple_network_setup/udevmodulelist/&%' | tr '\n' ' ')" #201017
-   if [ -n "$ACTIVE_CONNECTION_MODULE_NAME_PATH_LIST" ];then #201017
-    ACTIVE_CONNECTION_MODULE_LOAD_LIST="$(cat $ACTIVE_CONNECTION_MODULE_NAME_PATH_LIST | \
-      sort -u | sed 's%^.*/%%')" #201017
-    if [ -n "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" ];then #201017
-     ACTIVE_CONNECTION_MODULE_COUNT="$(echo "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" | wc -l)" #201017
-     if [ $ACTIVE_CONNECTION_MODULE_COUNT -ge $CONNECTION_DRIVER_COUNT ] \
-       || [ $WAITCNT -ge $WAITDRVRS ];then #190525
-      LOADED_CONNECTION_MODULE_PATTERNS="$(lsmod | cut -f 1 -d ' ' | \
-        grep -xF "${ACTIVE_CONNECTION_MODULE_LOAD_LIST}" | sed 's%^.*%|&|%')" #201017
-      LOADED_CONNECTION_MODULE_COUNT="$(echo "$LOADED_CONNECTION_MODULE_PATTERNS" | grep -vE '^$' | wc -l)"
-      [ $LOADED_CONNECTION_MODULE_COUNT -ge $ACTIVE_CONNECTION_MODULE_COUNT ] && break
-     fi #190525
-    fi #201017
-   fi #201017
-  fi #190525
-  [ $WAITCNT -ge $WAITDRVRS ] && break #all modules not loaded.
-  sleep 1
-  WAITCNT=$(($WAITCNT + 1))
- done
-fi #201017
-[ -z "$LOADED_CONNECTION_MODULE_PATTERNS" ] \
-  && [ -z "$CONNECTION_BUILTIN_DRIVERS" ] \
-  && cancel_splash_and_exit #201017
-
-AVAILABLE_CONNECTIONS='' #190525...
-CONNECTION_MACADDRESSES="$(cut -f 6 -d '|' /etc/simple_network_setup/connections | sort -u)" #201017
-CONNECTION_MACADDRESS_COUNT="$(echo "$CONNECTION_MACADDRESSES" | grep -vE '^$' | wc -l)"
-while [ 1 ];do
- ACTIVE_MACADDRESS_PATTERNS="$(ifconfig -a | grep 'Link encap:Ethernet' | grep -o 'HWaddr .*' | cut -f 2 -d ' ' | sed 's%^.*%|&|%')"
- AVAILABLE_CONNECTIONS="$(grep -F "${ACTIVE_MACADDRESS_PATTERNS}" /etc/simple_network_setup/connections)" #201017
- AVAILABLE_CONNECTION_COUNT="$(echo "$AVAILABLE_CONNECTIONS" | wc -l)"
- [ $AVAILABLE_CONNECTION_COUNT -ge $CONNECTION_MACADDRESS_COUNT ] && break
- [ $WAITCNT -ge $WAITMAX ] && break 
- sleep 1
- WAITCNT=$(($WAITCNT + 1))
-done
-[ $WAITCNT -gt 0 ] && echo "SNS rc.network: waited for ethernet interfaces: seconds=${WAITCNT}" #180115
-echo "$AVAILABLE_CONNECTIONS" > /tmp/sns_connections_available
-[ -z "$AVAILABLE_CONNECTIONS" ] && cancel_splash_and_exit #181109 end
-AVAILABLE_CONNECTION_MACADDRESSES="$(cut -f 6 -d '|' /tmp/sns_connections_available)"
-INTERFACES="`ifconfig -a | grep -F 'Link encap:Ethernet' | grep -F "$AVAILABLE_CONNECTION_MACADDRESSES" | cut -f1 -d' ' | tr '\n' ' '`" #190525 end
-
-##########WIRELESS##########
-
-! [ -d /tmp/simple_network_setup ] && mkdir -p /tmp/simple_network_setup
+mkdir -p /tmp/simple_network_setup
+find_available_drivers || cancel_splash_and_exit #201017
+find_available_interfaces
 
 echo -n "" > /tmp/simple_network_setup/rc_network_wireless_connection_log
+echo -n "" > /tmp/simple_network_setup/rc_network_wired_connection_log #210915
 
-[ -x /usr/sbin/connectwizard_crd ] && connectwizard_crd >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170612
- 
-grep '|Wireless|' /tmp/sns_connections_available > /tmp/sns_connections_wireless
-
-if [ -s /tmp/sns_connections_wireless ];then #170924
- ESSIDSwant="$(grep '|Wireless|' /etc/simple_network_setup/connections | cut -f 12 -d '|' | sort -u)"
- echo -n "$ESSIDSwant" > /tmp/simple_network_setup/essids-want
- for INTERFACE in $INTERFACES #exs: wlan0 eth0
- do
-  if ! interface_is_wireless ${INTERFACE} ; then
-    continue #only want wireless.
-  fi
-  rfkill unblock wlan #180125
-  # - problem: buggy/incorrect driver might freeze the system
-  # ignore INTERFACE if it hasn't been successfully set up first
-  #   * 2 pci wireless adapters: one of them freezes the system (with this command):
-  #                              ifconfig $INTERFACE up
-  #    the problematic adapter might work with ndiswrapper..
-  MACADDRESS="`ifconfig $INTERFACE | grep 'Link encap:Ethernet' | grep -o 'HWaddr .*' | cut -f 2 -d ' '`"
-  if ! grep -q "$MACADDRESS" /etc/simple_network_setup/connections ; then
-    continue
-  fi
-  # -
-  echo -e "\n ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-  ifconfig $INTERFACE up
-  [ $? -ne 0 ] && continue
-  echo " SUCCESS: ifconfig ${INTERFACE} up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-  sleep 1 #201017
-  SECS=1 #201017
-  ESSID_PATTERNS="$(sed 's/.*/ESSID:"&"/' /tmp/simple_network_setup/essids-want)"
-  echo " EXECUTING SCAN: iwlist ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706
-  for I in 1 2 3;do #201017
-   SCANRESULT="`iwlist $INTERFACE scan | grep -E 'Address:|Channel:|Frequency:|Quality[:=]|Encryption key:|ESSID:|Scan completed|No scan results'`" ###SCANNING### 110203 180706
-   echo " SCANRESULT=${SCANRESULT}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-   #note, possible to get: 'wlan0     No scan results' so delay then try again...
-   if [ "$ESSIDSwant" ];then
-    SCAN_WANTS="$(echo "$SCANRESULT" | grep -FB 5 "${ESSID_PATTERNS}")"
-   else
-    SCAN_WANTS="$(echo "$SCANRESULT" | grep -m 1 'Scan completed')"
-   fi
-   [  -n "$SCANRESULT" ] || [ $I -ge 3 ] && break #201017
-   sleep 2
-   SECS=$(($SECS + 2)) #201017
-   echo " EXECUTING SCAN AGAIN: iwlist ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706
-  done
-  ifconfig $INTERFACE down
-  echo " EXECUTING: ifconfig $INTERFACE down" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #110203
-  if [ "$SCAN_WANTS" = "" ];then #110203 180706
-   echo 'SCAN FAILURE, EXPECTED STRING "Scan completed"' >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-   continue #110203
-  fi
-  #convert each found network into a single line... 110203
-  SRLINES="`echo "$SCAN_WANTS" | grep -v 'Scan completed' | tr '|' ' ' | tr '\n' '|' | sed -e 's%       Cell %\n%g' | tr -s ' ' | sed -e 's%\(Signal level=\)\(-[0-9][0-9]*\)%\1@\2@%' | sort -g -r -t @ -k 2 | sed -e 's%\(Signal level=\)@\(-[0-9][0-9]*\)@%\1\2%'`"
-  echo "$SRLINES" |
-  while read ONELINE
-  do
-   [ "$ONELINE" = "" ] && continue
-   [ "$ONELINE" = " " ] && continue
-   CELL_ESSID="`echo -n "$ONELINE" | grep -o ' ESSID:.*' | cut -f 2 -d '"'`" #'geany
-   essidPATTERN='|'"$CELL_ESSID"'|'
-   CONNECTDATA="`grep "$essidPATTERN" /tmp/sns_connections_wireless`"
-   if [ "$CONNECTDATA" != "" ];then
-    MACADDRESS="`ifconfig -a $INTERFACE | grep -o 'HWaddr .*' | cut -f 2 -d ' '`"
-    maPATTERN='|'"$MACADDRESS"'|'
-    CONNECTDATA="`echo "$CONNECTDATA" | grep "$maPATTERN"`"
-    echo "   MACADDRESS=$MACADDRESS CONNECTDATA=$CONNECTDATA" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-    if [ "$CONNECTDATA" != "" ];then
-     #note, INTERFACE not necessarily the same as in first field of CONNECTDATA.
-     CELL_CHANNEL="`echo -n "$CONNECTDATA" | cut -f9 -d'|'`"
-     CELL_ENCRYPTIONKEY="`echo -n "$CONNECTDATA" | cut -f11 -d'|'`"
-     SEC_KEY="`echo -n "$CONNECTDATA" | cut -f13 -d'|'`" #ex: thebigbaddog
-     SEC_MGMT="`echo -n "$CONNECTDATA" | cut -f14 -d'|'`" #exs: WEP, WPA-PSK
-     ENCODEPROTO="`echo -n "$CONNECTDATA" | cut -f15 -d'|'`" #exs: WEP: restricted, open. WPA*: AES, TKIP.
-     WPA_DRIVER="`echo -n "$CONNECTDATA" | cut -f16 -d'|'`" #ex: wext
-     DHCPCDFIX="`echo -n "$CONNECTDATA" | cut -f17 -d'|'`" #100320 ex: -I ''
-     iwconfig $INTERFACE mode managed
-     echo "    RESULT=$? FOR: iwconfig $INTERFACE mode managed" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-     iwconfig $INTERFACE channel $CELL_CHANNEL
-     echo "    RESULT=$? FOR: iwconfig $INTERFACE channel $CELL_CHANNEL" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-     iwconfig $INTERFACE essid "$CELL_ESSID"
-     echo "    RESULT=$? FOR: iwconfig $INTERFACE essid \"$CELL_ESSID\"" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-     RUNWPASUPP='no'
-     if [ "$CELL_ENCRYPTIONKEY" == "on" ];then
-      case $SEC_MGMT in
-       WEP)  iwconfig $INTERFACE key $ENCODEPROTO $SEC_KEY ;; #ex: iwconfig wlan0 key open 00112233445566778899aabbcc
-       WPA*) RUNWPASUPP='yes' ;;
-      esac
-     fi
-     ifconfig $INTERFACE up #hmmm, it seems need to bring up after all the iwconfig operations!
-     RC=$? #170301
-     echo "     RESULT=$RC FOR: ifconfig $INTERFACE up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170301
-     if [ $RC -eq 0 ];then #170301
-      sleep ${SECS}
-      wCNT=0
-      if [ "$RUNWPASUPP" = "yes" ];then
-       if [ -f "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}" ];then
-        wpa_supplicant -B -D${WPA_DRIVER} -i${INTERFACE} -c"/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
-        echo "       RESULT=$? FOR: wpa_supplicant -B -D${WPA_DRIVER} -i${INTERFACE} -c\"/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}\"" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-        while [ $wCNT -le 20 ];do #100314 wait until wpa_supplicant has "connected".
-         sleep 1
-         echo "        TEST: wpa_cli -i $INTERFACE status" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-         wpa_cli -i $INTERFACE status >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-         echo "        RESULT=$? wCNT=$wCNT" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-         [ "`wpa_cli -i $INTERFACE status | grep '^bssid=[0-9a-f]'`" != "" ] && break
-         #[ "`wpa_cli -i $INTERFACE status | grep 'COMPLETED'`" != "" ] && break
-         wCNT=$(($wCNT + 1))
-        done
-       fi
-      fi
-      if [ $wCNT -le 20 ];then #170402
-       echo "        EXECUTING: dhcpcd ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924
-       dhcpcd $DHCPCDFIX $INTERFACE
-       RC=$? #170402
-       echo "        dhcpcd return value: ${RC}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924
-       sleep 0.1 #170924 Allow time for dhcpcd to write to resolv.conf
-       [ $RC -eq 0 ] && grep -q '^nameserver' /etc/resolv.conf \
-        && echo "$INTERFACE" > /tmp/sns_interface_success #100320 121115 170402
-      fi #170402
-     fi
-     if [ -f /tmp/sns_interface_success ];then #170402
-      echo "     SUCCESS" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-      #in situation bring up interface from desktop icon...
-      [ "$DISPLAY" ] &&  yaf-splash -placement bottom -bg green -timeout 5 -text "Network interface ${INTERFACE} has been activated" &
-      #break
-      touch /tmp/sns_rc.network_exit #'exit' only terminates this code block (which is running as a separate process).
-      cancel_splash_and_exit #one internet connection is enough! #170505
-     else
-      echo "     FAIL" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-      [ "`pidof wpa_supplicant`" != "" ] && wpa_cli terminate #kill wpa_supplicant.
-      ifconfig $INTERFACE down
-      [ "`iwconfig $INTERFACE | grep "$INTERFACE" | grep "ESSID"`" != "" ] && iwconfig $INTERFACE essid off
-      dhcpcd --release $INTERFACE 2>/dev/null
-      ip route flush dev $INTERFACE #100703
-     fi 
+TRIED_INTERFACES='' #211002
+for INTERFACE in $PRIORITIZED_INTERFACES; do #exs: wlan0 eth0 (may contain duplicate entries) #211002
+    grep -wq "${INTERFACE}" <<< "${TRIED_INTERFACES}" && continue #211002
+    if [ -d "/sys/class/net/${INTERFACE}/wireless" ] \
+      || grep -q "${INTERFACE}:" /proc/net/wireless; then
+        initiate_wireless_connection #exits if successful #170924
+    else
+        initiate_wired_connection #exits if successful #170924
     fi
-   fi
-  done
-  [ -f /tmp/sns_rc.network_exit ] && break #100320 bug fix, if more than one wireless interface.
- done
-fi #170924
-
-[ -f /tmp/sns_rc.network_exit ] && cancel_splash_and_exit #170505
-
-##########WIRED##########
-grep '|Wired|' /tmp/sns_connections_available > /tmp/sns_connections_wired
-for INTERFACE in $INTERFACES #exs: wlan0 eth0
-do
- if interface_is_wireless ${INTERFACE} ; then
-   continue #only want wired.
- fi
- ifconfig $INTERFACE up > /tmp/sns_wired_log 2>&1
- [ $? -ne 0 ] && continue
-
- LINK_DETECTED=no
- TIMEOUT=15 #200412
- while [ $TIMEOUT -ge 0 ]; do #200412
-   if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
-     LINK_DETECTED="yes"
-     break
-   fi
-   [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190212 200412
- done
- if [ "$LINK_DETECTED" = "no" ] ; then
-   ifconfig $INTERFACE down
-   continue #no network.
- fi
-
- MACADDRESS="`ifconfig -a $INTERFACE | grep -o 'HWaddr .*' | cut -f 2 -d ' '`"
- maPATTERN='|'"$MACADDRESS"'|'
- DHCPCDFIX="`grep "$maPATTERN" /tmp/sns_connections_wired | head -n 1 | cut -f 7 -d '|'`" #100325 ex: -I ''
-
- echo "EXECUTING: dhcpcd ${DHCPCDFIX} ${INTERFACE}" >> /tmp/sns_wired_log #170924
- dhcpcd $DHCPCDFIX $INTERFACE >> /tmp/sns_wired_log 2>&1
- RC=$? #170402
- echo "dhcpcd return value: ${RC}" >> /tmp/sns_wired_log #170924
- sleep 0.1 #170924 Allow time for dhcpcd to write to resolv.conf
- if [ $RC -eq 0 ] && grep -q '^nameserver' /etc/resolv.conf; then #170402
-  echo "$INTERFACE" > /tmp/sns_interface_success #100325
-  cancel_splash_and_exit #success. #170505
- else
-  ifconfig $INTERFACE down
-  dhcpcd --release $INTERFACE 2>/dev/null
-  ip route flush dev $INTERFACE #100703
- fi
- 
+    TRIED_INTERFACES="${TRIED_INTERFACES}${INTERFACE} " #211002
 done
 cancel_splash_and_exit #170505
-
 
 ###END###

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091,2089,2090
 #(c) Copyright Barry Kauler 2010, bkhome.org
 #2010 Lesser GPL licence v2 (/usr/share/doc/legal/lgpl-2.1.txt)
 #100308 first version of script, open and wep networks only.
@@ -43,709 +44,105 @@
 #200521 v2.3.2: Correct damage to SNS_error dialog window title syntax; export version.
 #201001 v2.3.3: Change SRLINES to handle (erroneously) positive signal level for sort.
 #201017 v2.4: Change module detection to handle multiple aliases for a device and driver preferences (in rc.network & build_udevmodulelist).
-#201110 v2.4.1: Test for connection with udhdpc (peasywifi), as well as dhcpcd; make SNS current before networkdisconnect.
- 
-export VERSION='2.4.1'  #UPDATE this with each release!
+#201110 v2.4.1: Test for connection with udhcpc (peasywifi), as well as dhcpcd; make SNS current before networkdisconnect.
+#210601 v2.4.2: Add wireless rescan button.
+#210130 Correct setting of DHCPCDFIX.
+#210201 Reorganized code into segments.
+#210202 Replace deprecated ifconfig and route with busybox-compatable subset of ip (assuming nonfunctional -oneline); replace iwconfig with iw; replace pidof with 'ps -C'; replace iwlist scan with 'iw scan'; use signal level instead of quality for strength icon.
+#210204 Replace busybox ps+grep with 'ps -C'+grep for dhcpcd & udhcpc.
+#210205 Shorten delays after bringing link up.
+#210206 Ensure driver names placed in udevmodulelist for immediate use.
+#210207 Change WEP support to use wpa_supplicant; add nl80211 as default wpa driver.
+#210208 Prepend new connection, so newest profile tried first at boot-up; replace profile only for same SSID and MAC address; use 'read' to extract scan content.
+#210209 add message and no interface buttons if no interface detected; ensure all active interfaces down before starting new interface; kill wpa_supplicant when bringing interface down.
+#210210 Obtain bus type from /sys/class/net/ instead of modinfo aliases, which may support multiple buses; simplify truncation of interface descriptions (info).
+#210211 Show correct interface (or space) in profile tab.
+#210212 BK: /tmp/sns_interface_success no longer used (derived from easyos 190215).
+#210213 Remove wpa_supplicant.conf for profile being deleted.
+#210226 Resolve shellcheck issues.
+#210623 v3.0 (not annotated) Support hidden networks; remove unnecessary user selection of encryption protocols; use 'read' to extract fields from one-line entries; change profile format to omit unused fields; add wireless network name to status message; use eval_gettext where appropriate; rework connection wait splash messaging.
+#210703 v3.1 Accommodate EasyOS which does not use pup_event_backend_modprobe for module loading (udev rule, build_udevmodulelist, rc.network); change yaf-splash to gtkdialog-splash.
+#211002 v3.2 Add 'wired' profiles to top of connections list (as well as 'wireless' profiles); add splash message if 'iw' command not installed.
 
-export TEXTDOMAIN=sns___sns
+#set -x; exec >&2 #DEBUG
+export VERSION='3.2'  #UPDATE this with each release!
+
+export TEXTDOMAIN=simple_network_setup
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
 
-[ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
+[ "$(whoami)" != "root" ] && exec sudo -A "${0}" "${@}" #110505
 
-if ps --no-headers -C 'sns' | grep -qwv "^ *$$";then #170514... 190216
- sleep 1 #190525
- if ps --no-headers -C 'sns' | grep -qwv "^ *$$";then #190525
-  Xdialog --left --wmclass "sns" --title "$(gettext 'Simple Network Setup')"  --backtitle "\n$(gettext 'Simple Network Setup cannot start now because it is already active.')" --icon /usr/local/lib/X11/pixmaps/error.xpm --msgbox "\n$(gettext 'Please use the active SNS session or\nterminate it and start SNS again.')\n" 0 70
-  exit 1
- fi #190525
+if ps --no-headers -C sns | grep -qwv "^ *$$"; then #170514... 190216
+    sleep 1 #190525
+    if ps --no-headers -C sns | grep -qwv "^ *$$"; then #190525
+        Xdialog --left --wmclass "sns" --title "$(gettext 'Simple Network Setup')"  --backtitle "\n$(gettext 'Simple Network Setup cannot start now because it is already active.')" --icon /usr/local/lib/X11/pixmaps/error.xpm --msgbox "\n$(gettext 'Please use the active SNS session or\nterminate it and start SNS again.')\n" 0 70
+        exit 1
+    fi #190525
 fi #170514 end
 
-#each line of /etc/simple_network_setup/connections has everything known about a connection:
+#each line of /etc/simple_network_setup/connections has everything needed about a connection:
 #(please ignore spaces, put here for readability only)
-#Wireless:
-#        1         2          3         4       5                                   6                 7           8                 9            10           11                 12         13                         14       15          16         17
-#format: INTERFACE|IF_INTTYPE|IF_DRIVER|IF_BUS |IF_INFO                            |MACADDRESS       |CELL_NUMBER|CELL_ADDRESS     |CELL_CHANNEL|CELL_QUALITY|CELL_ENCRYPTIONKEY|CELL_ESSID|SEC_KEY                   |SEC_MGMT|ENCODEPROTO|WPA_DRIVER|DHCPCDFIX|
-#ex:     wlan1    |Wireless  |rt73usb  |usb    |Ralink RT73 USB Wireless LAN driver|00:26:19:F5:AC:3D|01         |00:17:3F:68:33:7E|11          |70/70       |on                |belkin54g |000102030405060708090a0b0c|WEP     |           |          |
-#Wired:
-#        1         2          3         4       5                                       6                 7
-#format: INTERFACE|IF_INTTYPE|IF_DRIVER|IF_BUS |IF_INFO                                |MACADDRESS       |DHCPCDFIX|
-#ex:     eth0     |Wired     |sky2     |pci    |Marvell Yukon 2 Gigabit Ethernet driver|00:17:36:84:E5:1A|         |
+#        1                 2          3         4       5                                       6         7          8                 9        10                         11
+#format: MACADDRESS       |IF_INTTYPE|IF_DRIVER|IF_BUS |IF_INFO                                |DHCPCDFIX|CELL_ESSID|CELL_ADDRESS     |SEC_MGMT|SEC_KEY                   |WPA_DRIVER|
+#ex:     00:17:36:84:E5:1A|Wired     |sky2     |pci    |Marvell Yukon 2 Gigabit Ethernet driver|         |belkin54g |00:17:3F:68:33:7E|WPA-PSK |000102030405060708090a0b0c|nl80211   |
 
-# $1: interface
-interface_is_wireless() {
-	if [ ! "$1" ] ; then
-		return 1 #error
-	fi
-	if grep -q "${1}:" /proc/net/wireless ; then
-		return 0 #yes
-	fi
-	if [ -d /sys/class/net/${1}/wireless ] ; then
-		return 0 #yes
-	fi
-	# k3.2.x: my problematic wireless pci adapter is only recognized by iwconfig..
-	# hmm with 2 pci wireless adapters only iwconfig does the trick
-	if iwconfig ${1} 2>&1 | grep -q 'no wireless' ; then
-		return 1 #no
-	fi
-	return 0 #yes
-}
+find_interface_driver() {
+    FINDTYPE="$(readlink "/sys/class/net/$INTERFACE/device/driver")"
+    IF_DRIVER=${FINDTYPE##*/} #basename - ex: ath5k
+    IF_BUS="$(grep -o '/bus/[^/]*' <<< "$FINDTYPE" | cut -f 3 -d /)" #210210
+    IF_INFO="$(sed -n 's%^description: *%%p' <<< "$(modinfo "$IF_DRIVER" 2>/dev/null)")" #210210
+    if [ "$IF_DRIVER" = "ndiswrapper" ]; then
+        WINDRVR="$(ndiswrapper -l | grep '^[a-zA-Z0-9]' | cut -f 1 -d ' ')"
+        IF_INFO="MS Windows driver '${WINDRVR}'"
+    fi
+    if [ ! -e "/tmp/simple_network_setup/udevmodulelist/$IF_DRIVER" ]; then #210206...
+        mkdir -p /tmp/simple_network_setup/udevmodulelist
+        echo "$IF_DRIVER" > "/tmp/simple_network_setup/udevmodulelist/$IF_DRIVER"
+    fi
+} #find_interface_driver
 
-setup_wifi(){
+collect_interface_data() {
+    #want to manipulate the info string for display purposes...
+    local CNTLINE=-1; local CLEANINFO #210210...
+# shellcheck disable=SC2021
+    CLEANINFO="$(tr '[&|"<>]' ' ' <<< "$IF_INFO" | tr -s ' ')" #filter out chars that mess up xml.
+    for ONEWORD in $CLEANINFO; do
+        CNTLINE="$((CNTLINE + 1 + ${#ONEWORD}))"
+        [ "$CNTLINE" -gt 60 ] && break
+    done
+    IF_INFO="${CLEANINFO:0:$CNTLINE}"
 
-FLAGERR=
- rm -f /tmp/sns_scan_radiobuttons
- rm -f /tmp/sns_scan_radiobuttons_shield
- rm -f /tmp/sns_scan_radiobuttons_strength
- rm -f /tmp/sns_scan_radiobuttons_address
- rm -f /tmp/sns_scan_rawoneline
- rm -f /tmp/sns_scan_oneline
- yaf-splash -placement center -bg orange -text "$(gettext 'Please wait, scanning for wireless networks...')" &
- PIDXMSG=$!
- echo "Information about this interface:
- Interface: $INTERFACE  Driver: $IF_DRIVER  Bus: $IF_BUS  MacAddress: $MACADDRESS
- Description: $IF_INFO
- " > /tmp/sns_wireless_log
- [ "`iwconfig $INTERFACE | grep "$INTERFACE" | grep "ESSID"`" != "" ] && iwconfig $INTERFACE essid off
- echo "STEP1a: ifconfig $INTERFACE up" >> /tmp/sns_wireless_log
- ifconfig $INTERFACE up >> /tmp/sns_wireless_log 2>&1
- if [ $? -ne 0 ];then
-  FLAGERR=1
- else
-  sleep 4
-  echo "STEP1b: iwlist $INTERFACE scan | grep -E (messages & labels)" >> /tmp/sns_wireless_log #180706
-  SCANRESULT="`iwlist $INTERFACE scan | grep -E 'Address:|Channel:|Frequency:|Quality[:=]|Encryption key:|ESSID:|Scan completed|No scan results'`" ###SCANNING### 110203
-  if [ "`echo "$SCANRESULT" | grep -m 1 'Scan completed'`" = "" ];then #100513 110203 180706
-   sleep 2
-   SCANRESULT="`iwlist $INTERFACE scan | grep -E 'Address:|Channel:|Frequency:|Quality[:=]|Encryption key:|ESSID:|Scan completed|No scan results'`" ###SCANNING### 110203
-  fi
-  echo "$SCANRESULT" >> /tmp/sns_wireless_log
-  echo "STEP1c: ifconfig $INTERFACE down" >> /tmp/sns_wireless_log
-  ifconfig $INTERFACE down #100313
-  #convert each found network into a single line... 110203
-  SRLINES="`echo "$SCANRESULT" | grep -v 'Scan completed' | tr '|' ' ' | tr '\n' '|' | sed -e 's%       Cell %\n%g' | tr -s ' ' | sed -e 's%\(Signal level=\)\([0-9-]\+\)%\1@\2@%' | sort -g -r -t @ -k 2 | sed -e 's%\(Signal level=\)@\([0-9-]\+\)@%\1\2%'`" #170619 #201001
-  echo "$SRLINES" |
-  while read ONELINE
-  do
-   [ "$ONELINE" = "" ] && continue
-   [ "$ONELINE" = " " ] && continue
-   [ "`echo -n "$ONELINE" | grep 'No scan results'`" != "" ] && continue #101029
-   [ "`echo -n "$ONELINE" | grep ' ESSID:'`" = "" ] && continue #101029
-   CELL_NUMBER="`echo -n "$ONELINE" | cut -f1 -d' '`"
-   CELL_ADDRESS="`echo -n "$ONELINE" | grep -o ' Address: .*' | cut -f 3 -d ' ' | cut -f1 -d '|'`"
-   CELL_CHANNEL="`echo -n "$ONELINE" | grep -o ' Channel:.*' | cut -f2 -d':' | cut -f1 -d'|'`"
-   [ "$CELL_CHANNEL" == "" ] && CELL_CHANNEL="`echo -n "$ONELINE" | grep -o ' (Channel .*' | cut -f 3 -d ' ' | cut -f 1 -d')'`"
-   CELL_QUALITY="`echo -n "$ONELINE" | grep -o ' Quality[:=].*' | cut -f 2 -d ' ' | cut -f 2 -d '=' | cut -f 2 -d ':'`"
-   CELL_ESSID="`echo -n "$ONELINE" | grep -o ' ESSID:.*' | cut -f 2 -d '"'`" #190216
-   CELL_ENCRYPTIONKEY="`echo -n "$ONELINE" | grep -o 'Encryption key:.*' | cut -f 2 -d ':' | cut -f1 -d '|'`" #ex: off
+    if [ -d "/sys/class/net/${INTERFACE}/wireless" ] \
+      || grep -q "${INTERFACE}:" /proc/net/wireless ; then
+        IF_INTTYPE='Wireless'
+        IF_INTTYPE_XLATED="$(gettext 'Wireless')"
+    else
+        IF_INTTYPE='Wired'
+        IF_INTTYPE_XLATED="$(gettext 'Wired')"
+    fi
 
-   #build network list
-   if [ $CELL_ENCRYPTIONKEY = on ]; then
-	IMG_SHIELD=wifi_encrypted
-	TXT_SHIELD="$(gettext 'Encrypted')"
-   else
-    IMG_SHIELD=wifi_open
-	TXT_SHIELD="$(gettext 'Open')"
-   fi
-   IMG_QUALITY=quality_0
-   QTY=$(echo "100"'*'"$CELL_QUALITY" | bc)
-   if   [ $QTY -gt 80 ]; then IMG_QUALITY=quality_5
-   elif [ $QTY -gt 60 ]; then IMG_QUALITY=quality_4
-   elif [ $QTY -gt 40 ]; then IMG_QUALITY=quality_3
-   elif [ $QTY -gt 20 ]; then IMG_QUALITY=quality_2
-   elif [ $QTY -gt 5 ] ; then IMG_QUALITY=quality_1
-   fi
-   [ "$CELL_ESSID" ] || CELL_ESSID="(hidden ESSID)" #$CELL_ESSID must not be blank
-   echo '<radiobutton height-request="25" space-expand="false" space-fill="false">
-       <label>'${CELL_ESSID:0:20}'</label>
-       <variable>RADIO_'${CELL_NUMBER}'</variable>
-     </radiobutton>' >> /tmp/sns_scan_radiobuttons #190216
-   echo '
-   <hbox space-expand="false" space-fill="false">
-     <text xalign="1" yalign="1" use-markup="true" space-expand="true" space-fill="true">
-       <label>"<small><small>'${TXT_SHIELD}'</small></small>"</label>
-     </text>
-     <pixmap height-request="25" space-expand="false" space-fill="false">
-       <input file>/usr/share/pixmaps/puppy/'${IMG_SHIELD}'.svg</input>
-       <height>25</height>
-     </pixmap>
-   </hbox>' >> /tmp/sns_scan_radiobuttons_shield
-   echo '
-   <hbox space-expand="false" space-fill="false">
-     <text xalign="0" yalign="1" use-markup="true" space-expand="true" space-fill="true">
-       <label>"<small><small>'${CELL_QUALITY}'</small></small>"</label>
-     </text>
-     <pixmap height-request="25" space-expand="false" space-fill="false">
-       <input file>/usr/share/pixmaps/puppy/'${IMG_QUALITY}'.svg</input>
-       <height>25</height>
-     </pixmap>
-   </hbox>' >> /tmp/sns_scan_radiobuttons_strength
-   echo '
-   <hbox space-expand="false" space-fill="false" height-request="25">
-     <text xalign="1" yalign="1" use-markup="true" space-expand="true" space-fill="true">
-       <label>"'${CELL_ADDRESS}'"</label>
-     </text>
-   </hbox>' >> /tmp/sns_scan_radiobuttons_address
-   #---
-   
-   echo "$ONELINE" >> /tmp/sns_scan_rawoneline
-   echo "${CELL_NUMBER}|${CELL_ADDRESS}|${CELL_CHANNEL}|${CELL_QUALITY}|${CELL_ENCRYPTIONKEY}|${CELL_ESSID}" >> /tmp/sns_scan_oneline
-  done
- 
-  #my wpa_supplicant only supports: wext hostap atmel wired ralink roboswitch
-  case $IF_DRIVER in
-   hostap*)   WPA_DRIVER="hostap" ;;
-   rt61|rt73) WPA_DRIVER="ralink" ;;
-   *)         WPA_DRIVER="wext" ;;
-  esac
- 
-  if [ ! -f /tmp/sns_scan_radiobuttons ];then
-   FRAME1='<text space-expand="true" space-fill="true"><label>""</label></text>'
-   FRAME2=""
-   WIN2MSG1="$(gettext 'No wireless networks found')"
-   WIN2BUT1=""
-   WIN2BUT2=""
-  else
-   WIN2MSG1="$(gettext "Choose which network you want to use, type of encryption, then click <b>Connect</b> button.")"
-   RADIOBUTTONS='
-   <hbox space-expand="true" space-fill="true">
-     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons`'</vbox>
-     <text space-expand="true" space-fill="true"><label>""</label></text>
-     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_shield`'</vbox>
-     <text width-request="2" space-expand="false" space-fill="false"><label>""</label></text>
-     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_strength`'</vbox>
-     <vbox space-expand="false" space-fill="false">'`cat /tmp/sns_scan_radiobuttons_address`'</vbox>
-   </hbox>'
-   FRAME1='
-    <vbox space-expand="true" space-fill="true">
-    <frame '$(gettext 'Wireless networks')'>
-      <vbox scrollable="true" shadow-type="1" space-expand="false" space-fill="false">
-        <eventbox name="bg"  above-child="false" visible-window="true" space-expand="true" space-fill="true">
-          <vbox border-width="5" space-expand="true" space-fill="true">
-            '${RADIOBUTTONS}'
-          </vbox>
-        </eventbox>
-      </vbox>
-    </frame>
-    </vbox>'
-   FRAME2='
-   <vbox space-expand="false" space-fill="false">
-     <frame '$(gettext 'Encryption')'>
-       <hbox border-width="5" space-expand="true" space-fill="true">
-         <vbox space-expand="false" space-fill="false">
-           <radiobutton space-expand="false" space-fill="false">
-             <label>'$(gettext 'None')'</label>
-             <variable>BUTSEC_NONE</variable>
-           </radiobutton>
-           <radiobutton space-expand="false" space-fill="false">
-             <label>WEP</label>
-             <variable>BUTSEC_WEP</variable>
-           </radiobutton>
-           <radiobutton space-expand="false" space-fill="false">
-             <label>WPA</label>
-             <variable>BUTSEC_WPAPSK</variable>
-             <default>true</default>
-           </radiobutton>
-         </vbox>
+    #accumulate the results into columns...
+    ALL_IF_INTERFACE="${ALL_IF_INTERFACE}|${INTERFACE}"
+    ALL_IF_INTTYPE="${ALL_IF_INTTYPE}|${IF_INTTYPE_XLATED}"
+    ALL_IF_DRIVER="${ALL_IF_DRIVER}|${IF_DRIVER}"
+    ALL_IF_BUS="${ALL_IF_BUS}|${IF_BUS:=x}" #If null, replace with x #210210
+    ALL_IF_INFO="${ALL_IF_INFO}|${IF_INFO:=x}" #210210
+    INTERFACEBUTTONS="${INTERFACEBUTTONS} 
+  <button><label>${INTERFACE}</label><action type=\"exit\">Interface_${INTERFACE}</action></button>"
+    #save all data about each interface on one line...
+    #ex: wlan1|Wireless|ath5k|pci|Support for 5xxx series of Atheros 802.11 wireless LAN cards
+    echo "${INTERFACE}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}" >> /tmp/sns_interfaces
+} #collect_interface_data
 
-         <text width-request="30" space-expand="false" space-fill="false"><label>""</label></text>
-         <vbox space-expand="true" space-fill="true">
-           <hbox space-expand="true" space-fill="true">
-              <vbox>
-                <text xalign="0" space-expand="true" space-fill="true"><label>'$(gettext 'Password:')'</label></text>
-                <notebook show-tabs="false" show-border="false" visible="false">
-                  <vbox>
-                    <entry space-expand="true" space-fill="true" caps-lock-warning="true" 
-                     tooltip-markup="'$(gettext 'Enter your network password')'" visibility="false">
-                      <variable>PASS_SHOWN</variable>
-                      <input>echo "$PASS_HIDDEN"</input>
-                      <action>refresh:PASS_HIDDEN</action>
-                    </entry>
-                  </vbox>
-                  <vbox>
-                    <entry space-expand="true" space-fill="true" caps-lock-warning="true" 
-                     tooltip-markup="'$(gettext 'Enter your network password')'" visibility="true">
-                      <variable>PASS_HIDDEN</variable>
-                      <input>echo "$PASS_SHOWN"</input>
-                      <action>refresh:PASS_SHOWN</action>
-                    </entry>
-                  </vbox>
-                  <variable>SWITCH</variable>
-                  <input>echo $(( (SWITCH+1) &1 ))</input>
-                </notebook>
-                <checkbox space-expand="true" space-fill="true">
-                  <label>'$(gettext 'Show password')'</label>
-                  <action>refresh:SWITCH</action>
-                </checkbox>
-              </vbox>
-           </hbox>
-         </vbox>
+build_interface_display_list() {
+    ALL_IF_INTERFACE="$(tr '|' '\n' <<< "${ALL_IF_INTERFACE#|}")"
+    ALL_IF_INTTYPE="$(tr '|' '\n' <<< "${ALL_IF_INTTYPE#|}")"
+    ALL_IF_DRIVER="$(tr '|' '\n' <<< "${ALL_IF_DRIVER#|}")"
+    ALL_IF_BUS="$(tr '|' '\n' <<< "${ALL_IF_BUS#|}")"
+    ALL_IF_INFO="$(tr '|' '\n' <<< "${ALL_IF_INFO#|}")"
 
-       </hbox>
-     </frame>
-   </vbox>'
-   WIN2BUT1='
-   <button can-default="true" has-default="true" space-expand="false" space-fill="false">
-     <variable>BTN_CONNECT</variable>
-     <label>'$(gettext "Connect")'</label>
-     '"`/usr/lib/gtkdialog/xml_button-icon internet_connect.svg`"'
-     <action type="exit">BUT_CONNECT</action>
-   </button>'
-   WIN2BUT2='
-   <button space-expand="false" space-fill="false">
-     <label>'$(gettext 'Help')'</label>
-     '"`/usr/lib/gtkdialog/xml_button-icon help`"'
-     <action>/usr/local/simple_network_setup/help_security & </action>
-   </button>'
-  fi
-
-  kill $PIDXMSG 2>/dev/null ; PIDXMSG=""
-
-  export SNS_setup='<window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network" height-request="400">
-  <vbox space-expand="true" space-fill="true">
-    '"`/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext "${WIN2MSG1}")"`"' 
-    '${FRAME1}'
-    '${FRAME2}'
-    <hbox space-expand="false" space-fill="false">
-      <button space-expand="false" space-fill="false">
-        <label>'$(gettext "Rescan")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon refresh`"'
-        <action type="exit">BUT_RESCAN</action>
-      </button>
-      '${WIN2BUT2}'
-      <text space-expand="true" space-fill="true"><label>""</label></text>
-      <button space-expand="false" space-fill="false">
-        <label>'$(gettext "Cancel")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon cancel`"'
-        <action type="exit">BUT_GOBACK</action>
-      </button>
-      '${WIN2BUT1}'
-    </hbox>
-  </vbox>
-
-  <action signal="map-event">show:SWITCH</action>
-  <action signal="map-event">grabfocus:PASS_HIDDEN</action>
-</window>'
-  
-  #darker bg
-  echo '<?xml version="1.1" encoding="UTF-8"?><svg height="10" width="10">
-    <rect style="fill:#000000;fill-opacity:0.2" width="10" height="10" x="0" y="0"/></svg>' > /tmp/sns_bg.svg
-
-  echo '
-  pixmap_path "/tmp"
-  style "bg" { bg_pixmap[NORMAL] = "sns_bg.svg" }
-  widget "*bg*" style "bg"' > /tmp/gtkrc_mono
-  export GTK2_RC_FILES=/tmp/gtkrc_mono:/root/.gtkrc-2.0
-  #---
-  
-  . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
-  RETSTRING="`gtkdialog -p SNS_setup`" 
-  [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'BUT_GOBACK'`" != "" ] && exec sns
-  [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'BUT_RESCAN'`" != "" ] && setup_wifi
-  [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'BUT_CONNECT'`" == "" ] && exit
-
-  SEC_MGMT=""; WPA_ENC=""
-  SEC_KEY="`echo "$RETSTRING" | grep '^PASS_HIDDEN' | cut -f 2 -d '"' | tr -d '-'`" #'geany
-  BUTSEC="`echo "$RETSTRING" | grep '^BUTSEC_' | grep 'true' | cut -f 1 -d '=' | cut -f 2 -d '_'`"
-  case $BUTSEC in
-   WEP)        SEC_MGMT="WEP"; WPA_ENC=""  ;;
-   WPAPSK)     SEC_MGMT="WPA-PSK"; WPA_ENC="" ;;
-   WPAPSKTKIP) SEC_MGMT="WPA-PSK"; WPA_ENC="TKIP" ;;
-   WPAPSKAES)  SEC_MGMT="WPA-PSK"; WPA_ENC="AES" ;;
-   WPA2PSKAES) SEC_MGMT="WPA2-PSK"; WPA_ENC="AES"  ;;
-   *)          SEC_KEY="" ;; #no encryption.
-  esac 
- 
-  CELL_NUMBER="`echo "$RETSTRING" | grep '^RADIO' | grep 'true' | cut -f1 -d'=' | cut -f2 -d'_'`" #ex: 01
-  cnPATTERN='^'"$CELL_NUMBER"'|'
-  CELLDATA="`grep "$cnPATTERN" /tmp/sns_scan_oneline`"
-  CELL_ADDRESS="`echo -n "$CELLDATA" | cut -f2 -d'|'`"
-  CELL_CHANNEL="`echo -n "$CELLDATA" | cut -f3 -d'|'`"
-  CELL_QUALITY="`echo -n "$CELLDATA" | cut -f4 -d'|'`"
-  CELL_ENCRYPTIONKEY="`echo -n "$CELLDATA" | cut -f5 -d'|'`"
-  CELL_ESSID="`echo -n "$CELLDATA" | cut -f6 -d'|'`"
- 
-  if [ "$CELL_ENCRYPTIONKEY" == "on" ];then
-   [ "$SEC_KEY" == "" ] && FLAGERR=2
-   [ "$SEC_MGMT" == "" ] && FLAGERR=3
-  fi
-  if [ ! $FLAGERR ];then
- 
-   yaf-splash -placement center -bg orange -text "$(gettext 'Please wait, attempting to connect to') '${CELL_ESSID}'..." &
-   PIDX=$!
-   echo "STEP2: iwconfig $INTERFACE mode managed" >> /tmp/sns_wireless_log
-   iwconfig $INTERFACE mode managed  >> /tmp/sns_wireless_log 2>&1
-   echo "STEP3: iwconfig $INTERFACE channel $CELL_CHANNEL" >> /tmp/sns_wireless_log
-   iwconfig $INTERFACE channel $CELL_CHANNEL  >> /tmp/sns_wireless_log 2>&1
-   echo "STEP4: iwconfig $INTERFACE essid \"$CELL_ESSID\"" >> /tmp/sns_wireless_log
-   iwconfig $INTERFACE essid "$CELL_ESSID"  >> /tmp/sns_wireless_log 2>&1
-
-   #test essid is associated...
-   if [ $? -ne 0 ];then
-    FLAGERR=4
-   else
-   
-    RUNWPASUPP='no'
-    [ -f "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}" ] && rm -f "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
-    FIXUP='1 1 2 0'
-    [ "$IF_DRIVER" = "ndiswrapper" ] && FIXUP='2 1 0'
-    [ "$BUTSEC" = "WEP" ] && FIXUP='restricted open'
-    fuCNT=`echo -n "$FIXUP" | wc -w`
-    fuCNT=$(($fuCNT + 1)) #100321 bug fix.
-    for ONEFIX in $FIXUP ###BIG FOR LOOP###
-    do
-     FLAGERR= #100323
-     fuCNT=$(($fuCNT - 1))
-     if [ "$CELL_ENCRYPTIONKEY" == "on" ];then
-      case $BUTSEC in
-       WEP)
-        echo "STEP5: iwconfig $INTERFACE key $ONEFIX $SEC_KEY" >> /tmp/sns_wireless_log
-        iwconfig $INTERFACE key $ONEFIX "$SEC_KEY"
-       ;;
-       WPAPSK) #very simple, handles all ciphers.
-        #it works psk="passphrase" (with quotes), but for security encode psk into hex string...
-        hexSEC_KEY=`wpa_passphrase "$CELL_ESSID" "$SEC_KEY" | grep '[^#]psk=' | cut -f 2 -d '='`
-        echo "ctrl_interface=/var/run/wpa_supplicant
-ap_scan=${ONEFIX}
-
-network={
- ssid=\"${CELL_ESSID}\"
- key_mgmt=${SEC_MGMT}
- psk=${hexSEC_KEY}
-}" > "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
-        RUNWPASUPP='yes'
-        if [ "`pidof wpa_supplicant`" != "" ];then
-         wpa_cli terminate
-         killall wpa_supplicant
-        fi
-       ;;
-       WPA*)  
-        #it works psk="passphrase" (with quotes), but for security encode psk into hex string...
-        hexSEC_KEY=`wpa_passphrase "$CELL_ESSID" $SEC_KEY | grep '[^#]psk=' | cut -f 2 -d '='`
-        echo "ctrl_interface=/var/run/wpa_supplicant
-ap_scan=${ONEFIX}
-
-network={
- ssid=\"${CELL_ESSID}\"
- proto=WPA
- key_mgmt=${SEC_MGMT}
- pairwise=${WPA_ENC}
- group=${WPA_ENC}
- psk=${SEC_KEY}
- wpa_ptk_rekey=600
-}" > "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
-        RUNWPASUPP='yes'
-        if [ "`pidof wpa_supplicant`" != "" ];then
-         wpa_cli terminate #kills any running wpa_supplicant. no it doesn't, just brings down interface.
-         killall wpa_supplicant
-        fi
-       ;;
-      esac
-     fi
- 
-     echo "STEP5a: ifconfig $INTERFACE up" >> /tmp/sns_wireless_log
-     ifconfig $INTERFACE up
-     sleep 4
-     if [ "$RUNWPASUPP" = "yes" ];then
-      echo "STEP5b: wpa_supplicant -B -D${WPA_DRIVER} -i${INTERFACE} -c\"/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}\"" >> /tmp/sns_wireless_log
-      wpa_supplicant -B -D${WPA_DRIVER} -i${INTERFACE} -c"/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}" >> /tmp/sns_wireless_log 2>&1
-      wCNT=0
-      while [ 1 ];do
-       [ "`wpa_cli -i $INTERFACE status | grep '^bssid=[0-9a-f]'`" != "" ] && break
-       sleep 1
-       wCNT=`expr $wCNT + 1`
-       if [ $wCNT -gt 20 ];then
-        echo "Running: wpa_cli -i ${INTERFACE} status" >> /tmp/sns_wireless_log
-        wpa_cli -i $INTERFACE status >> /tmp/sns_wireless_log 2>&1
-        #FLAGERR=5
-        #100314 http://wiki.archlinux.org/index.php/WPA_supplicant has following advice...
-        #really weird, works for my wg311 ndiswrapper driver. but must have the ap_scan sequence 2 1 0...
-        #ignore error, do this instead...
-        killall -SIGHUP wpa_supplicant
-        iwconfig $INTERFACE essid "$CELL_ESSID"
-        break
-       fi
-      done
-     fi
-     if [ $FLAGERR ];then
-      if [ $fuCNT -ne 0 ];then
-       kill $PIDX 2>/dev/null
-       case $fuCNT in
-        1) BGCOLOR="HotPink" ;;
-        2) BGCOLOR="pink" ;;
-        *) BGCOLOR="DeepPink" ;;
-       esac
-       yaf-splash -placement center -bg $BGCOLOR -text "$(gettext 'Please keep waiting, retrying encrypted connection...')" &
-       PIDX=$!
-       continue #try next FIXUP value (see for-loop above). ###BIG FOR LOOP###
-      fi
-      if [ "`pidof wpa_supplicant`" != "" ];then
-       wpa_cli terminate
-       killall wpa_supplicant
-      fi
-      [ "`iwconfig $INTERFACE | grep "$INTERFACE" | grep "ESSID"`" != "" ] && iwconfig $INTERFACE essid off
-      ifconfig $INTERFACE down
-     else
- 
-      #wait until access point becomes available...
-      sCNT=0
-      while [ 1 ];do
-       TESTAP="`iwconfig ${INTERFACE} | grep -o 'Access Point: .*' | tr -s ' ' | cut -f 3 -d ' ' | sed -e 's%[^:]%%g'`"
-       [ "`echo -n "$TESTAP" | grep '::::'`" != "" ] && break
-       sleep 1
-       sCNT=`expr $sCNT + 1`
-       if [ $sCNT -gt 20 ];then
-        echo "" >> /tmp/sns_wireless_log #100320
-        echo "ERROR, TIMEOUT. Have not got an Access Point." >> /tmp/sns_wireless_log #100320
-        echo "Result of 'iwconfig ${INTERFACE}':" >> /tmp/sns_wireless_log #100320
-        iwconfig ${INTERFACE} >> /tmp/sns_wireless_log 2>&1 #100320
-        echo "" >> /tmp/sns_wireless_log #100320
-        FLAGERR=7
-        break
-       fi
-      done
-      if [ $FLAGERR ];then
-       if [ $fuCNT -ne 0 ];then
-        kill $PIDX 2>/dev/null
-        case $fuCNT in
-         1) BGCOLOR="HotPink" ;;
-         2) BGCOLOR="pink" ;;
-         *) BGCOLOR="DeepPink" ;;
-        esac
-        yaf-splash -placement center -bg $BGCOLOR -text "$(gettext 'Please keep waiting, retrying encrypted connection...')" &
-        PIDX=$!
-        continue #try next FIXUP parameter (see for-loop above). ###BIG FOR LOOP###
-       fi
-       [ "`iwconfig $INTERFACE | grep "$INTERFACE" | grep "ESSID"`" != "" ] && iwconfig $INTERFACE essid off
-       ifconfig $INTERFACE down
-      else
-    
-       #finally, run dhcpcd...
-       rm -f /tmp/sns_interface_success #170402
-       for iterDHCPCD in a b #100320
-       do
-        [ "$iterDHCPCD" = "a" ] && DHCPCDFIX=""
-        [ "$iterDHCPCD" = "b" ] && DHCPCDFIX="-I ''" #some dhcp servers require empty Client ID (default is macaddress).
-        echo "STEP6${iterDHCPCD}: dhcpcd $DHCPCDFIX $INTERFACE" >> /tmp/sns_wireless_log
-        dhcpcd $DHCPCDFIX $INTERFACE >> /tmp/sns_wireless_log 2>&1 ####DHCP CLIENT#### 121117
-        RC=$? #170402
-        sleep 0.1 #170924 Allow time for dhcpcd to write to resolv.conf
-        if [ $RC -eq 0 ] && grep -q '^nameserver' /etc/resolv.conf;then #170402
-         echo "$INTERFACE" > /tmp/sns_interface_success #100325
-        else #170402
-         sleep 1
-         [ "$iterDHCPCD" != "b" ] && dhcpcd --release $INTERFACE
-        fi #170402
-       done
-       [ -f /tmp/sns_interface_success ] || FLAGERR=6 #170402
-        
-       if [ $FLAGERR ];then
-        if [ "`pidof wpa_supplicant`" != "" ];then
-         wpa_cli terminate
-         killall wpa_supplicant
-        fi
-        [ "`iwconfig $INTERFACE | grep "$INTERFACE" | grep "ESSID"`" != "" ] && iwconfig $INTERFACE essid off
-        ifconfig $INTERFACE down
-        dhcpcd --release $INTERFACE 2>/dev/null
-        ip route flush dev $INTERFACE #100703
-       else
-
-        #success!
-        echo "$INTERFACE" > /tmp/sns_interface_success #101118
-        #100413 have one pc where blinky did not start. try again...
-        [ "`which blinky_tray`" ] && [ "`pidof blinky_tray`" = "" ] && blinky_tray &
-        essidPATTERN='|'"$CELL_ESSID"'|'
-        touch /etc/simple_network_setup/connections
-        grep -v "$essidPATTERN" /etc/simple_network_setup/connections > /tmp/sns_temp2
-        mv -f /tmp/sns_temp2 /etc/simple_network_setup/connections
-        case $SEC_MGMT in
-         WEP) ENCODEPROTO="$ONEFIX"; WPA_DRIVER="" ;; #exs: restricted, open
-         *) ENCODEPROTO="$WPA_ENC" ;; #exs: AES, TKIP
-        esac
-        echo "${IFDATA}|${MACADDRESS}|${CELLDATA}|${SEC_KEY}|${SEC_MGMT}|${ENCODEPROTO}|${WPA_DRIVER}|${DHCPCDFIX}|" >> /etc/simple_network_setup/connections
-        XML_FIREWALL=""
-        if ! [ -x /etc/rc.d/rc.firewall -o -x /etc/init.d/rc.firewall ];then
-         XML_FIREWALL='
-         <text><label>"'$(gettext "However, there is one item of recommended housekeeping: you really should be running a firewall. Puppy is inherently secure, however a firewall will give you that extra protection while online. Recommend that you tick the 'Start firewall' checkbox (the firewall will install and will automatically run at all future boots)...")'"</label></text>
-         <checkbox>
-           <label>'$(gettext 'Start firewall')'</label>
-           <default>true</default>
-           <variable>CHK_FIREWALL</variable>
-         </checkbox>
-         <hseparator></hseparator>'
-        fi
-        kill $PIDX 2>/dev/null
-        export SNS_complete='
-        <window title="'$(gettext 'SNS: Simple Network Setup')'" icon-name="gtk-network">
-        <vbox>
-          <frame>
-            '"`/usr/lib/gtkdialog/xml_pixmap dialog-complete.svg popup`"'
-            <text use-markup="true"><label>"<b>'$(gettext 'Successful connection to wireless network')' '${CELL_ESSID}'</b>"</label></text>
-            <text><label>""</label></text>
-            '${XML_FIREWALL}'
-            <hseparator></hseparator>
-            <text xalign="0"><label>'$(gettext "SNS will automatically connect to the Internet at bootup, wirelessly if possible.")'</label></text>
-            <text xalign="0"><label>'$(gettext "To make SNS the default network setup tool so that clicking the 'connect' icon on the desktop or selecting 'Setup networking' from the network tray icon will immediately launch SNS...")'</label></text>
-            <checkbox>
-              <label>'$(gettext 'Set SNS as default network setup tool')'</label>
-              <default>true</default>
-              <variable>CHK_SNSDEF</variable>
-            </checkbox>
-          </frame>
-          <hbox>
-            <button space-expand="false" space-fill="false">
-              <label>'$(gettext "Ok")'</label>
-              '"`/usr/lib/gtkdialog/xml_button-icon ok`"'
-              <action>exit:OK</action>
-            </button>
-          </hbox>
-        </vbox>
-        </window>' #190216
-        RETSTR3="`gtkdialog -p SNS_complete --center`"
-        if [ "`echo "$RETSTR3" | grep '^CHK_SNSDEF' | grep 'true'`" != "" ];then
-         echo -e '#!/bin/sh\nexec sns' > /usr/local/bin/defaultconnect
-        else
-         echo -e '#!/bin/sh\nexec connectwizard' > /usr/local/bin/defaultconnect
-        fi
-        if [ "`echo "$RETSTR3" | grep '^CHK_FIREWALL' | grep 'true'`" != "" ];then
-         "$FW_EXEC"
-        fi
-       fi #end test dhcpcd timeout.
-      fi #end test access point.
-     fi #end test wpa_supplicant timeout.
-     break
-    done #end for-loop. ###END BIG FOR LOOP###
-   fi #end test associate essid.
-  fi #end test exist security entries.
- fi #end test ifconfig up
-
- if [ $FLAGERR ];then
-  [ $PIDXMSG ] && kill $PIDXMSG 2>/dev/null
-  [ $PIDX ] && kill $PIDX 2>/dev/null
-  case $SEC_MGMT in
-  WPA*) ERR_EXTRA1="$(gettext 'Note: the network card and/or Linux driver might not support WPA2, in which case you will need to set the wireless router to WPA. Or, WPA might not be supported at all, in which case you will have to set the router and network card to use WEP.')" ;;
-  *)    ERR_EXTRA1="" ;;
-  esac
-  case $FLAGERR in
-   1) ERR_MSG="`eval_gettext \"Failed to activate interface '\\\${INTERFACE}. Sometimes this is just a temporary problem. Go back to the main window, and you can try again...\"`" ; ERR_EXTRA1="" ;; #'`"geany
-   2) ERR_MSG="$(gettext 'ERROR: you did not specify a Key')" ; ERR_EXTRA1="" ;;
-   3) ERR_MSG="$(gettext 'ERROR: you need to choose WEP or WPA security')" ; ERR_EXTRA1="" ;;
-   4) ERR_MSG="`eval_gettext \"Failed to associate '\\\${CELL_ESSID}' with ESSID.\"`"; ERR_EXTRA1="" ;; #'`"geany
-   7) ERR_MSG="$(gettext 'Failed to obtain Access Point of network.')";  ERR_EXTRA1="" ;;
-   5) ERR_MSG="$(gettext 'wpa_supplicant has timed out trying to associate with the network card.')" ;;
-   6) ERR_MSG="$(gettext 'DHCP client failed to negotiate with wireless network') '${CELL_ESSID}'" ;;
-   *) ERR_MSG="$(gettext 'Failed to connect to wireless network') '${CELL_ESSID}'" ;; 
-  esac
-  export SNS_error='
-  <window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network">
-  <vbox>
-    <frame>
-      '"`/usr/lib/gtkdialog/xml_pixmap dialog-error popup`"'
-      <text use-markup="true"><label>"<b>'${ERR_MSG}'</b>
-'${ERR_EXTRA1}'"</label></text>
-      <text xalign="0"><label>'$(gettext "So, what do you want to do? If you go back to the main window, you could test a different interface or network. Note, sometimes an error 'goes away' if you retry.")'</label></text>
-    </frame>
-    <hbox space-expand="false" space-fill="false">
-      <button tooltip-text="'$(gettext 'View log of attempted connection:')'" space-expand="false" space-fill="false">
-        <label>'$(gettext 'View Log')'</label>'"
-        <action>echo ' ' >> /tmp/sns_wireless_log</action>
-        <action>echo '*********************************************************' >> /tmp/sns_wireless_log</action>
-        <action>echo 'LAST 10 LINES of /var/log/messages:' >> /tmp/sns_wireless_log</action>
-        <action>tail -n 10 /var/log/messages >> /tmp/sns_wireless_log</action>
-        <action>defaulttextviewer /tmp/sns_wireless_log & </action>"'
-      </button>
-      <text space-expand="true" space-fill="true"><label>""</label></text>
-      <button space-expand="false" space-fill="false">
-        <label>'$(gettext "Retry")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon refresh`"'
-        <action type="exit">BUT_GOBACK</action>
-      </button>
-      <button space-expand="false" space-fill="false">
-        <label>'$(gettext "Quit")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon quit`"'
-        <action type="exit">BUT_QUIT</action>
-      </button>
-    </hbox>
-  </vbox>
-  </window>'
-  RETSTRING="`gtkdialog -p SNS_error --center`"
-  [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'BUT_GOBACK'`" != "" ] && exec sns
- fi
- exit
-}
-
-
-#firewall
-if which firewall_ng 2>&1 >/dev/null;then
- FW_EXEC=firewall_ng
-else
- FW_EXEC="urxvt -e firewallinstallshell"
-fi
-
-BIGGESTCNT=0
-echo -n '' > /tmp/sns_interfaces
-INTERFACES="`ifconfig -a | grep -F 'Link encap:Ethernet' | cut -f1 -d' ' | tr '\n' ' '`"
-for INTERFACE in $INTERFACES #exs: wlan0 eth0
-do
-
- FINDTYPE="`readlink /sys/class/net/$INTERFACE/device/driver`"
- IF_DRIVER=${FINDTYPE##*/} #basename - ex: ath5k
- IF_BUS=
- IF_INFO=
- while read F1 F2plus ; do
-	case $F1 in
-		"description:") IF_INFO="$F2plus" ;; #description: Support for Atheros 802.11n wireless LAN cards.
-		"alias:") IF_BUS="${F2plus%%:*}" ;;  #alias: pci:v0000168Cd00000027sv*sd*bc*sc*i*
-	esac
- done <<< "$(modinfo $IF_DRIVER 2>/dev/null)"
- if [ ! "$IF_BUS" ] && [ "$FINDTYPE" ];then
-	case $FINDTYPE in
-		*/bus/usb*) IF_BUS="usb" ;;
-		*/bus/pci*) IF_BUS="pci" ;;
-	esac
- fi
- [ "$IF_BUS" = "" ] && IF_BUS="x"
- [ "$IF_INFO" = "" ] && IF_INFO="x"
- if [ "$IF_DRIVER" == "ndiswrapper" ];then
-  WINDRVR="`ndiswrapper -l | grep '^[a-zA-Z0-9]' | cut -f 1 -d ' '`"
-  IF_INFO="MS Windows driver '${WINDRVR}'"
- fi
-
- #want to manipulate the info string for display purposes...
- CNTLINE=0;FINALINFO=""
- for ONEWORD in $IF_INFO
- do
-  CNTWORD=`echo "$ONEWORD" | wc -c`
-  CNTLINE=`expr $CNTLINE + $CNTWORD`
-  [ $CNTLINE -gt $BIGGESTCNT ] && BIGGESTCNT=$CNTLINE #use for window width.
-  [ $CNTLINE -gt 60 ] && break
-  FINALINFO="${FINALINFO}${ONEWORD} " #ensures whole words only in string.
- done
- IF_INFO="`echo -n "$FINALINFO"  | tr '[&|"<>]' ' ' | tr -s ' '`" #'geany. filter out chars that mess up xml.
-
- IF_INTTYPE='Wired'
- if interface_is_wireless ${INTERFACE} ; then
-   IF_INTTYPE='Wireless'
- fi
- #accumulate the results into columns...
- ALL_IF_INTERFACE="${ALL_IF_INTERFACE}|${INTERFACE}"
- ALL_IF_INTTYPE="${ALL_IF_INTTYPE}|${IF_INTTYPE}"
- ALL_IF_DRIVER="${ALL_IF_DRIVER}|${IF_DRIVER}"
- ALL_IF_BUS="${ALL_IF_BUS}|${IF_BUS}"
- ALL_IF_INFO="${ALL_IF_INFO}|${IF_INFO}"
- INTERFACEBUTTONS="${INTERFACEBUTTONS} 
- <button><label>${INTERFACE}</label><action type=\"exit\">Interface_${INTERFACE}</action></button>"
- #save all data about each interface on one line...
- #ex: wlan1|Wireless|ath5k|pci|Support for 5xxx series of Atheros 802.11 wireless LAN cards
- echo "${INTERFACE}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}" >> /tmp/sns_interfaces
-done
-ALL_IF_INTERFACE="`echo -n "$ALL_IF_INTERFACE" | sed -e 's%^|%%' | tr '|' '\n'`"
-ALL_IF_INTTYPE="`echo -n "$ALL_IF_INTTYPE" | sed -e 's%^|%%' | tr '|' '\n'`"
-ALL_IF_DRIVER="`echo -n "$ALL_IF_DRIVER" | sed -e 's%^|%%' | tr '|' '\n'`"
-ALL_IF_BUS="`echo -n "$ALL_IF_BUS" | sed -e 's%^|%%' | tr '|' '\n'`"
-ALL_IF_INFO="`echo -n "$ALL_IF_INFO" | sed -e 's%^|%%' | tr '|' '\n'`"
-
-INTERFACEDESCR="    <hbox border-width=\"7\" spacing=\"10\">
+    INTERFACEDESCR="    <hbox border-width=\"7\" spacing=\"10\">
       <text use-markup=\"true\"><label>\"<b>$(gettext 'Interface')</b>
 $ALL_IF_INTERFACE\"</label></text>
       <text use-markup=\"true\"><label>\"<b>$(gettext 'Type')</b>
@@ -757,119 +154,145 @@ $ALL_IF_BUS\"</label></text>
       <text use-markup=\"true\"><label>\"<b>$(gettext 'Description')</b>
 $ALL_IF_INFO\"</label></text>
     </hbox>"
+} #build_interface_display_list
 
-#test if connected to internet...
-FLAGINTERNETSTATUS='no'
-WORKINGIF=''
-if [ "`pidof dhcpcd udhcpc`" != "" ];then #201110
- if [ "`grep -v '^#' /etc/resolv.conf`" != "" ];then
-  PSALL="`busybox ps`"
-  PSDHCPCD="`echo "$PSALL" | grep -E 'dhcpcd|udhcpc'`" #201110
-  for ONEIF in `ifconfig | grep '^[a-z]' | cut -f 1 -d ' ' | grep -v '^lo' | tr '\n' ' '`
-  do
-   if [ "`echo "$PSDHCPCD" | grep "$ONEIF"`" != "" ];then
-    WORKINGIF="${WORKINGIF}${ONEIF} "
-    FLAGINTERNETSTATUS='yes'
-   fi
-  done
- fi
-fi
-if [ "$FLAGINTERNETSTATUS" == "yes" ];then
- WORKINGIF="`echo -n "$WORKINGIF" | sed -e 's% $%%'`"
- MSGWIF="interface <b>${WORKINGIF}</b>"
- [ `echo -n "$WORKINGIF" | wc -w` -gt 1 ] && MSGWIF="interfaces <b>${WORKINGIF}</b>"
- MSGSTATUS="$(gettext 'Currently a working Internet connection on') ${MSGWIF}"
- COLOR_BG='#80CE7F'; COLOR_FG='#235123'
-else
- MSGSTATUS="$(gettext 'Currently no Internet connection')"
- COLOR_BG='#CE837F'; COLOR_FG='#512323'
-fi
+find_usable_interfaces() {
+    #test if connected to internet...
+    FLAGINTERNETSTATUS='no'
+    WORKINGIF=''
+    if grep -qv '^#' /etc/resolv.conf; then
+        for ONEIF in $(ip link show | grep -B 1 'link/ether' | grep -w 'UP' | cut -f 2 -d : | tr -d '\n'); do #210202
+# shellcheck disable=SC2009
+            if ps -fC dhcpcd,udhcpc | grep -w "$ONEIF" >/dev/null 2>&1; then #201110 210202 210204
+                WORKINGIF="${WORKINGIF}${ONEIF} "
+                FLAGINTERNETSTATUS='yes'
+            fi
+        done
+        WORKINGIF="${WORKINGIF% }"
+    fi
+    if [ "$FLAGINTERNETSTATUS" = "yes" ]; then
+# shellcheck disable=SC2034 # Missed, but MSGWIF used in eval_gettext.
+        MSGWIF="<b>$WORKINGIF</b>"
+        if [ "$(wc -w <<< "$WORKINGIF")" -gt 1 ]; then
+            MSGSTATUS="$(eval_gettext "Current Internet connections are on interfaces \${MSGWIF}")"
+        else
+            WORKSSID="$(iw dev "$WORKINGIF" link | sed -n 's%.*SSID: \(.*\)%\1%p')"
+            if [ -n "$WORKSSID" ]; then
+                MSGWSSID="<b>${WORKSSID:0:20}</b>"
+                MSGSTATUS="$(eval_gettext "Current Internet connection is on interface \${MSGWIF} network \${MSGWSSID}")"
+            else
+                MSGSTATUS="$(eval_gettext "Current Internet connection is on interface \${MSGWIF}")"
+            fi
+        fi
+        COLOR_BG='#80CE7F'; COLOR_FG='#235123'
+    else
+        MSGSTATUS="$(gettext 'Currently no Internet connection')"
+        COLOR_BG='#CE837F'; COLOR_FG='#512323'
+    fi
 
-CLICKMSG="`/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Puppy has identified these network interfaces on your computer. Click a button to configure the interface for use.')"`"
-#100313 add a button for loading a Windows driver...
-modprobe -n ndiswrapper 2>/dev/null
-if [ $? -eq 0 -a "`echo "$ALL_IF_DRIVER" | grep 'ndiswrapper'`" == "" ];then
- CLICKMSG="`/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Puppy has identified these network interfaces on your computer. Click a button to configure the interface for use, or click 'Windows' button if you want to install and use a MS Windows driver.')"`"
- INTERFACEBUTTONS="${INTERFACEBUTTONS} 
+    CLICKMSG="$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Puppy has identified these network interfaces on your computer. Click a button to configure the interface for use.')")"
+    #100313 add a button for loading a Windows driver...
+    if ! grep -q 'ndiswrapper' <<< "$ALL_IF_DRIVER" \
+      && modprobe -n ndiswrapper 2>/dev/null; then
+        CLICKMSG="$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext "Puppy has identified these network interfaces on your computer. Click a button to configure the interface for use, or click 'Windows' button if you want to install and use a MS Windows driver.")")"
+        INTERFACEBUTTONS="${INTERFACEBUTTONS} 
   <button><label>Windows</label><action type=\"exit\">Interface_Windows</action></button>"
-else
- INTERFACEBUTTONS="${INTERFACEBUTTONS}
-  <button><label>Windows</label><sensitive>false</sensitive></button>"
-fi
+    elif [ -z "$ALL_IF_DRIVER" ]; then #210209...
+        CLICKMSG="$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Puppy has not identified any network interfaces on your computer.')")"
+        INTERFACEDESCR=''
+        INTERFACEBUTTONS='<text width-request="5"><label>""</label></text>'
+    fi
+} #find_usable_interfaces
 
 connect_button_splash() { #170505...
-	yaf-splash -bg orange -close never -fontsize large -text "Please wait..." &
-	echo $! >/tmp/sns_splash_pid
+    gtkdialog-splash -bg orange -close never -fontsize large -text "$(gettext 'Please wait...')" >/dev/null &
+    echo $! >/tmp/sns_splash_pid
 }
 export -f connect_button_splash #170505 end
 
-#120107 new 'Profile' frame...
-PROFILE_XML=""
-echo "<b>$(gettext 'Interface')</b>" >/tmp/sns_I_P;  echo "<b>$(gettext 'Type')</b>" >/tmp/sns_T_P; echo "<b>$(gettext 'Driver')</b>" >/tmp/sns_D_P; echo "<b>$(gettext 'Bus')</b>" >/tmp/sns_B_P; echo "<b>$(gettext 'Hardware')</b>" >/tmp/sns_M_P; echo "" >/tmp/sns_S_P; echo "" >/tmp/sns_DEL_BTN; echo "" >/tmp/sns_CNT_P; echo "<b>$(gettext 'Security')</b>" >/tmp/sns_SEC_P
-if [ -s /etc/simple_network_setup/connections ];then
- CNT=0
- [ "grep '|Wireless|' /etc/simple_network_setup/connections" != "" ] && echo "<b>$(gettext 'Network')</b>" >/tmp/sns_S_P
- cat /etc/simple_network_setup/connections |
- while read ONECONNECTION
- do
-  CNT=$(($CNT + 1))
-  echo "<b>$CNT</b>" >> /tmp/sns_CNT_P
-  INTERFACE_P="`echo -n "$ONECONNECTION" | cut -f 1 -d '|'`"
-  echo "$INTERFACE_P" >> /tmp/sns_I_P
-  TYPE_P="`echo -n "$ONECONNECTION" | cut -f 2 -d '|'`"
-  echo "$TYPE_P" >> /tmp/sns_T_P
-  DRIVER_P="`echo -n "$ONECONNECTION" | cut -f 3 -d '|'`"
-  echo "$DRIVER_P" >> /tmp/sns_D_P
-  BUS_P="`echo -n "$ONECONNECTION" | cut -f 4 -d '|'`"
-  echo "$BUS_P" >> /tmp/sns_B_P
-  MAC_P="`echo -n "$ONECONNECTION" | cut -f 6 -d '|'`"
-  echo "$MAC_P" >> /tmp/sns_M_P
-  if [ "$TYPE_P" = "Wireless" ];then
-   SSID_P="`echo -n "$ONECONNECTION" | cut -f 12 -d '|'`"
-   echo "$SSID_P" >> /tmp/sns_S_P
-   SEC_P="`echo -n "$ONECONNECTION" | cut -f 14 -d '|'`"
-   [ "$SEC_P" = "" ] && SEC_P="none"
-   echo "$SEC_P" >> /tmp/sns_SEC_P
-  else
-   echo " " >> /tmp/sns_S_P
-   echo " " >> /tmp/sns_SEC_P
-  fi
-  if [ $CNT -gt 12 ];then
-   echo "<i>more...</i>"  >> /tmp/sns_I_P
-   break
-  fi
-  xCONNECTION="$(echo -n "$ONECONNECTION" | tr \" .)" #170529
-  echo "<button><label>${CNT}</label><action>grep -v \"${xCONNECTION}\" /etc/simple_network_setup/connections > /tmp/sns_action1</action><action>mv -f /tmp/sns_action1 /etc/simple_network_setup/connections</action><action type=\"exit\">EXITRESTART></action></button>" >> /tmp/sns_DEL_BTN #170529
- done
- which connectwizard_exec >/dev/null 2>&1 \
-  && CONNECTWIZEXEC_XML="<action>$(which connectwizard_exec) sns</action>" \
-  || CONNECTWIZEXEC_XML='' #190223
- if [ "$FLAGINTERNETSTATUS" = "yes" ];then
-  grep -qswv 'sns' /root/.connectwizardrc \
-   && DISCONNECT_EXIT='EXITRESTART' \
-   || DISCONNECT_EXIT='EXITNOW' #190223
-  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_no.svg`<label>$(gettext 'Disconnect Now')</label>$CONNECTWIZEXEC_XML<action>/usr/sbin/networkdisconnect</action><action type=\"exit\">${DISCONNECT_EXIT}</action></button>" #190223 201110
- else
-  CONNECTBTN_XML="<button>`/usr/lib/gtkdialog/xml_button-icon internet_connect_yes.svg`<label>$(gettext 'Connect Now')</label>$CONNECTWIZEXEC_XML<action>/usr/sbin/networkdisconnect</action><action>/usr/local/simple_network_setup/rc.network start & </action><action>connect_button_splash</action><action type=\"exit\">EXITNOW</action></button>" #170505 190223 201110
- fi
- grep -qswv 'sns' /root/.connectwizardrc \
-  && DISCONNECT_XML="$(gettext '<b>Note:</b> The current connection was started by another network tool.  To control it with SNS, disconnect now, then re-connect or choose an interface.')" \
-  || DISCONNECT_XML='' #190223
- PROFILE_XML="`/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Connection profiles have previously been created by SNS.')" "$(gettext "The <b>Connect</b> button will try to establish an internet connection by any of the available profiles.")" "${DISCONNECT_XML}"`
- <hbox border-width=\"7\" spacing=\"10\"><text use-markup=\"true\"><label>\"`cat /tmp/sns_CNT_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_I_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_T_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_D_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_B_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_M_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_S_P`\"</label></text><text use-markup=\"true\"><label>\"`cat /tmp/sns_SEC_P`\"</label></text></hbox>
- <hbox><text><label>$(gettext 'Delete:')</label></text>`cat /tmp/sns_DEL_BTN`</hbox>
+build_connection_display_list() {
+    echo "" >/tmp/sns_CNT_P
+    echo "<b>$(gettext 'Interface')</b>" >/tmp/sns_I_P
+    echo "<b>$(gettext 'Type')</b>" >/tmp/sns_T_P
+    echo "<b>$(gettext 'Driver')</b>" >/tmp/sns_D_P
+    echo "<b>$(gettext 'Bus')</b>" >/tmp/sns_B_P
+    echo "<b>$(gettext 'Hardware')</b>" >/tmp/sns_M_P
+    echo "" >/tmp/sns_S_P; echo "" >/tmp/sns_SEC_P
+    if grep -q '^..:.*|Wireless|' /etc/simple_network_setup/connections; then
+        echo "<b>$(gettext 'Network')</b>" >/tmp/sns_S_P
+        echo "<b>$(gettext 'Security')</b>" >/tmp/sns_SEC_P
+    fi
+    echo "" >/tmp/sns_DEL_BTN
+    CNT=0
+    while read -r ONECONNECTION; do
+        IFS='|' read -r MAC_P TYPE_P DRIVER_P BUS_P _ _ SSID_P _ SEC_P _ <<< "$ONECONNECTION" #210211
+        if [ "${#MAC_P}" -ge 17 ]; then #ignore old profile format
+            ((++CNT))
+            echo "<b>$CNT</b>" >> /tmp/sns_CNT_P
+            INTERFACE_P="$(ip link show | grep -B 1 "link/ether $MAC_P" | sed -n "1 s/^[0-9]\+: \([^:]\+\).*/\1/p")" >> /tmp/sns_I_P #210211
+            echo "${INTERFACE_P:= }" >> /tmp/sns_I_P #i/f or space
+            if [ "$TYPE_P" = "Wireless" ]; then
+                echo "$(gettext 'Wireless')" >> /tmp/sns_T_P
+            else
+                echo "$(gettext 'Wired')" >> /tmp/sns_T_P
+            fi
+            echo "$DRIVER_P" >> /tmp/sns_D_P
+            echo "$BUS_P" >> /tmp/sns_B_P
+            echo "$MAC_P" >> /tmp/sns_M_P
+            if [ "$TYPE_P" = "Wireless" ]; then
+                echo "$SSID_P" >> /tmp/sns_S_P
+                [ -z "$SEC_P" ] && SEC_P="none"
+                echo "$SEC_P" >> /tmp/sns_SEC_P
+            else
+                echo " " >> /tmp/sns_S_P
+                echo " " >> /tmp/sns_SEC_P
+            fi
+            if [ "$CNT" -gt 12 ]; then
+                echo "<i>more...</i>"  >> /tmp/sns_I_P
+                break
+            fi
+            xCONNECTION="$(tr \" . <<< "$ONECONNECTION")" #170529
+            WPACONFSFX="$(cut -f 1,7 -d '|' <<< "$xCONNECTION" | sed 's/\(.*\)|\(.*\)/\2-\1/')" #210213
+            echo "<button><label>${CNT}</label>
+            <action>grep -v \"${xCONNECTION}\" /etc/simple_network_setup/connections > /tmp/sns_action1</action>
+            <action>mv -f /tmp/sns_action1 /etc/simple_network_setup/connections</action>
+            <action>rm -f /etc/simple_network_setup/wpa_supplicant.conf-\"$WPACONFSFX\"</action>
+            <action type=\"exit\">EXITRESTART></action></button>" >> /tmp/sns_DEL_BTN #170529 #210213
+        fi
+    done <<< "$(grep -s '^..:' /etc/simple_network_setup/connections)"
+} #build_connection_display_list
+
+build_display_connect_button() {
+    CONNECTWIZEXEC_XML='' #190223
+    which connectwizard_exec >/dev/null 2>&1 \
+      && CONNECTWIZEXEC_XML="<action>$(which connectwizard_exec) sns</action>" #190223
+    if [ "$FLAGINTERNETSTATUS" = "yes" ]; then
+        DISCONNECT_EXIT='EXITNOW' #190223
+        grep -qswv 'sns' /root/.connectwizardrc \
+          && DISCONNECT_EXIT='EXITRESTART' #190223
+        CONNECTBTN_XML="<button>$(/usr/lib/gtkdialog/xml_button-icon internet_connect_no.svg)<label>$(gettext 'Disconnect Now')</label>$CONNECTWIZEXEC_XML<action>/usr/sbin/networkdisconnect</action><action type=\"exit\">${DISCONNECT_EXIT}</action></button>" #190223 201110
+    else
+        CONNECTBTN_XML="<button>$(/usr/lib/gtkdialog/xml_button-icon internet_connect_yes.svg)<label>$(gettext 'Connect Now')</label>$CONNECTWIZEXEC_XML<action>/usr/sbin/networkdisconnect</action><action>/usr/local/simple_network_setup/rc.network start & </action><action>connect_button_splash</action><action type=\"exit\">EXITNOW</action></button>" #170505 190223 201110
+    fi
+    DISCONNECT_XML='' #190223
+    grep -qswv 'sns' /root/.connectwizardrc \
+      && DISCONNECT_XML="$(gettext '<b>Note:</b> The current connection was started by another network tool.  To control it with SNS, disconnect now, then re-connect or choose an interface.')" #190223
+    PROFILE_XML="$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Connection profiles have previously been created by SNS.')" "$(gettext "The <b>Connect</b> button will try to establish an internet connection by any of the available profiles.")" "${DISCONNECT_XML}")
+ <hbox border-width=\"7\" spacing=\"10\"><text use-markup=\"true\"><label>\"$(cat /tmp/sns_CNT_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_I_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_T_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_D_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_B_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_M_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_S_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_SEC_P)\"</label></text></hbox>
+ <hbox><text><label>$(gettext 'Delete:')</label></text>$(cat /tmp/sns_DEL_BTN)</hbox>
 " #190223
-fi
+} #build_display_connect_button
 
-if [ "$PROFILE_XML" ]; then
- PAGE_NR=0
-else
- PAGE_NR=1
- PROFILE_XML="`/usr/lib/gtkdialog/xml_info scale "internet_connect.svg" 60 "$(gettext '<b>No profiles</b>')" "$(gettext 'Set up an interface first, and when connected, a profile will be built for next run.')"`"
-fi
+build_and_display_main_window() {
+    if [ "$PROFILE_XML" ]; then
+        PAGE_NR=0
+    else
+        PAGE_NR=1
+        PROFILE_XML="$(/usr/lib/gtkdialog/xml_info scale "internet_connect.svg" 60 "$(gettext '<b>No profiles</b>')" "$(gettext 'Set up an interface first, and when connected, a profile will be built for next run.')")"
+    fi
 
-#bring up the main window...
-export SNS_main='
+    #bring up the main window...
+    SNS_main='
 <window title="SNS '$VERSION' - '$(gettext "Barry's Simple Network Setup")'" icon-name="gtk-network">
 <vbox spacing="0" space-expand="true" space-fill="true">
   <eventbox name="status" space-expand="false" space-fill="false">
@@ -892,18 +315,18 @@ export SNS_main='
     <hbox space-expand="false" space-fill="false">
       <button>
         <label>'$(gettext "Help")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon help`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon help)"'
         <action>/usr/local/simple_network_setup/help_profiles &</action>
       </button>
       <button space-expand="false" space-fill="false">
         <label>'$(gettext 'Network Information')'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon info`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon info)"'
         <action>ipinfo & </action>
       </button>
       <text space-expand="true" space-fill="true"><label>""</label></text>
       '${CONNECTBTN_XML}'
       <button space-expand="false" space-fill="false">
-        '"`/usr/lib/gtkdialog/xml_button-icon quit`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon quit)"'
         <label>'$(gettext 'Quit')'</label>
         <action type="exit">QUIT</action>
         </button>
@@ -911,150 +334,822 @@ export SNS_main='
   </vbox>
 </vbox>
 </window>' #170505 190217
+    export SNS_main
 
-echo 'style "status"
+    echo 'style "status"
 {
   fg[NORMAL] = "'$COLOR_FG'"
   bg[NORMAL] = "'$COLOR_BG'"
 }
 widget "*status*" style "status"' > /tmp/gtkrc_sns
-export GTK2_RC_FILES=/tmp/gtkrc_sns:/root/.gtkrc-2.0
+    export GTK2_RC_FILES=/tmp/gtkrc_sns:/root/.gtkrc-2.0
+    . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
+    RETSTRING="$(gtkdialog -p SNS_main)" ###main window### #170505
+} #build_and_display_main_window
 
-. /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
-RETSTRING="`gtkdialog -p SNS_main`" ###main window### #170505
-
-echo "$RETSTRING"
-EXIT="`echo "$RETSTRING" | grep '^EXIT' | cut -f2 -d'"'`" #'geany
-[ "`echo "$EXIT" | grep 'EXITRESTART'`" != "" ] && exec sns ###restarting sns###
-[ "`echo "$EXIT" | grep 'Interface'`" = "" ] && exit
- 
-INTERFACE="`echo -n "$EXIT" | cut -f2 -d '_'`" #ex: wlan1
-
-if [ "$INTERFACE" == "Windows" ];then #100313
- if [ -d /etc/ndiswrapper ];then
-  if [ "`ls /etc/ndiswrapper/*/*.inf 2>/dev/null`" != "" ];then
-   modprobe ndiswrapper
-   sleep 1
-   exec sns
-  fi
- fi
- INFFILE=$(/usr/lib/gtkdialog/file_chooser "$(gettext 'SNS: Install MS Windows driver')" \
- "$(gettext "Select the '.inf' file of the required MS Windows driver. If on a CD, you will have to mount it, then navigate to where the '.inf' file is. Note, choose a Windows XP driver if available...")")
- if [ -f "$INFFILE" ];then
-  case "$INFFILE" in
-   *.[iI][nN][fF]) 
-    FLAGND=""
-    ndiswrapper -i "$INFFILE" #installs driver at /etc/ndiswrapper.
-    if [ $? -eq 0 ];then
-     ndiswrapper -l #tests the driver
-     if [ $? -eq 0 ];then
-      modprobe ndiswrapper
-      [ $? -eq 0 ] && FLAGND="ok"
-      [ "$FLAGND" != "ok" ] && rmmod ndiswrapper 2>/dev/null
-     fi
+load_windows_driver() {
+    if [ -d /etc/ndiswrapper ]; then
+        if ls /etc/ndiswrapper/*/*.inf >/dev/null 2>&1; then
+            modprobe ndiswrapper
+            sleep 1
+            exec sns
+        fi
     fi
-    [ "$FLAGND" != "ok" ] && rm -rf /etc/ndiswrapper
-    [ "$FLAGND" != "ok" ] && /usr/lib/gtkdialog/box_ok "SNS" error "$(gettext 'Windows driver does not seem to work, it has been uninstalled')"
-    [ "$FLAGND" == "ok" ] && sleep 1
-   ;;
-   *) 
-    /usr/lib/gtkdialog/box_ok "SNS" error "`eval_gettext \"ERROR, \\\${INFFILE} is not a .inf file\"`"
-   ;;
-  esac
- fi
- exec sns
-fi
+    INFFILE=$(/usr/lib/gtkdialog/file_chooser "$(gettext 'SNS: Install MS Windows driver')" \
+ "$(gettext "Select the '.inf' file of the required MS Windows driver. If on a CD, you will have to mount it, then navigate to where the '.inf' file is. Note, choose a Windows XP driver if available...")")
+    if [ -f "$INFFILE" ]; then
+        case "$INFFILE" in
+          *.[iI][nN][fF]) 
+            FLAGND=""
+            if ndiswrapper -i "$INFFILE"; then #installs driver at /etc/ndiswrapper.
+                if ndiswrapper -l; then #tests the driver
+                    modprobe ndiswrapper && FLAGND="ok"
+                    [ "$FLAGND" != "ok" ] && rmmod ndiswrapper 2>/dev/null
+                fi
+            fi
+            [ "$FLAGND" != "ok" ] && rm -rf /etc/ndiswrapper
+            [ "$FLAGND" != "ok" ] && /usr/lib/gtkdialog/box_ok "SNS" error "$(gettext 'Windows driver does not seem to work, it has been uninstalled')"
+            [ "$FLAGND" = "ok" ] && sleep 1
+           ;;
+          *) 
+            /usr/lib/gtkdialog/box_ok "SNS" error "$(eval_gettext "ERROR, \$INFFILE is not a .inf file")"
+           ;;
+        esac
+    fi
+    exec sns
+} #load_windows_driver
+ 
+ensure_interface_is_down() {
+    if [ -n "$WORKINGIF" ]; then  #190525...
+        for ONEIF in $WORKINGIF; do #210209...
+            if ip link show "$ONEIF" | grep -wq 'UP'; then #210202
+                gtkdialog-splash -bg orange -placement center -text "$(eval_gettext "Please wait, bringing down '\$ONEIF'...")" >/dev/null &
+                PIDX1=$!
+                kill_wpa_supplicant #210209
+                iw dev "$ONEIF" info 2>/dev/null | grep -qw 'ssid' \
+                  && iw dev "$ONEIF" disconnect #210202
+                ip link set "$ONEIF" down #210202
+                dhcpcd --release "$ONEIF" 2>/dev/null
+                ip route flush dev "$ONEIF" #100703
+                sleep 1
+                kill $PIDX1 2>/dev/null
+            fi #190525 end
+        done
+    fi
+} #ensure_interface_is_down
 
-which connectwizard_exec >/dev/null 2>&1 \
- && connectwizard_exec sns #Update current exec name. 170329 190223
+extract_interface_data() {
+    fPATTERN='^'"${INTERFACE}"'|'
+    IFS='|' read -r _ IF_INTTYPE IF_DRIVER IF_BUS IF_INFO <<< "$(grep "$fPATTERN" /tmp/sns_interfaces)"
+# shellcheck disable=SC2060
+    MACADDRESS="$(ip link show "$INTERFACE" | grep -o 'link/ether [^ ]*' | cut -f 2 -d ' ')" #210202
+} #extract_interface_data
 
-if [ -n "$WORKINGIF" ];then  #190525...
- ifPATTERN='^'"$WORKINGIF"' '
- if [ "`ifconfig | grep "$ifPATTERN"`" != "" ];then
-  yaf-splash -bg orange -placement center -text "$(gettext 'Please wait, bringing down') '$WORKINGIF'..." &
-  PIDX1=$!
-  ifconfig $WORKINGIF down
-  [ "`iwconfig $WORKINGIF | grep "$WORKINGIF" | grep "ESSID"`" != "" ] && iwconfig $WORKINGIF essid off
-  iwconfig $WORKINGIF key off #100320 think need this for when I'm experimenting with different wep/wpa/open settings on the same interface.
-  dhcpcd --release $WORKINGIF 2>/dev/null
-  ip route flush dev $WORKINGIF #100703
-  sleep 1
-  kill $PIDX1 2>/dev/null
- fi #190525 end
-fi
+perform_wireless_setup() {
+    FLAGERR=
+    while true; do #210601
+        scan_for_wireless_networks #sets SCANRESULT
+        if [ -z "$FLAGERR" ]; then #210201
+            echo "STEP1c: ip link set $INTERFACE down" >> /tmp/sns_wireless_log #210202
+            ip link set "$INTERFACE" down #100313 210202
+            build_display_network_list
 
-fPATTERN='^'"${INTERFACE}"'|'
-IFDATA="`grep "$fPATTERN" /tmp/sns_interfaces`"
-IF_INTTYPE="`echo "$IFDATA" | cut -f2 -d'|'`" #ex: Wireless
-IF_DRIVER="`echo "$IFDATA" | cut -f3 -d'|'`" #ex: ath5k
-IF_BUS="`echo "$IFDATA" | cut -f4 -d'|'`" #ex: pci
-IF_INFO="`echo "$IFDATA" | cut -f5 -d'|'`"
-MACADDRESS="`ifconfig $INTERFACE | grep -o 'HWaddr .*' | cut -f 2 -d ' '`"
+            #my wpa_supplicant only supports: wext hostap atmel wired ralink roboswitch
+            case $IF_DRIVER in
+              hostap*)   WPA_DRIVER="hostap" ;;
+              rt61|rt73) WPA_DRIVER="ralink" ;;
+              *)         WPA_DRIVER="nl80211,wext" ;; #210207
+            esac
 
-############WIRELESS SETUP###############
-if [ "$IF_INTTYPE" == "Wireless" ];then
- #scan for networks...
- if rfkill list wlan | grep -q 'Soft blocked: yes' ; then
-   rfkill unblock wlan
- fi
- setup_wifi 
-fi #end test "$IF_INTTYPE" == "Wireless"
+            build_display_radio_buttons
+            build_and_display_wireless_setup_window #sets RETSTRING
+            case "$(sed -n 's/^EXIT="\(.*\)"/\1/p' <<< "$RETSTRING")" in #210601...
+              BUT_RESCAN) continue ;;
+              BUT_GOBACK) exec sns ;;
+              BUT_CONNECT) ;;
+              *) exit ;;
+            esac
 
-############Wired setup###############
-if [ "$IF_INTTYPE" == "Wired" ];then
- yaf-splash -placement center -bg orange -text "$(gettext 'Please wait, trying to connect to interface') '${INTERFACE}'..." &
- PIDXX=$!
- echo "Information about this interface:
+            extract_data_for_selected_network
+            if [ -z "$FLAGERR" ]; then
+                complete_the_wireless_connection
+            fi #end test exist security entries.
+        fi #end test ip link set up #210202
+        break
+    done #210601
+
+    if [ "$FLAGERR" ]; then
+        build_and_display_wireless_error_window # sets RETSTRING
+        grep '^EXIT' <<< "$RETSTRING" | grep -q 'BUT_GOBACK' && exec sns
+    else
+        #success!
+        add_wireless_connection_profile_and_conf #211002
+        build_and_display_wireless_success_window #sets RETSTR3
+        if grep '^CHK_SNSDEF' <<< "$RETSTR3" | grep -q 'true'; then
+            echo -e '#!/bin/sh\nexec sns' > /usr/local/bin/defaultconnect
+        else
+            echo -e '#!/bin/sh\nexec connectwizard' > /usr/local/bin/defaultconnect
+        fi
+        if grep '^CHK_FIREWALL' <<< "$RETSTR3" | grep -q 'true'; then
+            "$FW_EXEC"
+        fi
+    fi
+} #perform_wireless_setup
+
+complete_the_wireless_connection() {
+    RUNWPASUPP='no'
+    FIXUP='1 1 2 0'
+    [ "$IF_DRIVER" = "ndiswrapper" ] && FIXUP='2 1 0'
+    fuCNT=$(wc -w <<< "$FIXUP")
+    for ONEFIX in $FIXUP; do ###BIG FOR LOOP###
+        show_wait_splash "$fuCNT"
+        ((--fuCNT))
+        [ "$CELL_ENCRYPTIONKEY" = "on" ] && configure_wpa_supplicant
+        echo "STEP5a: ip link set $INTERFACE up" >> /tmp/sns_wireless_log #210202
+        ip link set "$INTERFACE" up #210202
+        sleep 4
+        if [ "$RUNWPASUPP" = "yes" ]; then
+            if run_wpa_supplicant; then
+                WPA_SEC_MGMT="$(wpa_cli -i "$INTERFACE" status | grep 'key_mgmt=' | cut -f 2 -d =)"
+            else
+                [ "$fuCNT" -gt 0 ] \
+                  && continue #try next FIXUP value. ###BIG FOR LOOP### #210202
+                kill_wpa_supplicant_and_link
+                FLAGERR=5
+            fi #210202
+        else #No security (null) #210202...
+            if [ -z "$SEC_KEY" ]; then
+                iw dev "$INTERFACE" connect "$CELL_ESSID" "$CELL_FREQUENCY" "$CELL_ADDRESS" \
+                  || FLAGERR=4
+            fi
+        fi
+        if [ ! $FLAGERR ]; then #210202 end
+            wait_until_link_available
+            if [ $FLAGERR ]; then
+                kill_wireless_link
+                [ "$CELL_ENCRYPTIONKEY" = "on" ] \
+                  && [ "$fuCNT" -gt 0 ] \
+                  && continue #try next FIXUP value. ###BIG FOR LOOP### #210202
+            else
+                run_dhcpcd
+                if [ $FLAGERR ]; then
+                    [ "$CELL_ENCRYPTIONKEY" = "on" ] \
+                      && [ "$fuCNT" -gt 0 ] \
+                      && continue #try next FIXUP value. ###BIG FOR LOOP### #210202
+                    kill_wpa_supplicant_and_link
+                fi #end test dhcpcd timeout.
+            fi #end test access point.
+        fi #end test wpa_supplicant timeout.
+        break
+    done #end for-loop. ###END BIG FOR LOOP###
+    [ -n "$PIDX" ] && kill "$PIDX" 2>/dev/null #210201?
+} #complete_the_wireless_connection
+
+scan_for_wireless_networks() {
+    if rfkill list wlan | grep -q 'Soft blocked: yes' ; then
+        rfkill unblock wlan
+    fi
+    rm -f /tmp/sns_scan_radiobuttons
+    rm -f /tmp/sns_scan_radiobuttons_shield
+    rm -f /tmp/sns_scan_radiobuttons_strength
+    rm -f /tmp/sns_scan_radiobuttons_address
+    rm -f /tmp/sns_scan_rawoneline
+    rm -f /tmp/sns_scan_oneline
+    gtkdialog-splash -placement center -bg orange -text "$(gettext 'Please wait, scanning for wireless networks...')" >/dev/null &
+    PIDXMSG=$!
+    echo "Information about this interface:
  Interface: $INTERFACE  Driver: $IF_DRIVER  Bus: $IF_BUS  MacAddress: $MACADDRESS
  Description: $IF_INFO
- " > /tmp/sns_wired_log
- 
- ifconfig $INTERFACE up >> /tmp/sns_wired_log 2>&1
- [ $? -eq 0 ] && IFACEUP=true || IFACEUP=false #170402
- if [ $IFACEUP = true ];then #170402
-  LINK_DETECTED=no
-  TIMEOUT=15 #200412
-  while [ $TIMEOUT -ge 0 ]; do #200412
-   if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
-    LINK_DETECTED="yes"
-    break
-   fi
-   [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190216 200412
-  done
-  if [ "$LINK_DETECTED" = "no" ] ; then
-   ifconfig $INTERFACE down
-   kill $PIDXX 2>/dev/null
-   /usr/lib/gtkdialog/box_ok "$(gettext 'Simple Network Setup')" error "<b>$(gettext 'There does not seem to be any network connected to') ${INTERFACE}</b>" " " "$(gettext "Is the network cable unplugged? Modem router turned off? If you can fix it, great, otherwise try a different interface.")"
-   exec sns
-   exit
-  fi
-  rm -f /tmp/sns_interface_success #170402
-  DHCPCDFIX=""
-  dhcpcd $INTERFACE >> /tmp/sns_wired_log 2>&1
-  RC=$? #170402
-  sleep 0.1 #170924 Allow time for dhcpcd to write to resolv.conf
-  if [ $RC -eq 0 ] && grep -q '^nameserver' /etc/resolv.conf; then #170402...
-   echo "$INTERFACE" > /tmp/sns_interface_success
-  else #170402 end  fail, try again.
-   DHCPCDFIX="-I ''"
-   dhcpcd --release $INTERFACE
-   dhcpcd -I '' $INTERFACE >> /tmp/sns_wired_log 2>&1
-   RC=$? #170402
-   sleep 0.1 #170924 Allow time for dhcpcd to write to resolv.conf
-   if [ $RC -eq 0 ] && grep -q '^nameserver' /etc/resolv.conf; then #170402
-    echo "$INTERFACE" > /tmp/sns_interface_success
-   fi #170402
-  fi
- fi
- kill $PIDXX 2>/dev/null
+ " > /tmp/sns_wireless_log
+    iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid' && iw dev "$INTERFACE" disconnect #210202
+    echo "STEP1a: ip link set $INTERFACE up" >> /tmp/sns_wireless_log #210202
+    if ! ip link set "$INTERFACE" up >> /tmp/sns_wireless_log 2>&1; then #210202
+        FLAGERR=1
+    else
+        sleep 0.1 #210205
+        echo "STEP1b: iw dev $INTERFACE scan | grep -E (messages & labels)" >> /tmp/sns_wireless_log #180706 210202
+# shellcheck disable=SC2034
+        for I in 1 2 3 4 5; do #210205
+            SCANRESULT="$(iw dev "$INTERFACE" scan | \
+              grep -E '^BSS |freq:|capability:|signal:|SSID:|DS Parameter set:|RSN:|Pairwise ciphers:|Authentication suites:|WPA:')" ###SCANNING### 110203 210203 210202
+            [ -n "$SCANRESULT" ] && break #210202
+            sleep 1 #210205
+        done #210205
+        echo "$SCANRESULT" >> /tmp/sns_wireless_log
+    fi #210201
+} #scan_for_wireless_networks
 
- if [ $IFACEUP = true ] \
-   && [ -f /tmp/sns_interface_success ];then #170402
-  export SNS_complete='
+build_display_network_list() {
+    echo -n '' > /tmp/sns_netname_default
+    echo -n 'false' > /tmp/sns_show_netname_box
+    echo -n 'true' > /tmp/sns_show_passphrase_box
+    #convert each found network into a single line... 110203
+    SRLINES="$(tr '|' ' ' <<< "$SCANRESULT" | tr '\n' '|' | tr -d '\t' | \
+      sed -e 's%BSS \([0-9a-f:]\+\)[^\|]*%\n\1%g' \
+        -e 's%freq: \([0-9]\+\)[^\|]*%\1%g' \
+        -e 's%capability: ESS \([^ \|]\+\)[^\|]*%\1%g' \
+        -e 's%signal: \([/0-9-]\+\)[^\|]*%\1%g' \
+        -e '{s%SSID: \\x00[^|]*%SSID: %g ; s%SSID: |%(hidden)|%g ; s%SSID: %%g}' \
+        -e 's%DS Parameter set: channel %%g' \
+        -e 's%\(RSN\)[^\|]*%\1%g' \
+        -e 's%\(WPA\)[^\|]*%\1%g' \
+        -e 's% \* Pairwise ciphers: %%g' \
+        -e 's% \* Authentication suites: %%g' | \
+      sort -g -r -t '|' -k 4)" #170619 #201001
+    CELL_NUMBER=0 #210208...
+    tee -a /tmp/sns_scan_rawoneline <<< "$SRLINES" |
+    while IFS='|' read -r CELL_ADDRESS CELL_FREQUENCY CELL_CAPABILITY CELL_SIGNAL CELL_ESSID CELL_CHANNEL CELL_SEC_MGMT CELL_CIPHERS CELL_AUTH CELL_SEC_MGMT2 CELL_CIPHERS2 _; do
+        ((++CELL_NUMBER)) #210208 end
+        [ -z "$CELL_ESSID" ] && continue #101029
+        # Build security summary field...
+        if [ "$CELL_CAPABILITY" = 'Privacy' ]; then
+            CELL_ENCRYPTIONKEY='on'
+            IMG_SHIELD=wifi_encrypted
+            PASSBOXVIS='show'
+            AUTHSUFFIX=''
+            [ "$CELL_AUTH" != 'PSK' ] && AUTHSUFFIX="-${CELL_AUTH:0:1}"
+            if [ -z "$CELL_SEC_MGMT" ]; then #200920
+                CELL_SEC_MGMT='WEP' #200920
+                TXT_SHIELD='WEP'
+            elif [ -z "$CELL_SEC_MGMT2" ]; then
+                TXT_SHIELD="${CELL_SEC_MGMT}-${CELL_CIPHERS}$AUTHSUFFIX"
+            else
+                if [ "$CELL_CIPHERS2" = "$CELL_CIPHERS" ]; then
+                    TXT_SHIELD="${CELL_SEC_MGMT:0:1}/${CELL_SEC_MGMT2:0:1}-${CELL_CIPHERS}$AUTHSUFFIX"
+                else
+                    TXT_SHIELD="${CELL_SEC_MGMT:0:1}/${CELL_SEC_MGMT2:0:1}-${CELL_CIPHERS%% .*} ${CELL_CIPHERS2%% .*}$AUTHSUFFIX"
+                fi
+            fi
+            TXT_SHIELD="$(sed '/ / {s/\([ -].\)[^ -]*/\1/g ; s% %/%g}' <<< "$TXT_SHIELD")"
+        else
+            CELL_ENCRYPTIONKEY='off'
+            IMG_SHIELD=wifi_open
+            TXT_SHIELD="$(gettext 'Open')"
+            PASSBOXVIS='hide'
+            [ "$CELL_NUMBER" -eq 1 ] && echo 'false' > /tmp/sns_show_passphrase_box
+        fi
+        # Determine signal level icon...
+        # If signal not in dBm, convert fractional format to pseudo dBm. #210202...
+        [ "${CELL_SIGNAL: -4}" = '/100' ] \
+          && CELL_SIGNAL=$(( -(100 - ${CELL_SIGNAL%/100}) ))
+        if   [ $CELL_SIGNAL -gt -50 ]; then IMG_QUALITY=quality_5 #Excellent single strength (Next to Router)
+        elif [ $CELL_SIGNAL -gt -67 ]; then IMG_QUALITY=quality_4 #Good signal strength for Web browsing, voice/video calls.
+        elif [ $CELL_SIGNAL -gt -70 ]; then IMG_QUALITY=quality_3 #Best effort for Web browsing for reliable packet delivery.
+        elif [ $CELL_SIGNAL -gt -80 ]; then IMG_QUALITY=quality_2 #Experience bad connectivity, Packet delivery may be unreliable.
+        elif [ $CELL_SIGNAL -gt -90 ] ; then IMG_QUALITY=quality_1 #Probably unusable.
+        else IMG_QUALITY=quality_0 #Unusable.
+        fi #210202 end
+        CELL_ESSID_XLATED="$CELL_ESSID"
+        [ "$CELL_ESSID" = '(hidden)' ] && CELL_ESSID_XLATED="$(gettext '(hidden)')"
+        # For hidden networks, let user provide actual name...
+        HIDNETBOXVIS='hide'
+        DEFAULTSSID=''
+        if [ "$CELL_ESSID" = '(hidden)' ]; then
+            HIDNETBOXVIS='show'
+            DEFAULTSSID="$(grep -sm 1 "^..:.*|$CELL_ADDRESS|" /etc/simple_network_setup/connections | cut -f 7 -d '|')"
+            if [ "$CELL_NUMBER" -eq 1 ]; then
+                echo -n "$DEFAULTSSID" > /tmp/sns_netname_default
+                echo 'true' > /tmp/sns_show_netname_box
+            fi
+        fi
+        # Build network column entries...
+# shellcheck disable=SC2086
+        echo '<radiobutton height-request="25" space-expand="false" space-fill="false">
+       <label>'${CELL_ESSID_XLATED}'</label>
+       <variable>RADIO_'${CELL_NUMBER}'</variable>
+       <action>'${HIDNETBOXVIS}':HIDNETBOX</action>
+       <action>echo -n '${DEFAULTSSID}' > /tmp/sns_netname_default</action>
+       <action>refresh:HIDDEN_NAME</action>
+       <action>'${PASSBOXVIS}':PASSBOX</action>
+     </radiobutton>' >> /tmp/sns_scan_radiobuttons #190216
+# shellcheck disable=SC2086
+        echo '
+   <hbox space-expand="false" space-fill="false">
+     <text xalign="0" yalign="1" use-markup="true" space-expand="true" space-fill="true">
+       <label>"<small><small>'${TXT_SHIELD}'</small></small>"</label>
+     </text>
+     <pixmap height-request="25" space-expand="false" space-fill="false">
+       <input file>/usr/share/pixmaps/puppy/'${IMG_SHIELD}'.svg</input>
+       <height>25</height>
+     </pixmap>
+   </hbox>' >> /tmp/sns_scan_radiobuttons_shield
+# shellcheck disable=SC2086
+        echo '
+   <hbox space-expand="false" space-fill="false">
+     <text xalign="0" yalign="1" use-markup="true" space-expand="true" space-fill="true">
+       <label>"<small><small>'${CELL_SIGNAL}' mDb</small></small>"</label>
+     </text>
+     <pixmap height-request="25" space-expand="false" space-fill="false">
+       <input file>/usr/share/pixmaps/puppy/'${IMG_QUALITY}'.svg</input>
+       <height>25</height>
+     </pixmap>
+   </hbox>' >> /tmp/sns_scan_radiobuttons_strength
+# shellcheck disable=SC2086
+        echo '
+   <hbox space-expand="false" space-fill="false" height-request="25">
+     <text xalign="1" yalign="1" use-markup="true" space-expand="true" space-fill="true">
+       <label>"'${CELL_ADDRESS}'"</label>
+     </text>
+   </hbox>' >> /tmp/sns_scan_radiobuttons_address
+        #---
+   
+        echo "${CELL_NUMBER}|${CELL_ADDRESS}|${CELL_CHANNEL}|${CELL_FREQUENCY}|${CELL_SIGNAL}|${CELL_ENCRYPTIONKEY}|${CELL_ESSID}|${CELL_SEC_MGMT}" >> /tmp/sns_scan_oneline
+    done
+} #build_display_network_list
+ 
+build_display_radio_buttons() {
+    if [ ! -f /tmp/sns_scan_radiobuttons ]; then
+        FRAME1='<text space-expand="true" space-fill="true"><label>""</label></text>'
+        HIDDENBOX=""
+        FRAME2=""
+        WIN2MSG1="$(gettext 'No wireless networks found')"
+        WIN2BUT1=""
+        WIN2BUT2=""
+    else
+        WIN2MSG1="$(gettext "Choose which network you want to use; enter network name if hidden; enter passphrase if encrypted; then click <b>Connect</b> button.")"
+        RADIOBUTTONS='
+   <hbox space-expand="true" space-fill="true">
+     <vbox space-expand="false" space-fill="false">'$(cat /tmp/sns_scan_radiobuttons)'</vbox>
+     <text space-expand="true" space-fill="true"><label>""</label></text>
+     <vbox space-expand="false" space-fill="false">'$(cat /tmp/sns_scan_radiobuttons_shield)'</vbox>
+     <text width-request="2" space-expand="false" space-fill="false"><label>""</label></text>
+     <vbox space-expand="false" space-fill="false">'$(cat /tmp/sns_scan_radiobuttons_strength)'</vbox>
+     <vbox space-expand="false" space-fill="false">'$(cat /tmp/sns_scan_radiobuttons_address)'</vbox>
+   </hbox>'
+        FRAME1='
+    <vbox space-expand="true" space-fill="true">
+    <frame '$(gettext 'Wireless networks')'>
+      <vbox scrollable="true" shadow-type="1" space-expand="false" space-fill="false">
+        <eventbox name="bg"  above-child="false" visible-window="true" space-expand="true" space-fill="true">
+          <vbox border-width="5" space-expand="true" space-fill="true">
+            '${RADIOBUTTONS}'
+          </vbox>
+        </eventbox>
+      </vbox>
+    </frame>
+    </vbox>'
+
+# shellcheck disable=SC2016
+        HIDDENBOX='
+   <vbox space-expand="false" space-fill="false">
+       <hbox border-width="5" space-expand="true" space-fill="true">
+             <text space-expand="false" space-fill="false">
+               <label>'$(gettext 'Hidden network name:')'</label>
+             </text>
+             <entry space-expand="true" space-fill="true" caps-lock-warning="true" 
+              tooltip-markup="'$(gettext 'Enter network name of selected hidden network')'">
+               <variable>HIDDEN_NAME</variable>
+               <input>cat /tmp/sns_netname_default</input>
+             </entry>
+       </hbox>
+     <variable>HIDNETBOX</variable>
+   </vbox>'
+
+# shellcheck disable=SC2016
+        FRAME2='
+   <vbox space-expand="false" space-fill="false">
+           <hbox border-width="5" space-expand="true" space-fill="true">
+             <vbox>
+               <hbox space-expand="true" space-fill="true">
+                 <text xalign="0" space-expand="false" space-fill="false"><label>'$(gettext 'Passphrase:')'</label></text>
+                 <notebook show-tabs="false" show-border="false" visible="false">
+                   <vbox>
+                     <entry space-expand="true" space-fill="true" caps-lock-warning="true" 
+                     tooltip-markup="'$(gettext 'Enter your network passphrase')'" visibility="false">
+                       <variable>PASS_SHOWN</variable>
+                       <input>echo "$PASS_HIDDEN"</input>
+                       <action>refresh:PASS_HIDDEN</action>
+                     </entry>
+                   </vbox>
+                   <vbox>
+                     <entry space-expand="true" space-fill="true" caps-lock-warning="true" 
+                     tooltip-markup="'$(gettext 'Enter your network passphrase')'" visibility="true">
+                       <variable>PASS_HIDDEN</variable>
+                       <input>echo "$PASS_SHOWN"</input>
+                       <action>refresh:PASS_SHOWN</action>
+                     </entry>
+                   </vbox>
+                   <variable>SWITCH</variable>
+                   <input>echo $(( (SWITCH+1) &1 ))</input>
+                 </notebook>
+               </hbox>
+               <checkbox space-expand="true" space-fill="true">
+                 <label>'$(gettext 'Show passphrase')'</label>
+                 <action>refresh:SWITCH</action>
+               </checkbox>
+             </vbox>
+           </hbox>
+     <variable>PASSBOX</variable>
+   </vbox>'
+        WIN2BUT1='
+   <button can-default="true" has-default="true" space-expand="false" space-fill="false">
+     <variable>BTN_CONNECT</variable>
+     <label>'$(gettext "Connect")'</label>
+     '"$(/usr/lib/gtkdialog/xml_button-icon internet_connect.svg)"'
+     <action type="exit">BUT_CONNECT</action>
+   </button>'
+        WIN2BUT2='
+   <button space-expand="false" space-fill="false">
+     <label>'$(gettext 'Help')'</label>
+     '"$(/usr/lib/gtkdialog/xml_button-icon help)"'
+     <action>/usr/local/simple_network_setup/help_security & </action>
+   </button>'
+    fi
+    kill $PIDXMSG 2>/dev/null ; PIDXMSG=""
+} #build_display_radio_buttons
+
+build_and_display_wireless_setup_window() {
+    SNS_setup='<window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network" height-request="400" width-request="540">
+  <vbox space-expand="true" space-fill="true">
+    '"$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "${WIN2MSG1}")"' 
+    '${FRAME1}'
+    '${HIDDENBOX}'
+    '${FRAME2}'
+    <hbox space-expand="false" space-fill="false">
+      <button space-expand="false" space-fill="false">
+        <label>'$(gettext "Rescan")'</label>
+        '"`/usr/lib/gtkdialog/xml_button-icon refresh`"'
+        <action type="exit">BUT_RESCAN</action>
+      </button>
+      '${WIN2BUT2}'
+      <text space-expand="true" space-fill="true"><label>""</label></text>
+      <button space-expand="false" space-fill="false">
+        <label>'$(gettext "Cancel")'</label>
+        '"$(/usr/lib/gtkdialog/xml_button-icon cancel)"'
+        <action type="exit">BUT_GOBACK</action>
+      </button>
+      '${WIN2BUT1}'
+    </hbox>
+  </vbox>
+
+  <action signal="map-event">show:SWITCH</action>
+  <action signal="map-event">grabfocus:PASS_HIDDEN</action>
+  <action signal="show" condition="file_is_false(/tmp/sns_show_netname_box) ">hide:HIDNETBOX</action>
+  <action signal="show" condition="file_is_false(/tmp/sns_show_passphrase_box) ">hide:PASSBOX</action>
+</window>'
+    export SNS_setup
+    #darker bg
+    echo '<?xml version="1.1" encoding="UTF-8"?><svg height="10" width="10">
+    <rect style="fill:#000000;fill-opacity:0.2" width="10" height="10" x="0" y="0"/></svg>' > /tmp/sns_bg.svg
+
+    echo '
+  pixmap_path "/tmp"
+  style "bg" { bg_pixmap[NORMAL] = "sns_bg.svg" }
+  widget "*bg*" style "bg"' > /tmp/gtkrc_mono
+    export GTK2_RC_FILES=/tmp/gtkrc_mono:/root/.gtkrc-2.0
+    #---
+  
+    . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
+    RETSTRING="$(gtkdialog -p SNS_setup)"
+} #build_and_display_wireless_setup_window
+
+extract_data_for_selected_network() {
+    SEC_KEY="$(grep '^PASS_HIDDEN' <<< "$RETSTRING" | cut -f 2 -d '"' | tr -d '-')" #'geany
+    CELL_NUMBER="$(grep '^RADIO' <<< "$RETSTRING" | grep 'true' | cut -f1 -d'=' | cut -f2 -d'_')" #ex: 01
+    cnPATTERN='^'"$CELL_NUMBER"'|'
+    #grep to temp file then read from temp file, because piping grep output to read fails. #210208
+    grep "$cnPATTERN" /tmp/sns_scan_oneline >/tmp/sns_oneline #210208
+    IFS='|' read -r CELL_NUMBER CELL_ADDRESS CELL_CHANNEL CELL_FREQUENCY CELL_SIGNAL CELL_ENCRYPTIONKEY CELL_ESSID CELL_SEC_MGMT CELL_CIPHERS CELL_AUTH CELL_SEC_MGMT2 CELL_CIPHERS2 </tmp/sns_oneline #210208
+    if [ "$CELL_ESSID" = '(hidden)' ]; then
+        CELL_ESSID="$(grep '^HIDDEN_NAME' <<< "$RETSTRING" | cut -f2 -d'=' | cut -f2 -d'"')"
+        SCAN_SSID=1
+    else
+        SCAN_SSID=0
+    fi
+    if [ -z "$CELL_ESSID" ]; then
+        FLAGERR=8
+    elif [ "$CELL_ENCRYPTIONKEY" = "on" ]; then
+        if [ -z "$SEC_KEY" ]; then
+            FLAGERR=2 #no security key
+        else
+            SEC_MGMT="$CELL_SEC_MGMT"
+            case $SEC_MGMT in
+              WEP) ;; #Restricted (shared key) is deprecated #210207
+              *) SEC_MGMT='WPA-PSK' ;; #exs: AES, TKIP
+            esac
+        fi
+    else
+        WPA_DRIVER=""
+    fi
+} #extract_data_for_selected_network
+
+configure_wpa_supplicant() {
+    FLAGERR= #100323
+    case $SEC_MGMT in
+      WEP)
+        WEP_KEY0='' #210207...
+        case "${#SEC_KEY}" in
+          5|13) WEP_KEY0="\"${SEC_KEY}\"" ;;
+          10|26) WEP_KEY0="${SEC_KEY}" ;;
+          *) echo "Invalid WEP key: $SEC_KEY" >> /tmp/sns_wireless_log ;;
+        esac
+        echo "ctrl_interface=/var/run/wpa_supplicant
+ap_scan=${ONEFIX}
+
+network={
+ ssid=\"${CELL_ESSID}\"
+ scan_ssid=${SCAN_SSID}
+ key_mgmt=NONE
+ wep_key0=${WEP_KEY0}
+ wep_tx_keyidx=0
+}" > "/tmp/sns_wpa_supplicant_conf"
+        RUNWPASUPP='yes'
+        kill_wpa_supplicant
+       ;;
+      WPA-PSK|WPA2-PSK) #very simple, handles all ciphers.
+        #it works psk="passphrase" (with quotes), but for security encode psk into hex string...
+        hexSEC_KEY=$(wpa_passphrase "$CELL_ESSID" "$SEC_KEY" | grep 'psk=[^"]' | cut -f 2 -d '=')
+        echo "ctrl_interface=/var/run/wpa_supplicant
+ap_scan=${ONEFIX}
+
+network={
+ ssid=\"${CELL_ESSID}\"
+ scan_ssid=${SCAN_SSID}
+ key_mgmt=${SEC_MGMT}
+ psk=${hexSEC_KEY}
+}" > "/tmp/sns_wpa_supplicant_conf"
+        RUNWPASUPP='yes'
+        kill_wpa_supplicant
+       ;;
+      WPA*)  
+        #it works psk="passphrase" (with quotes), but for security encode psk into hex string...
+        hexSEC_KEY=$(wpa_passphrase "$CELL_ESSID" "$SEC_KEY" | grep 'psk=[^"]' | cut -f 2 -d '=')
+        echo "ctrl_interface=/var/run/wpa_supplicant
+ap_scan=${ONEFIX}
+
+network={
+ ssid=\"${CELL_ESSID}\"
+ scan_ssid=${SCAN_SSID}
+ proto=WPA
+ key_mgmt=${SEC_MGMT}
+ pairwise=${WPA_ENC}
+ group=${WPA_ENC}
+ psk=${SEC_KEY}
+ wpa_ptk_rekey=600
+}" > "/tmp/sns_wpa_supplicant_conf"
+        RUNWPASUPP='yes'
+        kill_wpa_supplicant
+       ;;
+    esac
+} #configure_wpa_supplicant
+
+run_wpa_supplicant() {
+    echo "STEP5b: wpa_supplicant -B -D${WPA_DRIVER} -i${INTERFACE} -c\"/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}\"" >> /tmp/sns_wireless_log
+    wpa_supplicant -B -D"${WPA_DRIVER}" -i"${INTERFACE}" -c"/tmp/sns_wpa_supplicant_conf" >> /tmp/sns_wireless_log 2>&1
+    local wCNT=0
+    while [ $((++wCNT)) -le 20 ]; do
+        sleep 1
+        wpa_cli -i "$INTERFACE" status | grep -q '^bssid=[0-9a-f]' && break
+    done
+    if [ "$wCNT" -gt 20 ]; then
+        echo "Running: wpa_cli -i ${INTERFACE} status" >> /tmp/sns_wireless_log
+        wpa_cli -i "$INTERFACE" status >> /tmp/sns_wireless_log 2>&1
+        killall -SIGHUP wpa_supplicant
+        kill "$PIDX" 2>/dev/null #210201
+        return 1
+    fi
+    return 0
+} #run_wpa_supplicant
+
+kill_wpa_supplicant() {
+    if ps -C wpa_supplicant >/dev/null 2>&1; then #210202
+        wpa_cli terminate #kills any running wpa_supplicant. no it doesn't, just brings down interface.
+        killall -q wpa_supplicant
+    fi
+} #kill_wpa_supplicant
+
+show_wait_splash() { #Argument: fuCNT. Always returns 0.
+    [ -n "$PIDX" ] && kill "$PIDX" 2>/dev/null #210201
+    case "$1" in
+      3) BGCOLOR="DeepPink" ;;
+      2) BGCOLOR="pink" ;;
+      1) BGCOLOR="HotPink" ;;
+    esac
+    case "$1" in
+      4) gtkdialog-splash -placement center -bg orange -text "$(eval_gettext "Please wait, attempting to connect to '\${CELL_ESSID}'...")" >/dev/null & #210207
+        ;;
+      *) gtkdialog-splash -placement center -bg $BGCOLOR -text "$(gettext 'Please keep waiting, retrying encrypted connection...')" >/dev/null &
+        ;;
+    esac
+    PIDX=$! #210207?
+    sleep 0.1
+    return 0
+} #show_wait_splash
+ 
+wait_until_link_available() {
+    #wait until access point becomes available...
+    sCNT=0
+    while true; do
+        iw dev "${INTERFACE}" link | grep -q '^Connected' && break #210202
+        sleep 1
+        if [ $(( ++sCNT )) -gt 20 ]; then
+            {
+            echo "" #100320...
+            echo "ERROR, TIMEOUT. Have not got an Access Point."
+            echo "Result of 'iw dev ${INTERFACE} info':" #210202
+            iw dev "${INTERFACE}" info 2>&1 #210202
+            echo ""
+            } >> /tmp/sns_wireless_log #100320 end
+            FLAGERR=7
+            break
+        fi
+    done
+} #wait_until_link_available
+
+kill_wireless_link() {
+    iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid' && iw dev "$INTERFACE" disconnect #210202
+    ip link set "$INTERFACE" down #210202
+} #kill_wireless_link
+
+run_dhcpcd() {
+    for iterDHCPCD in a b; do #100320
+        [ "$iterDHCPCD" = "a" ] && DHCPCDFIX=""
+        [ "$iterDHCPCD" = "b" ] && DHCPCDFIX="-I ''" #some dhcp servers require empty Client ID (default is macaddress).
+        echo "STEP6${iterDHCPCD}: dhcpcd $DHCPCDFIX $INTERFACE" >> /tmp/sns_wireless_log
+# shellcheck disable=SC2086 #word-split $DHCPCDFIX
+        dhcpcd $DHCPCDFIX "$INTERFACE" >> /tmp/sns_wireless_log 2>&1 ####DHCP CLIENT#### 121117
+        local RC=$? #170402
+        [ $RC -eq 0 ] || break
+        #need to wait awhile #210212...
+        for ONESLEEP in 0.2 1 2; do
+            sleep $ONESLEEP
+            grep -q '^nameserver' /etc/resolv.conf && break
+        done
+        grep -q '^nameserver' /etc/resolv.conf && break
+        sleep 1
+        [ "$iterDHCPCD" != "b" ] && dhcpcd --release "$INTERFACE"
+    done
+    [ $RC -eq 0 ] \
+      && grep -q '^nameserver' /etc/resolv.conf || FLAGERR=6 #170402 #210212
+} #run_dhcpcd
+
+kill_wpa_supplicant_and_link() {
+    kill_wpa_supplicant
+    kill_wireless_link
+    dhcpcd --release "$INTERFACE" 2>/dev/null
+    ip route flush dev "$INTERFACE" #100703
+} #kill_wpa_supplicant_and_link
+
+add_wireless_connection_profile_and_conf() { #211002
+    #100413 have one pc where blinky did not start. try again...
+    if which blinky_tray >/dev/null \
+      && ! ps -C blinky_tray >/dev/null 2>&1; then
+        blinky_tray & #210202
+    fi
+    [ "$SEC_MGMT" != 'open' ] && SEC_MGMT="$WPA_SEC_MGMT"
+    macssidPATTERN="^$MACADDRESS|.*|$CELL_ESSID|" #210208
+    touch /etc/simple_network_setup/connections
+    echo -e "${MACADDRESS}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}|${DHCPCDFIX}|${CELL_ESSID}|${CELL_ADDRESS}|${SEC_MGMT}|${SEC_KEY}|${WPA_DRIVER}|\n$(grep -v "$macssidPATTERN" /etc/simple_network_setup/connections)" > /tmp/sns_connections.tmp #210207 210208 #210428 #211002
+    mv  /tmp/sns_connections.tmp /etc/simple_network_setup/connections #211002
+    mv -f /tmp/sns_wpa_supplicant_conf "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
+} #add_wireless_connection_profile_and_conf
+    
+build_and_display_wireless_success_window() {
+    XML_FIREWALL=""
+    if [ ! -x /etc/rc.d/rc.firewall ] && [ ! -x /etc/init.d/rc.firewall ]; then
+        XML_FIREWALL='
+         <text><label>"'$(gettext "However, there is one item of recommended housekeeping: you really should be running a firewall. Puppy is inherently secure, however a firewall will give you that extra protection while online. Recommend that you tick the 'Start firewall' checkbox (the firewall will install and will automatically run at all future boots)...")'"</label></text>
+         <checkbox>
+           <label>'$(gettext 'Start firewall')'</label>
+           <default>true</default>
+           <variable>CHK_FIREWALL</variable>
+         </checkbox>
+         <hseparator></hseparator>'
+    fi
+    kill $PIDX 2>/dev/null
+    SNS_complete='
+        <window title="'$(gettext 'SNS: Simple Network Setup')'" icon-name="gtk-network">
+        <vbox>
+          <frame>
+            '"$(/usr/lib/gtkdialog/xml_pixmap dialog-complete.svg popup)"'
+            <text use-markup="true"><label>"<b>'$(gettext 'Successful connection to wireless network')' '${CELL_ESSID}'</b>"</label></text>
+            <text><label>""</label></text>
+            '${XML_FIREWALL}'
+            <hseparator></hseparator>
+            <text xalign="0"><label>'$(gettext "SNS will automatically connect to the Internet at bootup, wirelessly if possible.")'</label></text>
+            <text xalign="0"><label>'$(gettext "To make SNS the default network setup tool so that clicking the 'connect' icon on the desktop or selecting 'Setup networking' from the network tray icon will immediately launch SNS...")'</label></text>
+            <checkbox>
+              <label>'$(gettext 'Set SNS as default network setup tool')'</label>
+              <default>true</default>
+              <variable>CHK_SNSDEF</variable>
+            </checkbox>
+          </frame>
+          <hbox>
+            <button space-expand="false" space-fill="false">
+              <label>'$(gettext "Ok")'</label>
+              '"$(/usr/lib/gtkdialog/xml_button-icon ok)"'
+              <action>exit:OK</action>
+            </button>
+          </hbox>
+        </vbox>
+        </window>' #190216
+    export SNS_complete
+    RETSTR3="$(gtkdialog -p SNS_complete --center)"
+} #build_and_display_wireless_success_window
+
+build_and_display_wireless_error_window() {
+    [ "$PIDXMSG" ] && kill "$PIDXMSG" 2>/dev/null
+    [ $PIDX ] && kill $PIDX 2>/dev/null
+    case $SEC_MGMT in
+      WPA*) ERR_EXTRA1="$(gettext 'Note: the network card and/or Linux driver might not support WPA2, in which case you will need to set the wireless router to WPA. Or, WPA might not be supported at all, in which case you will have to set the router and network card to use WEP.')" ;;
+      *)    ERR_EXTRA1="" ;;
+    esac
+    case $FLAGERR in
+      1) ERR_MSG="$(eval_gettext "Failed to activate interface '\${INTERFACE}'. Sometimes this is just a temporary problem. Go back to the main window, and you can try again...")" ; ERR_EXTRA1="" ;;
+      2) ERR_MSG="$(gettext 'ERROR: you did not specify a Passphrase')" ; ERR_EXTRA1="" ;;
+      4) ERR_MSG="$(eval_gettext "Failed to connect to SSID '\${CELL_ESSID}'.")"; ERR_EXTRA1="" ;; #210202
+      5) ERR_MSG="$(eval_gettext "wpa_supplicant failed to associate with the network card, perhaps due to an incorrect password for wireless network '\${CELL_ESSID}' or incorrect name for hidden network.")" ;;
+      6) ERR_MSG="$(eval_gettext "DHCP client failed to negotiate with wireless network '\${CELL_ESSID}'")" ;;
+      7) ERR_MSG="$(gettext 'Failed to obtain Access Point of network.')";  ERR_EXTRA1="" ;;
+      8) ERR_MSG="$(gettext 'ERROR: you did not specify a network name for the hidden network')" ;;
+      *) ERR_MSG="$(eval_gettext "Failed to connect to wireless network '\${CELL_ESSID}'")" ;; 
+    esac
+    SNS_error='
+  <window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network">
+  <vbox>
+    <frame>
+      '"$(/usr/lib/gtkdialog/xml_pixmap dialog-error popup)"'
+      <text use-markup="true"><label>"<b>'${ERR_MSG}'</b>
+'${ERR_EXTRA1}'"</label></text>
+      <text xalign="0"><label>'$(gettext "So, what do you want to do? If you go back to the main window, you could test a different interface or network. Note, sometimes an error 'goes away' if you retry.")'</label></text>
+    </frame>
+    <hbox space-expand="false" space-fill="false">
+      <button tooltip-text="'$(gettext 'View log of attempted connection:')'" space-expand="false" space-fill="false">
+        <label>'$(gettext 'View Log')'</label>'"
+        <action>echo ' ' >> /tmp/sns_wireless_log</action>
+        <action>echo '*********************************************************' >> /tmp/sns_wireless_log</action>
+        <action>echo 'LAST 10 LINES of /var/log/messages:' >> /tmp/sns_wireless_log</action>
+        <action>tail -n 10 /var/log/messages >> /tmp/sns_wireless_log</action>
+        <action>defaulttextviewer /tmp/sns_wireless_log & </action>"'
+      </button>
+      <text space-expand="true" space-fill="true"><label>""</label></text>
+      <button space-expand="false" space-fill="false">
+        <label>'$(gettext "Retry")'</label>
+        '"$(/usr/lib/gtkdialog/xml_button-icon refresh)"'
+        <action type="exit">BUT_GOBACK</action>
+      </button>
+      <button space-expand="false" space-fill="false">
+        <label>'$(gettext "Quit")'</label>
+        '"$(/usr/lib/gtkdialog/xml_button-icon quit)"'
+        <action type="exit">BUT_QUIT</action>
+      </button>
+    </hbox>
+  </vbox>
+  </window>'
+    export SNS_error
+    RETSTRING="$(gtkdialog -p SNS_error --center)"
+} #build_and_display_wireless_error_window
+
+detect_and_connect_wired_link() {
+    LINK_DETECTED=no
+    TIMEOUT=15 #200412
+    while [ $TIMEOUT -ge 0 ]; do #200412
+        if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
+            LINK_DETECTED="yes"
+            break
+        fi
+        [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190216 200412
+    done
+    if [ "$LINK_DETECTED" = "no" ] ; then
+        ip link set "$INTERFACE" down #210202
+        kill "$PIDXX" 2>/dev/null
+        /usr/lib/gtkdialog/box_ok "$(gettext 'Simple Network Setup')" error "<b>$(eval_gettext "There does not seem to be any network connected to \${INTERFACE}")</b>" " " "$(gettext "Is the network cable unplugged? Modem router turned off? If you can fix it, great, otherwise try a different interface.")"
+        exec sns
+        exit
+    fi
+    DHCPCDFIX=""
+    dhcpcd "$INTERFACE" >> /tmp/sns_wired_log 2>&1
+    RC=$? #170402
+    #need to wait awhile #210212...
+    if [ $RC -eq 0 ]; then
+        for ONESLEEP in 0.2 1 2; do
+            sleep $ONESLEEP
+            grep -q '^nameserver' /etc/resolv.conf && break
+        done
+    fi
+    if ! grep -q '^nameserver' /etc/resolv.conf; then #170402 end #210212 end
+        #fail, try again.
+        DHCPCDFIX="-I ''"
+        dhcpcd --release "$INTERFACE"
+        sleep 0.1
+        dhcpcd -I '' "$INTERFACE" >> /tmp/sns_wired_log 2>&1
+        RC=$? #170402
+       #need to wait awhile #210212...
+        if [ $RC -eq 0 ]; then
+            for ONESLEEP in 0.2 1 2; do
+                sleep $ONESLEEP
+                grep -q '^nameserver' /etc/resolv.conf && break
+            done
+        fi
+    fi
+} #detect_and_connect_wired_link
+
+build_and_display_wired_success_window() {
+    SNS_complete='
   <window title="'$(gettext 'SNS: Simple Network Setup')'" icon-name="gtk-network">
   <vbox>
     <frame>
-      '"`/usr/lib/gtkdialog/xml_pixmap dialog-complete popup`"'
+      '"$(/usr/lib/gtkdialog/xml_pixmap dialog-complete popup)"'
       <text use-markup="true"><label>"<b>'$(gettext 'Successful connection to wired network')' '${INTERFACE}'</b>"</label></text>
       <text><label>""</label></text>
       <hseparator></hseparator>
@@ -1069,34 +1164,39 @@ if [ "$IF_INTTYPE" == "Wired" ];then
     <hbox>
       <button space-expand="false" space-fill="false">
         <label>'$(gettext "Ok")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon ok`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon ok)"'
         <action>exit:OK</action>
       </button>
     </hbox>
   </vbox>
   </window>' #190216
-  RETSTR5="`gtkdialog -p SNS_complete --center`"
-  if [ "`echo "$RETSTR5" | grep '^CHK_SNSDEF' | grep 'true'`" != "" ];then
-   echo -e '#!/bin/sh\nexec sns' > /usr/local/bin/defaultconnect
-  else
-   echo -e '#!/bin/sh\nexec connectwizard' > /usr/local/bin/defaultconnect
-  fi
-  MACADDRESS="`ifconfig $INTERFACE | grep -o 'HWaddr .*' | cut -f 2 -d ' '`"
-  aPATTERN='|'"$MACADDRESS"'|'
-  touch /etc/simple_network_setup/connections
-  grep -v "$aPATTERN" /etc/simple_network_setup/connections > /tmp/sns_temp2
-  mv -f /tmp/sns_temp2 /etc/simple_network_setup/connections
-  echo "${IFDATA}|${MACADDRESS}|${DHCPCDFIX}|" >> /etc/simple_network_setup/connections
- else
-  ifconfig $INTERFACE down
-  dhcpcd --release $INTERFACE 2>/dev/null
-  ip route flush dev $INTERFACE #100703
-  export SNS_error='
+    export SNS_complete
+    RETSTR5="$(gtkdialog -p SNS_complete --center)"
+    if grep '^CHK_SNSDEF' <<< "$RETSTR5" | grep -q 'true'; then
+        echo -e '#!/bin/sh\nexec sns' > /usr/local/bin/defaultconnect
+    else
+        echo -e '#!/bin/sh\nexec connectwizard' > /usr/local/bin/defaultconnect
+    fi
+} #build_and_display_wired_success_window
+
+add_wired_connection_profile() { #211002...
+    MACADDRESS="$(ip link show "$INTERFACE" | grep 'link/ether' | tr -s ' ' | cut -f 3 -d ' ')" #210202
+    aPATTERN="^$MACADDRESS|"
+    touch /etc/simple_network_setup/connections
+    echo -e "${MACADDRESS}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}|${DHCPCDFIX}|\n$(grep -i -v "$aPATTERN" /etc/simple_network_setup/connections)" > /tmp/sns_connections.tmp #211002
+    mv  /tmp/sns_connections.tmp /etc/simple_network_setup/connections #211002
+} #add_wired_connection_profile
+
+build_and_display_wired_error_window() {
+    ip link set "$INTERFACE" down #210202
+    dhcpcd --release "$INTERFACE" 2>/dev/null
+    ip route flush dev "$INTERFACE" #100703
+    SNS_error='
   <window title="'$(gettext 'Simple Network Setup')'" icon-name="gtk-network">
   <vbox>
     <frame>
-      '"`/usr/lib/gtkdialog/xml_pixmap dialog-error popup`"'
-      <text use-markup="true"><label>"<b>'$(gettext 'Failed to connect to wired network')' '${INTERFACE}'</b>"</label></text>
+      '"$(/usr/lib/gtkdialog/xml_pixmap dialog-error popup)"'
+      <text use-markup="true"><label>"<b>'$(eval_gettext "Failed to connect to wired network \${INTERFACE}")'</b>"</label></text>
       <text xalign="0"><label>'$(gettext "The network does exist, however failed to negotiate with the DHCP server. Is there a wireless interface? -- maybe try that.")'</label></text>
     </frame>
     <hbox space-expand="false" space-fill="false">
@@ -1107,21 +1207,99 @@ if [ "$IF_INTTYPE" == "Wired" ];then
       <text space-expand="true" space-fill="true"><label>""</label></text>
       <button space-expand="false" space-fill="false">
         <label>'$(gettext "Retry")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon refresh`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon refresh)"'
         <action type="exit">BUT_GOBACK</action>
       </button>
       <button space-expand="false" space-fill="false">
         <label>'$(gettext "Quit")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon quit`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon quit)"'
         <action type="exit">BUT_QUIT</action>
       </button>
     </hbox>
   </vbox>
   </window>' #200521
-  RETSTRING="`gtkdialog -p SNS_error --center`"
-  [ "`echo "$RETSTRING" | grep '^EXIT' | grep 'BUT_GOBACK'`" != "" ] && exec sns
- fi
- exit
+    export SNS_error
+    RETSTRING="$(gtkdialog -p SNS_error --center)"
+} #build_and_display_wired_error_window
+
+
+################# MAIN ####################
+
+if ! which iw; then #211002...
+    gtkdialog-splash -bg orange -close never -fontsize large -timeout 20 -text "$(gettext 'Simple_network_setup needs the command: iw.  Please install it.')" >/dev/null
+    exit
+fi
+
+#firewall
+if which firewall_ng >/dev/null 2>&1; then
+    FW_EXEC=firewall_ng
+else
+    FW_EXEC="urxvt -e firewallinstallshell"
+fi
+
+echo -n '' > /tmp/sns_interfaces
+INTERFACES="$(ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ':' | tr -d '\n')" #210202
+for INTERFACE in $INTERFACES; do #exs: wlan0 eth0
+    find_interface_driver
+    collect_interface_data
+done
+build_interface_display_list
+find_usable_interfaces #sets WORKINGIF
+
+#120107 new 'Profile' frame...
+PROFILE_XML=""
+if grep -qs '^..:' /etc/simple_network_setup/connections; then
+    build_connection_display_list
+    build_display_connect_button
+fi
+build_and_display_main_window #sets RETSTRING
+#echo "$RETSTRING"
+EXIT="$(grep '^EXIT' <<< "$RETSTRING" | cut -f2 -d'"')" #'geany
+grep -q 'EXITRESTART' <<< "$EXIT" && exec sns ###restarting sns###
+grep -q 'Interface' <<< "$EXIT" || exit
+ 
+INTERFACE="$(grep 'Interface' <<< "$EXIT" | cut -f2 -d '_')" #ex: wlan1
+
+if [ "$INTERFACE" = "Windows" ]; then #100313
+    load_windows_driver
+fi
+
+which connectwizard_exec >/dev/null 2>&1 \
+  && connectwizard_exec sns #Update current exec name. 170329 190223
+
+ensure_interface_is_down
+extract_interface_data
+
+############ WIRELESS SETUP ###############
+if [ "$IF_INTTYPE" = "Wireless" ]; then
+    perform_wireless_setup
+    exit
+fi
+
+############ WIRED SETUP ###############
+if [ "$IF_INTTYPE" = "Wired" ]; then
+    gtkdialog-splash -placement center -bg orange -text "$(eval_gettext "Please wait, trying to connect to interface '\${INTERFACE}'...")" >/dev/null &
+    PIDXX=$!
+    echo "Information about this interface:
+ Interface: $INTERFACE  Driver: $IF_DRIVER  Bus: $IF_BUS  MacAddress: $MACADDRESS
+ Description: $IF_INFO
+ " > /tmp/sns_wired_log
+ 
+    if ip link set "$INTERFACE" up >> /tmp/sns_wired_log 2>&1; then #210202
+        detect_and_connect_wired_link
+        kill $PIDXX 2>/dev/null
+
+        if grep -q '^nameserver' /etc/resolv.conf; then #210212
+            add_wired_connection_profile #211002
+            build_and_display_wired_success_window
+        else
+            build_and_display_wired_error_window
+            grep '^EXIT' <<< "$RETSTRING" | grep -q 'BUT_GOBACK' && exec sns
+        fi
+    else
+        kill $PIDXX 2>/dev/null
+    fi
+    exit
 fi
 
 ###END###


### PR DESCRIPTION
SNS 3.x consists of code reorganized into segment/functions to facilitate maintenance, avoid dependence on deprecated ifconfig, iwconfig, route and iwlist commands, and add new capabilities.

Operational improvements include:
 1. Automatic connection startup/restart respecting the order of listed connections, with new profiles added to the beginning of the list
 2. Simplification of wireless setup dialog to request only the input fields needed by selected network's protocol, including hidden networks
 3. Correction of interface and bus type listed for each connection profile
 4. Addition of nl80211 (before wext) as default wpa drivers, for newer interfaces
 5. Correction of connection profile deletion to also terminate wpa_supplicant for interface
 6. Adjustment of various wait times for asynchronous operations
 7. Correction of various exception handling
 8. Correction of 'wait' splash messaging
 9. WEP protocol support by wpa_supplicant
 10. Internationalization improvements utilizing new textdomain simple_network_setup
 11. Compatibility with EasyOS

There may not be any language translations for this upgrade, yet.

The format of the stored connection profiles is simplified.  The pinstall and puninstall scripts save any old-format profiles and restore them if a 3.x package is uninstalled.
