### PR TITLE
Optionally produce installable, bootable BIOS and UEFI ext4 images

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -51,6 +51,8 @@ if [ "$BUILD_ZIP" = "yes" ]; then
 	SDFLAG="zip"
 elif [ "$BUILD_CROS_IMAGE" = "yes" ]; then
 	CROSFLAG=1
+elif [ -z "$BUILD_ISO" -o "$BUILD_ISO" = "yes" ]; then
+	ISOFLAG=1
 elif [ "$DISTRO_TARGETARCH" = "arm" ]; then
 	SDFLAG=1
 fi
@@ -146,6 +148,12 @@ and edit it to include your customised package list.
 		frisbee|network_wizard|pupdial|simple_network_setup)
 			state=true
 			[ -d packages-${DISTRO_FILE_PREFIX}/connman ] && state=false
+			;;
+		simple_installer)
+			state=false
+			case $WOOF_TARGETARCH in
+			x86*) [ ! "$ISOFLAG" ] && state=true ;;
+			esac
 			;;
 		*)
 			state=true
@@ -673,7 +681,7 @@ touch ../devx-only-installed-packages
 cp ../devx-only-installed-packages rootfs-complete${PACKAGES_DIR}/
 
 # certain utilities are not appropriate when booting on an arm board...
-if [ "$SDFLAG" -o "$CROSFLAG" ]; then
+if [ ! "$ISOFLAG" ]; then
 	for i in usr/sbin/grubconfig usr/sbin/remasterpup2 \
 		usr/share/applications/Grub-bootloader-config.desktop \
 		usr/share/applications/BootFlash-usb-installer.desktop \
@@ -1073,8 +1081,14 @@ if [ "$SDFLAG" = "" -a "$CROSFLAG" = "" ] ; then #120506
 		mv -f ${NLSXSFS} ../${WOOF_OUTPUT}/
 		( cd ../${WOOF_OUTPUT} ; md5sum ${NLSXSFS} > ${NLSXSFS}.md5.txt )
 	fi
-	echo "Running ../support/mk_iso.sh"
-	../support/mk_iso.sh || exit 1
+	if [ "$ISOFLAG" ]; then
+		echo "Running ../support/mk_iso.sh"
+		../support/mk_iso.sh || exit 1
+	else
+		WOOF_OUTPUT="woof-output-${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}"
+		mkdir -p ../$WOOF_OUTPUT
+		. ../support/pc_image.sh
+	fi
 fi
 
 #==================================================================================

--- a/woof-code/rootfs-packages/simple_installer/pet.specs
+++ b/woof-code/rootfs-packages/simple_installer/pet.specs
@@ -1,0 +1,1 @@
+simple_installer-1|simple_installer|1||System|1K||simple_installer-1.pet||Simple Puppy installer||||

--- a/woof-code/rootfs-packages/simple_installer/pinstall.sh
+++ b/woof-code/rootfs-packages/simple_installer/pinstall.sh
@@ -1,0 +1,2 @@
+. ./etc/DISTRO_SPECS
+sed "s/Puppy/${DISTRO_NAME}/g" -i usr/share/applications/simple_installer.desktop

--- a/woof-code/rootfs-packages/simple_installer/usr/sbin/simple_installer
+++ b/woof-code/rootfs-packages/simple_installer/usr/sbin/simple_installer
@@ -1,0 +1,134 @@
+#!/bin/sh
+
+. /etc/DISTRO_SPECS
+
+TARGET="$1"
+FSOPTS="$2"
+[ -z "$FSOPTS" ] && FSOPTS="encrypt"
+
+if [ -z "$TARGET" ]; then
+	if [ -z "$DISPLAY" ]; then
+		echo "Usage: $0 DEV"
+		exit 1
+	fi
+
+	set -ex
+
+	ENTRIES=
+	for DEVPATH in /sys/class/block/*; do
+		DEV="${DEVPATH##*/}"
+		case "$DEV" in
+		mmcblk[0-9]*p*|nvme[0-9]*n[0-9]*p*) continue ;;
+		sd*[^0-9]) DRIVE="$DEVPATH" ;;
+		mmcblk[0-9]*) DRIVE="${DEVPATH%p[0-9]*}" ;;
+		nvme[0-9]*n[0-9]*) DRIVE="${DEVPATH%p[0-9]*}" ;;
+		*) continue ;;
+		esac
+		if [ -z "$ENTRIES" ]; then
+			ENTRIES="$DEV
+`cat ${DRIVE}/device/model`"
+		else
+			ENTRIES="$ENTRIES
+$DEV
+`cat ${DRIVE}/device/model`"
+		fi
+	done
+
+	TARGET=
+	while [ -z "$TARGET" ]; do
+		TARGET=`echo "$ENTRIES" | yad --title Installer --window-icon=/usr/share/pixmaps/puppy/puppy_install.svg --image="/usr/share/doc/puppylogo96.png" --text "Please select the device to install ${DISTRO_NAME} on:" --list --column=Name --column=Description --separator= --print-column=1`
+	done
+
+	if [ "`yad --title Installer --window-icon=/usr/share/pixmaps/puppy/puppy_install.svg --image="/usr/share/doc/puppylogo96.png" --text "This will erase all data on ${TARGET}. Are you sure?" --form --field "Journaled file system:chk" --separator= --button="gtk-yes:0" --button="gtk-no:1" true`" = "TRUE" ]; then
+		FSOPTS="encrypt"
+	else
+		FSOPTS="^has_journal,encrypt"
+	fi
+
+	exec rxvt -e sh -c "${0} ${TARGET} ${FSOPTS} && echo \"Done installing ${DISTRO_NAME} on ${TARGET}\" || echo \"Failed to install ${DISTRO_NAME} on ${TARGET}\"; read"
+else
+	set -ex
+fi
+
+case "${TARGET}" in
+sd*)
+	TARGETP1="/dev/${TARGET}1"
+	TARGETP2="/dev/${TARGET}2"
+	;;
+*)
+	TARGETP1="/dev/${TARGET}p1"
+	TARGETP2="/dev/${TARGET}p2"
+	;;
+esac
+TARGET="/dev/${TARGET}"
+
+if [ -L "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_esp" -a -L "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_uefi_root" ]; then
+	parted --script ${TARGET} mklabel gpt
+	blockdev --rereadpt ${TARGET}
+	sleep 4
+
+	mkdir -p /mnt/efi /mnt/root
+	mount -o ro "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_esp" /mnt/efi
+	mount -o ro "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_uefi_root" /mnt/root
+
+	parted --script ${TARGET} mkpart "${DISTRO_FILE_PREFIX}_esp" fat32 1MiB 261MiB
+	parted --script ${TARGET} set 1 esp on
+	parted --script ${TARGET} mkpart "${DISTRO_FILE_PREFIX}_uefi_root" ext4 261MiB 100%
+	blockdev --rereadpt ${TARGET}
+	sleep 4
+	mkfs.fat -F 32 ${TARGETP1}
+	mkfs.ext4 -F -b 4096 -m 0 -O "${FSOPTS}" ${TARGETP2}
+
+	mkdir -p /mnt/targetp1 /mnt/targetp2
+	mount-FULL -o noatime ${TARGETP1} /mnt/targetp1
+	install -D -m 644 /mnt/efi/EFI/BOOT/BOOTX64.EFI /mnt/targetp1/EFI/BOOT/BOOTX64.EFI
+	install -m 644 /mnt/efi/EFI/BOOT/efilinux.cfg /mnt/targetp1/EFI/BOOT/efilinux.cfg
+	install -m 644 /mnt/efi/EFI/BOOT/vmlinuz /mnt/targetp1/EFI/BOOT/vmlinuz
+	install -m 644 /mnt/efi/EFI/BOOT/initrd.gz /mnt/targetp1/EFI/BOOT/initrd.gz
+	[ ! -e /mnt/efi/EFI/BOOT/ucode.cpio ] || install -m 644 /mnt/efi/EFI/BOOT/ucode.cpio /mnt/targetp1/EFI/BOOT/ucode.cpio
+	busybox umount /mnt/targetp1 2>/dev/null
+
+	mount-FULL -o noatime ${TARGETP2} /mnt/targetp2
+	cp -a /mnt/root/*.sfs /mnt/targetp2/
+	busybox umount /mnt/targetp2 2>/dev/null
+	rmdir /mnt/targetp2
+
+	busybox umount /mnt/efi 2>/dev/null
+	busybox umount /mnt/root 2>/dev/null
+	rmdir /mnt/efi /mnt/root /mnt/targetp1
+
+	sync
+elif [ -L "/dev/disk/by-label/${DISTRO_FILE_PREFIX}_bios" ]; then
+	parted --script ${TARGET} mklabel msdos
+	blockdev --rereadpt ${TARGET}
+	sleep 4
+
+	mkdir -p /mnt/root
+	mount -o ro "/dev/disk/by-label/${DISTRO_FILE_PREFIX}_bios" /mnt/root
+
+	parted --script ${TARGET} mkpart primary "" ext4 2048s 100%
+	parted --script ${TARGET} set 1 boot on
+	blockdev --rereadpt ${TARGET}
+	sleep 4
+	mkfs.ext4 -F -b 4096 -m 0 -O "${FSOPTS}" -L "${DISTRO_FILE_PREFIX}_bios" ${TARGETP1}
+
+	mkdir -p /mnt/targetp1
+	mount-FULL -o noatime ${TARGETP1} /mnt/targetp1
+	extlinux -i /mnt/targetp1
+	dd if=/usr/lib/EXTLINUX/mbr.bin of=${TARGET}
+	install -m 644 /mnt/root/extlinux.conf /mnt/targetp1/extlinux.conf
+	install -m 644 /mnt/root/vmlinuz /mnt/targetp1/vmlinuz
+	install -m 644 /mnt/root/initrd.gz /mnt/targetp1/initrd.gz
+	[ ! -e /mnt/root/ucode.cpio ] || cp -f /mnt/root/ucode.cpio /mnt/targetp1/
+	cp -a /mnt/root/*.sfs /mnt/targetp1/
+	busybox umount /mnt/targetp1 2>/dev/null
+	rmdir /mnt/targetp1
+
+	busybox umount /mnt/root 2>/dev/null
+	rmdir /mnt/root
+
+	sync
+else
+	echo "Unable to locate ${DISTRO_NAME} files"
+	exit 1
+fi

--- a/woof-code/rootfs-packages/simple_installer/usr/share/applications/simple_installer.desktop
+++ b/woof-code/rootfs-packages/simple_installer/usr/share/applications/simple_installer.desktop
@@ -1,0 +1,18 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Puppy installer
+Name[de]=Puppy Installer
+Name[es]=Puppy-Instalador
+Name[hu_HU]=Puppy telepítő
+Name[ja]=Puppyをインストール
+Name[pt]=Instalador do Puppy
+Name[ru]=Универсальный
+Name[zh_CN]=Puppy 安装程序
+Name[zh_TW]=Puppy 安裝程式
+Icon=/usr/share/pixmaps/puppy/puppy_install.svg
+Comment=Install Puppy
+Exec=simple_installer
+Terminal=false
+Type=Application
+Categories=X-SetupUtility
+GenericName=Puppy installer

--- a/woof-code/support/cros_image.sh
+++ b/woof-code/support/cros_image.sh
@@ -7,8 +7,6 @@ SD_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb.img
 INSTALL_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-install.img
 
 SSD_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-16gb.img
-LEGACY_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-legacy.img
-UEFI_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-uefi.img
 
 echo "console=tty1 root=PARTUUID=%U/PARTNROFF=1 init=/init rootfstype=ext4 rootwait rw" > cmdline
 vmlinuz=build/vmlinuz
@@ -107,81 +105,6 @@ cp -a rootfs-complete/* /mnt/ssdimagep2/
 echo -e '#!/bin/sh\nexec /sbin/init initrd_full_install' > /mnt/ssdimagep2/init
 chmod 755 /mnt/ssdimagep2/init
 cp -a /mnt/ssdimagep2/* /mnt/sdimagep2/
-
-case $WOOF_TARGETARCH in
-x86*)
-	dd if=/dev/zero of=${LEGACY_IMG_BASE} bs=50M count=40 conv=sparse
-	parted --script ${LEGACY_IMG_BASE} mklabel msdos
-	parted --script ${LEGACY_IMG_BASE} mkpart primary "" ext4 2048s 100%
-	parted --script ${LEGACY_IMG_BASE} set 1 boot on
-	LOOP=`losetup -Pf --show ${LEGACY_IMG_BASE}`
-	PARTUUID=`blkid -s PARTUUID -o value ${LOOP}p1`
-	mkfs.ext4 -F -b 4096 -m 0 -O ^has_journal,encrypt ${LOOP}p1
-
-	mkdir -p /mnt/legacyimagep1
-	mount-FULL -o noatime ${LOOP}p1 /mnt/legacyimagep1
-
-	extlinux -i /mnt/legacyimagep1
-	dd if=/usr/lib/EXTLINUX/mbr.bin of=${LOOP}
-	if [ -e /mnt/ssdimagep2/ucode.cpio ]; then
-		cat << EOF > /mnt/legacyimagep1/extlinux.conf
-DEFAULT puppy
-
-LABEL puppy
-	LINUX vmlinuz
-	INITRD ucode.cpio
-	APPEND root=PARTUUID=$PARTUUID init=/init rootfstype=ext4 rootwait rw
-EOF
-	else
-		cat << EOF > /mnt/legacyimagep1/extlinux.conf
-DEFAULT puppy
-
-LABEL puppy
-	LINUX vmlinuz
-	APPEND root=PARTUUID=$PARTUUID init=/init rootfstype=ext4 rootwait rw
-EOF
-	fi
-	cp -a /mnt/ssdimagep2/* /mnt/legacyimagep1/
-	cp -f build/vmlinuz /mnt/legacyimagep1/
-	busybox umount /mnt/legacyimagep1 2>/dev/null
-	losetup -d ${LOOP}
-	mv -f ${LEGACY_IMG_BASE} ../${WOOF_OUTPUT}/
-	;;
-esac
-
-if [ "$WOOF_TARGETARCH" = "x86_64" ]; then
-	dd if=/dev/zero of=${UEFI_IMG_BASE} bs=50M count=40 conv=sparse
-	parted --script ${UEFI_IMG_BASE} mklabel gpt
-	parted --script ${UEFI_IMG_BASE} mkpart "${DISTRO_FILE_PREFIX}_esp" fat32 1MiB 261MiB
-	parted --script ${UEFI_IMG_BASE} set 1 esp on
-	parted --script ${UEFI_IMG_BASE} mkpart "${DISTRO_FILE_PREFIX}_root" ext4 261MiB 100%
-	LOOP=`losetup -Pf --show ${UEFI_IMG_BASE}`
-	mkfs.fat -F 32 ${LOOP}p1
-	mkfs.ext4 -F -b 4096 -m 0 -O ^has_journal,encrypt ${LOOP}p2
-
-	mkdir -p /mnt/uefiimagep1 /mnt/uefiimagep2
-
-	unsquashfs -d kernel_sources ../kernel-kit/output/kernel_sources-*.sfs
-	cd kernel_sources/usr/src/linux
-	cat << EOF >> .config
-CONFIG_EFI_STUB=y
-CONFIG_CMDLINE_BOOL=y
-CONFIG_CMDLINE="root=PARTLABEL=${DISTRO_FILE_PREFIX}_root init=/init rootfstype=ext4 rootwait rw"
-EOF
-	make -j`nproc` bzImage
-	mount-FULL -o noatime ${LOOP}p1 /mnt/uefiimagep1
-	install -D -m 644 arch/x86/boot/bzImage /mnt/uefiimagep1/EFI/BOOT/BOOTX64.EFI
-	busybox umount /mnt/uefiimagep1 2>/dev/null
-	cd ../../../..
-	[ -n "$GITHUB_ACTIONS" ] && rm -rf kernel_sources
-
-	mount-FULL -o noatime ${LOOP}p2 /mnt/uefiimagep2
-	cp -a /mnt/ssdimagep2/* /mnt/uefiimagep2/
-	busybox umount /mnt/uefiimagep2 2>/dev/null
-	losetup -d ${LOOP}
-
-	mv -f ${UEFI_IMG_BASE} ../${WOOF_OUTPUT}/
-fi
 
 busybox umount /mnt/sdimagep2 2>/dev/null
 busybox umount /mnt/ssdimagep2 2>/dev/null

--- a/woof-code/support/pc_image.sh
+++ b/woof-code/support/pc_image.sh
@@ -1,0 +1,78 @@
+BIOS_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-bios.img
+UEFI_IMG_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}-ext4-2gb-uefi.img
+
+set -e
+
+echo "Building ${BIOS_IMG_BASE}"
+
+dd if=/dev/zero of=${BIOS_IMG_BASE} bs=50M count=40 conv=sparse
+parted --script ${BIOS_IMG_BASE} mklabel msdos
+parted --script ${BIOS_IMG_BASE} mkpart primary "" ext4 2048s 100%
+parted --script ${BIOS_IMG_BASE} set 1 boot on
+LOOP=`losetup -Pf --show ${BIOS_IMG_BASE}`
+mkfs.ext4 -F -b 4096 -m 0 -O ^has_journal,encrypt -L "${DISTRO_FILE_PREFIX}_bios" ${LOOP}p1
+
+mkdir -p /mnt/biosimagep1
+mount-FULL -o noatime ${LOOP}p1 /mnt/biosimagep1
+
+extlinux -i /mnt/biosimagep1
+dd if=/usr/lib/EXTLINUX/mbr.bin of=${LOOP}
+if [ -e build/ucode.cpio ]; then
+	cp -f build/ucode.cpio /mnt/biosimagep1/
+	cat << EOF > /mnt/biosimagep1/extlinux.conf
+DEFAULT ${DISTRO_FILE_PREFIX}
+
+LABEL ${DISTRO_FILE_PREFIX}
+	LINUX vmlinuz
+	INITRD ucode.cpio,initrd.gz
+EOF
+else
+	cat << EOF > /mnt/biosimagep1/extlinux.conf
+DEFAULT ${DISTRO_FILE_PREFIX}
+
+LABEL ${DISTRO_FILE_PREFIX}
+	LINUX vmlinuz
+	INITRD initrd.gz
+EOF
+fi
+cp -f build/vmlinuz build/initrd.gz /mnt/biosimagep1/
+cp -a build/*.sfs /mnt/biosimagep1/
+busybox umount /mnt/biosimagep1 2>/dev/null
+losetup -d ${LOOP}
+mv -f ${BIOS_IMG_BASE} ../${WOOF_OUTPUT}/
+
+if [ "$WOOF_TARGETARCH" = "x86_64" ]; then
+	echo "Building ${UEFI_IMG_BASE}"
+
+	dd if=/dev/zero of=${UEFI_IMG_BASE} bs=50M count=40 conv=sparse
+	parted --script ${UEFI_IMG_BASE} mklabel gpt
+	parted --script ${UEFI_IMG_BASE} mkpart "${DISTRO_FILE_PREFIX}_esp" fat32 1MiB 261MiB
+	parted --script ${UEFI_IMG_BASE} set 1 esp on
+	parted --script ${UEFI_IMG_BASE} mkpart "${DISTRO_FILE_PREFIX}_uefi_root" ext4 261MiB 100%
+	LOOP=`losetup -Pf --show ${UEFI_IMG_BASE}`
+	mkfs.fat -F 32 ${LOOP}p1
+	mkfs.ext4 -F -b 4096 -m 0 -O ^has_journal,encrypt ${LOOP}p2
+
+	mkdir -p /mnt/uefiimagep1 /mnt/uefiimagep2
+
+	mount-FULL -o noatime ${LOOP}p1 /mnt/uefiimagep1
+	[ -f ../../local-repositories/efilinux.efi ] || wget --tries=1 --timeout=10 -O ../../local-repositories/efilinux.efi https://github.com/puppylinux-woof-CE/efilinux/releases/latest/download/efilinux.efi
+	install -D -m 644 ../../local-repositories/efilinux.efi /mnt/uefiimagep1/EFI/BOOT/BOOTX64.EFI
+	install -m 644 build/vmlinuz /mnt/uefiimagep1/EFI/BOOT/vmlinuz
+	install -m 644 build/initrd.gz /mnt/uefiimagep1/EFI/BOOT/initrd.gz
+	if [ -e build/ucode.cpio ]; then
+		install -m 644 build/ucode.cpio /mnt/uefiimagep1/EFI/BOOT/ucode.cpio
+		echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+	else
+		echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+	fi
+	busybox umount /mnt/uefiimagep1 2>/dev/null
+
+	mount-FULL -o noatime ${LOOP}p2 /mnt/uefiimagep2
+	cp -a build/*.sfs /mnt/uefiimagep2/
+	busybox umount /mnt/uefiimagep2 2>/dev/null
+
+	losetup -d ${LOOP}
+
+	mv -f ${UEFI_IMG_BASE} ../${WOOF_OUTPUT}/
+fi


### PR DESCRIPTION
I want Vanilla Dpup to have one _working_ installer that covers at least 80% of use cases. Right now, it has two installers, neither supports UEFI. I don't like the idea of using binary blobs from an unknown source (like FrugalPup's EFI executables), and avoid the use of .pet packages at all costs (so PPM can be replaced in the future).
 
This installer is simple and easy to maintain: only extlinux or efilinux, only ext4, only frugal installations. There's only one configuration option: a checkbox that allows the user to disable the ext4 journal, to minimize writes at the cost of possible corruption on power failure.

`BUILD_ISO=no` activates the generation of these bootable images - the default is to build an ISO, with the old installers.

Tested on a virtual SCSI drive, a virtual NVMe drive, BIOS and UEFI (secure boot off).

![1](https://user-images.githubusercontent.com/1471149/144888010-20c1d447-1939-4e36-aa69-3c658689d3e6.png)
![2](https://user-images.githubusercontent.com/1471149/144888017-0d8eddba-4e2f-4bdd-a6a9-33db177f1747.png)
![3](https://user-images.githubusercontent.com/1471149/144888021-403792a0-aed8-4e78-ad2d-b39b5d4e6d7e.png)
![4](https://user-images.githubusercontent.com/1471149/144888025-972eba0f-9062-4a2b-a131-0c5578535bfe.png)
 