### PR TITLE
Fix failure of partview when df lists the partition as /dev/root

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/partview
+++ b/woof-code/rootfs-skeleton/usr/sbin/partview
@@ -81,7 +81,7 @@ do
 			MNTSTATUS='(not mounted)'
 			mkdir -p /mnt/$ADEVNAME
 			mount -t $AFS /dev/$ADEVNAME /mnt/$ADEVNAME > /dev/null 2>&1 || continue
-			AUSED=`df -k | grep "$AFPATTERN" | head -n 1 | tr -s " " | cut -f 3 -d " "`
+			AUSED=`df -k /mnt/$ADEVNAME | grep "$AFPATTERN" | head -n 1 | tr -s " " | cut -f 3 -d " "`
 			umount /dev/$ADEVNAME
 		fi
 	fi


### PR DESCRIPTION
When booting without an initrd, with `root=/dev/sdb2`:

```
~$ mount -t ext4 /dev/sdb2 /mnt/sdb2
~$ df -k
Filesystem     1K-blocks     Used Available Use% Mounted on
...
/dev/root       60963060 26636208  34310468  44% /initrd                         <- we can't df -k | grep sdb2
...
```

```
./woof-code/rootfs-skeleton/usr/sbin/partview: line 99: arithmetic syntax error
```

This happens because:

```
        AUSED=                                                                                            
        ...                                  
        if [ "$AUSED" = "" ] ; then                         
                AFPATTERN="^/dev/$ADEVNAME "  
                AUSED=`df -k | grep "$AFPATTERN" | head -n 1 | tr -s " " | cut -f 3 -d " "`
                if [ "$AUSED" ] && [ "$(echo -n "$AFPATTERN" | grep \/luks)" != "" ] ; then
                        ADEVNAME="${ADEVNAME#mapper/}"
                fi                                                                              
                if [ ! "$AUSED" ];then                                                             
                        MNTSTATUS='(not mounted)'                                          
                        mkdir -p /mnt/$ADEVNAME                  
                        mount -t $AFS /dev/$ADEVNAME /mnt/$ADEVNAME > /dev/null 2>&1 || continue
                        AUSED=`df -k | grep "$AFPATTERN" | head -n 1 | tr -s " " | cut -f 3 -d " "`           <- grep returns nothing
                        umount /dev/$ADEVNAME                                              
                fi                                                              
        fi
        ...
        AFREE=$(($ASIZE - $AUSED))                  <- syntax error here, because AUSED is an empty string
```

If we ask `df` to list only file systems under the mount point for the partition, partview works correctly:

```
~$ df -k /mnt/sdb2
Filesystem     1K-blocks     Used Available Use% Mounted on
/dev/sdb2       60963060 26636208  34310468  44% /mnt/sdb2                <- we can df -k | grep sdb2
```