### PR TITLE
Add the Debian security updates repo during 0setup

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -153,6 +153,25 @@ case $DISTRO_BINARY_COMPAT in ubuntu|trisquel|debian|devuan) #130319 removed |ra
    PKGLISTS_COMPAT_UPDATES=$(echo "$PKGLISTS_COMPAT_U" | cut -f 3 -d "|" | tr '\n' ' ')
 esac
 
+if [ "$DISTRO_BINARY_COMPAT" = "debian" ]; then
+  wget --spider --tries 1 -T 3 -F --max-redirect 0 http://deb.debian.org/debian-security/dists/${DISTRO_COMPAT_VERSION}-security/
+  if [ $? -eq 0 ]; then
+   PKGLISTS_COMPAT_S="z|http://deb.debian.org/debian-security/dists/${DISTRO_COMPAT_VERSION}-security/main/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-security-main
+z|http://deb.debian.org/debian-security/dists/${DISTRO_COMPAT_VERSION}-security/non-free/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-security-non-free
+z|http://deb.debian.org/debian-security/dists/${DISTRO_COMPAT_VERSION}-security/contrib/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-security-contrib
+"
+   download_pkg_dbs compat $PKGLISTS_COMPAT_S
+   PKGLISTS_COMPAT_UPDATES="$PKGLISTS_COMPAT_UPDATES $(echo "$PKGLISTS_COMPAT_S" | cut -f 3 -d "|" | tr '\n' ' ')"
+
+   if [ "$RUNNINGPUP" = "no" ]; then
+    cat << EOF >> $DCRFILE
+# appended by 0setup
+REPOS_DISTRO_COMPAT="$REPOS_DISTRO_COMPAT z|http://deb.debian.org/debian-security|Packages-debian-${DISTRO_COMPAT_VERSION}-*"
+EOF
+   fi
+ fi
+fi
+
 case $DISTRO_BINARY_COMPAT in slackware*) # slackware official updates = patches repo
    DBUPDATEFLAG='yes'
    PKGLISTS_COMPAT_U=$(echo "$PKG_DOCS_DISTRO_COMPAT" | tr ' ' '\n' | grep official | \
@@ -282,14 +301,15 @@ if [ "$DBUPDATEFLAG" = "yes" ];then
  for ONE_PKGLISTS_COMPAT in $PKGLISTS_COMPAT
  do
   REPOFIELD="`echo -n "$ONE_PKGLISTS_COMPAT" | rev | cut -f 1 -d '-' | rev`" #ex: main
-  PKGUPDATES="`echo -n "$PKGLISTS_COMPAT_UPDATES" | tr ' ' '\n' | grep "\-${REPOFIELD}$" | head -n 1`" #ex: Packages-ubuntu-precise_updates-main
-  [ ! -f "$PKGUPDATES" ] && continue
-  cat $PKGUPDATES > /tmp/0setup_xxx1
-  cat $ONE_PKGLISTS_COMPAT >> /tmp/0setup_xxx1
-  #want to discard the older package...
-  sort --unique --field-separator='|' --key=2,2 /tmp/0setup_xxx1 > $ONE_PKGLISTS_COMPAT
-  #...assumes pkg names remain the same, ex "firefox" (2nd field in db).
-  mv -f $PKGUPDATES /tmp/$PKGUPDATES #dump -updates db file.
+  echo -n "$PKGLISTS_COMPAT_UPDATES" | tr ' ' '\n' | grep "\-${REPOFIELD}$" | while read PKGUPDATES
+  do
+   [ ! -f "$PKGUPDATES" ] && continue
+   cat $PKGUPDATES $ONE_PKGLISTS_COMPAT > /tmp/0setup_xxx1
+   #want to discard the older package...
+   sort --version-sort --unique --field-separator='|' --key=2,2 /tmp/0setup_xxx1 > $ONE_PKGLISTS_COMPAT
+   #...assumes pkg names remain the same, ex "firefox" (2nd field in db).
+   mv -f $PKGUPDATES /tmp/$PKGUPDATES #dump -updates db file.
+  done
  done
 fi
 


### PR DESCRIPTION
I also added `--version-sort` to that `sort` call, because:

```
~$ (echo 10; echo 2; echo 9;) | sort --version-sort 
2
9
10
~$ (echo 10; echo 2; echo 9;) | sort 
10
2
9
```

In some cases (like v9 in main and v10 in updates), 0setup will pick the older package.

(This introduces a bug in PPM: installation of packages from the security updates repository fails, because it tries to download them from the wrong mirror. I think fixing it is a waste of time.)