### PR TITLE
Bugfix the alignment of ${DISTRO_NAME} if it is longer than "Puppy Li…

### DIFF
--- a/woof-code/rootfs-skeleton/pinstall.sh
+++ b/woof-code/rootfs-skeleton/pinstall.sh
@@ -6,6 +6,17 @@
 . etc/DISTRO_SPECS
 
 sed -i "s/Puppy Linux/${DISTRO_NAME}/g" usr/share/backgrounds/*.svg
+# take some pixels off for better alignment for 431.svg
+if [ -e usr/share/backgrounds/431.svg ];then
+	XVAL=872.666
+	P="Puppy Linux"
+	if [ $((${#DISTRO_NAME} - ${#P})) -gt 0 ];then
+		VAL=$((${#DISTRO_NAME} - ${#P}))
+		VAL=${VAL}0
+		NVAL=`dc -e"$XVAL $VAL - p"` # ex: if VAL=40 NVAL=832.666
+		sed -i "s/$XVAL/$NVAL/" usr/share/backgrounds/431.svg
+	fi
+fi
 
 echo "Configuring Puppy skeleton..."
 echo "Configuring Puppy Help page..."


### PR DESCRIPTION
…nux"

#### Before
![bgno](https://user-images.githubusercontent.com/1019119/149644194-0c19aa8d-d2ff-4a08-a23d-96b7256ed43b.png)

#### After
![bg](https://user-images.githubusercontent.com/1019119/149644204-44716819-8866-4490-a10c-59529982b22a.png)


