### PR TITLE
Fix operator order when deciding whether or not to include simple_updater

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -162,7 +162,7 @@ and edit it to include your customised package list.
 		simple_updater)
 			state=false
 			case $WOOF_TARGETARCH in
-			x86*) [ ! "$ISOFLAG" -a "$GITHUB_REPOSITORY" ] && state=true ;;
+			x86*) [ -z "$ISOFLAG" -a -n "$GITHUB_REPOSITORY" ] && state=true ;;
 			esac
 			;;
 		*)


### PR DESCRIPTION
```
before() {
	ISOFLAG=$1
	GITHUB_REPOSITORY=$2
	state=false
	[ ! "$ISOFLAG" -a "$GITHUB_REPOSITORY" ] && state=true
	echo $state
}

after() {
	ISOFLAG=$1
	GITHUB_REPOSITORY=$2
	state=false
	[ -z "$ISOFLAG" -a -n "$GITHUB_REPOSITORY" ] && state=true
	echo $state
}

before 1 ""
before "" ""
before "" a
before 1 a

after 1 ""
after "" ""
after "" a
after 1 a
```

The output of this truth table is:

```
true         <- before: simple_updater is included if building an ISO locally                        - bug
true         <- before: simple_updater is included if building an ext4 image locally             - bug
true         <- before: simple_updater is included if building an ext4 image on GitHub
false        <- before: simple_updater is included if building an ISO on GitHub                  - bug
false        <- after: simple_updater is not included if building an ISO locally
false        <- after: simple_updater is not included if building an ext4 image locally
true         <- after: simple_updater is included if building an ext4 image on GitHub
false        <- after: simple_updater is not included if building an ISO on GitHub
```

What I don't understand is, why CI builds don't behave according to this truth table. The two 3builddistro in the Vanilla Dpup build flow (`BUILD_ISO=yes` and `no`) work as they should, and simple_updater is **not** included in the latest dpup64 build:

```
2022-01-10T01:50:44.3805744Z copying acpid_busybox
2022-01-10T01:50:44.3806298Z copying backend_modprobe
2022-01-10T01:50:44.3806924Z copying change_kernels
2022-01-10T01:50:44.3807376Z copying check_deps_gui
2022-01-10T01:50:44.3807816Z copying firewall_ng
2022-01-10T01:50:44.3808247Z copying imageview
2022-01-10T01:50:44.3808671Z copying jwm_config
2022-01-10T01:50:44.3809079Z copying pclock
2022-01-10T01:50:44.3809469Z copying pdiag
2022-01-10T01:50:44.3809880Z copying pfilesearch
2022-01-10T01:50:44.3810303Z copying pfind
2022-01-10T01:50:44.3810712Z copying pschedule
2022-01-10T01:50:44.3811134Z copying ptheme
2022-01-10T01:50:44.3811538Z copying ptiming
2022-01-10T01:50:44.3811984Z copying pup_advert_blocker
2022-01-10T01:50:44.3812483Z copying redshiftgui_wrapper
2022-01-10T01:50:44.3812961Z copying wallpaper
2022-01-10T01:50:44.3813380Z copying xlock_gui
2022-01-10T01:50:44.3814074Z Copying to sandbox3/rootfs-complete...
```