### PR TITLE
Always show the graphics section of quicksetup on Wayland

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -951,18 +951,19 @@ fi #end SET_COUNTRY
 ###setup x###
 if [ "$SET_XWIZARD" ];then
   #put up a button to launch xorgwizard...
-  XDRIVERSUCCESS=$(report-video driver)
+  if [ -z "$WAYLAND_DISPLAY" ];then
+    XDRIVERSUCCESS=$(report-video driver)
+    TT_xorg=$(gettext 'Xorg Video Wizard')
+    XMSGX=$(gettext "The <b>${XDRIVERSUCCESS}</b> video driver is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
+    XMSGRES=$(gettext "Current resolution:<b> $(report-video res) </b> ($(report-video depth) bit)")
+  else
+    XDRIVERSUCCESS=true
+    TT_xorg=$(gettext 'Wayland Video Wizard')
+    XMSGX=$(gettext "The <b>Wayland Display Server</b> is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
+    XMSGRES=$(gettext "Current resolution:<b> $(while read a ; do echo $a | grep -q 'preferred'  && echo ${a%% *} && break; done <<<$(wlr-randr)) </b> ($(report-video depth) bit)")
+  fi
   if [ "$XDRIVERSUCCESS" ];then #precaution.
     B_xwiz=$(gettext 'Run Video Wizard')
-    if [ -z "$WAYLAND_DISPLAY" ];then
-		TT_xorg=$(gettext 'Xorg Video Wizard')
-	    XMSGX=$(gettext "The <b>${XDRIVERSUCCESS}</b> video driver is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
-	    XMSGRES=$(gettext "Current resolution:<b> $(report-video res) </b> ($(report-video depth) bit)")
-    else
-		TT_xorg=$(gettext 'Wayland Video Wizard')
-		XMSGX=$(gettext "The <b>Wayland Display Server</b> is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
-	    XMSGRES=$(gettext "Current resolution:<b> $(while read a ; do echo $a | grep -q 'preferred'  && echo ${a%% *} && break; done <<<$(wlr-randr)) </b> ($(report-video depth) bit)")
-    fi
     XWIZARDXML='
      <hbox space-expand="true" space-fill="true">
        '"`/usr/lib/gtkdialog/xml_pixmap graphics.svg icon`"'


### PR DESCRIPTION
`report-video driver` always fails on Wayland:

```
$ report-video driver
grep: /var/log/Xorg.0.log: No such file or directory
```

Because quicksetup hides the graphics section when this fails, it's always hidden when using Wayland. There's no "driver" to detect when using Wayland anyway, so there's no reason to even try this.

(`report-video driver` does work when running quicksetup after switching away from X.Org, without rebooting first)