### PR TITLE
Set the wallpaper using JWM, if ROX-Filer is missing

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -211,6 +211,7 @@
 <Include>/root/.jwm/jwmrc-tray8</Include>
 <Include>/root/.jwm/jwmrc-corners</Include>
 <Include>/root/.jwm/jwmrc-theme</Include>
+<Include>/root/.jwm/jwmrc-wallpaper</Include>
 <Include>/root/.jwm/jwmrc-personal</Include>
 
 </JWM>

--- a/woof-code/rootfs-packages/ptheme/pinstall.sh
+++ b/woof-code/rootfs-packages/ptheme/pinstall.sh
@@ -51,6 +51,18 @@ for I in 1 2 3 4; do
 		grep -vF '_hybrid</Include>' root/.jwm/jwmrc-tray$I | sed -e 's%autohide="\(top\|bottom\|left\|right\)" %autohide="off"%' -e "s%layer=\"above\"%layer=\"below\"%" > root/.jwm/jwmrc-tray${I}_hybrid
 	fi
 done
+
+cat << EOF > root/.jwm/jwmrc-wallpaper
+<?xml version="1.0"?>
+
+<JWM>
+
+<Desktops>
+	<Background type="image">/usr/share/backgrounds/${PTHEME_WALL}</Background>
+</Desktops>
+</JWM>
+EOF
+
 #---
 echo "$PTHEME_JWM_TRAY" > root/.jwm/tray_active_preset
 echo "jwm tray: ${PTHEME_JWM_TRAY}"

--- a/woof-code/rootfs-skeleton/usr/sbin/set_bg
+++ b/woof-code/rootfs-skeleton/usr/sbin/set_bg
@@ -8,7 +8,30 @@ if [ "$PCMANFM" ] ; then
 	pcmanfm -w "$1"
 fi
 
-! [ "$ROX_DESKTOP" ] && exit
+if [ "$1" = "-clear" ] ; then
+ cat << EOF > $HOME/.jwm/jwmrc-wallpaper
+<?xml version="1.0"?>
+
+<JWM>
+</JWM>
+EOF
+else
+ cat << EOF > $HOME/.jwm/jwmrc-wallpaper
+<?xml version="1.0"?>
+
+<JWM>
+
+<Desktops>
+	<Background type="image">$1</Background>
+</Desktops>
+</JWM>
+EOF
+fi
+
+if ! [ "$ROX_DESKTOP" ] ; then
+ jwm -restart
+ exit
+fi
 
 # Determine the path to this application.
 CURDIR="`pwd`"


### PR DESCRIPTION
I want to make GTK+ 2 dependencies optional, and the first step is making ROX-Filer optional. (The other dependencies are Sylpheed, Xdialog and gtk2dialog).

Before and after `echo true > /etc/desktop_app`:

![before](https://user-images.githubusercontent.com/1471149/144718686-f5e64dad-daa3-49f8-b242-cc8d2bf56d20.png)
![after](https://user-images.githubusercontent.com/1471149/144718681-c459216b-c047-4b73-9952-62b23a8101bb.png)


