### PR TITLE
Use overlayfs in CI

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1028,7 +1028,7 @@ if [ "$BUILD_DEVX" = "yes" ] ; then
 	done
 
 	echo -e "\ncleaning out whiteouts"
-	clean_out_whiteouts $sandbox3/devx # _00func
+	clean_out_whiteouts sandbox3/devx # _00func
 
 	sh $MWD/support/files2delete.sh sandbox3/devx
 	for i in usr/share/gtk-doc usr/share/doc/*-dev usr/share/doc/*-common ; do

--- a/woof-code/_00func
+++ b/woof-code/_00func
@@ -175,6 +175,10 @@ EOD
 }
 
 function set_layer_type() { # sets $LAYER_TYPE
+	if [ -n "$GITHUB_ACTIONS" ]; then
+		LAYER_TYPE='overlay'
+		return
+	fi
 	LAYER_TYPE='aufs'
 	modprobe aufs >/dev/null 2>&1
 	cat /proc/filesystems | grep -q 'aufs' && return


### PR DESCRIPTION
Looks aufs is gone from hosted GitHub Actions runners, and aufs is becoming less common as overlayfs takes its place.