### PR TITLE
Fall back to the missing application placeholder

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/defaultchat
+++ b/woof-code/rootfs-skeleton/usr/local/bin/defaultchat
@@ -3,3 +3,4 @@
 which hexchat >/dev/null 2>&1 && exec hexchat "$@"
 which xchat >/dev/null 2>&1 && exec xchat "$@"
 which pidgin >/dev/null 2>&1 && exec pidgin "$@"
+exec missingdefaultapp defaultchat

--- a/woof-code/rootfs-skeleton/usr/local/bin/defaultprocessmanager
+++ b/woof-code/rootfs-skeleton/usr/local/bin/defaultprocessmanager
@@ -7,3 +7,4 @@ else
 	which htop >/dev/null 2>&1 && exec htop
 fi
 
+exec missingdefaultapp defaultprocessmanager

--- a/woof-code/rootfs-skeleton/usr/local/bin/defaulttorrent
+++ b/woof-code/rootfs-skeleton/usr/local/bin/defaulttorrent
@@ -9,3 +9,5 @@ else
 	which rtorrent >/dev/null 2>&1 && exec rtorrent "$@"
 	which ctorrent >/dev/null 2>&1 && exec ctorrent "$@"
 fi
+
+exec missingdefaultapp defaulttorrent


### PR DESCRIPTION
3builddistro doesn't replace these with the placeholder, so it must be invoked explicitly.