### PR TITLE
Add frugalify support to ext4 images

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -704,6 +704,9 @@ if [ ! "$ISOFLAG" ]; then
 		      rootfs-skeleton/usr/sbin/pupsave-backup \
 		      rootfs-complete/usr/share/applications/Pupsave-hot-backup.desktop
 	fi
+	if [ "$FRUGALIFY" ]; then
+		rm -f rootfs-complete/usr/share/applications/SFS-Load.desktop
+	fi
 fi
 
 # puppyPDF needs Abiword
@@ -877,6 +880,11 @@ fi
 if [ "$SDFLAG" != "" -o "$CROSFLAG" != "" ];then
 	echo "BOOT_DIRTYWRITE='1500'" >> rootfs-complete/etc/rc.d/BOOTCONSTRAINED #defer writing to disk. refer: http://www.lesswatts.org/tips/disks.php
 	echo "BOOT_BOARD='${BOOT_BOARD}'" >> rootfs-complete/etc/rc.d/BOOTCONSTRAINED #120714 read by quicksetup.
+fi
+
+if [ "$FRUGALIFY" ]; then
+	echo "PUPMODE='6'" > rootfs-complete/etc/rc.d/PUPSTATE
+	echo "PUNIONFS='overlay'" >> rootfs-complete/etc/rc.d/PUPSTATE
 fi
 
 if grep -q '^spot:' rootfs-complete/etc/passwd ; then

--- a/woof-code/rootfs-packages/simple_installer/usr/sbin/simple_installer
+++ b/woof-code/rootfs-packages/simple_installer/usr/sbin/simple_installer
@@ -84,11 +84,12 @@ if [ -L "/dev/disk/by-partlabel/${DISTRO_FILE_PREFIX}_esp" -a -L "/dev/disk/by-p
 	install -D -m 644 /mnt/efi/EFI/BOOT/BOOTX64.EFI /mnt/targetp1/EFI/BOOT/BOOTX64.EFI
 	install -m 644 /mnt/efi/EFI/BOOT/efilinux.cfg /mnt/targetp1/EFI/BOOT/efilinux.cfg
 	install -m 644 /mnt/efi/EFI/BOOT/vmlinuz /mnt/targetp1/EFI/BOOT/vmlinuz
-	install -m 644 /mnt/efi/EFI/BOOT/initrd.gz /mnt/targetp1/EFI/BOOT/initrd.gz
+	[ ! -e /mnt/efi/EFI/BOOT/initrd.gz ] || install -m 644 /mnt/efi/EFI/BOOT/initrd.gz /mnt/targetp1/EFI/BOOT/initrd.gz
 	[ ! -e /mnt/efi/EFI/BOOT/ucode.cpio ] || install -m 644 /mnt/efi/EFI/BOOT/ucode.cpio /mnt/targetp1/EFI/BOOT/ucode.cpio
 	busybox umount /mnt/targetp1 2>/dev/null
 
 	mount-FULL -o noatime ${TARGETP2} /mnt/targetp2
+	[ ! -e /mnt/root/frugalify ] || install -m 755 /mnt/root/frugalify /mnt/targetp2/frugalify
 	cp -a /mnt/root/*.sfs /mnt/targetp2/
 	busybox umount /mnt/targetp2 2>/dev/null
 	rmdir /mnt/targetp2
@@ -118,8 +119,9 @@ elif [ -L "/dev/disk/by-label/${DISTRO_FILE_PREFIX}_bios" ]; then
 	dd if=/usr/lib/EXTLINUX/mbr.bin of=${TARGET}
 	install -m 644 /mnt/root/extlinux.conf /mnt/targetp1/extlinux.conf
 	install -m 644 /mnt/root/vmlinuz /mnt/targetp1/vmlinuz
-	install -m 644 /mnt/root/initrd.gz /mnt/targetp1/initrd.gz
+	[ ! -e /mnt/root/initrd.gz ] || install -m 644 /mnt/root/initrd.gz /mnt/targetp1/initrd.gz
 	[ ! -e /mnt/root/ucode.cpio ] || cp -f /mnt/root/ucode.cpio /mnt/targetp1/
+	[ ! -e /mnt/root/frugalify ] || install -m 755 /mnt/root/frugalify /mnt/targetp1/frugalify
 	cp -a /mnt/root/*.sfs /mnt/targetp1/
 	busybox umount /mnt/targetp1 2>/dev/null
 	rmdir /mnt/targetp1

--- a/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
+++ b/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
@@ -186,6 +186,17 @@ if [ $UEFI -eq 1 ]; then
 			exit 1
 		fi
 	fi
+
+	if [ -e /mnt/root/frugalify ]; then
+		echo "Updating frugalify"
+		install -m 755 frugalify /mnt/root/frugalify
+		if [ $? -ne 0 ]; then
+			echo "Failed to update frugalify"
+			cd ..
+			[ "$1" = ask ] && read
+			exit 1
+		fi
+	fi
 else
 	echo "Updating the kernel"
 	mv -f vmlinuz ..
@@ -196,6 +207,12 @@ else
 	if [ -e ucode.cpio ]; then
 		echo "Updating microcode"
 		mv -f ucode.cpio ..
+	fi
+
+	if [ -e ../frugalify ]; then
+		echo "Updating frugalify"
+		mv -f frugalify ..
+		chmod 755 ../frugalify
 	fi
 fi
 

--- a/woof-code/rootfs-skeleton/etc/init.d/00sys_logger
+++ b/woof-code/rootfs-skeleton/etc/init.d/00sys_logger
@@ -1,5 +1,8 @@
 #!/bin/ash
 
+. /etc/rc.d/PUPSTATE
+[ $PUPMODE -eq 6 ] && exit 0
+
 case $1 in
  start)
   syslogd -m 0

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -295,7 +295,7 @@ case $PUPMODE in
  ;;
 
  77) /usr/sbin/savesession-dvd ;; #requires /tmp/rc.shutdown_config - save to folder on multisession CD/DVD (including 1st shutdown)
- 2)  echo -n ;; #echo "$(printf "$(gettext '%s mounted directly, session already saved.')" "$PDEV1")" >/dev/console
+ 2|6)  echo -n ;; #echo "$(printf "$(gettext '%s mounted directly, session already saved.')" "$PDEV1")" >/dev/console
  12) echo "$(printf "$(gettext '%s mounted directly top layer, session already saved.')" "${SAVEFILE##*/}")" >/dev/console ;;
  13) #PDEV1 and PUPSFS and PUPSAVE 
   #/initrd/pup_rw has tmpfs, pup_ro1 has ${DISTRO_FILE_PREFIX}save.2fs file (PUPSAVE), pup_ro2 has PUPSFS file. 

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -112,10 +112,11 @@ loadswap_func() { #w481 made into a function.
 #================================================================
 #                         MAIN
 #================================================================
-# mount devtmpfs early
-busybox mount -t devtmpfs devtmpfs /dev 2>/dev/null
-
 . /etc/rc.d/PUPSTATE
+
+# mount devtmpfs early
+[ $PUPMODE -ne 6 ] && busybox mount -t devtmpfs devtmpfs /dev 2>/dev/null
+
 . /etc/DISTRO_SPECS
 . /etc/rc.d/BOOTCONSTRAINED # has BOOT_DISABLESWAP, BOOT_ATIME, BOOT_DIRTYWRITE.
 . /etc/rc.d/MODULESCONFIG #modules loading configuration.
@@ -124,7 +125,7 @@ busybox mount -t devtmpfs devtmpfs /dev 2>/dev/null
 [ $pdev1 ] && PDEV1=$pdev1    #boot parameter, partition have booted off. ex: hda3
 
 #if have just done a switch_root, output a 'done' message...
-[ $PUPMODE -ne 2 ] && status_func 0
+[ $PUPMODE -ne 2 -a $PUPMODE -ne 6 ] && status_func 0
 
 ORIGLANG="`grep '^LANG=' /etc/profile | cut -f 2 -d '=' | cut -f 1 -d ' '`" #120217
 ORIGLANG1="${ORIGLANG%_*}" #ex: en
@@ -146,14 +147,16 @@ STATUS=0
 
 echo -n "Making the filesystem usable..." >/dev/console
 
-# busybox mount /proc before remounting / as rw (full install)
-busybox mount -t proc none /proc 2>/dev/null; STATUS=$((STATUS+$?))
+if [ $PUPMODE -ne 6 ] ; then
+ # busybox mount /proc before remounting / as rw (full install)
+ busybox mount -t proc none /proc 2>/dev/null; STATUS=$((STATUS+$?))
+fi
 
 FREERAM=`free | grep -o 'Mem: .*' | tr -s ' ' | cut -f 4 -d ' '` #w481 110405
 QTRFREERAM=`expr $FREERAM \/ 4`
 
 #=============== full-hd-install
-if [ $PUPMODE -eq 2 ] ; then
+if [ $PUPMODE -eq 2 -o $PUPMODE -eq 6 ] ; then
  #no longer deleting /tmp/* in rc.shutdown... (note, init script in initrd.gz wipes it)
  rm -rf /tmp/*
  rm -rf /tmp/.[0-9a-zA-Z]*

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -193,7 +193,7 @@ case $PUPMODE in
   fi
   exit ###EXIT###
  ;;
- *) #PUPMODE=2 (full hd install) then just exit.
+ *) #PUPMODE=2/6 (full hd install) then just exit.
   # need to consider situation of a full-hd install that is not pre-setup, as would normally be done by 3builddistro in Woof and the Universal Installer.
   if [ -f /var/local/full_install_update_flag ] ; then
    find -L / \( -mount -path '*/lib/*' -type l -name *.so -o -path '*/lib/*' -type l -name *.so.* \) -delete

--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -64,7 +64,7 @@ export LANG=C
 
 [ "$PUPMODE" == "" ] && PUPMODE=2
 
-[ "$PUPMODE" = "2" ] && [ ! -d /audit ] && mkdir -p /audit
+[ "$PUPMODE" = "2" -o "$PUPMODE" = "6" ] && [ ! -d /audit ] && mkdir -p /audit
 
 DLPKG="$1"
 DLPKG_BASE="`basename "$DLPKG"`" #ex: scite-1.77-i686-2as.tgz
@@ -167,7 +167,7 @@ read -r TFS TMAX TUSED TMPK TPERCENT TMNTPT <<<$(df -k | grep -w '^tmpfs') #free
 SIZEB=`stat -c %s "${DLPKG_PATH}"/${DLPKG_BASE}`
 SIZEK=$(( $SIZEB / 1024 ))
 EXPK=$(( $SIZEK * 5)) #estimated worst-case expanded size.
-if [ "$PUPMODE" = "2" ]; then # from BK's quirky6.1
+if [ "$PUPMODE" = "2" -o "$PUPMODE" = "6" ]; then # from BK's quirky6.1
 	#131220  131229 detect if not enough room in /tmp...
 	DIRECTSAVEPATH="/tmp/petget_proc/petget/directsavepath"
 	NEEDK=$EXPK
@@ -335,7 +335,7 @@ case $DLPKG_BASE in
  ;;
 esac
 
-if [ "$PUPMODE" = "2" ]; then #from BK's quirky6.1
+if [ "$PUPMODE" = "2" -o "$PUPMODE" = "6" ]; then #from BK's quirky6.1
 	mkdir /audit/${DLPKG_NAME}DEPOSED
 	echo -n '' > /tmp/petget_proc/petget/FLAGFND
 	find ${DIRECTSAVEPATH}/ -mindepth 1 | sed -e "s%${DIRECTSAVEPATH}%%" |
@@ -367,7 +367,7 @@ if [ "$PUPMODE" = "2" ]; then #from BK's quirky6.1
 	echo "$FIXEDFILES" | sed -e "s#^\.\/#\/#g" -e "s#^#\/#g" -e "s#^\/\/#\/#g" -e 's#^\/$##g' -e 's#^\/\.$##g' | sort > /root/.packages/${DLPKG_NAME}.files 
 	DIRECTSAVEPATH=/ # set it to the new cocation
 
-else #-- anything other than PUPMODE 2 (full install) --
+else #-- anything other than PUPMODE 2 or 6 (full install) --
 
 	[ "$DL_SAVE_FLAG" != "true" ] &&  rm -f $DLPKG_BASE 2>/dev/null
 	rm -f $DLPKG_MAIN.tar.${EXT} 2>/dev/null #131122

--- a/woof-code/rootfs-skeleton/usr/local/petget/removepreview.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/removepreview.sh
@@ -181,7 +181,7 @@ $possible5"
 fi
 
 
-if [ "$PUPMODE" = "2" ]; then
+if [ "$PUPMODE" = "2" -o "$PUPMODE" = "6" ]; then
 #any user-installed deps?...
 remPATTERN='^'"$DB_pkgname"'|'
 DEP_PKGS="`grep "$remPATTERN" /root/.packages/user-installed-packages | cut -f 9 -d '|' | tr ',' '\n' | grep -v '^\\-' | sed -e 's%^+%%' |cut -f1 -d '&'`" #names-only, one each line. 

--- a/woof-code/rootfs-skeleton/usr/sbin/bootmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/bootmanager
@@ -382,6 +382,15 @@ if [ $PUPMODE -eq 2 ];then #PUPMODE=2, full hd install, will not have this.
       </vbox>
     </frame>
     </vbox>'
+elif [ $PUPMODE -eq 6 ];then
+	SFSFRAME_XML='
+    <vbox margin="8">
+    <frame '$(gettext 'Load SFS files')'>
+      <vbox space-expand="true" space-fill="true">
+        '"`/usr/lib/gtkdialog/xml_info scale package_sfs.svg 60 "$(gettext "NOTICE: As this is an installation of Puppy without an initrd, SFS files are automatically loaded at bootup.")" " "`"'
+      </vbox>
+    </frame>
+    </vbox>'
 else
     SFSLOAD_XML="$(gettext "The SFS-Load application will load SFS files immediately. Loaded SFS files will continue to be loaded through subsequent reboots, until they are unloaded.")"
 	XML_FRAME=$(gettext 'Load SFS files')

--- a/woof-code/rootfs-skeleton/usr/sbin/download_file
+++ b/woof-code/rootfs-skeleton/usr/sbin/download_file
@@ -138,7 +138,7 @@ if [ "$SIZEB_ONLINE" != "" ] ; then
 			MSGs="$(gettext 'You need to shutdown and create a save-file, then you will have more space.
 See menu Shutdown -> Reboot')"
 			;;
-		2)
+		2|6)
 			MSGs="$(gettext 'The partition is full, you will have to delete something.')"
 			;;
 		77) #tmpfs on top, full partition underneath

--- a/woof-code/rootfs-skeleton/usr/sbin/extrasfsfind
+++ b/woof-code/rootfs-skeleton/usr/sbin/extrasfsfind
@@ -84,7 +84,7 @@ SFS_TO_SKIP=$(echo $SFS_TO_SKIP | tr ' ' '|')
 # home path
 SRCPATH=""
 
-if [ $PUPMODE -eq 2 ] ; then #full install
+if [ $PUPMODE -eq 2 -o $PUPMODE -eq 6 ] ; then #full install
 	SRCPATH='/'
 else
 	PDEV1_MP=$(LANG=C mount | grep "^/dev/${PDEV1} " | cut -f 3 -d ' ')

--- a/woof-code/rootfs-skeleton/usr/sbin/momanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/momanager
@@ -90,7 +90,7 @@ POEDITOR="`which poeditor`"
 
 PATHPREFIX=""
 case $PUPMODE in
- 2) PATHPREFIX="" ;; #full hd installation.
+ 2|6) PATHPREFIX="" ;; #full hd installation.
  3) PATHPREFIX="" ;;
  *) PATHPREFIX="/initrd/pup_ro2" ;;
 esac

--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -363,7 +363,7 @@ SINGLEFLAG="true" #default tabbed interface.
 
 #v3.96 'mount' misreports which partition mounted on '/'...
 ROOTDEV2=""
-if [ "$PUPMODE" = "2" ] ; then
+if [ "$PUPMODE" = "2" -o "$PUPMODE" = "6" ] ; then
  ROOTDEV2="`df | grep ' /$' | grep '^/dev/' | cut -f 1 -d ' '`"
 fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/pupswap
+++ b/woof-code/rootfs-skeleton/usr/sbin/pupswap
@@ -116,7 +116,7 @@ TOTAL_SWAP_SIZES=$X
 if [ "$MOUNTED_PARTITIONS" = "" ] ; then #MOUNTED_PARTITIONS can be exported
 	MOUNTED_PARTITIONS="`mount | grep -E "/(s|h)d[a-z][0-9]" | awk '{print $3}' | sort -u`"
 fi
-if [ $PUPMODE -eq 2 ] ; then #full install
+if [ $PUPMODE -eq 2 -o $PUPMODE -eq 6 ] ; then #full install
 	MOUNTED_PARTITIONS="/
 $MOUNTED_PARTITIONS"
 fi

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -1722,7 +1722,7 @@ if [ "$PUPMODE_dummy" ] ; then ############ for debugging
 	[ "$PUPMODE_dummy" = "CD" ] && PUPMODE_dummy=5 && PUPSFS="sr0,iso9660,$SFSBASE"
 	[ "$PUPMODE_dummy" ] && PUPMODE=$PUPMODE_dummy
 	case "$PUPMODE_dummy" in
-		2) SAVE_LAYER=''; PUP_HOME='/'; PUPSAVE="";;
+		2|6) SAVE_LAYER=''; PUP_HOME='/'; PUPSAVE="";;
 		5) SAVE_LAYER=''; PUP_HOME=''; PUPSAVE="";;
 		12) SAVE_LAYER='/pup_rw'; PUP_HOME='/mnt/dev_save';;
 		13) SAVE_LAYER='/pup_ro1'; PUP_HOME='/mnt/dev_save';;
@@ -1768,9 +1768,11 @@ if [ "$PUPSAVE" != "" ]; then
 	[ "$PUPHOME" = "$INITRDHOME" ] && PUPHOME=$MNTHOME && DESTDIR=$PUPHOME
 	[ "$PUPMODE" = "66" ] && PUPHOME="/mnt/${PUPSAVE%%,*}"
 else
-	# PUPMODE=2 or 5
+	# PUPMODE=2, 6 or 5
 	if [ "$PUPMODE" = "2" ]; then
 		DESTDIR="/root"; PUPHOME="/"
+	elif [ "$PUPMODE" = "6" ]; then
+		DESTDIR="/initrd"; PUPHOME="/"
 	else
 		# PUPMODE=5
 		[  -s "$PUPSAVECONF" ] && source "$PUPSAVECONF" && PUPSAVE="$SAVEPART,,$SAVEFILE"
@@ -1800,7 +1802,7 @@ case "$PUPMODE" in
 		else SFSMODE="tmp"
 		fi
 		;;
-	12|13|66) SFSMODE="y";;
+	6|12|13|66) SFSMODE="y";;
 	77) SFSMODE="cd";;
 	*) SFSMODE="";;
 esac

--- a/woof-code/support/pc_image.sh
+++ b/woof-code/support/pc_image.sh
@@ -4,6 +4,15 @@ TAR_BASE=${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}.tar
 
 set -e
 
+if [ "$FRUGALIFY" = "yes" ]; then
+	case $WOOF_TARGETARCH in
+	x86_64) FRUGALIFYEXEC=frugalify-overlayfs-x86_64;;
+	x86) FRUGALIFYEXEC=frugalify-overlayfs-i386 ;;
+	arm|aarch64) FRUGALIFYEXEC=frugalify-overlayfs-arm ;;
+	esac
+	[ -f ../../local-repositories/${FRUGALIFYEXEC} ] || wget --tries=1 --timeout=10 -O ../../local-repositories/${FRUGALIFYEXEC} https://github.com/puppylinux-woof-CE/frugalify/releases/latest/download/${FRUGALIFYEXEC}
+fi
+
 echo "Building ${BIOS_IMG_BASE}"
 
 dd if=/dev/zero of=${BIOS_IMG_BASE} bs=50M count=40 conv=sparse
@@ -11,6 +20,7 @@ parted --script ${BIOS_IMG_BASE} mklabel msdos
 parted --script ${BIOS_IMG_BASE} mkpart primary "" ext4 2048s 100%
 parted --script ${BIOS_IMG_BASE} set 1 boot on
 LOOP=`losetup -Pf --show ${BIOS_IMG_BASE}`
+PARTUUID=`blkid -s PARTUUID -o value ${LOOP}p1`
 mkfs.ext4 -F -b 4096 -m 0 -O ^has_journal,encrypt -L "${DISTRO_FILE_PREFIX}_bios" ${LOOP}p1
 
 mkdir -p /mnt/biosimagep1
@@ -18,25 +28,51 @@ mount -o noatime ${LOOP}p1 /mnt/biosimagep1
 
 extlinux -i /mnt/biosimagep1
 dd if=/usr/lib/EXTLINUX/mbr.bin of=${LOOP}
-if [ -e build/ucode.cpio ]; then
-	cp -f build/ucode.cpio /mnt/biosimagep1/
-	cat << EOF > /mnt/biosimagep1/extlinux.conf
+if [ "$FRUGALIFY" = "yes" ]; then
+	if [ -e build/ucode.cpio ]; then
+		cp -f build/ucode.cpio /mnt/biosimagep1/
+		cat << EOF > /mnt/biosimagep1/extlinux.conf
+DEFAULT ${DISTRO_FILE_PREFIX}
+
+LABEL ${DISTRO_FILE_PREFIX}
+	LINUX vmlinuz
+	INITRD ucode.cpio
+	APPEND root=PARTUUID=$PARTUUID init=/frugalify rootfstype=ext4 rootwait rw
+EOF
+	else
+		cat << EOF > /mnt/biosimagep1/extlinux.conf
+DEFAULT ${DISTRO_FILE_PREFIX}
+
+LABEL ${DISTRO_FILE_PREFIX}
+	LINUX vmlinuz
+	APPEND root=PARTUUID=$PARTUUID init=/frugalify rootfstype=ext4 rootwait rw
+EOF
+	fi
+
+	install -m 755 ../../local-repositories/${FRUGALIFYEXEC} /mnt/biosimagep1/frugalify
+else
+	if [ -e build/ucode.cpio ]; then
+		cp -f build/ucode.cpio /mnt/biosimagep1/
+		cat << EOF > /mnt/biosimagep1/extlinux.conf
 DEFAULT ${DISTRO_FILE_PREFIX}
 
 LABEL ${DISTRO_FILE_PREFIX}
 	LINUX vmlinuz
 	INITRD ucode.cpio,initrd.gz
 EOF
-else
-	cat << EOF > /mnt/biosimagep1/extlinux.conf
+	else
+		cat << EOF > /mnt/biosimagep1/extlinux.conf
 DEFAULT ${DISTRO_FILE_PREFIX}
 
 LABEL ${DISTRO_FILE_PREFIX}
 	LINUX vmlinuz
 	INITRD initrd.gz
 EOF
+	fi
+
+	cp -f build/initrd.gz /mnt/biosimagep1/
 fi
-cp -f build/vmlinuz build/initrd.gz /mnt/biosimagep1/
+cp -f build/vmlinuz /mnt/biosimagep1/
 cp -a build/*.sfs /mnt/biosimagep1/
 umount /mnt/biosimagep1 2>/dev/null
 losetup -d ${LOOP}
@@ -60,16 +96,27 @@ if [ "$WOOF_TARGETARCH" = "x86_64" ]; then
 	[ -f ../../local-repositories/efilinux.efi ] || wget --tries=1 --timeout=10 -O ../../local-repositories/efilinux.efi https://github.com/puppylinux-woof-CE/efilinux/releases/latest/download/efilinux.efi
 	install -D -m 644 ../../local-repositories/efilinux.efi /mnt/uefiimagep1/EFI/BOOT/BOOTX64.EFI
 	install -m 644 build/vmlinuz /mnt/uefiimagep1/EFI/BOOT/vmlinuz
-	install -m 644 build/initrd.gz /mnt/uefiimagep1/EFI/BOOT/initrd.gz
-	if [ -e build/ucode.cpio ]; then
-		install -m 644 build/ucode.cpio /mnt/uefiimagep1/EFI/BOOT/ucode.cpio
-		echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+	if [ "$FRUGALIFY" = "yes" ]; then
+		if [ -e build/ucode.cpio ]; then
+			install -m 644 build/ucode.cpio /mnt/uefiimagep1/EFI/BOOT/ucode.cpio
+			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio root=PARTLABEL=${DISTRO_FILE_PREFIX}_uefi_root init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+		else
+			echo "-f 0:\EFI\BOOT\vmlinuz root=PARTLABEL=${DISTRO_FILE_PREFIX}_uefi_root init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+		fi
 	else
-		echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+		if [ -e build/ucode.cpio ]; then
+			install -m 644 build/ucode.cpio /mnt/uefiimagep1/EFI/BOOT/ucode.cpio
+			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+		else
+			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+		fi
+
+		install -m 644 build/initrd.gz /mnt/uefiimagep1/EFI/BOOT/initrd.gz
 	fi
 	umount /mnt/uefiimagep1 2>/dev/null
 
 	mount -o noatime ${LOOP}p2 /mnt/uefiimagep2
+	[ "$FRUGALIFY" != "yes" ] || install -m 755 ../../local-repositories/${FRUGALIFYEXEC} /mnt/uefiimagep2/frugalify
 	cp -a build/*.sfs /mnt/uefiimagep2/
 	umount /mnt/uefiimagep2 2>/dev/null
 
@@ -80,6 +127,7 @@ fi
 
 echo "Building ${TAR_BASE}"
 [ "$WOOF_TARGETARCH" != "x86_64" ] || cp -f ../../local-repositories/efilinux.efi build/
+[ "$FRUGALIFY" != "yes" ] || cp -f ../../local-repositories/${FRUGALIFYEXEC} build/frugalify
 cd build
 sha256sum * > sha256.sum
 tar -c * > ../../${WOOF_OUTPUT}/${TAR_BASE}


### PR DESCRIPTION
frugalify is a static executable that replaces initrd.gz, init, syslogd and klogd, while also providing periodic TRIM.

See https://github.com/puppylinux-woof-CE/frugalify/blob/master/README.md for more information about it.

I've used and tested it extensively in dpup OS, for almost a year, and I think it's a great way to simplify Puppy, get rid of some old cruft (like the static binaries in initrd.gz) and make it boot faster. It's mature enough to make it an option in 3builddistro.

(It supports both overlay and aufs; this PR only adds support for the overlay variant.)

As always, this feature is optional, and it's activated only when `BUILD_ISO=no FRUGALIFY=yes`.