### PR TITLE
xdg-open: add defaultemail case for file managers other than rox

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/xdg-open
+++ b/woof-code/rootfs-skeleton/usr/local/bin/xdg-open
@@ -17,6 +17,7 @@ else
 		'') exit ;;
 		file://*) exec defaultfilemanager "$1" ;;
 		*://*)    exec defaultbrowser "$1" ;;
+		*@*.*)    exec defaultemail "$1" ;;
 		magnet:*) exec defaulttorrent "$1" ;;
 		*)        exec defaultfilemanager "$1" ;;
 	esac


### PR DESCRIPTION
It was missing.