### PR TITLE
Add libboost-regex1.74.0 to dpup (fixes #2636)

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -153,7 +153,7 @@ no|gamin|gamin,libgamin0,libgamin-dev|exe,dev,doc,nls
 yes|gawk|gawk|exe,dev>null,doc,nls||deps:yes
 yes|gcc_dev|gcc-10-base,gcc,gcc-10,g++,g++-10,cpp,cpp-10|exe>dev,dev,doc,nls||deps:yes #cloog-isl removed
 no|gconf|gconf2-common,gconf2,libgconf-2-4,libgconf2-dev,libgconf-2-4,gconf-service|exe,dev,doc,nls||deps:yes
-yes|gdb|gdb|exe>dev,dev,doc,nls||deps:yes
+yes|gdb|gdb,libboost-regex1.74.0|exe>dev,dev,doc,nls||deps:yes
 yes|gdbm|libgdbm6|exe,dev,doc,nls||deps:yes
 yes|gdk-pixbuf|libgdk-pixbuf-2.0-0,libgdk-pixbuf2.0-common,libgdk-pixbuf-2.0-dev,libgdk-pixbuf2.0-0,libgdk-pixbuf2.0-dev,libgdk-pixbuf-xlib-2.0-0,libgdk-pixbuf-xlib-2.0-dev|exe,dev,doc,nls||deps:yes
 no|gdmap|gdmap|exe,dev>null,doc,nls


### PR DESCRIPTION
gdb depends on libboost-regex1.74.0-icu67, a virtual package provided by libboost-regex1.74.0. The Puppy package list format does not support virtual packages, so woof-code/support/resolvedeps.sh fails to resolve this dependency.