### PR TITLE
Run xdg_autostart.sh when labwc starts

### DIFF
--- a/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/autostart
+++ b/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/autostart
@@ -24,6 +24,7 @@ xhost +local:
 run-as-spot dbus-launch --exit-with-x11 > /tmp/.spot-session-bus
 PULSE_SERVER= run-as-spot sh -c "pulseaudio --kill > /dev/null 2>&1; pulseaudio --start --log-target=syslog"
 
+xdg_autostart.sh
 /usr/sbin/delayedrun &
 
 yambar >/dev/null 2>&1 &

--- a/woof-code/rootfs-skeleton/bin/xdg_autostart.sh
+++ b/woof-code/rootfs-skeleton/bin/xdg_autostart.sh
@@ -26,6 +26,17 @@ verify_not_running() {
 	return 0
 }
 
+run_desktop() {
+	while read j
+	do
+		case $j in "Exec="*)
+			sh -c "${j#Exec=}" &
+			break
+			;;
+		esac
+	done < "$1"
+}
+
 #=================================================
 
 for i in /etc/xdg/autostart/*.desktop
@@ -36,7 +47,7 @@ do
 	if ! verify_not_running $i ; then
 		continue
 	fi
-	xdg-open $i
+	run_desktop $i
 done
 
 #=================================================
@@ -52,7 +63,7 @@ do
 	if ! verify_not_running $i ; then
 		continue
 	fi
-	xdg-open $i
+	run_desktop $i
 done
 
 ### END ###


### PR DESCRIPTION
535810c needs to be cherry-picked into stable, it's a bug. xdg_autostart.sh can "run" .desktop files via xdg-open because ROX-Filer, unlike other file managers, just runs the command line in the Exec= line, without prompting the user first or defaulting to opening .desktop files with a text editor.