### PR TITLE
Fix detection of mounted partition in pmount if mounted at /

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/probepart
+++ b/woof-code/rootfs-skeleton/sbin/probepart
@@ -144,6 +144,12 @@ probepart_func() {
 		while read dev etc ; do
 			[ "$dev" = "$blockdev" ] && MOUNT_STATUS="mounted" && break
 		done < /proc/mounts
+		if [ "$MOUNT_STATUS" != "mounted" ]; then
+			devmajorminor=`cat /sys/class/block/${ONEDEV}/dev`
+			while read mountid parentid majorminor etc; do
+				[ "$majorminor" = "$devmajorminor" ] && MOUNT_STATUS="mounted" && break
+			done < /proc/self/mountinfo
+		fi
 		EXTRA_STUFF="|${PARTITION_LABEL}|${MOUNT_STATUS}"
 	fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/pmount
+++ b/woof-code/rootfs-skeleton/usr/sbin/pmount
@@ -473,7 +473,10 @@ do
 	if [ "$ONEFS" = "crypto_LUKS" ]; then
 		ONEMNTPT="$(grep " /mnt/$DEVNAME " /proc/mounts | cut -f 2 -d ' ')"
 	else
-		ONEMNTPT="`grep "${ONEDEV} " /proc/self/mountinfo | grep '/ ' | cut -f 5 -d ' '`"
+		MAJORMINOR=`cat /sys/class/block/${DEVNAME}/dev`
+		while read ONEMOUNTID ONEPARENTID ONEMAJORMINOR ONEROOT ONEMOUNTPOINT ONETC; do
+			[ "$ONEMAJORMINOR" = "$MAJORMINOR" ] && ONEMNTPT=$ONEMOUNTPOINT && break
+		done < /proc/self/mountinfo
 	fi
 	[ "$ROOTDEV2" != "" ] && [ "$ROOTDEV2" = "$ONEDEV" ] && ONEMNTPT='/' #v3.96
 


### PR DESCRIPTION
This is one of the issues in #2803:

```
Another little annoyance is the behaviour of /mnt/home desktop icon that instead of opening the drive when clicking, brings up pmount unless you (try to) unmount it first clicking the eject arrow.
```

The user should not be able to unmount /.

```
~/woof-CE$ mount
...
/dev/root on /initrd type ext4 (rw,noatime)               <- this is /dev/sdb2
...
~/woof-CE$ grep 8:18 /proc/self/mountinfo   
56 55 8:18 / /initrd rw,noatime - ext4 /dev/root rw                   <- it's mounted at /initrd (originally at /, it was moved); no "sdb2" in this line
57 55 8:18 / /mnt/home rw,noatime - ext4 /dev/root rw                <- and at /mnt/home; no "sdb2" in this line either
~/woof-CE$ probepart -k -extra-info
...
/dev/sdb2|ext4|62255104||not_mounted                                 <- bug
~/woof-CE$ ./woof-code/rootfs-skeleton/sbin/probepart -k -extra-info
...
/dev/sdb2|ext4|62255104||mounted
```
