### PR TITLE
Set XDG_SESSION_TYPE when using X

### DIFF
--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -5,6 +5,8 @@
 #130212 removed glipper code, see latest glipper pet.
 #130525 old pc celeron 2ghz cpu, 256mb ram, CPUSPEED=1999, 1st bootup rox failed to start. try experiment.
 
+export XDG_SESSION_TYPE=x11
+
 [ -f /etc/desktop_app ] && read -r desktop < /etc/desktop_app
 [ "$desktop" = "" ] && desktop=rox
 


### PR DESCRIPTION
XDG_SESSION_TYPE is a good way to distinguish between X and Wayland desktops.

DISPLAY will be set in either, if the Wayland compositor supports Xwayland.

Once we have XDG_SESSION_TYPE everywhere, we can use `case` instead of `if` and clean up wizards that have different variants for Wayland, X or TTY.

This environment variable will be useful for #2716.