### PR TITLE
Make fixmenus safe to run concurrently

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/fixmenus
+++ b/woof-code/rootfs-skeleton/usr/sbin/fixmenus
@@ -39,18 +39,20 @@ do
 
 	[ "$MENHEIGHT" ] && MH=$MENHEIGHT || MH=24
 
+	TMPDEST=`mktemp $ONEDEST.XXXXXXXXXX`
+
 	sed "s|MENHEIGHT|$MH|" ${ONESRC} | \
 	(
 	while read ONELINE
 	do
 		case "$ONELINE" in PUPPYMENU*)
 			EXECMENU="${ONELINE#PUPPYMENU }" #remove leading PUPPYMENU
-			${EXECMENU} ${MENHEIGHT} #>> ${ONEDEST}
+			${EXECMENU} ${MENHEIGHT} #>> ${TMPDEST}
 			continue
 		esac
-		echo "$ONELINE" #>> ${ONEDEST}
+		echo "$ONELINE" #>> ${TMPDEST}
 	done
-	) > ${ONEDEST}
+	) > ${TMPDEST}
 
 	#120207 translate some strings... 120216...
 	if [ "$LANG1" != "en" ];then
@@ -62,11 +64,12 @@ do
 				#121124 ensure that all [ ] are escaped... 121125 revert... 121126 restore, plus escape '.' chars...
 				sed -i -e 's%\[%\\[%g' -e 's$\]$\\]$g' -e 's%\\\\\[%\\[%g' -e 's%\\\\\]%\\]%g' /tmp/fixmenus-translationblock
 				sed -i -e 's%\.%\\.%g' -e 's%\\\\\.%\\.%g' /tmp/fixmenus-translationblock #note: 2nd ptn gets rid of prior escape char, so there remains just one.
-				sed -i -f /tmp/fixmenus-translationblock ${ONEDEST}
+				sed -i -f /tmp/fixmenus-translationblock ${TMPDEST}
 			fi
 		fi
 	fi
 
+	mv -f ${TMPDEST} ${ONEDEST}
 done
 
 # support labwc menu iconfont


### PR DESCRIPTION
`rename()` is atomic, `open()+write()+close()` aren't. This becomes extra important with #2778.