### PR TITLE
mount-pup: added NTFS3 support

### DIFF
--- a/woof-code/rootfs-skeleton/bin/mount-pup
+++ b/woof-code/rootfs-skeleton/bin/mount-pup
@@ -91,11 +91,7 @@ elif [ "$NTFS_FLAG" = "yes" ];then
     *"-o "*) #don't override -o
     
     #check for NTFS3 modules
-    NTFS3_FOUND="$(zcat /proc/config.gz 2>/dev/null | grep "CONFIG_NTFS3_FS=y")"
-      
-    if [ "$NTFS3_FOUND" != "" ]; then
-     USE_NTFS3="y"
-    elif [ -e /sys/modules/ntfs3 ]; then
+    if [ -e /sys/modules/ntfs3 ]; then
      USE_NTFS3="y"
     elif [ "$(cat /proc/filesystems | grep ntfs3)" != "" ]; then
      USE_NTFS3="y"
@@ -152,11 +148,7 @@ elif [ "$NTFS_FLAG" = "yes" ];then
      
      [ -f /tmp/ntfs-errors/ntfsmnterr-${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr-${MYPID}.txt
       
-      NTFS3_FOUND="$(zcat /proc/config.gz 2>/dev/null | grep "CONFIG_NTFS3_FS=y")"
-      
-     if [ "$NTFS3_FOUND" != "" ]; then
-      USE_NTFS3="y"
-     elif [ -e /sys/modules/ntfs3 ]; then
+     if [ -e /sys/modules/ntfs3 ]; then
       USE_NTFS3="y"
      elif [ "$(cat /proc/filesystems | grep ntfs3)" != "" ]; then
       USE_NTFS3="y"

--- a/woof-code/rootfs-skeleton/bin/mount-pup
+++ b/woof-code/rootfs-skeleton/bin/mount-pup
@@ -113,8 +113,26 @@ elif [ "$NTFS_FLAG" = "yes" ];then
        #mount using ntfs3
        busybox mount "$(echo "${@}" | sed -e 's#\ ntfs\ #\ ntfs3 \#')"
        RETVAL=$?
-       #mount success
-       [ $RETVAL -eq 0 ] && NTFS_3G="" 
+       	   if [ $RETVAL -eq 0 ]; then
+	    #mount success
+	    NTFS_3G="" 
+	   else
+	   
+	     for arg1 in ${@}
+	     do
+	      #Look for device or mountpoint
+	      if [ "$(echo "$arg1" | grep "/")" != "" ]; then
+	       ptn="$arg1"
+	       break
+	      fi
+	     done
+	     
+	     if [ "$ptn" != "" ]; then
+	      #mounted but with flaws
+	      [ "$(mount | grep -ow "$ptn")" != "" ] && NTFS_3G="" 
+	     fi
+	     
+	   fi
       fi	
       
       if [ "$NTFS_3G" != "" ]; then
@@ -159,7 +177,26 @@ elif [ "$NTFS_FLAG" = "yes" ];then
         busybox mount -t ntfs3 -o ${USER_OTPS},force $CMDPRMS
         RETVAL=$?
        fi
-       [ $RETVAL -eq 0 ] && NTFS_3G=""  
+          if [ $RETVAL -eq 0 ]; then
+	    #mount success
+	    NTFS_3G="" 
+	  else
+	   
+	     for arg1 in $CMDPRMS
+	     do
+	      #Look for device or mountpoint
+	      if [ "$(echo "$arg1" | grep "/")" != "" ]; then
+	       ptn="$arg1"
+	       break
+	      fi
+	     done
+	     
+	     if [ "$ptn" != "" ]; then
+	      #mounted but with flaws
+	      [ "$(mount | grep -ow "$ptn")" != "" ] && NTFS_3G="" 
+	     fi
+	     
+	  fi  
       fi
       
       if [ "$NTFS_3G" != "" ]; then

--- a/woof-code/rootfs-skeleton/bin/mount-pup
+++ b/woof-code/rootfs-skeleton/bin/mount-pup
@@ -87,9 +87,44 @@ elif [ "$NTFS_FLAG" = "yes" ];then
   [ ! -d /tmp/ntfs-errors ] && mkdir -p /tmp/ntfs-errors
 
   case "$@" in
+  case "$@" in
     *"-o "*) #don't override -o
-      ntfs-3g "${@}" || busybox mount "${@}"
+    
+    #check for NTFS3 modules
+    NTFS3_FOUND="$(zcat /proc/config.gz 2>/dev/null | grep "CONFIG_NTFS3_FS=y")"
+      
+    if [ "$NTFS3_FOUND" != "" ]; then
+     USE_NTFS3="y"
+    elif [ -e /sys/modules/ntfs3 ]; then
+     USE_NTFS3="y"
+    elif [ "$(cat /proc/filesystems | grep ntfs3)" != "" ]; then
+     USE_NTFS3="y"
+    elif [ -e /sys/fs/ntfs3 ]; then
+     USE_NTFS3="y" 
+    elif [ -e /lib/modules/$(uname -r)/kernel/fs/ntfs3 ]; then
+     USE_NTFS3="y" 
+    else
+     USE_NTFS3=""
+    fi
+     
+     NTFS_3G="y" 
+      
+      if [ "$USE_NTFS3" != "" ]; then
+       #mount using ntfs3
+       busybox mount "$(echo "${@}" | sed -e 's#\ ntfs\ #\ ntfs3 \#')"
+       RETVAL=$?
+       #mount success
+       [ $RETVAL -eq 0 ] && NTFS_3G="" 
+      fi	
+      
+      if [ "$NTFS_3G" != "" ]; then
+       #fallback mount ntfs using ntfs-3g
+       ntfs-3g "${@}" || busybox mount "${@}"
+       RETVAL=$?
+      fi
+      
       RETVAL=$?
+      
       ;;
     *)
       #screen out all the options...

--- a/woof-code/rootfs-skeleton/bin/mount-pup
+++ b/woof-code/rootfs-skeleton/bin/mount-pup
@@ -87,7 +87,6 @@ elif [ "$NTFS_FLAG" = "yes" ];then
   [ ! -d /tmp/ntfs-errors ] && mkdir -p /tmp/ntfs-errors
 
   case "$@" in
-  case "$@" in
     *"-o "*) #don't override -o
     
     #check for NTFS3 modules
@@ -163,10 +162,10 @@ elif [ "$NTFS_FLAG" = "yes" ];then
       NTFS_3G="y" 
 	
       if [ "$USE_NTFS3" != "" ]; then
-        busybox mount -t ntfs3 -o ${USER_OTPS} $CMDPRMS
+        busybox mount -t ntfs3 -o ${USER_OTPS},iocharset=utf8 $CMDPRMS
         RETVAL=$?
        if [ $RETVAL -ne 0 ]; then
-        busybox mount -t ntfs3 -o ${USER_OTPS},force $CMDPRMS
+        busybox mount -t ntfs3 -o ${USER_OTPS},force,iocharset=utf8 $CMDPRMS
         RETVAL=$?
        fi
           if [ $RETVAL -eq 0 ]; then

--- a/woof-code/rootfs-skeleton/bin/mount-pup
+++ b/woof-code/rootfs-skeleton/bin/mount-pup
@@ -131,9 +131,42 @@ elif [ "$NTFS_FLAG" = "yes" ];then
       CMDPRMS="`echo -n "$*" | tr '\t' ' ' | tr -s ' ' | tr ' ' '\n' | grep '^/' | tr '\n' ' '`"
       #kirk advised these options so Rox will not complain about file
       #permissions when copy a file to a ntfs partition...
-      [ -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
+     
+     [ -f /tmp/ntfs-errors/ntfsmnterr-${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr-${MYPID}.txt
+      
+      NTFS3_FOUND="$(zcat /proc/config.gz 2>/dev/null | grep "CONFIG_NTFS3_FS=y")"
+      
+     if [ "$NTFS3_FOUND" != "" ]; then
+      USE_NTFS3="y"
+     elif [ -e /sys/modules/ntfs3 ]; then
+      USE_NTFS3="y"
+     elif [ "$(cat /proc/filesystems | grep ntfs3)" != "" ]; then
+      USE_NTFS3="y"
+     elif [ -e /sys/fs/ntfs3 ]; then
+      USE_NTFS3="y" 
+     elif [ -e /lib/modules/$(uname -r)/kernel/fs/ntfs3 ]; then
+      USE_NTFS3="y" 
+     else
+      USE_NTFS3=""
+     fi
+     
+      NTFS_3G="y" 
+	
+      if [ "$USE_NTFS3" != "" ]; then
+        busybox mount -t ntfs3 -o ${USER_OTPS} $CMDPRMS
+        RETVAL=$?
+       if [ $RETVAL -ne 0 ]; then
+        busybox mount -t ntfs3 -o ${USER_OTPS},force $CMDPRMS
+        RETVAL=$?
+       fi
+       [ $RETVAL -eq 0 ] && NTFS_3G=""  
+      fi
+      
+      if [ "$NTFS_3G" != "" ]; then
+      
       ntfs-3g $CMDPRMS -o ${USER_OTPS}silent 2>/tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
       RETVAL=$?
+      
       #v2.16 ntfs-3g v1.417, part. scheduled for check, failed with value 10...
       #v4.00 ntfs-3g v1.2412 does not have 4,10, has 15 for dirty f.s., 14 hiberneted...
       case $RETVAL in 4|10|15) #14 = must mount read-only
@@ -154,6 +187,8 @@ boot Windows and fix the filesystem first!!!" &
        [ ! -s /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt ] && rm -f /tmp/ntfs-errors/ntfsmnterr${MYPID}.txt
        ;;
       esac
+      
+      fi
  
       #ntfs-3g plays very safe and will not mount if thinks anything
       #wrong with ntfs f.s. But, we may want to recover files from a


### PR DESCRIPTION
NTFS3 is new native linux ntfs driver written by paragon software
It will use ntfs3 as primary for mounting ntfs formatted disk if detected otherwise use ntfs-3g as fallback