### PR TITLE
Disable Xwayland by default and automatically switch to Xorg if Xwayland fails to start

### DIFF
--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -4,7 +4,6 @@
 
 # this configuration file is modified by xkbconfigmanager
 [ ! -f ~/.Xwaylandrc ] && cat << EOF > ~/.Xwaylandrc
-XSERVER=xwayland
 XKB_DEFAULT_LAYOUT=
 XKB_DEFAULT_MODEL=
 XKB_DEFAULT_OPTIONS=

--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -69,7 +69,6 @@ export GDK_BACKEND=x11
 unset SDL_VIDEODRIVER
 
 "$1"
-ret=$?
 
 # sometimes cage doesn't exit (https://github.com/Hjdskes/cage/issues/146) and cannot be started again unless we kill it
 sleep 1
@@ -83,4 +82,4 @@ if [ $? -eq 0 ]; then
 	fi
 fi
 
-exit $ret
+exit 0

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -337,7 +337,7 @@ fi
 if [ $XWAYLAND -eq 1 ] ; then
 	startxwayland ${XINITRC} > $LOGFILE_X 2>&1
 	if [ $? -eq 11 ]; then
-		rm -f /var/local/xwin_enable_xwayland
+		rm -f /var/local/xwin_enable_xwayland /root/.XLOADED
 		exec xwin
 	fi
 else

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -336,6 +336,10 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 fi
 if [ $XWAYLAND -eq 1 ] ; then
 	startxwayland ${XINITRC} > $LOGFILE_X 2>&1
+	if [ $? -eq 11 ]; then
+		rm -f /var/local/xwin_enable_xwayland
+		exec xwin
+	fi
 else
 	/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1
 fi

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -29,22 +29,17 @@ else
 	LOGFILE_X='/tmp/xerrs.log'
 fi
 
-XSERVER="xorg"
-
-# if X.Org is present, we want to use X.Org until NVIDIA drivers and qemu's std
-# VGA card have proper Wayland support, and assume all nouveau users switch to
-# the proprietary driver
-if [ -z "`grep -e ^nouveau -e ^nvidia -e ^bochs_drm /proc/modules`" ]; then
-	command -v startxwayland > /dev/null 2>&1 && XSERVER="xwayland"
+if [ -f /var/local/xwin_enable_xwayland ] ; then
+	XWAYLAND=1
+else
+	XWAYLAND=0
 fi
 
-[ -f ~/.Xwaylandrc ] && . ~/.Xwaylandrc
-
-if [ "$XSERVER" = "xorg" -a `id -u` -eq 0 -a -h /usr/bin/X ] ; then
+if [ $XWAYLAND -eq 0 -a `id -u` -eq 0 -a -h /usr/bin/X ] ; then
 	ln -snf Xorg /usr/bin/X
 fi
 
-if [ "$XSERVER" = "xorg" -a "$1" = "-default" ] ; then
+if [ $XWAYLAND -eq 0 -a "$1" = "-default" ] ; then
 	xorgwizard-automatic
 	shift
 fi
@@ -155,7 +150,7 @@ if [ ! -d /var/hwdata ]; then
  mkdir -p /var/hwdata
 fi
 
-if [ "$XSERVER" = "xwayland" ]; then
+if [ $XWAYLAND -eq 1 ]; then
  xConfig=0
 elif [ ! -f /var/hwdata/screen.lst ]; then
  xConfig=1
@@ -248,7 +243,7 @@ fi
 
 # Puppy Xorg Video Wizard...
 # boot param pfix=xorgwizard
-if [ "$XSERVER" = "xorg" -a -f /tmp/xwin_xorgwizard_cli ] ; then
+if [ $XWAYLAND -eq 0 -a -f /tmp/xwin_xorgwizard_cli ] ; then
 	rm -f /tmp/xwin_xorgwizard_cli
 	xorgwizard-cli
 	xorgwizard-automatic
@@ -271,7 +266,7 @@ elif [ -f /etc/X11/xorg.conf ];then
 else
 	#* /etc/X11/xorg.conf does not exist *
 	rm -f /root/.XLOADED 2> /dev/null #not necessary, precaution.
-	if [ "$XSERVER" = "xorg" ]; then
+	if [ $XWAYLAND -eq 0 ]; then
 		if [ "$DISTRO_XORG_AUTO" != "yes" -o -f /var/local/xwin_no_xorg_auto_flag ] ; then
 			xorgwizard-cli # 1st dialog offers to use Xorg vesa...
 		fi
@@ -280,7 +275,7 @@ else
 fi
 
 if [ "$(uname -m | grep -E "[i|x]*86")" != "" ] || [ "$(uname -m)" == "x86_64" ]; then
- [ "$XSERVER" = "xorg" ] && config_video
+ [ $XWAYLAND -eq 0 ] && config_video
 fi
 
 # J_Reys idea (see note further down)...
@@ -339,7 +334,7 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 	echo 'logging of X errors is disabled' > /tmp/xerrs.log
 	echo 'remove /var/local/xwin_disable_xerrs_log_flag to enable it, then restart X' >> /tmp/xerrs.log
 fi
-if [ "$XSERVER" = "xwayland" ] ; then
+if [ $XWAYLAND -eq 1 ] ; then
 	startxwayland ${XINITRC} > $LOGFILE_X 2>&1
 else
 	/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1

--- a/woof-code/rootfs-skeleton/usr/sbin/setxserver
+++ b/woof-code/rootfs-skeleton/usr/sbin/setxserver
@@ -3,12 +3,13 @@
 export TEXTDOMAIN=xorgwizard
 export OUTPUT_CHARSET=UTF-8
 
-[ ! -f ~/.Xwaylandrc ] && exit 1
+[ ! -f /usr/bin/startxwayland ] && exit 1
 
-. ~/.Xwaylandrc
-[ "$XSERVER" = "$1" ] && exit 0
-
-sed -i "s%^XSERVER=.*%XSERVER=$1%" ~/.Xwaylandrc
+if [ "$1" = "xwayland" ]; then
+	touch /var/local/xwin_enable_xwayland
+else
+	rm -f /var/local/xwin_enable_xwayland
+fi
 
 /usr/lib/gtkdialog/box_yesno --yes-first "$(gettext 'Xorg Video Wizard')" "$(gettext 'For the changes to effect you must restart X... Would you like to restart X now?')"
 [ $? -eq 0 ] && restartwm

--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
@@ -488,11 +488,10 @@ if which nvidia-settings >/dev/null 2>&1 && NRATE=$(nvidia-settings -q RefreshRa
 	USING_NVIDIA=1
 fi
 
-XSERVER=xorg
-USING_XORG=true
-if [ -f ~/.Xwaylandrc ]; then
-	. ~/.Xwaylandrc
-	[ "$XSERVER" != "xorg" ] && USING_XORG=false
+if [ -f /var/local/xwin_enable_xwayland ]; then
+	USING_XORG=false
+else
+	USING_XORG=true
 fi
 
 #--------------------
@@ -694,11 +693,11 @@ fi
 
 
 xXSERVER=""
-if [ "$XSERVER" = "xorg" -a -f ~/.Xwaylandrc ]; then
+if [ -f /usr/bin/startxwayland -a ! -f /var/local/xwin_enable_xwayland ]; then
  xXSERVER="<hseparator></hseparator>
 $(gui_opt "setxserver xwayland" wm_restart.svg "$(gettext '<b>X Server</b>
 Change to Xwayland..')" true)"
-elif [ "$XSERVER" = "xwayland" -a -f ~/.Xwaylandrc ]; then
+elif [ -f /usr/bin/startxwayland -a -f /var/local/xwin_enable_xwayland ]; then
  xXSERVER="<hseparator></hseparator>
 $(gui_opt "setxserver xorg" wm_restart.svg "$(gettext '<b>X Server</b>
 Change to X.Org..')" true)"

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -139,4 +139,5 @@ for i in usr/share/ptheme/globals/*; do case \"\$i\" in \"usr/share/ptheme/globa
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
+[ -f usr/bin/startxwayland ] && touch var/local/xwin_enable_xwayland
 "


### PR DESCRIPTION
It is possible to opt-in to Xwayland through the graphics wizard, as before. And if Xwayland fails and gets disabled, it's possible to re-enable it.