### PR TITLE
Add a "rolling" dpup build based on Debian Sid

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,10 @@ jobs:
             compat-distro: ubuntu
             compat-distro-version: bionic64
             kernel: 4.19.x-x86_64
+          - arch: x86_64
+            compat-distro: debian
+            compat-distro-version: sid64
+            kernel: 5.15.x-x86_64
           - arch: arm
             compat-distro: debian
             compat-distro-version: bullseye-veyron-speedy

--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -142,15 +142,20 @@ download_pkg_dbs compat $PKG_DOCS_DISTRO_COMPAT #---
 # -update dbs... #${DISTRO_BINARY_COMPAT}-updates package databases
 PKGLISTS_COMPAT_UPDATES=""
 case $DISTRO_BINARY_COMPAT in ubuntu|trisquel|debian|devuan) #130319 removed |raspbian
-   DBUPDATEFLAG='yes'
-   #Packages-ubuntu-precise-main -> Packages-ubuntu-precise_updates-main
-   #http://archive.ubuntu.com/ubuntu/dists/precise/main/binary-i386/Packages.bz2 -> http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/binary-i386/Packages.bz2
-   PKGLISTS_COMPAT_U=$(echo "$PKG_DOCS_DISTRO_COMPAT" | tr ' ' '\n' | grep -v 'deb-multimedia' | \
-     sed -e "s|-${DISTRO_COMPAT_VERSION}-|-${DISTRO_COMPAT_VERSION}_updates-|" \
-         -e "s|/${DISTRO_COMPAT_VERSION}/|/${DISTRO_COMPAT_VERSION}-updates/|")
-   download_pkg_dbs compat $PKGLISTS_COMPAT_U
-   #see further down
-   PKGLISTS_COMPAT_UPDATES=$(echo "$PKGLISTS_COMPAT_U" | cut -f 3 -d "|" | tr '\n' ' ')
+   case $DISTRO_COMPAT_VERSION in
+   sid|ceres) ;;
+   *)
+      DBUPDATEFLAG='yes'
+      #Packages-ubuntu-precise-main -> Packages-ubuntu-precise_updates-main
+      #http://archive.ubuntu.com/ubuntu/dists/precise/main/binary-i386/Packages.bz2 -> http://archive.ubuntu.com/ubuntu/dists/precise-updates/main/binary-i386/Packages.bz2
+      PKGLISTS_COMPAT_U=$(echo "$PKG_DOCS_DISTRO_COMPAT" | tr ' ' '\n' | grep -v 'deb-multimedia' | \
+        sed -e "s|-${DISTRO_COMPAT_VERSION}-|-${DISTRO_COMPAT_VERSION}_updates-|" \
+            -e "s|/${DISTRO_COMPAT_VERSION}/|/${DISTRO_COMPAT_VERSION}-updates/|")
+      download_pkg_dbs compat $PKGLISTS_COMPAT_U
+      #see further down
+      PKGLISTS_COMPAT_UPDATES=$(echo "$PKGLISTS_COMPAT_U" | cut -f 3 -d "|" | tr '\n' ' ')
+      ;;
+   esac
 esac
 
 case $DISTRO_BINARY_COMPAT in slackware*) # slackware official updates = patches repo

--- a/woof-distro/x86_64/debian/sid64/DISTRO_COMPAT_REPOS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_COMPAT_REPOS-debian-sid
@@ -1,0 +1,49 @@
+#
+# DISTRO_COMPAT_REPOS
+#
+
+if [ "$DISTRO_COMPAT_VERSION" = "" ] ; then
+	[ -f ./DISTRO_SPECS ] && . ./DISTRO_SPECS
+fi
+
+case "$DISTRO_TARGETARCH" in
+	x86)    DBIN_ARCH=i386  ;;
+	x86_64) DBIN_ARCH=amd64 ;;
+	arm)    DBIN_ARCH=armhf ;;
+esac
+
+#----------------------
+#PKG_DOCS_DISTRO_COMPAT - where to download the compat-distro pkgs databases from
+#---------------------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the database file.
+#   3 - name of db file when local and after being processed into standard format
+
+PKG_DOCS_DISTRO_COMPAT="
+z|https://http.us.debian.org/debian/dists/${DISTRO_COMPAT_VERSION}/main/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-main
+z|https://http.us.debian.org/debian/dists/${DISTRO_COMPAT_VERSION}/non-free/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-non-free
+z|https://http.us.debian.org/debian/dists/${DISTRO_COMPAT_VERSION}/contrib/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-contrib
+"
+
+#-------------------
+#REPOS_DISTRO_COMPAT - hardcode the compat-distro repos in here...
+#-------------------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the repo
+#   3 - name of db-file(s) associated with that repo. it may have glob wildcards.
+
+REPOS_DISTRO_COMPAT="
+z|https://http.us.debian.org/debian|Packages-debian-${DISTRO_COMPAT_VERSION}-*
+z|https://mirrors.kernel.org/debian|Packages-debian-${DISTRO_COMPAT_VERSION}-*
+z|https://ftp.de.debian.org/debian|Packages-debian-${DISTRO_COMPAT_VERSION}-*
+"
+
+
+#---------------
+# fix variables
+#---------------
+PKG_DOCS_DISTRO_COMPAT="$(echo $PKG_DOCS_DISTRO_COMPAT)"
+REPOS_DISTRO_COMPAT="$(echo $REPOS_DISTRO_COMPAT)"
+

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PET_REPOS
@@ -1,0 +1,53 @@
+#------------------
+#PKG_DOCS_PET_REPOS - where to download the pet pkgs databases from.
+#------------------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the database file.
+#   3 - name of db file when local and after being processed into standard format
+#  (in the case of PET databases, the names are the same and no processing is required)
+
+if [ "${BUILD_FROM_WOOF//;/_}" != "$BUILD_FROM_WOOF" ] ; then
+	WCE_BRANCH="${BUILD_FROM_WOOF%%;*}" #cut -f 1 -d ';'
+else
+	WCE_BRANCH=testing
+fi
+# TODO: remove this when C201 support lands in testing
+WCE_BRANCH=testing
+
+PKG_DOCS_PET_REPOS="
+z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woof-distro/Packages-puppy-noarch-official|z
+"
+
+#---------
+#PET_REPOS - hardcode the pet repos in here...
+#---------
+# 1|2|3
+#   1 - domain. for testing the url.
+#   2 - full URI of the repo
+#   3 - name of db-file(s) associated with that repo. it may have glob wildcards.
+#   ex: Packages-puppy-4-official (note, url paths are in the database)
+
+PET_REPOS="
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-noarch-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-noarch-official
+z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
+"
+
+#----------------------
+#PACKAGELISTS_PET_ORDER
+#----------------------
+#   this defines where Woof (and PPM) looks first and second
+#   (and third, etc.) for pet pkgs
+
+PACKAGELISTS_PET_ORDER="
+Packages-puppy-noarch-official
+"
+
+#---------------
+# fix variables
+#---------------
+PKG_DOCS_PET_REPOS="$(echo $PKG_DOCS_PET_REPOS)"
+PET_REPOS="$(echo $PET_REPOS)"
+PACKAGELISTS_PET_ORDER="$(echo $PACKAGELISTS_PET_ORDER)"
+

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -1,0 +1,678 @@
+#fallbacks when looking for pkgs (space-separated list)...
+FALLBACKS_COMPAT_VERSIONS=''
+
+#PKGS_SPECS_TABLE table format:
+#will pkg be in puppy-build.
+#    Generic name for pkg. Note: PET packages, if exist, use this name.
+#            Comma-separated list of compatible-distro pkg(s). '-' prefix, exclude.
+#            Must be exact name-only of pkg, else '*' on end is wildcard to search full name.
+#            Empty field, then use PET pkg.
+#                                    How the package will get split up in woof (optional redirection '>' operator).
+#                                    Missing field, it goes into exe. Can also redirect >null, means dump it.
+#yes|abiword|iceword,iceword-plugins|exe,dev,doc,nls
+
+#example showing wildcard. finds all full pkg names with 'gcc-4.3*',
+#but, exclude any 'gcc-4.3-doc*' matches...
+# yes|gcc|gcc,gcc-4.3*,-gcc-4.3-doc*|exe,dev,doc,nls
+
+#110817 Comments preferred to be on end of line, ex:
+# yes|abiword|iceword,iceword-plugins|exe,dev,doc,nls| #this is a comment.
+
+#110829 enhancements:
+#                                                     Force pkg is from compat-distro repo, specifically 'salix' repo.
+# yes|abiword|iceword,iceword-plugins|exe,dev,doc,nls|compat:salix
+#Generic format:
+# yes|genericpkgname|[pkgnames]|[splitup]|[pet:[repo]]
+# yes|genericpkgname|[pkgnames]|[splitup]|[compat:[repo]]
+#for a fuller explanation of the entries in PKGS_SPECS_TABLE, please see:
+# http://bkhome.org/blog/?viewDetailed=02414
+
+PKGS_SPECS_TABLE='
+no|a52dec|liba52-0.7.4,liba52-0.7.4-dev|exe,dev,doc,nls
+no|aalib|libaa1|exe,dev>null,doc,nls #ascii library, needed by mplayer, gphoto
+yes|acl|libacl1|exe,dev,doc,nls||deps:yes
+no|acpi|acpi|exe,dev,doc,nls
+no|acpid-busibox||exe
+yes|adduser|adduser|exe>null,dev>null,doc>null,nls>null
+no|advancecomp|advancecomp|exe>dev,dev,doc,nls
+no|alsaequal|libasound2-plugin-equal,caps|exe,dev,doc,nls| #needed by pequalizer.
+yes|alsa-lib|libasound2,libasound2-data,libasound2-dev,alsa-topology-conf,alsa-ucm-conf|exe,dev,doc,nls||deps:yes
+yes|libasound2-plugins-pulseonly|libasound2-plugins|exe,dev,doc,nls
+yes|alsa-utils|alsa-utils|exe,dev,doc,nls||deps:yes
+no|apulse||exe,dev,doc
+no|aspell|libaspell15,libaspell-dev|exe,dev,doc,nls #needed by abiword.
+yes|atk|libatk1.0-0,libatk1.0-dev|exe,dev,doc,nls||deps:yes
+yes|at-spi2-atk|libatspi2.0-0,libatk-bridge2.0-0,libatk-bridge2.0-dev,libatspi2.0-dev|exe,dev,doc,nls||deps:yes #needed by gtk+3.
+yes|attr|libattr1|exe,dev,doc,nls||deps:yes
+no|audiofile|libaudiofile1,libaudiofile-dev|exe,dev,doc,nls
+yes|audit|libaudit1|exe,dev,doc,nls||deps:yes #needed by xorg.
+yes|autoconf|autoconf|exe>dev,dev,doc,nls||deps:yes
+yes|automake|automake,autotools-dev|exe>dev,dev,doc,nls||deps:yes
+yes|autopoint|autopoint|exe>dev,dev,doc,nls||deps:yes
+no|avahi|avahi-daemon,libavahi-core7,libavahi-client3,libavahi-client-dev,libavahi-glib1,libavahi-glib-dev,libavahi-common3,libavahi-common-data,libavahi-common-dev,libavahi-compat-libdnssd1,libavahi-compat-libdnssd-dev|exe,dev,doc,nls #avahi-daemon and libavahi-core7 are required to prevent gdbus error messages when opening print dialogs
+no|axel|axel|exe,dev>null,doc,nls
+yes|base-files|base-files|exe>null,dev>null,doc>null,nls>null
+yes|bash|bash|exe,dev,doc,nls||deps:yes
+yes|bash-completion|bash-completion|exe,dev>null,doc,nls||deps:yes
+yes|bbe|bbe|exe,dev,doc,nls||deps:yes #sed-like editor for binary files.
+yes|bc|bc|exe,dev,doc,nls||deps:yes
+no|bcrypt|bcrypt|exe,dev,doc,nls
+yes|bdb|libdb5.3|exe,dev,doc,nls||deps:yes
+no|bin86|bin86|exe>dev,dev,doc,nls
+yes|binutils|binutils|exe>dev,dev,doc,nls||deps:yes
+yes|bison|bison|exe>dev,dev,doc,nls||deps:yes
+yes|blueman|blueman|exe,dev,doc,nls||deps:yes
+yes|bluez|bluez,bluez-obexd|exe,dev,doc,nls||deps:yes
+no|boehm-gc|libgc1,libgc-dev|exe,dev,doc,nls||deps:yes
+no|busybox||exe
+yes|bzip2|bzip2,libbz2-1.0|exe,dev,doc,nls||deps:yes
+yes|brightnessctl|brightnessctl|exe,dev,doc,nls||deps:yes
+yes|ca-certificates|ca-certificates|exe,dev,doc,nls||deps:yes
+yes|cairo|libcairo2,libcairo2-dev,libcairo-gobject2,libcairo-gobject2,libcairo-script-interpreter2|exe,dev,doc,nls||deps:yes
+yes|ccache|ccache|exe>dev,dev,doc,nls||deps:yes
+no|cdparanoia|cdparanoia,libcdparanoia0,libcdparanoia-dev|exe,dev,doc,nls
+yes|cgpt|cgpt|exe>dev,dev,doc,nls||deps:yes
+no|cifs-utils|cifs-utils|exe,dev,doc,nls
+yes|connman|connman|exe,dev,doc,nls||deps:yes
+no|copy-fast||exe,doc,nls
+yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
+yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc,nls||deps:yes
+no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
+yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
+yes|crda|crda,wireless-regdb|exe,dev,doc,nls||deps:yes
+no|ctorrent|ctorrent|exe,dev>null,doc,nls
+no|cryptsetup||exe # must use wce static binary
+no|cups|cups-bsd,cups,cups-common,cups-core-drivers,cups-server-common,cups-client,cups-ppdc,libcups2,libcups2-dev,libcupsimage2,libcupsimage2-dev,cups-daemon|exe,dev,doc,nls
+no|cups-filters|cups-filters,cups-filters-core-drivers,libcupsfilters1,libcupsfilters-dev,libfontembed1,libfontembed-dev|exe,dev,doc,nls #extra cups filters, especially pdftops.
+yes|curl|curl,libcurl4,libcurl4-openssl-dev|exe,dev,doc,nls||deps:yes
+no|cvs|cvs|exe>dev,dev,doc,nls
+yes|cyrus-sasl2|libsasl2-2|exe,dev,doc,nls||deps:yes
+yes|dash|dash|exe>dev,dev,doc,nls||deps:yes
+yes|dbus|dbus,dbus-x11,libdbus-1-3,libdbus-1-dev,libapparmor1|exe,dev,doc,nls||deps:yes
+yes|dbus-glib|libdbus-glib-1-2|exe,dev,doc,nls||deps:yes
+yes|dbus-user-session|dbus-user-session|exe>null,dev>null,doc>null,nls>null
+yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1|exe,dev,doc,nls||deps:yes #needed by gsettings-desktop-settings
+#yes|deadbeef|deadbeef,deadbeef-waveform-seekbar,deadbeef-vu-meter,deadbeef-spectrogram,deadbeef-rating,deadbeef-musical-spectrum,deadbeef-infobar|exe|
+yes|debconf|debconf|exe>null,dev>null,doc>null,nls>null
+yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
+yes|dejavu_fonts|fonts-dejavu-core,fonts-dejavu-extra|exe,dev,doc,nls||deps:yes
+no|desk_icon_theme_uniform||exe
+no|desk_icon_theme_neon||exe
+no|desktop-file-utils|desktop-file-utils|exe,dev,doc,nls
+no|devmapper|libdevmapper1.02.1,libdevmapper-dev,libdevmapper-event1.02.1|exe,dev,doc,nls
+yes|dhcpcd|dhcpcd5|exe,dev>null,doc,nls||deps:yes
+yes|dialog|dialog|exe,dev>null,doc,nls||deps:yes
+no|dictd||exe,dev>null,doc,nls
+no|dietlibc|dietlibc-dev|exe>dev,dev,doc,nls
+no|diffstat|diffstat|exe,dev>null,doc,nls
+yes|diffutils|diffutils|exe,dev>null,doc,nls||deps:yes
+no|directfb|lib++dfb-1.7-7,libdirectfb-*,libdirectfb-dev,libdirectfb-extra|exe,dev,doc,nls
+no|disktype||exe,dev>null,doc,nls
+yes|dmidecode|dmidecode|exe,dev>null,doc,nls||deps:yes
+yes|docbook|docbook|exe>dev,dev,doc,nls||deps:yes
+yes|dosfstools|dosfstools|exe,dev>null,doc,nls||deps:yes
+yes|dpkg-deb|dpkg|exe,dev>null,doc,nls||deps:yes
+yes|dpkg-dev|dpkg-dev|exe>null,dev>null,doc>null,nls>null
+no|dvdauthor|dvdauthor|exe,dev>null,doc,nls
+no|dvd+rwtools|dvd+rw-tools,growisofs|exe,dev>null,doc,nls
+yes|dwarves|dwarves|exe>dev,dev,doc,nls||deps:yes
+yes|e2fsprogs|e2fsprogs,libblkid-dev,comerr-dev,ss-dev,uuid-dev|exe,dev,doc,nls||deps:yes #note, strange ubuntu seems to have lost the dev component of libuuid.
+yes|efibootmgr|efibootmgr|exe,dev,doc,nls||deps:yes
+no|edid|read-edid|exe,dev>null,doc,nls
+yes|egl-wayland|libnvidia-egl-wayland1,libnvidia-egl-wayland-dev|exe,dev,doc,nls||deps:yes
+yes|eject|eject|exe,dev>null,doc,nls||deps:yes
+no|elfutils|elfutils,libasm1,libasm-dev,libdw1,libdw-dev,libelf1,libelf-dev|exe,dev,doc,nls #note, libelf is a different pkg.
+no|enchant|libenchant1c2a,libenchant-dev|exe,dev,doc,nls
+yes|ethtool|ethtool|exe,dev>null,doc,nls||deps:yes
+no|exiv2|exiv2,libexiv2-14,libexiv2-dev|exe,dev,doc,nls
+no|exfat|exfat-fuse,exfat-utils|exe,dev,doc,nls #requires fuse
+yes|expat|libexpat1,libexpat1-dev|exe,dev,doc,nls||deps:yes
+no|f2fs-tools||exe,dev
+no|faac|libfaac0|exe,dev,doc,nls
+no|faad|faad,libfaad2,libfaad-dev|exe,dev,doc,nls
+no|ffconvert||exe,dev,doc,nls
+no|ffmpeg|ffmpeg,libaom0,libaom-dev,libavcodec58,libavcodec-extra58,libavcodec-dev,libavutil56,libavdevice58,libavdevice-dev,libswresample3,libswresample-dev,libavresample4,libavresample-dev,libavfilter-extra*,libpostproc55,libpostproc-dev,libavutil-dev,libavutil-dev,libavformat58,libavformat-dev,libavdevice-dev,libavfilter7,libavfilter-dev,libbs2b0,libbs2b-dev,libcodec2-0.8.1,libcodec2-dev,libflite1,libgme0,libiec61883-0,liblilv-0-0,liblilv-dev,libjack-jackd2-0,libjack-jackd2-dev,libnorm1,libnorm-dev,libnuma1,libnuma-dev,libopenal1,libopenal-data,libopenal-dev,libshine3,libshine-dev,libsnappy1v5,libsodium23,libsodium-dev,libsoxr0,libsoxr-dev,libssh-gcrypt-4,libssh-gcrypt-dev,libswscale5,libswscale-dev,libwavpack1,libwavpack-dev,libzmq5,libsndio7.0,libsndio-dev,libsdl2-2.0-0,libsdl2-dev,libavc1394-0,libtwolame0,libmodplug1,librubberband2,libebur128-1,libass9,libass-dev,libchromaprint1,libzvbi0,libzvbi-common,libwebpmux3,libwebp6,libcrystalhd3,libjson-c3,libjson-c-dev,libspeex1,libcaca0,libopenmpt0,libmpg123-0,libpgm-5.2-0,libmysofa0,libmysofa-dev,libvidstab1.1,libvidstab-dev|exe,dev,doc,nls
+yes|file|file,libmagic1,libmagic-mgc|exe,dev,doc,nls||deps:yes
+no|file_sharing-curlftpfs-mpscan||exe
+yes|findutils|findutils|exe,dev>null,doc,nls||deps:yes
+yes|firefox-esr|firefox-esr,firefox-esr-l10n-all|exe,dev>null,doc,nls||deps:yes
+no|firmware_linux_module_b43||exe| #120919 have taken these out of woof, now pets.
+no|firmware_linux_module_b43legacy||exe
+yes|flac|libflac8|exe,dev,doc,nls||deps:yes
+yes|flex|flex|exe>dev,dev,doc,nls||deps:yes
+no|foomatic-db-engine|foomatic-db-engine|exe,dev,doc,nls
+no|foomatic-filters|foomatic-filters|exe,dev,doc,nls
+yes|fonts-liberation|fonts-liberation|exe,dev,doc,nls||deps:yes
+no|fpm2||exe,dev
+no|freeglut|freeglut3,freeglut3-dev|exe,dev,doc,nls
+no|freememapplet||exe
+yes|freetype|libfreetype6,libfreetype-dev,libfreetype6-dev|exe,dev,doc,nls||deps:yes
+yes|fribidi|libfribidi0,libfribidi-dev|exe,dev,doc,nls||deps:yes
+no|fuse|fuse,libfuse2,libfuse-dev|exe,dev,doc,nls||deps:yes
+no|gadmin-rsync|gadmin-rsync|exe,dev>null,doc,nls
+no|gail|libgail18,libgail-common,libgail-dev|exe,dev,doc,nls
+yes|galculator|galculator|exe,dev>null,doc,nls||deps:yes
+no|gamin|gamin,libgamin0,libgamin-dev|exe,dev,doc,nls
+yes|gawk|gawk|exe,dev>null,doc,nls||deps:yes
+yes|gcc_dev|gcc,g++,cpp|exe>dev,dev,doc,nls||deps:yes #cloog-isl removed
+yes|gcc_lib|libatomic1,libcc1-0,libgcc-s1,libgomp1,libisl23,libitm1,libquadmath0|exe,dev,doc,nls||deps:yes #libcloog-isl4 and libisl15 removed for Bullseye
+no|gconf|gconf2-common,gconf2,libgconf-2-4,libgconf2-dev,libgconf-2-4,gconf-service|exe,dev,doc,nls||deps:yes
+yes|gdb|gdb,libboost-regex1.74.0|exe>dev,dev,doc,nls||deps:yes
+yes|gdbm|libgdbm6|exe,dev,doc,nls||deps:yes
+yes|gdk-pixbuf|libgdk-pixbuf-2.0-0,libgdk-pixbuf2.0-common,libgdk-pixbuf-2.0-dev,libgdk-pixbuf2.0-0,libgdk-pixbuf2.0-dev,libgdk-pixbuf-xlib-2.0-0,libgdk-pixbuf-xlib-2.0-dev|exe,dev,doc,nls||deps:yes
+no|gdmap|gdmap|exe,dev>null,doc,nls
+no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
+no|getflash||exe
+no|get_libreoffice||exe
+yes|gettext_devxonly|gettext-base,gettext|exe>dev,dev,doc,nls||deps:yes
+yes|gettext|gettext-base,gettext|exe,dev>null,doc,nls||deps:yes
+no|gexec|gexec|exe,dev>null,doc,nls
+no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
+no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls
+no|gifsicle|gifsicle|exe,dev>null,doc,nls
+yes|git|git|exe>dev,dev,doc,nls||deps:yes
+no|glade2|glade,libgladeui-2-6,libgladeui-common,libgladeui-dev|exe>dev,dev,doc,nls
+yes|glib|libglib2.0-bin,libglib2.0-0,libglib2.0-data,libglib2.0-dev,libglib2.0-dev-bin|exe,dev,doc,nls||deps:yes
+no|glibc32|libc6-i386|exe,dev,doc,nls
+yes|glibc|libc-bin,libc6,libc6-dev,tzdata|exe,dev,doc,nls||deps:yes
+yes|glibc_locales|locales|exe,dev,doc,nls>exe||deps:yes
+yes|glibc_l10n|libc-l10n|exe,dev,doc,nls||deps:yes
+no|gmeasures||exe,dev>null,doc,nls
+yes|gmp|libgmp10,libgmpxx4ldbl,libgmp-dev|exe,dev,doc,nls||deps:yes #in precise, this was only in devx, but abiword needs it.
+no|gnome-doc-utils|gnome-doc-utils|exe>dev,dev,doc,nls|+python-libxml2
+yes|gnome-icon-theme|gnome-icon-theme|exe>null,dev>null,doc>null,nls>null
+no|gnome-keyring|gnome-keyring|exe,dev,doc,nls
+no|gnome-menus||exe,dev #use my pet, version 2.14.3, needed by xdg_puppy.
+no|gnome-mplayer||exe #needs libgmlib1
+no|gnome-vfs|libgnomevfs2-0,libgnomevfs2-dev,libgnomevfs2-common|exe,dev,doc,nls
+yes|gnu-efi|gnu-efi|exe>dev,dev,doc,nls||deps:yes
+no|gnumeric||exe,dev,doc,nls
+yes|gnutls|libgnutls30,libgnutls28-dev|exe,dev,doc,nls||deps:yes
+no|goffice||exe,dev,doc,nls
+no|gpart|gpart|exe,dev>null,doc,nls #gparted
+no|gparted|gparted,libglibmm-2.4-1v5,libglibmm-2.4-dev,libatkmm-1.6-1v5,libatkmm-1.6-dev,libcairomm-1.0-1v5,libcairomm-1.0-dev,libpangomm-1.4-1v5,libpangomm-1.4-dev,libgtkmm-2.4-1v5,libgtkmm-2.4-dev|exe,dev,doc,nls
+yes|gperf|gperf|exe>dev,dev>null,doc,nls||deps:yes
+no|gphoto2|gphoto2|exe,dev>null,doc,nls
+no|gphotofs|gphotofs|exe,dev>null,doc,nls
+no|gpm|libgpm2|exe,dev>null,doc,nls #needed by mplayer, gphoto2.
+no|gpptp||exe,dev>null,doc,nls
+no|gptfdisk||exe,doc,dev,nls
+yes|graphite2|libgraphite2-3,libgraphite2-dev|exe,dev,doc,nls||deps:yes #needed by harfbuzz.
+yes|grep|grep|exe,dev>null,doc,nls||deps:yes
+yes|groff|groff|exe>dev,dev,doc,nls||deps:yes
+no|grsync||exe,dev,doc,nls
+no|grub2_efi||exe
+no|grub4dos||exe,dev>null,doc,nls
+no|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev #needs d-conf.
+no|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
+no|gstreamer1|libgstreamer1.0-0,libgstreamer-plugins-base1.0-0|exe,dev,doc,nls
+yes|gtk+|libgtk2.0-0,libgtk2.0-dev|exe,dev,doc,nls||deps:yes
+yes|gtk2-engines-pixbuf|gtk2-engines-pixbuf|exe,dev,doc,nls||deps:yes
+yes|gtk+3|libgtk-3-0,libgtk-3-dev,libgtk-3-common,gtk-update-icon-cache,adwaita-icon-theme|exe,dev,doc,nls||deps:yes #have taken out all gtk3 apps. 140127 still have gnome-mplayer --no
+no|gtkam|gtkam|exe,dev>null,doc,nls
+no|gtk-chtheme|gtk-chtheme|exe,dev>null,doc,nls
+no|gtkdialog||exe,dev,doc>dev,nls
+no|gtkhash||exe,dev
+no|gtklp|gtklp|exe,dev,doc,nls
+no|gtk_theme_stark||exe
+no|gtk_theme_flatbluecontrast||exe
+no|gtk_theme_flat_grey_rounded||exe
+no|gtk_theme_gradient_grey||exe
+no|gtk_theme_polished_blue||exe
+no|gtk_theme_stark-blueish||exe
+no|gtksourceview|libgtksourceview2.0-0,libgtksourceview2.0-common,libgtksourceview2.0-dev|exe,dev,doc,nls
+no|gtkspell|libgtkspell0,libgtkspell-dev|exe,dev,doc,nls
+no|gutenprint|printer-driver-gutenprint,libgutenprint9,libgutenprint-dev,libgutenprintui2-2,libgutenprintui2-dev,printer-driver-gutenprint|exe,dev,doc,nls
+no|gview||exe,dev,dev>null,doc,nls
+no|gwhere||exe,dev,dev>null,doc,nls
+no|gxmessage||exe #use my pet, as has xmessage symlink to gxmessage.
+no|gzip|gzip|exe,dev>null,doc,nls||deps:yes
+no|hardinfo|hardinfo|exe,dev #our pet is patched to recognise puppy linux distro.
+yes|harfbuzz|libharfbuzz0b,libharfbuzz-dev|exe,dev,doc,nls||deps:yes
+yes|hdparm|hdparm|exe,dev>null,doc,nls||deps:yes
+no|heimdal|heimdal-dev,heimdal-multidev,libasn1-8-heimdal,libsl0-heimdal,libgssapi3-heimdal,libhcrypto4-heimdal,libhdb9-heimdal,libheimbase1-heimdal,libhx509-5-heimdal,libkadm5clnt7-heimdal,libkadm5srv8-heimdal,libkafs0-heimdal,libkdc2-heimdal,libkrb5-26-heimdal,libwind0-heimdal,libroken18-heimdal,libheimntlm0-heimdal|exe,dev,doc,nls||deps:yes #all this crap needed by cupsd.
+no|helpsurfer||exe| #simple html viewer, needs libgtkhtml.
+no|hexchat|hexchat,libproxy1v5|exe,dev,doc,nls
+yes|hicolor-icon-theme|hicolor-icon-theme|exe,dev>null,doc,nls||deps:yes
+no|htop|htop|exe,dev>null,doc,nls
+no|hunspell|hunspell,libhunspell-*,libhunspell-dev|exe,dev,doc,nls
+no|hunspell-en-us|hunspell-en-us|exe,dev,doc,nls
+no|icedtea-netx|icedtea-netx,default-jre,default-jre-headless,librhino-java,libtagsoup-java|exe,dev,doc,nls #java jnlp, needs openjdk-*-jre
+yes|icu|libicu67,libicu-dev|exe,dev,doc,nls||deps:yes #scribus needs this though it is not listed as a dep. note, it is big, 7MB pkg. crap, better put it into main f.s. NO have manually put this dep into main db. harfbuzz needs icu also.
+no|id3lib|libid3-3.8.3v5,libid3-3.8.3-dev|exe,dev,doc,nls
+no|ijs|libijs-0.35,libijs-dev|exe,dev,doc,nls
+yes|imake|xutils-dev|exe>dev,dev,doc,nls||deps:yes
+yes|initscripts|initscripts|exe,dev,doc,nls||deps:yes
+yes|init-system-helpers|init-system-helpers|exe>null,dev>null,doc,nls||deps:yes #to prevent it from being installed as dependency..
+no|inkscapelite||exe,dev,doc,nls
+no|inotify-tools|inotify-tools,libinotifytools0|exe,dev,doc,nls
+yes|installwatch|checkinstall|exe>dev,dev,doc,nls||deps:yes
+yes|intltool|intltool|exe>dev,dev,doc,nls||deps:yes #previously only in devx, but need in main f.s. to run momanager without devx.
+yes|iptables|iptables,libip4tc2,libip6tc2,libxtables12,libnftnl11|exe,dev,doc,nls||deps:yes
+no|iso-codes|iso-codes|exe,dev,doc,nls #needed by gstreamer. very big. GSTREAMER1.0 GSTREAMER0.10
+no|isomaster|isomaster|exe,dev,doc,nls
+yes|iw|iw|exe,dev,doc,nls||deps:yes
+no|jbig2dec|libjbig2dec0,libjbig2dec0-dev|exe,dev,doc,nls||deps:yes #needed by ghostscript.
+yes|jbigkit|libjbig0|exe,dev,doc,nls||deps:yes #needed by libtiff5.
+no|jwm|jwm|exe,dev,doc,nls
+yes|jq|jq,libjq1|exe,dev,doc,nls||deps:yes
+no|JWMDesk||exe,dev,doc,nls
+yes|keyutils|libkeyutils1|exe,dev>null,doc,nls||deps:yes
+yes|kmod|kmod,libkmod2,libkmod-dev|exe,dev,doc,nls||deps:yes #er, no, looks like compiled without gzip support --but i think only need that in initrd, where already have old modprobe.
+yes|krb5|libkrb5-3,libkrb5support0,libk5crypto3,libgssapi-krb5-2|exe,dev,doc,nls||deps:yes
+no|lame|lame,libmp3lame0,libmp3lame-dev|exe,dev,doc,nls
+no|lcms|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc,nls
+no|lcms2|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc,nls
+#yes|leafpad|leafpad|exe,dev>null,doc,nls
+yes|less|less|exe,dev>null,doc,nls||deps:yes
+no|libaacs|libaacs0,libaacs-dev|exe,dev,doc,nls #mplayer needs this.
+no|libao|libao4,libao-common,libao-dev|exe,dev,doc,nls||deps:yes
+yes|libavcodec|libavcodec58,libavcodec-extra58|exe,dev,doc,nls||deps:yes
+no|libappindicator|libappindicator3-1,libappindicator3-dev,libindicator3-7,libindicator3-dev|exe,dev,doc,nls #needs gtk3, needed by transmission. no, using my pet.
+yes|libarchive|libarchive13|exe>dev,dev,doc,nls||deps:yes #needed by cmake.
+no|libart|libart-2.0-2,libart-2.0-dev|exe,dev,doc,nls
+yes|libasyncns|libasyncns0|exe,dev,doc,nls||deps:yes #needed by mplayer.
+no|libayatana|libayatana-appindicator3-1,libayatana-indicator3-7,libayatana-indicator7,libayatana-appindicator3-dev,libayatana-ido3-0.4-0,libayatana-ido3-dev|exe,dev,doc,nls
+no|libb2-1|libb2-1,libb2-dev|exe,dev,doc,nls>nul
+no|libbluray|libbluray2,libbluray-dev|exe,dev,doc,nls #needed by mplayer.
+no|libbonobo|libbonobo2-0,libbonobo2-dev,libbonoboui2-0,libbonoboui2-dev|exe,dev,doc,nls
+no|libboost-filesystem|libboost-filesystem1.67.0,libboost-filesystem1.67-dev|exe,dev,doc,nls
+no|libboost-system|libboost-system1.67.0,libboost-system1.67-dev|exe,dev,doc,nls
+yes|libbsd|libbsd0|exe,dev,doc,nls||deps:yes #needed by libedit.
+yes|libcanberra-pulseonly|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev,libcanberra-pulse|exe,dev,doc,nls||deps:yes #libbonobui needs this.
+yes|libcap|libcap2|exe,dev,doc,nls||deps:yes
+yes|libcap-ng|libcap-ng0|exe,dev,doc,nls||deps:yes
+no|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls #debian/ubuntu pkg missing cddb_query, also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.
+no|libcdio|libcdio18,libcdio-dev,libcdio-cdda2,libcdio-cdda-dev,libcdio-paranoia2,libcdio-paranoia-dev,libcdio-utils,libiso9660-*,libiso9660-dev,libudf0,libudf-dev|exe,dev,doc,nls #not compatible with my libcddb pet, use my pet. 120907 yes.
+no|libcdk5|libcdk5nc6,libcdk5-dev|exe,dev,doc,nls
+no|libcroco|libcroco3,libcroco3-dev|exe,dev,doc,nls
+yes|libbrotli|libbrotli1,libbrotli-dev|exe,dev,doc,nls||deps:yes
+yes|libcrypt|libcrypt1,libcrypt-dev|exe,dev,doc,nls||deps:yes
+yes|libcurl3-gnutls|libcurl3-gnutls|exe,dev,doc,nls||deps:yes #this is needed by git in the devx sfs file. update: conky needs it in the main f.s.
+no|libdaemon|libdaemon0,libdaemon-dev|exe,dev,doc,nls||deps:yes
+yes|libdatrie|libdatrie1,libdatrie-dev|exe,dev,doc,nls||deps:yes
+yes|libdb|libdb5.3,libdb5.3-dev|exe>dev,dev,doc,nls||deps:yes
+no|libdbusmenu|libdbusmenu-gtk3-4,libdbusmenu-glib4|exe,dev,doc,nls #needed by libappindicator. left off dev debs.
+no|libdc1394|libdc1394-22,libdc1394-22-dev|exe,dev,doc,nls #ffmpeg3 compiled in luci needs this
+no|libdca|libdca0,libdca-dev|exe,dev,doc,nls #mplayer needs this.
+yes|libdeflate|libdeflate0|exe,dev,doc,nls||deps:yes
+no|libdmx|libdmx1,libdmx-dev|exe,dev,doc,nls||deps:yes #this is actaully part of xorg.
+no|libdvdcss||exe,dev,doc,nls
+no|libdvdnav|libdvdnav4|exe,dev,doc,nls #needed by mplayer.
+no|libdvdread|libdvdread4,libdvdread-dev|exe,dev,doc,nls
+yes|libedit|libedit2|exe,dev,doc,nls||deps:yes
+yes|libelf|libelf1,libelf-dev|exe,dev,doc,nls||deps:yes
+no|libenca|libenca0,libenca-dev|exe,dev,doc,nls
+yes|liberror-perl|liberror-perl|exe>dev,dev,doc,nls||deps:yes #needed by git.
+yes|libevdev|libevdev2,libevdev-dev|exe,dev,doc,nls||deps:yes
+yes|libevent|libevent-2.1-7,libevent-dev|exe,dev,doc,nls||deps:yes #needed by transmission.
+no|libexif|libexif12,libexif-dev|exe,dev,doc,nls
+no|libexif-gtk|libexif-gtk5,libexif-gtk-dev|exe,dev,doc,nls
+no|libf2fs|libf2fs5,libf2fs-dev|exe,dev,doc,nls
+yes|libffi|libffi8,libffi-dev|exe,dev,doc,nls||deps:yes
+no|libfftw3|libfftw3-3,libfftw3-bin,libfftw3-double3,libfftw3-long3,libfftw3-single3,libfftw3-quad3,libfftw3-dev|exe,dev,doc,nls
+no|libfs|libfs6,libfs-dev|exe,dev,doc,nls #120603 mavrothal reported need this for compiling xorg drivers.
+yes|libgcrypt|libgcrypt20|exe,dev,doc,nls||deps:yes
+no|libgd2|libgd3,libgd-dev|exe,dev,doc,nls #needed by libgphoto2.
+no|libgee|libgee-0.8-2,libgee-0.8-dev|exe,dev,doc,nls
+no|libgeoip|libgeoip1,libgeoip-dev|exe,dev,doc,nls
+no|libgif|libgif7,libgif-dev|exe,dev,doc,nls
+no|libglade2|libglade2-0,libglade2-dev|exe,dev,doc,nls
+no|libglide3|libglide3,libglide3-dev|exe,dev,doc,nls
+no|libgnome|libgnome-2-0,libgnome2-dev|exe,dev,doc,nls
+no|libgnomecanvas2|libgnomecanvas2-0,libgnomecanvas2-dev|exe,dev,doc,nls
+no|libgnomeui|libgnomeui-0,libgnomeui-dev|exe,dev,doc,nls
+yes|libgpg-error|libgpg-error0|exe,dev,doc,nls||deps:yes
+no|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc,nls
+no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
+no|libgsf|libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc,nls
+no|libgtkhtml||exe,dev,doc,nls #needed by my osmo pet.
+yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc,nls||deps:yes
+no|libical|libical2,libical-dev|exe,dev,doc,nls
+no|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls
+no|libidl|libidl-2-0,libidl-dev|exe,dev,doc,nls
+no|libidn|libidn11|exe,dev,doc,nls
+yes|libidn2|libidn2-0,libidn2-dev|exe,dev,doc,nls||deps:yes
+no|libieee1284|libieee1284-3|exe,dev,doc,nls
+no|libimlib|libimlib2,libimlib2-dev|exe,dev,doc,nls
+no|libindicator|libindicator7,libindicator-dev|exe,dev,doc,nls #needed by libappindicator.
+yes|libinput|libinput10,libinput-bin,libinput-dev,libwacom2,libwacom-dev|exe,dev,doc,nls||deps:yes
+no|libjack|libjack0,libjack-dev|exe,dev,doc,nls||deps:yes
+no|libjansson4|libjansson4,libjansson-dev|exe,dev,doc,nls
+yes|libjpeg62|libjpeg62-turbo,libjpeg62-turbo-dev,libjpeg-dev|exe,dev,doc,nls||deps:yes
+yes|libjson-c|libjson-c5,libjson-c-dev|exe,dev,doc,nls
+no|libjsoncpp1|libjsoncpp1,libjsoncpp-dev|exe,dev,doc,nls
+no|libjson-glib|libjson-glib-1.0-0,libjson-glib-1.0-common,libjson-glib-dev|exe,dev,doc,nls
+no|libloudmouth|libloudmouth1-0,libloudmouth1-dev|exe,dev,doc,nls
+yes|libltdl|libltdl7|exe,dev,doc,nls||deps:yes #note, this is really part of libtool pkg, but libs needed at runtime.
+no|libmad|libmad0,libmad0-dev|exe,dev,doc,nls
+no|libmcrypt|libmcrypt4,libmcrypt-dev|exe,dev,doc,nls
+yes|libmd|libmd0|exe,dev,doc,nls||deps:yes
+no|libmng|libmng1,libmng-dev|exe,dev,doc,nls
+yes|libmnl|libmnl0|exe,dev,doc,nls||deps:yes
+no|libmpcdec|libmpcdec6,libmpcdec-dev|exe,dev,doc,nls
+yes|libmpfr|libmpfr6|exe,dev,doc,nls||deps:yes
+no|libmtp||exe,dev,doc,nls #pupmtp
+yes|libnatpmp|libnatpmp1,libnatpmp-dev|exe,dev,doc,nls||deps:yes #needed by transmission.
+yes|libnfnetlink|libnfnetlink0|exe,devdoc,nls||deps:yes
+yes|libnetfilter-conntrack|libnetfilter-conntrack3|exe,dev,doc,nls||deps:yes
+yes|libnghttp2|libnghttp2-14|exe,dev,doc,nls||deps:yes #stretch: needed by curl, cmake, etc...
+yes|libnl3|libnl-3-200,libnl-genl-3-200,libnl-route-3-200|exe,dev,doc,nls||deps:yes
+no|libnotify|libnotify4,libnotify-dev|exe,dev,doc,nls
+yes|libnsl|libnsl2,libnsl-dev|exe,dev,doc,nls||deps:yes
+no|libopenjp2|libopenjp2-7,libopenjp2-7-dev|exe,dev,doc,nls
+no|libopencore|libopencore-amrnb0,libopencore-amrnb-dev,libopencore-amrwb0,libopencore-amrwb-dev|exe,dev,doc,nls #was libopencore dep for ffmpeg3 or mplayer2--can delete if mplayer2
+yes|libogg|libogg0|exe,dev,doc,nls||deps:yes
+yes|libonig|libonig5|exe,dev,doc,nls||deps:yes
+no|libpaper|libpaper1,libpaper-dev,libpaper-utils|exe,dev,doc,nls
+no|libpcap|libpcap0.8,libpcap0.8-dev|exe,dev,doc,nls||deps:yes
+yes|libpciaccess|libpciaccess0,libpciaccess-dev|exe,dev,doc,nls||deps:yes
+no|libpcsclite|libpcsclite1,libpcsclite-dev|exe,dev,doc,nls||deps:yes
+no|libpipeline|libpipeline1,libpipeline-dev|exe,dev,doc,nls| #needed by usb-modeswitch
+yes|libpng|libpng16-16,libpng-dev|exe,dev,doc,nls||deps:yes
+no|libpng12||exe,dev>null,doc,nls #from precise..
+yes|libpsl|libpsl5|exe,dev,doc,nls||deps:yes #stretch: wget dep
+yes|libpthread-stubs|libpthread-stubs0-dev|exe>dev,dev,doc,nls||deps:yes
+no|libraw1394|libraw1394-11,libraw1394-dev|exe,dev,doc,nls
+no|librest|librest-0.7-0,librest-dev|exe,dev,doc,nls
+no|librevenge|librevenge-0.0-0,librevenge-dev|exe,dev,doc,nls
+yes|librsvg|librsvg2-2,librsvg2-dev,librsvg2-bin,librsvg2-common|exe,dev,doc,nls||deps:yes #shows gtk3 as dep, but might work without.
+yes|librtmp|librtmp1|exe,dev,doc,nls||deps:yes
+yes|libsamplerate|libsamplerate0|exe,dev,doc,nls||deps:yes
+yes|libselinux|libselinux1,libselinux1-dev|exe,dev,doc,nls||deps:yes
+yes|libsepol|libsepol2,libsepol-dev|exe,dev,doc,nls||deps:yes
+no|libserd|libserd-0-0,libserd-dev|exe,dev,doc,nls
+no|libsigc++|libsigc++-2.0-0v5,libsigc++-2.0-dev|exe,dev,doc,nls
+yes|libsigsegv|libsigsegv2|exe,dev,doc,nls||deps:yes
+no|libslang|libslang2|exe,dev>null,doc,nls
+no|libsmartcols|libsmartcols1|exe,dev,doc,nls
+yes|libsndfile|libsndfile1|exe,dev,doc,nls||deps:yes
+no|libsord|libsord-0-0,libsord-dev|exe,dev,doc,nls
+no|libsoup|libsoup2.4-1,libsoup2.4-dev,libsoup-gnome2.4-1,libsoup-gnome2.4-dev|exe,dev,doc,nls
+yes|libsoxr|libsoxr0|exe,dev,doc,nls||deps:yes
+yes|libspeexdsp1|libspeexdsp1|exe,dev,doc,nls||deps:yes
+no|libsratom|libsratom-0-0,libsratom-dev|exe,dev,doc,nls
+yes|libssh2|libssh2-1|exe,dev,doc,nls||deps:yes #stretch: needed by curl, etc.
+yes|libstdc++6|libstdc++6|exe,dev,doc,nls||deps:yes
+yes|libstdc++10|libstdc++-10-dev|exe,dev,doc,nls||deps:yes
+yes|libsystemd|libsystemd0,libsystemd-dev|exe,dev,doc,nls||deps:yes
+no|libtar|libtar0,libtar-dev|exe,dev,doc,nls #needed by osmo.
+yes|libtasn1|libtasn1-6,libtasn1-6-dev|exe,dev,doc,nls||deps:yes
+no|libtext-unidecode-perl|libtext-unidecode-perl|exe>dev,dev,doc,nls||deps:yes
+yes|libthai|libthai0,libthai-data,libthai-dev|exe,dev,doc,nls||deps:yes
+no|libtheora|libtheora0,libtheora-dev|exe,dev,doc,nls
+yes|libtiff|libtiff5|exe,dev,doc,nls||deps:yes
+yes|libtool|libtool,autotools-dev|exe>dev,dev,doc,nls||deps:yes
+yes|libtirpc|libtirpc3,libtirpc-common,libtirpc-dev|exe,dev,doc,nls||deps:yes
+yes|libudev|libudev1,libudev-dev|exe,dev,doc,nls||deps:yes
+yes|libunbound|libunbound8|exe,dev,doc,nls||deps:yes
+yes|libunistring|libunistring2|exe,dev,doc,nls||deps:yes
+no|libusb|libusb-0.1-4,libusb-dev|exe,dev,doc,nls
+yes|libusb1|libusb-1.0-0|exe,dev,doc,nls||deps:yes #libusb1 necesssary for ffmpeg3
+yes|libutf8proc|libutf8proc2|exe>dev,dev,doc,nls||deps:yes
+no|libv4l|libv4l-0,libv4l-dev,libv4lconvert0|exe,dev,doc,nls
+yes|libva|libva2,libva-drm2,libva-x11-2,vainfo,va-driver-all|exe,dev,doc,nls||deps:yes #needed by mplayer.
+no|libvdpau|libvdpau1,mesa-vdpau-drivers,vdpau-va-driver,libvdpau-dev|exe,dev,doc,nls #needed by mplayer. no, this has another big dep: Failed to open VDPAU backend libvdpau_nvidia.so missing.
+yes|libvorbis|libvorbis0a,libvorbisenc2|exe,dev,doc,nls||deps:yes
+yes|libvpx|libvpx7|exe,dev,doc,nls||deps:yes #needed by mplayer.
+yes|libvulkan|libvulkan1,libvulkan-dev|exe,dev,doc,nls||deps:yes
+no|libwmf|libwmf0.2-7,libwmf-dev|exe,dev,doc,nls
+no|libwpg|libwpg-0.3-3|exe,dev>null,doc,nls
+no|libwpd|libwpd-0.10-10,libwpd-dev|exe,dev,doc,nls
+no|libxatracker2|libxatracker2,libxatracker-dev|exe,dev,doc,nls
+yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-xinput0,libxcb-xinput-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-res0,libxcb-res0-dev|exe,dev,doc,nls||deps:yes
+yes|libz3|libz3-4|exe,dev,doc,nls||deps:yes
+no|libzip|libzip4,libzip-dev|exe,dev,doc,nls
+yes|xcb-util|libxcb-util1,libxcb-util-dev|exe,dev,doc,nls||deps:yes
+no|libxdg-basedir|libxdg-basedir1,libxdg-basedir-dev|exe,dev,doc,nls
+yes|libxkbcommon|libxkbcommon0,libxkbcommon-dev,libxkbcommon-x11-0,libxkbcommon-x11-dev|exe,dev,doc,nls||deps:yes #needed by gtk+3. have taken out gtk3
+yes|libxml2|libxml2,libxml2-dev|exe,dev,doc,nls||deps:yes
+yes|libxml2-utils|libxml2-utils|exe>dev,dev,doc,nls||deps:yes
+yes|libxshmfence|libxshmfence1,libxshmfence-dev|exe,dev,doc,nls||deps:yes #xorg needs this.
+yes|libxslt|libxslt1.1|exe,dev,doc,nls||deps:yes
+no|libxvmc|libxvmc1,libxvmc-dev|exe,dev,doc,nls||deps:yes #this is actually part of xorg.
+yes|libyaml|libyaml-0-2,libyaml-dev|exe,dev,doc,nls||deps:yes
+yes|libzstd|libzstd1|exe,dev,doc,nls||deps:yes
+no|linux_firmware_dvb||exe
+yes|linux-header|linux-libc-dev|exe>dev,dev,doc,nls||deps:yes
+no|lirc|liblircclient0,liblircclient-dev|exe,dev,doc,nls
+yes|llvm|libllvm11|exe,dev||deps:yes #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
+yes|login|login|exe>null,dev>null,doc>null,nls>null
+yes|lsb-base|lsb-base|exe,dev,doc,nls||deps:yes
+no|lxrandr||exe,dev,doc,nls
+no|lxtask||exe,dev,doc,nls
+no|lxterminal||exe,dev,doc,nls
+no|lxde_apps|gpicview,lxinput|exe,dev,doc,nls
+no|gmrun||exe
+no|pcmanfm|pcmanfm,libfm4,libfm-data,libfm-extra4,libfm-gtk4,libfm-gtk-data,libmenu-cache3,libmenu-cache-bin,lxmenu-data
+no|pup-volume-monitor||exe
+yes|lzma|lzma|exe,dev,doc,nls||deps:yes
+yes|lz4|liblz4-1|exe,dev,doc,nls||deps:yes
+yes|lzo2|liblzo2-2|exe,dev,doc,nls||deps:yes
+no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
+yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
+no|madplay|madplay|exe,dev,doc,nls
+yes|make|make|exe>dev,dev,doc,nls||deps:yes
+yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
+yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,mesa-va-drivers,libglu1-mesa,libglu1-mesa-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
+yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
+no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls
+no|mhwaveedit|mhwaveedit|exe,dev>null,doc,nls
+no|miniupnpc|libminiupnpc*,libminiupnpc-dev|exe,dev,doc,nls #needed by transmission.
+no|mirdir||exe
+yes|mpclib3|libmpc3|exe>dev,dev,doc,nls||deps:yes #needed by gcc.
+no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
+yes|mpfr|libmpfr6|exe>dev,dev,doc,nls||deps:yes
+no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
+no|mpv|mpv,libguess1,libguess-dev,libuchardet0,libuchardet-dev|exe,dev,doc,nls
+no|mplayer_samba|libsmbclient,libldb1,liblmdb0,libtalloc2,libtevent0,libwbclient0,python-talloc,samba-libs|exe,dev,doc,nls
+no|ms-sys||exe
+yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls||deps:yes #needed by synaptics_drv.so in xorg.
+no|mtpaint|mtpaint|exe,dev,doc,nls
+no|mtr|mtr|exe,dev,doc,nls
+no|musl|musl,musl-dev,musl-tools|exe>dev,dev,doc,nls
+no|nano|nano|exe,dev,doc,nls
+no|nas|libaudio2,libaudio-dev|exe,dev,doc,nls #needed by mplayer, qupzilla
+yes|nasm|nasm|exe>dev,dev,doc,nls||deps:yes
+no|nbtscan|nbtscan|exe,dev
+yes|ncurses|ncurses-base,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
+no|nenscript||exe
+yes|netbase|netbase|exe>null,dev>null,doc>null,nls>null
+yes|net-tools|net-tools|exe,dev,doc,nls||deps:yes
+yes|nettle|libnettle8,nettle-dev,libhogweed6|exe,dev,doc,nls||deps:yes #needed by libarchive.
+no|netmon_wce||exe,dev
+no|network_roxapp_samba||exe
+yes|ninja|ninja-build|exe>dev,dev,doc,nls||deps:yes
+no|normalize|normalize-audio|exe,dev,doc,nls
+no|notecase||exe,dev,doc,nls
+no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
+yes|nscd|unscd|exe||deps:yes
+yes|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
+yes|nss|libnss3|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
+no|ntfs-3g|ntfs-3g,libntfs-*,ntfs-3g-dev|exe,dev,doc,nls #this seems to have taken over the full functionality of ntfsprogs.
+yes|ntpdate|ntpdate|exe,dev,doc,nls||deps:yes #used by psync to sync local time and date from the internet.
+no|numlockx||exe| #needed by shinobars firstrun.
+no|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc,nls #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
+no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected
+yes|openldap|libldap-2.4-2|exe,dev,doc,nls||deps:yes
+no|opensp|opensp,libosp-dev|exe>dev,dev,doc,nls|+sgml-base,+sgml-data,+xml-core
+yes|openssh-client|openssh-client|exe,dev,doc,nls||deps:yes
+yes|openssl|openssl,libssl1.1,libssl-dev|exe,dev,doc,nls||deps:yes #libssl1.0.2 = older libssl
+no|optipng|optipng|exe>dev,dev,doc,nls
+yes|opus|libopus0|exe,dev,doc,nls||deps:yes #needed by ffmpeg
+no|orbit2|liborbit2,liborbit-2-0,liborbit2-dev|exe,dev,doc,nls
+yes|orc|liborc-0.4-0|exe,dev,doc,nls||deps:yes #needed by mplayer.
+#yes|osmo||exe,dev,doc,nls
+no|ots|libots0,libots-dev|exe,dev,doc,nls
+no|p7zip-full|p7zip-full|exe,dev,doc,nls
+yes|p11-kit|libp11-kit0,libp11-kit-dev|exe,dev,doc,nls||deps:yes #needed by cupsd (ubuntu cups pkg). 121210 need dev pkg for gnutls, refer forum t=82092&start=135
+no|PackIt||exe,dev
+yes|pam|libpam0g|exe,dev,doc,nls||deps:yes
+yes|pango|libpango-1.0-0,libpango1.0-dev,libpangoft2-1.0-0,libpangocairo-1.0-0,libpangoxft-1.0-0,gir1.2-pango-1.0|exe,dev,doc,nls||deps:yes
+yes|parted|parted|exe,dev,doc,nls||deps:yes
+yes|passwd|passwd|exe>null,dev>null,doc>null,nls>null
+yes|patch|patch|exe>dev,dev,doc,nls||deps:yes
+yes|patchelf|patchelf|exe>dev,dev,doc,nls||deps:yes
+yes|patchutils|patchutils|exe>dev,dev,doc,nls||deps:yes
+yes|pavucontrol|pavucontrol|exe,dev,doc,nls||deps:yes
+no|pbackup||exe
+yes|pciutils|pciutils,libpci3|exe,dev,doc,nls||deps:yes
+no|pcmciautils|pcmciautils|exe,dev,doc,nls
+yes|pcre|libpcre2-8-0,libpcre2-dev,libpcre3,libpcre3-dev,libpcre16-3,libpcrecpp0v5|exe,dev,doc,nls||deps:yes
+no|pdiag||exe| #diagnostic tool created by rerwin.
+no|pdvdrsab||exe
+no|peasydisc||exe
+no|peasyglue||exe,dev
+no|peasypdf||exe,dev
+no|peasyport||exe| #rcrsn51, alternative to superscan.
+no|peasyprint||exe,dev
+no|peasyscale||exe #rcrsn51, jpg image resizer.
+no|peasyscan_pdf_plugin||exe,dev
+yes|perl|perl,perl-base,perl-modules-5.32|exe>dev,dev||deps:yes
+yes|perl_tiny|perl,perl-base,perl-modules-5.32|exe,dev>null,doc,nls||deps:yes
+no|perl-compress-zlib|libcompress-raw-zlib-perl|exe>dev,dev||deps:yes
+no|perl-digest-sha1|libdigest-sha-perl|exe,dev||deps:yes
+no|perl-extutils-depends|libextutils-depends-perl|exe>dev,dev||deps:yes
+no|perl-extutils-pkgconfig|libextutils-pkgconfig-perl|exe>dev,dev||deps:yes
+no|perl-html-parser|libhtml-parser-perl|exe,dev||deps:yes
+no|perl-uri|liburi-perl|exe>dev,dev||deps:yes
+no|perl-xml-parser|libxml-parser-perl|exe>dev,dev||deps:yes
+no|perl-xml-simple|libxml-simple-perl|exe>dev,dev||deps:yes
+no|picocom|picocom|exe,dev
+yes|pigz|pigz|exe,dev,doc,nls||deps:yes
+yes|pixman|libpixman-1-0,libpixman-1-dev|exe,dev||deps:yes
+yes|pkgconfig|pkg-config|exe>dev,dev||deps:yes
+no|pmirrorget||exe
+no|pnethood||exe| #using network_roxapp and YASSM instead. leave it in, some users want it.
+no|pnscan||exe,dev,doc,nls #peasyport
+no|poppler|libpoppler102,libpoppler-dev,poppler-utils,libpoppler-glib8,libpoppler-glib-dev|exe,dev
+yes|popt|libpopt0|exe>dev,dev||deps:yes
+no|powerapplet_tray||exe
+no|ppp|ppp|exe,dev>null
+no|pptp|pptp-linux|exe,dev,doc,nls
+yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
+yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
+yes|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
+no|psynclient||exe
+no|pupmixer||exe
+no|Pup-Kview||exe
+no|Pup-SysInfo||exe
+no|puppy_icon_theme||exe #gtk theme
+no|puppy-podcast-grabber||exe
+no|pure-ftpd||exe
+no|pwsget||exe
+yes|python|python3,python3-minimal,python3.9-minimal,python3.9,libpython3.9,libpython3.9-stdlib,libpython3.9-minimal,python3-setuptools,python3-wheel,python3-pkg-resources,python3-distutils,python3-lib2to3|exe,dev,doc,nls||deps:yes
+yes|python3-pip|python3-pip|exe>dev,dev,doc,nls||deps:yes
+yes|python3-venv|python3-venv|exe>dev,dev,doc,nls||deps:yes
+no|python-libxml2|python2-libxml2|exe,dev,doc,nls #121022 moved from devx to main f.s.
+no|python-dev|libpython3-dev,libpython3.9-dev,python3-dev,python3.9-dev|exe,dev,doc,nls||deps:yes
+no|qpdf|libqpdf21,libqpdf-dev|exe,dev,doc,nls #needed by cups.
+no|qemu||exe>dev
+no|qtweb||exe
+no|radeon_firmware||exe,dev
+no|raptor2|libraptor2-0,libraptor2-dev|exe,dev,doc,nls #needed by redland.
+yes|readline|libreadline8,libreadline-dev,readline-common|exe,dev,doc,nls||deps:yes
+no|redland|librdf0,librasqal3|exe,dev,doc,nls #needed by abiword. left out -dev libs.
+no|redshift|redshift|exe,dev,doc,nls
+no|retrovol||exe
+yes|rman|rman|exe>dev,dev,doc,nls||deps:yes
+no|rox-filer||exe
+yes|rsync|rsync|exe>dev,dev||deps:yes
+no|rtmpdump|rtmpdump,librtmp1,librtmp-dev,flvstreamer|exe,dev,doc,nls
+no|rxvt-unicode||exe,dev>null,doc,nls
+no|sane-backends||exe,dev,doc,nls
+no|scale2x||exe
+no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc,nls
+yes|scdoc|scdoc|exe>dev,dev,doc,nls||deps:yes
+yes|sed|sed|exe,dev>null,doc,nls||deps:yes
+yes|sensible-utils|sensible-utils|exe>null,dev>null,doc>null,nls>null
+yes|serf|libserf-1-1|exe>dev,dev,doc,nls||deps:yes #needed by svn.
+no|setserial|setserial|exe,dev>null,doc,nls
+yes|sgml-base|sgml-base|exe>dev,dev,doc,nls||deps:yes
+yes|sgml-data|sgml-data|exe>dev,dev,doc,nls||deps:yes
+yes|shared-mime-info|shared-mime-info|exe,dev,doc,nls||deps:yes
+no|simple-mtpfs||exe,dev,doc,nls #pupmtp
+yes|sqlite|libsqlite3-0|exe,dev,doc,nls||deps:yes
+yes|squashfs-tools|squashfs-tools|exe,dev,doc,nls||deps:yes
+no|ssh_gui||exe
+no|startup-notification|libstartup-notification0,libstartup-notification0-dev|exe,dev,doc,nls
+yes|strace|strace|exe>dev,dev,doc,nls||deps:yes
+no|streamripper|streamripper|exe,dev
+yes|subversion|subversion,libsvn1,libdb5.3,libaprutil1,libapr1|exe>dev,dev,doc,nls||deps:yes
+no|sudo||exe,dev
+yes|sysfsutils|libsysfs2,sysfsutils|exe,dev,doc,nls||deps:yes
+yes|syslinux|syslinux,syslinux-common,syslinux-utils,syslinux-efi,extlinux,isolinux|exe,dev,doc,nls||deps:yes
+yes|sysv-rc|sysv-rc|exe>null,dev>null,doc>null,nls>null
+no|taglib|libtag1v5,libtag1-dev,libtag1v5-vanilla|exe,dev,doc,nls #needed by lots of media apps.
+yes|tar|tar|exe,dev>null,doc,nls||deps:yes
+no|tas||exe,nls
+no|tbb|libtbb2|exe,dev>null,doc,nls #needed by libopencv-core. have left off the dev.
+yes|tcp-wrappers|libwrap0|exe,dev,doc,nls||deps:yes #needed by mplayer, skype
+yes|tdb|libtdb1|exe,dev,doc,nls||deps:yes #needed by mplayer and libcanberra.
+no|telepathy-glib|libtelepathy-glib0|exe,dev,doc,nls #needed by abiword. left out -dev lib.
+yes|texinfo|texinfo|exe>dev,dev,doc,nls||deps:yes
+no|tidy|libtidy5deb1,libtidy-dev|exe,dev,doc,nls #needed by abiword.
+yes|time|time|exe,dev>null,doc,nls||deps:yes
+no|transmission|transmission-gtk,transmission-common|exe,dev,doc,nls
+no|tree|tree|exe,dev,doc,nls
+yes|udev|udev|exe,dev,doc,nls||deps:yes
+no|eudev||exe,dev #pet pkg: replaces udev and libudev
+no|uget|uget,aria2,libc-ares2,libc-ares-dev,libaria2,libaria2-0,libaria2-0-dev|exe,dev,doc,nls
+yes|unclutter|unclutter|exe,dev>null,doc,nls||deps:yes
+yes|unzip|unzip|exe,dev>null,doc,nls||deps:yes
+no|UrxvtControl||exe,dev
+no|usb-modeswitch|usb-modeswitch,libjim0.76|exe,dev,doc,nls
+no|usb-modeswitch||exe,dev,doc,nls
+no|usb-modeswitch-data||exe,dev,doc,nls
+yes|usbutils|usbutils|exe,dev,doc,nls||deps:yes
+yes|util-linux|util-linux,mount,libuuid1,libblkid1,libmount1,libsmartcols1,uuid-dev|exe,dev,doc,nls||deps:yes
+no|uextract||exe,dev
+no|vala|valac,libvala-*|exe>dev,dev,doc>dev,nls
+no|vamps|vamps|exe,dev,doc,nls
+no|vobcopy|vobcopy|exe,dev,doc,nls
+no|vorbis-tools|vorbis-tools|exe,dev,doc,nls
+yes|vboot-kernel-utils|vboot-kernel-utils|exe->dev,dev,doc,nls||deps:yes
+yes|vte|libvte-2.91-0,libvte-2.91-common,libvte-2.91-dev|exe,dev,doc,nls||deps:yes
+yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0,libwayland-dev,wayland-protocols,libwayland-bin|exe,dev,doc,nls||deps:yes
+no|wcpufreq||exe,dev| #using this instead of cpu-scaling-ondemand.
+yes|wget|wget|exe,dev>null,doc,nls||deps:yes
+yes|wireless-tools|wireless-tools,libiw30,libiw-dev|exe,dev,doc,nls||deps:yes
+no|wmctrl|wmctrl|exe,dev,doc,nls
+yes|wpa_supplicant|wpasupplicant|exe,dev>null,doc,nls||deps:yes
+no|wv|wv,libwv-1.2-4,libwv-dev|exe,dev,doc,nls
+no|wvdial|wvdial,libuniconf4.6,libwvstreams4.6-base,libwvstreams4.6-extras,libwvstreams-dev|exe
+yes|x11proto|x11proto-dev|exe>dev,dev,doc,nls||deps:yes
+no|x264|libx264-*,libx264-dev|exe,dev,doc,nls
+no|x265|libx265-*,libx265-dev|exe,dev,doc,nls
+no|xarchive||exe
+yes|xclip|xclip|exe,dev,doc,nls||deps:yes
+no|xcur2png||exe #pcur needs this
+no|xdelta||exe
+no|xdg-puppy-jwm||exe
+yes|xdg-utils|xdg-utils|exe,dev,doc,nls||deps:yes
+yes|xdotool|xdotool,libxdo3|exe,dev,doc,nls||deps:yes
+no|Xdialog||exe
+no|xfdiff-cut||exe
+no|xlock_gui||exe
+no|xlockmore||exe
+yes|xml-core|xml-core|exe>dev,dev,doc,nls||deps:yes
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,xfonts-utils,mesa-common-dev,libgl1,libgl1-mesa-dri,x11-xkb-utils,x11-xserver-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libglvnd-dev,libglu1-mesa,libglu1-mesa-dev,libice6,libice-dev,libsm6,libsm-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libx11-data,libxau6,libxau-dev,libxaw7,libxcomposite1,libxcomposite-dev,libxcursor1,libxcursor-dev,libxdamage1,libxdamage-dev,libxdmcp6,libxdmcp-dev,libxext6,libxext-dev,libxfixes3,libxfixes-dev,libxfont2,libxfont-dev,libxft2,libxft-dev,libxi6,libxi-dev,libxinerama1,libxkbfile1,libxkbfile-dev,libxmu6,libxmu-dev,libxmuu1,libxpm4,libxpm-dev,libxrandr2,libxrandr-dev,libxrender1,libxrender-dev,libxt6,libxt-dev,libxtst6,libxtst-dev,libxv1,libxxf86dga1,libxxf86vm1,xkb-data,xinput,xbitmaps,xauth,x11-common|exe,dev,doc,nls||deps:yes
+yes|xorg_dri|libgl1-mesa-dri,mesa-utils,libglew2.2,libsensors5|exe,dev,doc,nls||deps:yes
+yes|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xserver-xorg-input-wacom,xserver-xorg-video-intel,xserver-xorg-video-qxl,xinit|exe,dev,doc,nls||deps:yes
+no|xsane||exe
+no|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xinit|exe,dev,doc,nls||deps:yes
+yes|xsltproc|xsltproc|exe>dev,dev,doc,nls||deps:yes
+no|xsoldier|xsoldier|exe,dev>null,doc,nls
+yes|xtrans|xtrans-dev|exe>dev,dev,doc,nls||deps:yes
+no|xvidcore|libxvidcore4,libxvidcore-dev|exe,dev,doc,nls
+yes|xwayland|xwayland|exe>null,dev>null,doc>null,nls>null # fake install, using petbuild
+yes|xz|xz-utils,liblzma5,liblzma-dev|exe,dev,doc,nls||deps:yes
+no|yad||exe
+no|yajl|libyajl2,libyajl-dev|exe,dev,doc,nls #needed by raptor2.
+no|yasm|yasm|exe>dev,dev>null,doc,nls
+no|YASSM||exe,dev>null,doc,nls
+yes|zip|zip|exe,dev>null,doc,nls||deps:yes
+yes|zlib|zlib1g,zlib1g-dev|exe,dev,doc,nls||deps:yes
+yes|zstd|zstd|exe,dev,doc,nls||deps:yes
+no|zzznet||exe
+'

--- a/woof-distro/x86_64/debian/sid64/DISTRO_SPECS
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_SPECS
@@ -1,0 +1,18 @@
+#One or more words that identify this distribution:
+DISTRO_NAME='Vanilla Dpup'
+#version number of this distribution:
+DISTRO_VERSION=9.9.0
+#The distro whose binary packages were used to build this distribution:
+DISTRO_BINARY_COMPAT='debian'
+#Prefix for some filenames: exs: sidsave.2fs, sid-8.0.sfs
+DISTRO_FILE_PREFIX='vanilladpup'
+#The version of the distro whose binary packages were used to build this distro:
+DISTRO_COMPAT_VERSION='sid'
+#the kernel pet package used:
+DISTRO_KERNEL_PET='Huge_Kernel'
+#read by /usr/bin to bypass Xorg Wizard at first boot:
+DISTRO_XORG_AUTO='yes'
+#subname for online PETs dir. Ex: "slacko14", dir "pet_packages-slacko14", db file "Packages-puppy-slacko14-official":
+#note: prior to existence of this variable, online subname was set to $DISTRO_COMPAT_VERSION or via some hack code.
+DISTRO_DB_SUBNAME='sid'
+DISTRO_TARGETARCH='x86_64'

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -1,0 +1,139 @@
+#
+#  persistent configuration options
+#
+#  see also DISTRO_SPECS DISTRO_PET_REPOS DISTRO_COMPAT_REPOS-*
+#
+#  **NOTE**: check the original file every once in a while
+#            settings might be added or removed...
+#
+
+# 2createpackages
+STRIP_BINARIES=no
+
+## UnionFS: aufs or overlay
+UNIONFS=overlay
+
+## Kernel tarballs repo URL for choosing/downloading kernel
+KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
+
+### Kernel tarball URL - avoid being asked questions about downloading/choosing a kernel
+#KERNEL_TARBALL_URL=http://distro.ibiblio.org/puppylinux/huge_kernels/huge-5.10-kernel-kit.tar.bz2
+
+## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
+## ADRV_INC="abiword gnumeric goffice"
+ADRV_INC="firefox-esr galculator libavcodec libva geany gpicview lxtask mtpaint transmission xarchiver"
+## YDRV_INC=""
+YDRV_INC=""
+## FDRV_INC="" #this one is very experimental and it's recommended to be left unset
+FDRV_INC=""
+
+## Include kernel-kit generated FDRIVE
+## set to yes or no or leave commented to be asked the question at build time
+#KFDRIVE=no
+
+## build devx? yes/no - any other value = ask
+BUILD_DEVX=yes
+
+## include devx SFS in ISO?
+DEVX_IN_ISO=no
+
+## packages to build from source
+PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rxvt-unicode transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver connman-ui labwc xdg-puppy-labwc pcmanfm pupmoon-font yambar"
+
+## GTK+ version to use when building packages that support GTK+ 2
+PETBUILD_GTK=3
+
+## Include the windows puppy installer LICK by Luke Lorimer aka <noryb009>
+LICK_IN_ISO=yes
+
+## compression method to be used (SFS files)
+#SFSCOMP='-comp xz -Xbcj x86 -b 512K'
+#SFSCOMP='-comp xz -Xbcj arm,armthumb -b 512K'
+#SFSCOMP='-comp gzip'
+#SFSCOMP='-noI -noD -noF -noX'
+SFSCOMP='-comp zstd -Xcompression-level 19 -b 256K -no-exports -no-xattrs'
+
+## if "$WOOF_HOSTARCH" = "$WOOF_TARGETARCH"
+## This is usually not needed
+EXTRA_STRIPPING=no
+
+## -- pTheme -- applies only if ptheme pkg is being used
+##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
+## You can choose a ptheme here if you wish
+## otherwise 3builddistro will ask you to choose one
+#PTHEME="Dark Touch"
+#PTHEME="Dark Mouse"
+#PTHEME="Bright Touch"
+#PTHEME="Bright Mouse"
+#PTHEME="Dark_Blue"
+PTHEME="412"
+
+## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
+## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
+## For testing builds XERRS_FLG=yes is recommended. If the target device is low RAM suggest to leave this unset, especially for release
+#XERRS_FLG=yes
+
+## include Pkg in build (y/n). If commented then asked in 3builddistro
+INCLUDE_PKG=y
+
+## ucode.cpio initial ram disk with CPU bugfixes
+## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown
+## You can specify 'amd' or 'intel' as args to latest_microcode.sh
+## comment out to exclude bulding ucode.cpio
+#UCODE_EXEC=../support/latest_microcode.sh amd
+#UCODE_EXEC=../support/latest_microcode.sh intel
+UCODE_EXEC=../support/latest_microcode.sh
+
+## choice to build 64 bit support only for UEFI booting
+## or 64 bit and 32 bit UEFI support
+## if not set then only 64 bit support is builtin to the iso image
+## which is the default
+#UEFI_32=y
+
+## -- Default Apps --
+## Not all are implemented in the puppy scripts,
+##   but you can specify a default app if you wish...
+## If you specify a value it will override anything that previously
+##   set that value in the corresponding script...
+## These are the current default*apps (scripts) in /usr/local/bin
+DEFAULTAPPS=""
+
+## PROMPT - change the CLI prompt to whatever you like. Default is unset
+PROMPT='PS1="\w\$ "'
+
+## -- EXTRA FLAG --
+## This allows some customisation for the iso name
+## eg: slacko64-6.9.9.1-uefi-k3.16.iso
+## where XTRA_FLG='-k3.16' (the dash is a requirement)
+#XTRA_FLG=''
+
+## - extra commands --
+## Here add custom commands to be executed inside sandbox3/rootfs-complete
+EXTRA_COMMANDS="
+chroot . /usr/sbin/firewall_ng enable
+[ -d ../adrv ] && sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i ../adrv/usr/share/applications/firefox-esr.desktop || sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i usr/share/applications/firefox-esr.desktop
+[ -d ../adrv ] && touch usr/bin/firefox-esr
+chroot . /usr/sbin/setup-spot firefox-esr=true
+[ -d ../adrv ] && mv -f ../adrv/usr/bin/firefox-esr{,.bin}
+[ -d ../adrv ] && mv -f usr/bin/firefox-esr ../adrv/usr/bin/
+[ -d ../adrv ] && rm -f usr/bin/firefox-esr.bin
+[ -d ../adrv ] && touch usr/bin/transmission-gtk
+chroot . /usr/sbin/setup-spot transmission-gtk=true
+[ -d ../adrv ] && mv -f ../adrv/usr/bin/transmission-gtk{,.bin}
+[ -d ../adrv ] && mv -f usr/bin/transmission-gtk ../adrv/usr/bin/
+[ -d ../adrv ] && rm -f usr/bin/transmission-gtk.bin
+mv -f root/.spot-status root/.spot-status.orig
+chroot . /usr/sbin/setup-spot powerapplet_tray=true
+mv -f root/.spot-status.orig root/.spot-status
+./usr/sbin/pup-advert-blocker start ./etc/hosts
+mv root/Downloads home/spot/
+chroot . chown -R spot:spot /home/spot/Downloads
+ln -s ../home/spot/Downloads root/
+rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop
+for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey) ;; *) rm -vrf \"\$i\" ;; esac; done
+for i in usr/share/ptheme/globals/*; do case \"\$i\" in \"usr/share/ptheme/globals/Dark Gray\"|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412) ;; *) rm -vf \"\$i\" ;; esac; done
+rm -vf usr/share/backgrounds/*.jpg
+rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
+ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
+[ -f usr/bin/startxwayland ] && touch var/local/xwin_enable_xwayland
+"

--- a/woof-distro/x86_64/debian/sid64/_00build_2.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build_2.conf
@@ -1,0 +1,9 @@
+#
+# use defaults (_00build.conf)
+#
+# but override these settings:
+
+## Download and include custom SFS (XDRV_INC= overrides this)
+#ADRV_SFS_URL=
+#YDRV_SFS_URL=
+#FDRV_SFS_URL=


### PR DESCRIPTION
Bullseye is simply too old to fix #2611 cleanly. Some wlroots 0.15.0 changes must be reverted to allow older dependency versions (for example, https://gitlab.freedesktop.org/wlroots/wlroots/-/commit/bedfec94bb57cf7dc32f03fce463a30d3370bb20).

However, the situation is getting much worse over time, because Debian Bullseye was already "old" when it was released.

Therefore, all Wayland-related development should be much easier against a Sid base. When the Bookworm freeze starts, it should be possible to copy woof-distro/x86_64/debian/sid64 into woof-distro/x86_64/debian/bookworm64 and start stabilizing a Vanilla Dpup 10.x release.