### PR TITLE
Link Cage against wlroots statically

### DIFF
--- a/woof-code/rootfs-petbuilds/cage/petbuild
+++ b/woof-code/rootfs-petbuilds/cage/petbuild
@@ -34,7 +34,7 @@ build() {
     tar -xzf wlroots-0.14.1.tar.gz
     cd wlroots-0.14.1
     patch -p1 < ../bullseye.patch
-    meson --buildtype=minsize --prefix=/usr -Dxwayland=disabled -Dx11-backend=disabled build
+    meson --buildtype=minsize --prefix=/usr --default-library=static -Dxwayland=disabled -Dx11-backend=disabled build
     ninja -C build install
     cd ..
 


### PR DESCRIPTION
This makes the package smaller, and prevents potential future collision with the different wlroots version required by labwc (#2615).