### PR TITLE
Remove /root/.cache from petbuild output

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -180,6 +180,7 @@ for NAME in $PETBUILDS; do
         cp -a ../rootfs-petbuilds/${NAME}/* petbuild-rootfs-complete-${NAME}/tmp/
         CC="$WOOF_CC" CXX="$WOOF_CXX" CFLAGS="$WOOF_CFLAGS" CXXFLAGS="$WOOF_CXXFLAGS" LDFLAGS="$WOOF_LDFLAGS" MAKEFLAGS="$MAKEFLAGS" CCACHE_DIR=/root/.ccache CCACHE_NOHASHDIR=1 PKG_CONFIG_PATH="$PKG_CONFIG_PATH" PYTHONDONTWRITEBYTECODE=1 PYTHONPYCACHEPREFIX=/root/.cache/__pycache__ PETBUILD_GTK=$PETBUILD_GTK $CHROOT_PFIX chroot petbuild-rootfs-complete-${NAME} bash -ec "cd /tmp && . ./petbuild && build"
         ret=$?
+        umount -l petbuild-rootfs-complete-${NAME}/root/.cache
         umount -l petbuild-rootfs-complete-${NAME}/root/.ccache
         umount -l petbuild-rootfs-complete-${NAME}/tmp
         umount -l petbuild-rootfs-complete-${NAME}/dev
@@ -198,6 +199,7 @@ for NAME in $PETBUILDS; do
             exit 1
         fi
 
+        rm -rf ../petbuild-output/${NAME}-${HASH}/root/.cache
         rm -rf ../petbuild-output/${NAME}-${HASH}/root/.ccache
         rm -rf ../petbuild-output/${NAME}-${HASH}/tmp
         rm -rf ../petbuild-output/${NAME}-${HASH}/etc/ssl


### PR DESCRIPTION
This bug was introduced in 8fed355e8d47e9792b0b2a3e0a8bfdcf9e5a8fad.