### PR TITLE
Hide the X server switch button if X.Org is missing

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
@@ -695,11 +695,11 @@ fi
 
 
 xXSERVER=""
-if [ -f /usr/bin/startxwayland -a ! -f /var/local/xwin_enable_xwayland ]; then
+if [ -e /usr/bin/X -a -f /usr/bin/startxwayland -a ! -f /var/local/xwin_enable_xwayland ]; then
  xXSERVER="<hseparator></hseparator>
 $(gui_opt "setxserver xwayland" wm_restart.svg "$(gettext '<b>X Server</b>
 Change to Xwayland..')" true)"
-elif [ -f /usr/bin/startxwayland -a -f /var/local/xwin_enable_xwayland ]; then
+elif [ -e /usr/bin/X -a -f /usr/bin/startxwayland -a -f /var/local/xwin_enable_xwayland ]; then
  xXSERVER="<hseparator></hseparator>
 $(gui_opt "setxserver xorg" wm_restart.svg "$(gettext '<b>X Server</b>
 Change to X.Org..')" true)"


### PR DESCRIPTION
Now that xorgwizard is useful under Wayland, this irrelevant part should be hidden on a Puppy without X.Org.