### PR TITLE
Add devx, docx and nlsx to ext4 images

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1087,22 +1087,27 @@ if [ "$SDFLAG" = "" -a "$CROSFLAG" = "" ] ; then #120506
 	#--
 	. ../support/docx_nlsx.sh
 	#--
-	if [ -f ${DEVXSFS} ] ; then
-		mv -f ${DEVXSFS} ../${WOOF_OUTPUT}/
-		( cd ../${WOOF_OUTPUT} ; md5sum ${DEVXSFS} > ${DEVXSFS}.md5.txt )
-	fi
-	if [ -f ${DOCXSFS} ] ; then
-		mv -f ${DOCXSFS} ../${WOOF_OUTPUT}/
-		( cd ../${WOOF_OUTPUT} ; md5sum ${DOCXSFS} > ${DOCXSFS}.md5.txt )
-	fi
-	if [ -f ${NLSXSFS} ] ; then
-		mv -f ${NLSXSFS} ../${WOOF_OUTPUT}/
-		( cd ../${WOOF_OUTPUT} ; md5sum ${NLSXSFS} > ${NLSXSFS}.md5.txt )
-	fi
 	if [ "$ISOFLAG" ]; then
+		if [ -f ${DEVXSFS} ] ; then
+			mv -f ${DEVXSFS} ../${WOOF_OUTPUT}/
+			( cd ../${WOOF_OUTPUT} ; md5sum ${DEVXSFS} > ${DEVXSFS}.md5.txt )
+		fi
+		if [ -f ${DOCXSFS} ] ; then
+			mv -f ${DOCXSFS} ../${WOOF_OUTPUT}/
+			( cd ../${WOOF_OUTPUT} ; md5sum ${DOCXSFS} > ${DOCXSFS}.md5.txt )
+		fi
+		if [ -f ${NLSXSFS} ] ; then
+			mv -f ${NLSXSFS} ../${WOOF_OUTPUT}/
+			( cd ../${WOOF_OUTPUT} ; md5sum ${NLSXSFS} > ${NLSXSFS}.md5.txt )
+		fi
+
 		echo "Running ../support/mk_iso.sh"
 		../support/mk_iso.sh || exit 1
 	else
+		[ "$BUILD_DEVX" = "yes" -a -f ${DEVXSFS} ] && mv -f ${DEVXSFS} ./build/
+		[ -f ${DOCXSFS} ] && mv -f ${DOCXSFS} ./build/
+		[ -f ${NLSXSFS} ] && mv -f ${NLSXSFS} ./build/
+
 		WOOF_OUTPUT="woof-output-${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}"
 		mkdir -p ../$WOOF_OUTPUT
 		. ../support/pc_image.sh

--- a/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
+++ b/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
@@ -113,24 +113,15 @@ fi
 cd "/mnt/root/${RELEASE_TAG}"
 
 ASSET_NAME=`echo "$RELEASE_ASSETS" | jq -r ".[$ASSET_CHOICE].name"`
-echo "Downloading ${ASSET_NAME}"
+echo "Downloading and extracting ${ASSET_NAME}"
 ASSET_URL=`echo "$RELEASE_ASSETS" | jq -r ".[$ASSET_CHOICE].url"`
-wget -O "$ASSET_NAME" --header "Accept: application/octet-stream" "$ASSET_URL"
+wget -O- --header "Accept: application/octet-stream" "$ASSET_URL" | tar -xf-
 if [ $? -ne 0 ]; then
 	echo "Failed to download ${ASSET_NAME}"
 	cd ..
 	[ "$1" = ask ] && read
 	exit 1
 fi
-
-echo "Extracting ${ASSET_NAME}"
-tar xf "${ASSET_NAME}"
-if [ $? -ne 0 ]; then
-	echo "Failed to extract ${ASSET_NAME}"
-	[ "$1" = ask ] && read
-	exit 1
-fi
-rm -f "${ASSET_NAME}"
 
 echo "Verifying ${ASSET_NAME}"
 sha256sum -c sha256.sum


### PR DESCRIPTION
These images are not limited to 700 MB, and it's nice to have 1) man pages 2) all locales available by default and 3) things from the devx that are also useful for regular users, like rsync.

7729fab makes it possible to update a Vanilla Dpup release, when booting from a 2 GB flash drive, despite the increase in release size.