### PR TITLE
Allow Wayland applications to run as spot (fixes #2642)

### DIFF
--- a/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/autostart
+++ b/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/autostart
@@ -9,7 +9,16 @@ esac
 
 swaybg -i `cat ~/.config/wallpaper/bg_img` -m $mode &
 
-# hack for Firefox
+# allow applications running as spot to talk to labwc
+SPOT_RUNTIME_DIR=`run-as-spot sh -c 'mkdir -p $XDG_RUNTIME_DIR && echo $XDG_RUNTIME_DIR'`
+for F in $WAYLAND_DISPLAY $WAYLAND_DISPLAY.lock; do
+	umount -l $SPOT_RUNTIME_DIR/$F 2>/dev/null
+	touch $SPOT_RUNTIME_DIR/$F
+	chown spot:spot $XDG_RUNTIME_DIR/$F
+	mount --bind $XDG_RUNTIME_DIR/$F $SPOT_RUNTIME_DIR/$F
+done
+
+# allow applications running as spot to talk to Xwayland
 xhost +local:
 
 run-as-spot dbus-launch --exit-with-x11 > /tmp/.spot-session-bus

--- a/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/environment
+++ b/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/environment
@@ -1,2 +1,3 @@
 PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
 PULSE_COOKIE=/home/spot/.config/pulse/cookie
+MOZ_ENABLE_WAYLAND=1


### PR DESCRIPTION
Now Transmission and Firefox use their Wayland backends, instead of falling back to their X11 backend via Xwayland.