### PR TITLE
Optionally symlink directories at / to /usr

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -73,6 +73,42 @@ cp DISTRO_SPECS sandbox3/rootfs-complete/etc/
 
 #copy the skeleton...
 cp -a rootfs-skeleton/* sandbox3/rootfs-complete/
+
+mergedir() {
+	if [ ! -e ${2} ]; then
+		mkdir -vp `dirname ${2}`
+		mv -v ${1} ${2} || exit 1
+		return
+	fi
+
+	echo "Merging ${1} with ${2}"
+
+	for NAME in `ls ${1} 2>/dev/null`; do
+		if [ -d ${1}/${NAME} ]; then
+			mergedir ${1}/${NAME} ${2}/${NAME}
+		else
+			rm -f ${2}/${NAME}
+			mv -vf ${1}/${NAME} ${2}/ || exit 1
+		fi
+	done
+
+	rmdir -v ${1} || exit 1
+}
+
+usrmerge() {
+	USRDIRS="bin sbin lib"
+	[ "$DISTRO_TARGETARCH" = "x86_64" ] && USRDIRS="$USRDIRS lib64 lib32 libx32"
+
+	for USRDIR in $USRDIRS; do
+		[ -d ${1}/${USRDIR} ] && mergedir ${1}/${USRDIR} ${1}/usr/${USRDIR}
+
+		if [ $2 -eq 1 ]; then
+			[ ! -e ${1}/usr/${USRDIR} ] && mkdir -v ${1}/usr/${USRDIR}
+			ln -vs usr/${USRDIR} ${1}/${USRDIR} || exit 1
+		fi
+	done
+}
+
 if [ "$XAUTOCONF" = 'yes' ];then
 	echo 'enabling xorg-autoconf'; sleep 1
 	chmod 755 sandbox3/rootfs-complete/usr/sbin/xorg-autoconf
@@ -151,7 +187,7 @@ and edit it to include your customised package list.
 			;;
 		change_kernels)
 			state=false
-			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" ] && state=true
+			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" -a "$USR_SYMLINKS" != "yes" ] && state=true
 			;;
 		simple_installer)
 			state=false
@@ -299,6 +335,7 @@ if [ "$BUILD_DEVX" = "yes" -o -n "$PETBUILDS" ] ; then
 		fi
 	done
 	rm -f /tmp/ALLGENNAMESD
+	[ "$USR_SYMLINKS" = "yes" ] && usrmerge sandbox3/devx 0
 	echo
 fi
 
@@ -351,12 +388,14 @@ if [ -n "$ADRV_INCLUDE" -o -n "$FDRV_INCLUDE" -o -n "$YDRV_INCLUDE" ];then
 			echo '#!/bin/sh' > sandbox3/apinstall.sh
 			mkdir -p sandbox3/adrv/usr/local/bin
 			copy_pkgs_to_build "${ADRV_INC}" adrv
+			[ "$USR_SYMLINKS" = "yes" ] && usrmerge sandbox3/adrv 0
 			chmod 755 sandbox3/apinstall.sh
 			echo;;
 		fdrv)
 			echo '#!/bin/sh' > sandbox3/fpinstall.sh
 			mkdir -p sandbox3/fdrv/
 			copy_pkgs_to_build "${FDRV_INC}" fdrv
+			[ "$USR_SYMLINKS" = "yes" ] && usrmerge sandbox3/fdrv 0
 			chmod 755 sandbox3/fpinstall.sh
 			echo
 			CONF_DIR=no;;
@@ -364,6 +403,7 @@ if [ -n "$ADRV_INCLUDE" -o -n "$FDRV_INCLUDE" -o -n "$YDRV_INCLUDE" ];then
 			echo '#!/bin/sh' > sandbox3/ypinstall.sh
 			mkdir -p sandbox3/ydrv/usr/local/bin
 			copy_pkgs_to_build "${YDRV_INC}" ydrv
+			[ "$USR_SYMLINKS" = "yes" ] && usrmerge sandbox3/ydrv 0
 			chmod 755 sandbox3/ypinstall.sh
 			echo;;
 		esac
@@ -756,19 +796,23 @@ fi
 
 #shared library loading...
 mkdir -p rootfs-complete/etc/ld.so.conf.d/ # may not be there
-( # > rootfs-complete/etc/ld.so.conf
-	echo 'include /etc/ld.so.conf.d/*.conf'
-	echo "/lib${lsuffix}"
-	echo "/usr/lib${lsuffix}"
-	if [ "$ARCHDIR" = "x86_64-linux-gnu" ] ; then #WOOF_TARGETARCH='x86_64'
-		echo "/lib64"
-		echo "/usr/lib64"
-		echo -e "/lib64\n/usr/lib64" > rootfs-complete/etc/ld.so.conf.d/lib64.conf
-	fi
-	[ -d rootfs-complete/usr/local/lib${lsuffix} ] && echo "/usr/local/lib${lsuffix}"
-	[ -d rootfs-complete/opt/qt4/lib${lsuffix} ] && echo "/opt/qt4/lib${lsuffix}"
-	echo "/root/my-applications/lib"
-) > rootfs-complete/etc/ld.so.conf
+if [ "$USR_SYMLINKS" = "yes" ];then
+	echo "/root/my-applications/lib" > rootfs-complete/etc/ld.so.conf.d/my-applications.conf
+else
+	( # > rootfs-complete/etc/ld.so.conf
+		echo 'include /etc/ld.so.conf.d/*.conf'
+		echo "/lib${lsuffix}"
+		echo "/usr/lib${lsuffix}"
+		if [ "$ARCHDIR" = "x86_64-linux-gnu" ] ; then #WOOF_TARGETARCH='x86_64'
+			echo "/lib64"
+			echo "/usr/lib64"
+			echo -e "/lib64\n/usr/lib64" > rootfs-complete/etc/ld.so.conf.d/lib64.conf
+		fi
+		[ -d rootfs-complete/usr/local/lib${lsuffix} ] && echo "/usr/local/lib${lsuffix}"
+		[ -d rootfs-complete/opt/qt4/lib${lsuffix} ] && echo "/opt/qt4/lib${lsuffix}"
+		echo "/root/my-applications/lib"
+	) > rootfs-complete/etc/ld.so.conf
+fi
 
 echo "Updating system config.."
 mkdir -p rootfs-complete/var/cache/fontconfig
@@ -962,10 +1006,47 @@ fi
 
 if [ "$BUILD_SFS" = 'yes' ]; then
 	sh $MWD/support/files2delete.sh rootfs-complete
+	[ "$USR_SYMLINKS" = "yes" ] && usrmerge rootfs-complete 1
 	#build the rootfs-complete sfs...
 	echo -e "\nNow building the main f.s., ${PUPPYSFS}..."
 	rm -f build/${PUPPYSFS} 2>/dev/null
 	mksquashfs rootfs-complete build/${PUPPYSFS} ${SFSCOMP} #100911 110713
+	###########
+	if [ "$USR_SYMLINKS" = "yes" ]; then
+		KSFSCOMP="$SFSCOMP"
+
+		if [ -f build/${ZDRVSFS} ]; then
+			echo -e "\nNow building the zdrv f.s., $ZDRVSFS ..."
+			rm -rf zdrv
+			unsquashfs -d zdrv build/${ZDRVSFS}
+			rm -f build/${ZDRVSFS}
+
+			# use the same mksquashfs options used by kernel-kit
+			KSFSCOMP=`sh -c '. $(ls zdrv/etc/modules/build.conf-* 2>/dev/null) 2>/dev/null && echo "$COMP"'`
+			[ -z "$KSFSCOMP" ] && KSFSCOMP="$SFSCOMP"
+
+			usrmerge zdrv 0
+
+			if [ "$ARCHDIR" = "x86_64-linux-gnu" -a -d zdrv/usr/lib64 -a ! -e zdrv/usr/lib/${ARCHDIR} ]; then
+				mkdir -vp zdrv/usr/lib
+				mv -v zdrv/usr/lib64 zdrv/usr/lib/${ARCHDIR}
+			fi
+
+			mksquashfs zdrv build/${ZDRVSFS} ${KSFSCOMP}
+			[ -n "$GITHUB_ACTIONS" ] && rm -rf zdrv
+		fi
+
+		if [ -f build/${FDRVSFS} ]; then
+			echo -e "\nNow building the fdrv f.s., $FDRVSFS ..."
+			rm -rf fdrv
+			unsquashfs -d fdrv build/${FDRVSFS}
+			rm -f build/${FDRVSFS}
+
+			usrmerge fdrv 0
+			mksquashfs fdrv build/${FDRVSFS} ${KSFSCOMP}
+			[ -n "$GITHUB_ACTIONS" ] && rm -rf fdrv
+		fi
+	fi
 	###########
 	if [ -d adrv -o -d fdrv -o -d ydrv ];then
 		#build the {a,f,y}drive sfs...

--- a/woof-code/support/docx_nlsx.sh
+++ b/woof-code/support/docx_nlsx.sh
@@ -32,6 +32,7 @@ if [ "$BUILD_DOCX" = "yes" ] ; then
 	done
 	echo
 	rm -f docx/pet.specs
+	[ "$USR_SYMLINKS" = "yes" ] && usrmerge docx 0
 	echo "Creating $DOCXSFS..."
 	mksquashfs docx ${DOCXSFS} ${SFSCOMP}
 fi
@@ -52,6 +53,7 @@ if [ "$BUILD_NLSX" = "yes" ] ; then
 	rm -f nlsx/pet.specs
 	mkdir -p nlsx/var/local
 	touch nlsx/var/local/nlsx_loaded
+	[ "$USR_SYMLINKS" = "yes" ] && usrmerge nlsx 0
 	echo "Creating $NLSXSFS..."
 	mksquashfs nlsx ${NLSXSFS} ${SFSCOMP}
 fi


### PR DESCRIPTION
This is #2445, re-opened.

This PR adds **optional** support for linking /bin, /sbin, /lib, etc' to their counterparts under /usr, as most major distros do these days. To enable: put `USR_SYMLINKS=yes` in _00build.conf, or an environment variable (`USR_SYMLINKS=yes ./3builddistro`).

This is required to get the package managers of these distros to work well. (I'm working on getting apt to work under dpup, and this is a blocker.)

And yes, this comes at a certain cost: you can't swap the kernel if the kernel package is going to replace your /lib symlink with a directory that has nothing but /lib/{modules,firmware}. It **will** break your system, hence change_kernels is out of the build when this feature is enabled.

#2779 works without this PR, but it's cleaner to have only one bin, sbin and lib directory, and that's what third-party packages for Debian or Ubuntu expect, so this might improve Puppy's compatibility with foreign packages.

---

Spoiler:

![apt](https://user-images.githubusercontent.com/1471149/149618287-b76966d4-77cd-480e-991c-ba368c459629.png)