### PR TITLE
Add an update tool to ext4 images

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -283,6 +283,7 @@ if which git &>/dev/null && [ "`git log -n 1`" != "" ]; then
 	else
 		echo "BUILD_FROM_WOOF='${GITBRANCH};${GITHEAD}'" >> ${WOOF_OUT}/DISTRO_SPECS
 	fi
+	[ -n "$GITHUB_REPOSITORY" ] && sed "s~^UPDATE_REPO=.*~UPDATE_REPO=$GITHUB_REPOSITORY~" -i ${WOOF_OUT}/rootfs-packages/simple_updater/etc/simple_updater.conf
 else
 	echo "BUILD_FROM_WOOF=\"No woof-CE-git info available\"" >> ${WOOF_OUT}/DISTRO_SPECS
 fi

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -149,10 +149,20 @@ and edit it to include your customised package list.
 			state=true
 			[ -d packages-${DISTRO_FILE_PREFIX}/connman ] && state=false
 			;;
+		change_kernels)
+			state=false
+			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" ] && state=true
+			;;
 		simple_installer)
 			state=false
 			case $WOOF_TARGETARCH in
 			x86*) [ ! "$ISOFLAG" ] && state=true ;;
+			esac
+			;;
+		simple_updater)
+			state=false
+			case $WOOF_TARGETARCH in
+			x86*) [ ! "$ISOFLAG" -a "$GITHUB_REPOSITORY" ] && state=true ;;
 			esac
 			;;
 		*)

--- a/woof-code/rootfs-packages/simple_updater/etc/simple_updater.conf
+++ b/woof-code/rootfs-packages/simple_updater/etc/simple_updater.conf
@@ -1,0 +1,2 @@
+# the repo to pull releases from
+UPDATE_REPO=puppylinux-woof-CE/woof-CE

--- a/woof-code/rootfs-packages/simple_updater/pet.specs
+++ b/woof-code/rootfs-packages/simple_updater/pet.specs
@@ -1,0 +1,1 @@
+simple_updater-1|simple_updater|1||System|1K||simple_updater-1.pet||Simple Puppy updater||||

--- a/woof-code/rootfs-packages/simple_updater/pinstall.sh
+++ b/woof-code/rootfs-packages/simple_updater/pinstall.sh
@@ -1,0 +1,2 @@
+. ./etc/DISTRO_SPECS
+sed "s/Puppy/${DISTRO_NAME}/g" -i usr/share/applications/simple_updater.desktop

--- a/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
+++ b/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
@@ -1,0 +1,219 @@
+#!/bin/sh
+
+. /etc/DISTRO_SPECS
+. /etc/simple_updater.conf
+
+if [ "$1" = ask ]; then
+	echo -n "Press ENTER to check for updates for ${DISTRO_NAME} ${DISTRO_VERSION}"
+	read
+fi
+
+DISTRO_MAJOR_VERSION=${DISTRO_VERSION%.*}
+echo "Listing available ${DISTRO_NAME} ${DISTRO_MAJOR_VERSION}.x releases"
+
+RELEASES=`wget -O- --header "Accept: application/vnd.github.v3+json" https://api.github.com/repos/${UPDATE_REPO}/releases`
+
+COUNT=`echo "$RELEASES" | jq length`
+if [ -z "$COUNT" ] || [ $COUNT -eq 0 ]; then
+	echo "Failed to list ${DISTRO_NAME} ${DISTRO_MAJOR_VERSION}.x releases"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+RELEASE_CHOICE=-1
+for i in `seq 0 $(($COUNT - 1))`; do
+	DRAFT=`echo "$RELEASES" | jq -r ".[$i].draft"`
+	[ "$DRAFT" = true ] && continue
+
+	PRERELEASE=`echo "$RELEASES" | jq -r ".[$i].prerelease"`
+	[ "$PRERELEASE" = true ] && continue
+
+	RELEASE_NAME=`echo "$RELEASES" | jq -r ".[$i].name"`
+	case "$RELEASE_NAME" in
+	${DISTRO_FILE_PREFIX}-${DISTRO_TARGETARCH}-${DISTRO_MAJOR_VERSION}.*)
+		RELEASE_VER=${RELEASE_NAME#${DISTRO_FILE_PREFIX}-${DISTRO_TARGETARCH}-}
+		vercmp ${RELEASE_VER} le ${DISTRO_VERSION} && continue
+		RELEASE_CHOICE=$i
+		break
+		;;
+	esac
+done
+
+if [ $RELEASE_CHOICE -lt 0 ]; then
+	echo "No ${DISTRO_NAME} ${DISTRO_MAJOR_VERSION}.x update available"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+
+# make sure we haven't updated yet
+if [ -e "/mnt/root/${RELEASE_TAG}" ]; then
+	echo "/mnt/root/${RELEASE_TAG} already exists"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+
+RELEASE_ASSETS=`echo "$RELEASES" | jq -r ".[$RELEASE_CHOICE].assets"`
+COUNT=`echo "$RELEASE_ASSETS" | jq length`
+
+ASSET_CHOICE=
+for i in `seq 0 $(($COUNT - 1))`; do
+	ASSET_NAME=`echo "$RELEASE_ASSETS" | jq -r ".[$i].name"`
+
+	case "$ASSET_NAME" in
+	${DISTRO_FILE_PREFIX}-${DISTRO_MAJOR_VERSION}.*.tar)
+		ASSET_CHOICE="$i"
+		break
+		;;
+	esac
+done
+
+if [ -z "$ASSET_CHOICE" ]; then
+	echo "No ${DISTRO_NAME} ${DISTRO_MAJOR_VERSION}.x update available"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+
+RELEASE_TAG=`echo "$RELEASES" | jq -r ".[$RELEASE_CHOICE].tag_name"`
+
+if [ "$1" = ask ]; then
+	echo -n "Press ENTER to update to ${RELEASE_VER}"
+	read
+fi
+
+cleanup() {
+	cd /
+	rm -rf "/mnt/root/${RELEASE_TAG}"
+	umount -l /mnt/root
+	rmdir /mnt/root
+	umount -l /mnt/efi
+	rmdir /mnt/efi
+}
+trap "cleanup 2>/dev/null" ERR INT EXIT
+
+UEFI=0
+if [ -L "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_esp" -a -L "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_uefi_root" ]; then
+	mkdir -p /mnt/efi /mnt/root
+	mount "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_esp" /mnt/efi
+	mount "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_uefi_root" /mnt/root
+	UEFI=1
+elif [ -L "/dev/disk/by-label/${DISTRO_FILE_PREFIX}_bios" ]; then
+	mount "/dev/disk/by-label/${DISTRO_FILE_PREFIX}_bios" /mnt/root
+else
+	echo "Unable to locate ${DISTRO_NAME} files"
+	exit 1
+fi
+
+mkdir "/mnt/root/${RELEASE_TAG}"
+if [ $? -ne 0 ]; then
+	echo "Failed to create /mnt/root/${RELEASE_TAG}"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+
+cd "/mnt/root/${RELEASE_TAG}"
+
+ASSET_NAME=`echo "$RELEASE_ASSETS" | jq -r ".[$ASSET_CHOICE].name"`
+echo "Downloading ${ASSET_NAME}"
+ASSET_URL=`echo "$RELEASE_ASSETS" | jq -r ".[$ASSET_CHOICE].url"`
+wget -O "$ASSET_NAME" --header "Accept: application/octet-stream" "$ASSET_URL"
+if [ $? -ne 0 ]; then
+	echo "Failed to download ${ASSET_NAME}"
+	cd ..
+	[ "$1" = ask ] && read
+	exit 1
+fi
+
+echo "Extracting ${ASSET_NAME}"
+tar xf "${ASSET_NAME}"
+if [ $? -ne 0 ]; then
+	echo "Failed to extract ${ASSET_NAME}"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+rm -f "${ASSET_NAME}"
+
+echo "Verifying ${ASSET_NAME}"
+sha256sum -c sha256.sum
+if [ $? -ne 0 ]; then
+	echo "Failed to verify ${RELEASE_TAG} files"
+	[ "$1" = ask ] && read
+	exit 1
+fi
+rm -f sha256.sum README.txt
+
+echo "Flushing ${RELEASE_TAG} to disk"
+sync
+
+for SFS in *.sfs; do
+	echo "Updating ${SFS}"
+	mv -f "${SFS}" ..
+done
+sync
+
+if [ $UEFI -eq 1 ]; then
+	echo "Updating boot loader"
+	cp -f efilinux.efi /mnt/efi/EFI/BOOT/BOOTX64.EFI
+	if [ $? -ne 0 ]; then
+		echo "Failed to move efilinux to EFI partition"
+		[ "$1" = ask ] && read
+		exit 1
+	fi
+
+	echo "Updating the kernel"
+	cp -f vmlinuz /mnt/efi/EFI/BOOT/vmlinuz
+	if [ $? -ne 0 ]; then
+		echo "Failed to move kernel to EFI partition"
+		[ "$1" = ask ] && read
+		exit 1
+	fi
+
+	echo "Updating initrd"
+	cp -f initrd.gz /mnt/efi/EFI/BOOT/initrd.gz
+	if [ $? -ne 0 ]; then
+		echo "Failed to move initrd.gz to EFI partition"
+		[ "$1" = ask ] && read
+		exit 1
+	fi
+
+	rm -f /mnt/efi/EFI/BOOT/ucode.cpio
+	if [ -e ucode.cpio ]; then
+		echo "Updating microcode"
+		cp -f ucode.cpio /mnt/efi/EFI/BOOT/ucode.cpio
+		if [ $? -ne 0 ]; then
+			echo "Failed to move microcode to EFI partition"
+			cd ..
+			[ "$1" = ask ] && read
+			exit 1
+		fi
+	fi
+else
+	echo "Updating the kernel"
+	mv -f vmlinuz ..
+
+	echo "Updating initrd"
+	mv -f initrd.gz ..
+
+	if [ -e ucode.cpio ]; then
+		echo "Updating microcode"
+		mv -f ucode.cpio ..
+	fi
+fi
+
+sync
+
+cd ..
+
+ls -t *_${DISTRO_FILE_PREFIX}_${DISTRO_MAJOR_VERSION}.*.sfs | while read SFS; do
+	case "$SFS" in
+	*_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs|*_${DISTRO_FILE_PREFIX}_${RELEASE_VER}.sfs) continue ;;
+	esac
+
+	echo "Removing ${SFS}"
+	rm -rf "${SFS}"
+done
+
+sync
+
+if [ "$1" = ask ]; then
+	echo "Done"
+	read
+fi

--- a/woof-code/rootfs-packages/simple_updater/usr/share/applications/simple_updater.desktop
+++ b/woof-code/rootfs-packages/simple_updater/usr/share/applications/simple_updater.desktop
@@ -1,0 +1,10 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Puppy updater
+Icon=/usr/share/pixmaps/puppy/refresh.svg
+Comment=Update Puppy
+Exec=rxvt -e simple_updater ask
+Terminal=false
+Type=Application
+Categories=X-SetupUtility
+GenericName=Puppy updater

--- a/woof-code/support/cros_image.sh
+++ b/woof-code/support/cros_image.sh
@@ -101,7 +101,6 @@ mount-FULL -o loop,noatime,offset=${P2STARTBYTES} ${SSD_IMG_BASE} /mnt/ssdimagep
 mount-FULL -o loop,noatime,offset=${P2STARTBYTES} ${SD_IMG_BASE} /mnt/sdimagep2
 
 cp -a rootfs-complete/* /mnt/ssdimagep2/
-[ ! -e build/ucode.cpio ] || install -m 644 build/ucode.cpio /mnt/ssdimagep2/ucode.cpio
 echo -e '#!/bin/sh\nexec /sbin/init initrd_full_install' > /mnt/ssdimagep2/init
 chmod 755 /mnt/ssdimagep2/init
 cp -a /mnt/ssdimagep2/* /mnt/sdimagep2/


### PR DESCRIPTION
![update](https://user-images.githubusercontent.com/1471149/145269160-d59fb432-d007-431b-92d2-5d93e54ad0ca.png)

Once this branch is merged into the `images` branch, I'll run two dpup draft releases based on `images`, test update from the first release to the second release, delete the drafts and merge `images` to `testing`. (I tested the updater manually and it works for both UEFI and BIOS.)