### PR TITLE
Allow connman-gtk to be used as a network wizard replacement

### DIFF
--- a/woof-code/rootfs-petbuilds/connman-gtk/petbuild
+++ b/woof-code/rootfs-petbuilds/connman-gtk/petbuild
@@ -9,4 +9,5 @@ build() {
     patch -p1 < ../icons.patch
     meson --buildtype=release --prefix=/usr -Duse_status_icon=false build
     ninja -C build install
+    rm -rf /usr/share/applications
 }

--- a/woof-code/rootfs-petbuilds/connman-ui/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/connman-ui/pinstall.sh
@@ -1,9 +1,3 @@
-echo -e '#!/bin/sh\nexec connman-ui-gtk' > usr/local/bin/defaultconnect
-chmod 755 usr/local/bin/defaultconnect
-
-echo "CURRENT_EXEC=connman-ui-gtk" > root/.connectwizardrc
-rm -f usr/share/applications/Internet-Connection-Wizard.desktop
-
 [ -f root/.spot-status ] && mv -f root/.spot-status root/.spot-status.orig
 chroot . /usr/sbin/setup-spot connman-ui-gtk=true
 [ -f root/.spot-status.orig ] && mv -f root/.spot-status.orig root/.spot-status || rm -f root/.spot-status

--- a/woof-code/rootfs-skeleton/usr/sbin/connectwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/connectwizard
@@ -35,6 +35,23 @@
 export TEXTDOMAIN=connectwizard
 export OUTPUT_CHARSET=UTF-8
 
+#v411 commandline param, this section irrelevant...
+DEFAULTCONNECT="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`"
+
+case $DEFAULTCONNECT in
+ connman-gtk)  exec connman-gtk   ;;
+ gnome-ppp)    DEFGNOMEPPP="yes"  ;;
+ pupdial)      DEFPUPDIAL="yes"   ;;
+ pppoe_gui)    DEFRPPPPOE="yes"   ;;
+ pppoeconf)    DEFPPPOECONF="yes" ;;
+ frisbee)      DEFFRISBEE="yes"   ;;
+ net-setup.sh) DEFNETWIZARD="yes" ;;
+ sns)          DEFSNS="yes"       ;;
+ pgprs)        DEFMTGPRS="yes"    ;; #170308
+ peasywifi)    DEFPWF="yes" ;; #180919
+ *) DEFICW="yes" ;;
+esac
+
 firewall_func() {
 	which firewall_ng 2>&1 >/dev/null
 	ret=$?
@@ -46,20 +63,6 @@ firewall_func() {
 }
 export -f firewall_func
 
-WIZARDPIDS="$(ps --no-headers -fC gtkdialog | grep -E 'Network_Connection_Wizard|InternetConnectionWizard' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')" #170510
-[ -n "$WIZARDPIDS" ] && kill $WIZARDPIDS #170510
-
-# test conectivity
-if wget -q --spider http://distro.ibiblio.org ;then # returns other than 0 we're not connected
- ONLINE='true'
- FIERWALL_LABEL=$(gettext "Setup a firewall")
-else
- ONLINE='false'
- FIERWALL_LABEL=$(gettext "Firewall can be setup after connection")
-fi
-
-#v411 commandline param, this section irrelevant...
-DEFAULTCONNECT="`cat /usr/local/bin/defaultconnect | tail -n 1 | tr -s " " | cut -f 2 -d " "`"
 #radiobuttons...
 DEFGNOMEPPP="no"
 DEFPUPDIAL="no"
@@ -72,18 +75,17 @@ DEFNETWIZARD="no" #100227
 DEFSNS="no" #100310
 DEFPWF="no" #180919
 
-case $DEFAULTCONNECT in
- gnome-ppp)    DEFGNOMEPPP="yes"  ;;
- pupdial)      DEFPUPDIAL="yes"   ;;
- pppoe_gui)    DEFRPPPPOE="yes"   ;;
- pppoeconf)    DEFPPPOECONF="yes" ;;
- frisbee)      DEFFRISBEE="yes"   ;;
- net-setup.sh) DEFNETWIZARD="yes" ;;
- sns)          DEFSNS="yes"       ;;
- pgprs)        DEFMTGPRS="yes"    ;; #170308
- peasywifi)    DEFPWF="yes" ;; #180919
- *) DEFICW="yes" ;;
-esac
+WIZARDPIDS="$(ps --no-headers -fC gtkdialog | grep -E 'Network_Connection_Wizard|InternetConnectionWizard' | tr -s ' ' | cut -f 2 -d ' ' | tr '\n' ' ')" #170510
+[ -n "$WIZARDPIDS" ] && kill $WIZARDPIDS #170510
+
+# test conectivity
+if wget -q --spider http://distro.ibiblio.org ;then # returns other than 0 we're not connected
+ ONLINE='true'
+ FIERWALL_LABEL=$(gettext "Setup a firewall")
+else
+ ONLINE='false'
+ FIERWALL_LABEL=$(gettext "Firewall can be setup after connection")
+fi
 
 #101002 rerwin: Wait for initialization scripts to complete... 101122 breakout.
 BRKCNT=0 ; BRKPID=0

--- a/woof-code/rootfs-skeleton/usr/sbin/welcome1stboot
+++ b/woof-code/rootfs-skeleton/usr/sbin/welcome1stboot
@@ -8,11 +8,7 @@ export OUTPUT_CHARSET=UTF-8
 W_MSG="$(gettext "Welcome,
 This is the first time you are running ${DISTRO_NAME}!...")"
 
-CURRENT_EXEC=
-[ -f ~/.connectwizardrc ] && . ~/.connectwizardrc
-if [ "$CURRENT_EXEC" = "connman-ui-gtk" -o "$CURRENT_EXEC" = "connman-gtk" ] ; then
-	LABEL_INTERNET=
-elif check_internet ; then
+if check_internet ; then
 	LABEL_INTERNET="$(gettext "Congratulations, you seem to be connected to the Internet. Experiment with mouse-over, left-click and right-click on the 'network' icon in the tray. Click on the icon on the right (or on the desktop) if you need to reconfigure the Internet connection")"
 elif check_internet working_network ; then
 	LABEL_INTERNET="$(gettext "There is a working network interface, but you are not connected to the Internet. Click on the 'connect' icon on the right, or on left-side of the desktop (do NOT double-click), to setup the Internet connection. Note the network status icon in the tray.")"
@@ -20,19 +16,17 @@ else
 	LABEL_INTERNET="$(gettext "Click on the button on the right, or icon at left of the screen (one click only!). You will then see some buttons for choosing how you wish to connect to the Internet. It is easy...")"
 fi
 
+LABEL_INTERNET="$(gettext "<b>Internet connection</b>
+${LABEL_INTERNET}")"
 LABEL_NEEDHELP="$(gettext "<b>I need help!</b>
 Explore the Menu -- see bottom-left of screen. Lots of local help is available -- select Help in the menu. The local Help page also has the Release Notes for this version of ${DISTRO_NAME}-- well worth checking out! When you get online, the web browser home page has many more links.")"
 LABEL_SETUP="$(gettext '<b>Setup</b>
 Want to install an upgraded video driver? Country localization? Printing? Sound? Mouse? Keyboard? Click here (or 'setup' icon at top of screen).')"
 
-if [ -n "$LABEL_INTERNET" ] ; then
-	LABEL_INTERNET="$(gettext "<b>Internet connection</b>
-${LABEL_INTERNET}")"
-
-	export WELCOME_DIALOG='
+export WELCOME_DIALOG='
 <window title="'$(gettext 'Welcome')'" icon-name="gtk-info" resizable="false">
 <vbox>
-    <hbox border-width="7" space-expand="true" space-fill="true">
+	<hbox border-width="7" space-expand="true" space-fill="true">
       <pixmap icon_size="4"><input file>/usr/share/doc/puppylogo96.png</input></pixmap>
       <text use-markup="true"><label>"<big>'"${W_MSG}"'</big>"</label></text>
     </hbox>
@@ -76,44 +70,6 @@ ${LABEL_INTERNET}")"
     </hbox>
   </vbox>
 </window>'
-else
-	export WELCOME_DIALOG='
-<window title="'$(gettext 'Welcome')'" icon-name="gtk-info" resizable="false">
-<vbox>
-    <hbox border-width="7" space-expand="true" space-fill="true">
-      <pixmap icon_size="4"><input file>/usr/share/doc/puppylogo96.png</input></pixmap>
-      <text use-markup="true"><label>"<big>'"${W_MSG}"'</big>"</label></text>
-    </hbox>
-    <hbox border-width="7" space-expand="true" space-fill="true">
-      <text space-expand="false" space-fill="false"><label>""</label></text>
-      <text xalign="0" use-markup="true" space-expand="true" space-fill="true"><label>"'"${LABEL_SETUP}"'"</label></text>
-      <vbox space-expand="false" space-fill="false">
-        <button>
-         '$(/usr/lib/gtkdialog/xml_button-icon /usr/local/lib/X11/pixmaps/configuration48.png huge)'
-         <action>/usr/sbin/wizardwizard & </action>
-        </button>
-      </vbox>
-    </hbox>
-    <hseparator></hseparator>
-
-    <hbox border-width="7" space-expand="true" space-fill="true">
-      <text space-expand="false" space-fill="false"><label>""</label></text>
-      <text xalign="0" use-markup="true" space-expand="true" space-fill="true"><label>"'"${LABEL_NEEDHELP}"'"</label></text>
-      <vbox space-expand="false" space-fill="false">
-        <text space-expand="false" space-fill="false"><label>""</label></text>
-        <button>
-         '$(/usr/lib/gtkdialog/xml_button-icon help.svg huge)'
-         <action>basichtmlviewer file:///usr/share/doc/index.html & </action>
-        </button>
-      </vbox>
-    </hbox>
-    <hbox border-width="7" space-expand="true" space-fill="true">
-      <pixmap><input file>/usr/share/doc/tray.png</input></pixmap>
-      <text xalign="0" use-markup="true" space-expand="true" space-fill="true"><label>"'$(gettext "...mouse-over and click the tray applets!")'"</label></text>
-    </hbox>
-  </vbox>
-</window>'
-fi
 
 gtkdialog --center -p WELCOME_DIALOG 2>/dev/null
 

--- a/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
@@ -66,7 +66,6 @@ export WizardWizard='
 
     <hbox spacing="10" homogeneous="true" space-expand="true" space-fill="true">
       <button image-position="2">
-        <sensitive>'$(command -v connmand > /dev/null && echo false || echo true)'</sensitive>
         <label>'$(gettext 'Internet')'</label>
         '"`/usr/lib/gtkdialog/xml_button-icon internet_connect.svg huge`"'
         <action>/usr/sbin/connectwizard &</action>

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -205,6 +205,7 @@ for NAME in $PETBUILDS; do
         rm -rf ../petbuild-output/${NAME}-${HASH}/tmp
         rm -rf ../petbuild-output/${NAME}-${HASH}/etc/ssl
         rm -f ../petbuild-output/${NAME}-${HASH}/etc/resolv.conf
+        rm -f ../petbuild-output/${NAME}-${HASH}/etc/ld.so.cache
         rm -f ../petbuild-output/${NAME}-${HASH}/root/.wget-hsts
 
         rm -rf ../petbuild-output/${NAME}-${HASH}/usr/share/man

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -38,7 +38,7 @@ BUILD_DEVX=yes
 DEVX_IN_ISO=no
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver connman-ui"
+PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver connman-ui connman-gtk"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
At least one user pointed out that connman-ui can be confusing: you need to left-click it to enable the network interface (if it's disabled), then right-click it to select the SSID you want to connect to.

It's good to have connman-gtk as a more traditional-looking alternative, and restore the network button in welcome1stboot. connman-gtk and connman-ui complement each other well when the former is built without its tray icon feature.

![1](https://user-images.githubusercontent.com/1471149/147847428-58b8d607-07d5-41e1-8da0-6542ae158381.png)
![2](https://user-images.githubusercontent.com/1471149/147847429-7bc31da5-8fad-466d-b2ae-9037cc750453.png)