### PR TITLE
Do not mount x under /mnt/x if already mounted elsewhere

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/pup_event/drive_all
+++ b/woof-code/rootfs-skeleton/usr/local/pup_event/drive_all
@@ -138,7 +138,13 @@ fi
 #if it is a mountable partition then mount and open with rox. If already mntd then open in rox...
 EXITFLAG=no
 if [ "$xFSTYPE" ] ; then
-	if [ "`df | grep "^/dev/${ONEDRVNAME} "`" = "" ];then
+	MNTPT=
+	MAJORMINOR=`cat /sys/class/block/${xONEDRVNAME}/dev`
+	while read ONEMOUNTID ONEPARENTID ONEMAJORMINOR ONEROOT ONEMNTPT ONETC; do
+		[ "$ONEMAJORMINOR" = "$MAJORMINOR" ] && MNTPT=$ONEMNTPT && break
+	done < /proc/self/mountinfo
+
+	if [ "$MNTPT" = "" ];then
 		#not mounted...
 		mkdir -p /mnt/$xONEDRVNAME
 		case $xFSTYPE in
@@ -161,7 +167,6 @@ if [ "$xFSTYPE" ] ; then
 		fi
 	else
 		#mounted...
-		MNTPT="`mount | grep -m1 "^/dev/${ONEDRVNAME} " | cut -f 3 -d ' '`"
 		if [ -h /mnt/home ];then
 			[ "`readlink /mnt/home`" = "$MNTPT" ] && MNTPT="/mnt/home"
 		fi


### PR DESCRIPTION
```
~$ bash -x /usr/local/pup_event/drive_all sdb2
```

Before:

```
+ '[' ext4 ']'
++ df
++ grep '^/dev/sdb2 '                        <- wrong check: sdb2 is mounted at /initrd, not at /mnt/sdb2; this won't return anything
+ '[' '' = '' ']'
+ mkdir -p /mnt/sdb2
+ case $xFSTYPE in
+ mount -t ext4 /dev/sdb2 /mnt/sdb2             <- we mount it again 😱 
+ RETVAL1=0
+ '[' 0 -eq 0 ']'
+ EXITFLAG=yes
+ defaultfilemanager_x /mnt/sdb2
+ '[' yes = yes ']'
+ exit
```

After:

```
+ '[' ext4 ']'
+ MNTPT=
++ cat /sys/class/block/sdb2/dev
+ MAJORMINOR=8:18
+ read ONEMOUNTID ONEPARENTID ONEMAJORMINOR ONEROOT ONEMNTPT ONETC
+ '[' 0:18 = 8:18 ']'
+ read ONEMOUNTID ONEPARENTID ONEMAJORMINOR ONEROOT ONEMNTPT ONETC
+ '[' 8:18 = 8:18 ']'                  <- boom, found a mountpoint of sdb2
+ MNTPT=/initrd
+ break
+ '[' /initrd = '' ']'                   <- not mounting it again 🥳  
+ '[' -h /mnt/home ']'
+ case $MNTPT in
+ EXITFLAG=yes
+ defaultfilemanager_x /initrd
+ '[' yes = yes ']'
+ exit
```