### PR TITLE
Add a urxvt and xterm replacement that runs lxterminal (fixes #2716)

### DIFF
--- a/woof-code/rootfs-petbuilds/lxterminal/petbuild
+++ b/woof-code/rootfs-petbuilds/lxterminal/petbuild
@@ -15,6 +15,9 @@ build() {
         ./configure --prefix=/usr --enable-gtk3
     fi
     make install
+    cd ..
     rm -rf /usr/share/icons
     sed -e 's/^Categories=.*/Categories=TerminalEmulator;/' -e 's~^Icon=.*~Icon=/usr/share/pixmaps/puppy/terminal.svg~' -i /usr/share/applications/lxterminal.desktop
+
+    $CC $CFLAGS `pkg-config --cflags glib-2.0` -D_GNU_SOURCE urxvt.c $LDFLAGS `pkg-config --libs glib-2.0` -o /usr/bin/lxterminal-urxvt
 }

--- a/woof-code/rootfs-petbuilds/lxterminal/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/lxterminal/pinstall.sh
@@ -1,3 +1,12 @@
 echo '#!/bin/sh
 exec lxterminal "$@"' > usr/local/bin/defaultterminal
 chmod 755 usr/local/bin/defaultterminal
+
+if [ -e usr/bin/urxvt ]; then
+	rm -f usr/bin/lxterminal-urxvt
+else
+	ln -s lxterminal-urxvt usr/bin/urxvt
+	ln -s lxterminal-urxvt usr/bin/rxvt
+	rm -f usr/bin/xterm
+	ln -s lxterminal-urxvt usr/bin/xterm
+fi

--- a/woof-code/rootfs-petbuilds/lxterminal/urxvt.c
+++ b/woof-code/rootfs-petbuilds/lxterminal/urxvt.c
@@ -1,0 +1,53 @@
+#include <string.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <glib/gprintf.h>
+
+int main(int argc, char **argv)
+{
+	static char *new_argv[32] = {
+		"lxterminal",
+		"--no-remote",
+		"-e"
+	};
+	gchar *cmd;
+	int i;
+	gboolean hold = FALSE;
+
+	for (i = 1; i < argc; ++i) {
+		if ((strcmp(argv[i], "-hold") == 0) || (strcmp(argv[1], "--hold") == 0)) {
+			hold = TRUE;
+			break;
+		}
+	}
+
+	for (i = 1; i < argc; ++i) {
+		if ((strcmp(argv[i], "-e") == 0) && (i < (argc - 1))) {
+			cmd = g_strjoinv(" ", &argv[i + 1]);
+
+			if (hold) {
+				new_argv[3] = "/bin/sh";
+				new_argv[4] = "-c";
+				new_argv[5] = g_strdup_printf("%s; echo; echo -n \"FINISHED. PRESS ENTER KEY TO CLOSE THIS WINDOW: \"; read simuldone", cmd);
+				g_free(cmd);
+				new_argv[6] = NULL;
+
+				execvp(new_argv[0], new_argv);
+				g_free(new_argv[5]);
+			}
+			else {
+				new_argv[3] = cmd;
+
+				execvp(new_argv[0], new_argv);
+				g_free(cmd);
+			}
+
+			return EXIT_FAILURE;
+		}
+	}
+
+	argv[0] = new_argv[0];
+	execvp(argv[0], argv);
+	return EXIT_FAILURE;
+}

--- a/woof-distro/x86/debian/bullseye/_00build_2.conf
+++ b/woof-distro/x86/debian/bullseye/_00build_2.conf
@@ -13,4 +13,4 @@ defaultconnect=sns
 "
 PETBUILD_GTK=2
 ADRV_INC="firefox-esr galculator libavcodec libva geany-gtk2 gpicview lxtask mtpaint sylpheed transmission xarchiver"
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany-gtk2 gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver fixmenusd"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany-gtk2 gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm leafpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver fixmenusd"

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver connman-ui connman-gtk fixmenusd"
+PETBUILDS="busybox aaa_pup_c cage disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons ram-saver connman-ui connman-gtk fixmenusd"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint rxvt-unicode transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons ram-saver labwc xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons ram-saver labwc xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
When PPM runs `xterm`, it reaches `woof-code/rootfs-skeleton/usr/bin/xterm`, a shell script (!!!) that writes a shell script (`$command; read`) to simulate `--hold`, if `--hold` was specified. Then, it runs `urxvt` with the same arguments, minus `--hold`.

Ugly! But wait, it gets better.

With this PR, `urxvt` is a tiny C wrapper that ~~runs `xterm` with the same arguments if `--hold` was specified. Why? Because it's inconsistent: woof-CE has some direct `urxvt --hold` calls.~~ runs `lxterminal -e sh -c "command; read"`, to simulate what this `xterm` hack does.

Otherwise, this wrapper just runs ~~`defaultterminal`~~ `lxterminal` with `-e` and everything that came after `-e`. All other arguments (for example, `-title`) are ignored, ~~because some terminal emulators don't support them.~~

If `-e` wasn't specified, the wrapper just calls ~~`defaultterminal`~~ `lxterminal` with all arguments. For example, `urxvt --help` runs `lxterminal --help`.

This ~~two or four stage chain (`urxvt->defaultterminal` or `urxvt->xterm->urxvt->defaultterminal`)~~ makes it possible to ~~use any terminal emulator that supports `-e` as `defaultterminal`,~~ migrate all existing users of `rxvt` or `xterm` to ~~`defaultterminal`~~ `lxterminal` ~~(often, a nicer terminal emulator with anti-aliased fonts and even some degree of hardware acceleration)~~ and completely drop the rxvt-unicode dependency.

~~Yes, there is some risk here - `defaultterminal` must not run `urxvt`.~~

If all new code starts using `defaultterminal -e` directly, this stub and the `xterm` wrapper (years and years of technical debt) can be deleted in the future.

Screenshots of PPM and pmount under labwc, with lxterminal as a replacemnt for rxvt-unicode:

![ppm](https://user-images.githubusercontent.com/1471149/150954914-ce619d47-05f1-4543-ad96-f6aa332981ae.png)

![pmount](https://user-images.githubusercontent.com/1471149/150954906-238bf087-019c-455d-bb38-c7b461f0e2d7.png)

