### PR TITLE
Prefer a package from the security repo only if newer

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -311,7 +311,7 @@ if [ "$DBUPDATEFLAG" = "yes" ];then
    [ ! -f "$PKGUPDATES" ] && continue
    cat $PKGUPDATES $ONE_PKGLISTS_COMPAT > /tmp/0setup_xxx1
    #want to discard the older package...
-   sort --version-sort --unique --field-separator='|' --key=2,2 /tmp/0setup_xxx1 > $ONE_PKGLISTS_COMPAT
+   sort --reverse --version-sort --field-separator='|' --key=3,3 /tmp/0setup_xxx1 | sort --stable --unique --field-separator='|' --key=2,2 > $ONE_PKGLISTS_COMPAT
    #...assumes pkg names remain the same, ex "firefox" (2nd field in db).
    mv -f $PKGUPDATES /tmp/$PKGUPDATES #dump -updates db file.
   done


### PR DESCRIPTION
The current logic is flawed, and sometimes picks the older package in security instead of taking the newer one in main. #2713 updated Firefox and some other packages, but also rolled back some updates.

0setup should sort packages by version, then *group packages by name* and take the newest (instead of grouping by version and taking the first, because two different packages can have the same version number).

```
~/woof-out_x86_64_x86_64_debian_bullseye64$ diff -up status/findpkgs_FINAL_PKGS-debian-bullseye /tmp/woof-out_x86_64_x86_64_debian_bullseye64/status/findpkgs_FINAL_PKGS-debian-bullseye | grep -e ^- -e ^\+ | cut -f 1,4 -d \| 
--- status/findpkgs_FINAL_PKGS-debian-bullseye	2022-01-03 20:08:14.321032556 +0800
+++ /tmp/woof-out_x86_64_x86_64_debian_bullseye64/status/findpkgs_FINAL_PKGS-debian-bullseye	2022-01-03 19:51:53.337064213 +0800
-:intltool:|libencode-perl_3.08-1+deb11u1
+:intltool:|libencode-perl_3.08-1+deb11u2
-:perl:|libperl5.32_5.32.1-4+deb11u1
+:perl:|libperl5.32_5.32.1-4+deb11u2
-:linux-header:|linux-libc-dev_5.10.46-5
+:linux-header:|linux-libc-dev_5.10.84-1
-:perl_tiny::perl:|perl-base_5.32.1-4+deb11u1
-:perl_tiny::perl:|perl-modules-5.32_5.32.1-4+deb11u1
-:perl_tiny::perl:|perl_5.32.1-4+deb11u1
+:perl_tiny::perl:|perl-base_5.32.1-4+deb11u2
+:perl_tiny::perl:|perl-modules-5.32_5.32.1-4+deb11u2
+:perl_tiny::perl:|perl_5.32.1-4+deb11u2
```