### PR TITLE
Look for the major kernel version only at the beginning of the line

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -87,7 +87,7 @@ if [ -n "$DOTconfig_file" -a -n "$LatestK" ] ; then
 	[ -e "$DOTconfig_file" ] || exit_error "$DOTconfig_file doesn't exist"
 	IFS='-' read a b c <<< $DOTconfig_file
 	DOTconfig_sver=${b%\.*}
-	DOTconfig_new_ver_pre=`grep "$DOTconfig_sver" /tmp/kernels.txt`
+	DOTconfig_new_ver_pre=`grep "^$DOTconfig_sver" /tmp/kernels.txt`
 	if [ -z "$DOTconfig_new_ver_pre" ] ; then
 		log_msg "No latest stable or longterm kernel for Linux $b, Continuing with $DOTconfig_file"
 	elif [ "$b" == "${DOTconfig_new_ver_pre% *}" ] ; then


### PR DESCRIPTION
```
+ DOTconfig_sver=5.4
++ grep 5.4 /tmp/kernels.txt
+ DOTconfig_new_ver_pre='5.15.4 (stable)
5.4.161 (longterm)'
```

Because `5.4` is a substring of both `5.4.161` and `5.15.4`:

```
~$ grep 5.4 /tmp/kernels.txt
5.15.4 (stable)
5.4.161 (longterm)
~$ grep ^5.4 /tmp/kernels.txt
5.4.161 (longterm)
```
