### PR TITLE
Disable the ConnMan DNS proxy if unscd is installed

### DIFF
--- a/woof-code/packages-templates/connman_FIXUPHACK
+++ b/woof-code/packages-templates/connman_FIXUPHACK
@@ -1,0 +1,8 @@
+case ${DISTRO_BINARY_COMPAT} in ubuntu|trisquel|debian|devuan|raspbian)
+ cat << EOF > pinstall.sh
+if [ -e etc/init.d/unscd ]; then
+ mkdir -p etc/default
+ echo 'DAEMON_OPTS="--nodnsproxy"' > etc/default/connman
+fi
+EOF
+esac


### PR DESCRIPTION
Two layers of caching are a waste of RAM.