### PR TITLE
init: Copy cryptsetup static binary

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1345,6 +1345,9 @@ cp -a /init* /sbin /README.txt /pup_new/initrd/
 chmod -x /pup_new/initrd/init
 dmesg > /tmp/dmesg.txt
 
+[ -f /bin/cryptsetup ] && cp -af /bin/cryptsetup /pup_new/initrd/bin/ 
+[ -f /sbin/cryptsetup ] && cp -af /sbin/cryptsetup /pup_new/initrd/sbin/ 
+
 [ -d "/pup_new/initrd/tmp" ] && rm -rf /pup_new/initrd/tmp
 mkdir -p /pup_new/initrd/tmp
 cp -af /tmp/* /pup_new/initrd/tmp/ #keep any log files.


### PR DESCRIPTION
This will be use for encrypting save file upon shutdown if the user choose to encrypt the save file.
Using cryptsetup from initrd will provide consistent encryption and decryption of savefile