### PR TITLE
Configure PCManFM to look and behave more like ROX-Filer

### DIFF
--- a/woof-code/rootfs-petbuilds/pcmanfm/libfm-defaults.patch
+++ b/woof-code/rootfs-petbuilds/pcmanfm/libfm-defaults.patch
@@ -1,0 +1,35 @@
+diff -rupN libfm-1.3.2-orig/data/libfm.conf libfm-1.3.2/data/libfm.conf
+--- libfm-1.3.2-orig/data/libfm.conf	2022-01-08 18:04:44.318354384 +0800
++++ libfm-1.3.2/data/libfm.conf	2022-01-08 18:41:18.794283567 +0800
+@@ -1,13 +1,19 @@
+ [config]
+-single_click=0
++single_click=1
+ use_trash=1
+ confirm_del=1
++terminal=defaultterminal
+ thumbnail_local=1
+ thumbnail_max=2048
++force_startup_notify=0
+ 
+ [ui]
+ big_icon_size=48
+ small_icon_size=24
+ thumbnail_size=128
+ pane_icon_size=24
+-show_thumbnail=1
++show_thumbnail=0
++
++[places]
++places_desktop=0
++places_applications=0
+diff -rupN libfm-1.3.2-orig/data/terminals.list libfm-1.3.2/data/terminals.list
+--- libfm-1.3.2-orig/data/terminals.list	2022-01-08 18:04:44.318354384 +0800
++++ libfm-1.3.2/data/terminals.list	2022-01-08 18:41:07.690283925 +0800
+@@ -75,3 +75,6 @@ desktop_id=terminology.desktop
+ open_arg=-e
+ noclose_arg=--hold -e
+ desktop_id=termite.desktop
++
++[defaultterminal]
++open_arg=-e

--- a/woof-code/rootfs-petbuilds/pcmanfm/pcmanfm-defaults.patch
+++ b/woof-code/rootfs-petbuilds/pcmanfm/pcmanfm-defaults.patch
@@ -1,0 +1,19 @@
+diff -rupN pcmanfm-1.3.2-orig/data/pcmanfm.conf pcmanfm-1.3.2/data/pcmanfm.conf
+--- pcmanfm-1.3.2-orig/data/pcmanfm.conf	2022-01-08 18:08:39.678346789 +0800
++++ pcmanfm-1.3.2/data/pcmanfm.conf	2022-01-08 18:27:26.386310429 +0800
+@@ -15,11 +15,13 @@ show_wm_menu=0
+ 
+ [ui]
+ win_width=640
+-win_height=480
++win_height=240
+ splitter_pos=150
+-side_pane_mode=1
++side_pane_mode=hidden;places
+ view_mode=0
+ show_hidden=0
+ sort_type=0
+ sort_by=2
+ max_tab_chars=32
++show_statusbar=0
++pathbar_mode_buttons=1

--- a/woof-code/rootfs-petbuilds/pcmanfm/petbuild
+++ b/woof-code/rootfs-petbuilds/pcmanfm/petbuild
@@ -19,6 +19,7 @@ build() {
     cd ..
 
     cd libfm-1.3.2
+    patch -p1 < ../libfm-defaults.patch
     PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" ./configure --prefix=/usr --libexecdir=/usr/lib/pcmanfm --disable-old-actions --with-gtk=$PETBUILD_GTK
     make install
     cd ..
@@ -26,6 +27,7 @@ build() {
     tar -xJf pcmanfm-1.3.2.tar.xz
     cd pcmanfm-1.3.2
     patch -p1 < ../root.patch
+    patch -p1 < ../pcmanfm-defaults.patch
     PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" ./configure --prefix=/usr --with-gtk=$PETBUILD_GTK
     make install
 

--- a/woof-code/rootfs-petbuilds/pcmanfm/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/pcmanfm/pinstall.sh
@@ -1,2 +1,2 @@
 echo '#!/bin/sh
-exec pcmanfm "$@"' > usr/local/bin/defaultfilemanager
+exec pcmanfm -n "$@"' > usr/local/bin/defaultfilemanager


### PR DESCRIPTION
Single-click mode is on, thumbnails are disabled, the side pane and the status bar are hidden and the path bar is slightly thinner.

In addition, new invocations of `defaultfilemanager` open a new window instead of opening a tab in the existing window.

![pcmanfm](https://user-images.githubusercontent.com/1471149/148653634-52d4149f-4dc0-4890-9c2b-402450723a87.png)
