### PR TITLE
If using Xwayland and numlockx is missing, do not enable it

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -912,6 +912,7 @@ if [ "$SET_COUNTRY" ];then
      </button>
    </hbox>'
   fi
+  CHECK_NUMLOCK="$DEFAULT_NUMLOCK"
 
   KEYBOARDXML='
   <vbox space-expand="false" space-fill="false">


### PR DESCRIPTION
`if [ "$DEFAULT_NUMLOCK" != "$CHECK_NUMLOCK" ];then` is always true, if `DEFAULT_NUMLOCK=true` or `DEFAULT_NUMLOCK=false`, but `CHECK_NUMLOCK=`. The value of `CHECK_NUMLOCK` must be initialized with `$DEFAULT_NUMLOCK`, in case gtkdialog doesn't specify a different value.

This should affect X.Org too.