### PR TITLE
Allow rc.shutdown to kill the login shell

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/poweroff
+++ b/woof-code/rootfs-skeleton/sbin/poweroff
@@ -2,6 +2,10 @@
 #110505 support sudo for non-root user.
 #140622 shinobar avoid freeze on a virtual terminal
 
+# continue running if the parent process is the login shell and we must
+# kill it to unmount a file system
+trap "" HUP
+
 script=""
 
 for i in $@ ; do


### PR DESCRIPTION
If the interactive shell running under tty1 is the process that uses a mounted file system (which does happen - in my case, it's the login shell - `sh -l`), `poweroff` ends up killing that process, which in turn, kills `poweroff` (because the controlling TTY is closed when the session leader is killed).

~~Instead, rc.shutdown should do a lazy unmount (to prevent new processes from touching this mount point), let init kill existing processes, then flush unwritten buffers.~~

~~init takes care of killing all processes and calling sync(), so there's no reason to simulate that in rc.shutdown using fuser.~~