### PR TITLE
Delete the D-Bus pidfile after improper shutdown

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -659,6 +659,7 @@ fi
 #start dbus-daemon
 if which dbus-daemon >/dev/null 2>&1 ; then
  if [ "$(pidof dbus-daemon)" == "" ]; then
+  rm -f /run/dbus/pid
   dbus-daemon --system
  fi
 fi


### PR DESCRIPTION
Sometimes, D-Bus (and ConnMan) don't start on my X220 running dpup. The old battery doesn't hold charge, and sometimes the laptop shuts down abruptly, leaving the D-Bus pidfile behind.