### PR TITLE
Simple Network Setup 3.3

### DIFF
--- a/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
+++ b/woof-code/rootfs-packages/simple_network_setup/etc/udev/rules.d/51-simple_network_setup.rules
@@ -1,7 +1,6 @@
 # Accumulate names of modules to be loaded, for use by rc.network -- if pup_event_backend_modprobe installed.
+#Note that for ssb (and probably brcm) subsystem, %s{modalias} = null, so is unusable.
+#Note that ENV{MODALIAS}=="?*" may kill the rule in later kernels (e.g., for VoidPup).
 
-PROGRAM=="/usr/bin/test -x /sbin/pup_event_backend_modprobe", \
-  PROGRAM=="/usr/bin/test -s /etc/simple_network_setup/connections", \
-  SUBSYSTEM=="?*", SUBSYSTEM!="acpi|input|platform", \
-  ENV{MODALIAS}=="?*", ACTION=="add", \
-  RUN+="/usr/local/simple_network_setup/build_udevmodulelist $env{MODALIAS}"
+SUBSYSTEM=="pci|usb|ssb|bcma|pcmcia", ACTION=="add", \
+  RUN+="/usr/local/simple_network_setup/build_udevmodulelist"

--- a/woof-code/rootfs-packages/simple_network_setup/pet.specs
+++ b/woof-code/rootfs-packages/simple_network_setup/pet.specs
@@ -1,1 +1,1 @@
-simple_network_setup-3.2|simple_network_setup|3.2||Network|160K||simple_network_setup-3.2.pet|+gtkdialog,+iw|Barry's simple network manager||||
+simple_network_setup-3.3|simple_network_setup|3.3||Network|164K||simple_network_setup-3.3.pet|+gtkdialog,+iw|Barry's simple network manager||||

--- a/woof-code/rootfs-packages/simple_network_setup/pinstall.sh
+++ b/woof-code/rootfs-packages/simple_network_setup/pinstall.sh
@@ -13,9 +13,9 @@ if [ "$(pwd)" = '/' ]; then
         fi
     fi
 
+    #v3.3 Remove connections if in old format...
     grep '^..[^:]' etc/simple_network_setup/connections \
-      && [ ! -f etc/simple_network_setup/connections-oldformat ] \
-      && mv etc/simple_network_setup/connections etc/simple_network_setup/connections-oldformat
+      && rm -f etc/simple_network_setup/connections
 
     if ! which iw >/dev/null 2>&1; then
         BACK_TITLE="This version of simple-network-setup cannot manage wireless connections, due to the absence of the 'iw' command in this installation, but can control wired ethernet connections."

--- a/woof-code/rootfs-packages/simple_network_setup/puninstall.sh
+++ b/woof-code/rootfs-packages/simple_network_setup/puninstall.sh
@@ -4,7 +4,3 @@ if [ -e /usr/sbin/sns-old.bak ];then
     mv -f /usr/sbin/sns-old.bak /usr/sbin/sns
     chmod +x
 fi
-
-#Version 3.0:
-[ -f /etc/simple_network_setup/connections-oldformat ] \
-  && mv -f /etc/simple_network_setup/connections-oldformat /etc/simple_network_setup/connections

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/build_udevmodulelist
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/build_udevmodulelist
@@ -5,18 +5,19 @@
 # Invoked by udev rule file 51-simple_network_setup.rules
 #201017 v2.4: Rewritten to save module names expected to be loaded, accessed by connection driver name (from /sys/class/net/*/device/driver link). 
 #210703 v3.1 Accept modalias as argument, to avoid depending on MODALIAS environment variable.
+#211215 v3.3 Simplify udev rule; revert 210703 because udev-rule %s{modalias} argument unreliable for ssb subsystem; test for connections, etc., because udev-rule test command location inconsistent across kernel versions.
 
-[ -z "$1" ] && exit
-MODALIAS="$1"
+[ -n "$MODALIAS" ] \
+  && [ -s /etc/simple_network_setup/connections ] \
+  && [ -x /sbin/pup_event_backend_modprobe ] \
+  || exit #211215
 usleep 1000 #precaution for multiple cores
-MODULES="$(/sbin/modprobe -i --config /dev/null \
+MODULE="$(/sbin/modprobe -i --config /dev/null \
   --show-depends "$MODALIAS" 2>/dev/null | \
-  grep -E '/kernel/drivers/net/|/kernel/drivers/staging/' | \
-  grep -o '[^/]*\.ko' | cut -f 1 -d '.')"
-if [ -n "$MODULES" ]; then
-    MODULE="$(/sbin/modprobe -i --show-depends "$MODALIAS" 2>/dev/null | \
-      grep -E '/kernel/drivers/net/|/kernel/drivers/staging/' | \
-      grep -o '[^/]*\.ko' | cut -f 1 -d '.' | tail -n 1)"
+  grep -E '/kernel/drivers/(net|staging)' | \
+  grep -o '[^/]*\.ko' | cut -f 1 -d '.' | tail -n 1)"
+if [ -n "$MODULE" ]; then
+    LOAD_MODULE="${MODULE//-/_}"
     PREFLIST=''
     if [ -f /etc/rc.d/MODULESCONFIG-backend_modprobe ]; then
 # shellcheck disable=SC1091
@@ -34,14 +35,14 @@ if [ -n "$MODULES" ]; then
                 echo "blacklist $MODULE" >> /tmp/sns_blacklist.conf
                 xMODULE="$(/sbin/modprobe -i --config /tmp/sns_blacklist.conf \
                   --show-depends "$MODALIAS" 2>/dev/null | \
+                  grep -E '/kernel/drivers/(net|staging)' | \
                   tail -n 1 | grep -o '[^/]*\.ko' | cut -f 1 -d '.')"
-                [ "$xMODULE" = "$PREFMOD" ] && MODULE="$xMODULE"
+                [ "$xMODULE" = "$PREFMOD" ] && LOAD_MODULE="${xMODULE//-/_}"
             done
             rm -f /tmp/sns_blacklist.conf
         fi
     fi
     mkdir -p /tmp/simple_network_setup/udevmodulelist
-    for ONEMODULE in $MODULES; do
-        echo "$MODULE" > /tmp/simple_network_setup/udevmodulelist/"${ONEMODULE//-/_}"
-    done
+    ! grep -qsw "$LOAD_MODULE" /tmp/simple_network_setup/udevmodulelist/"$MODULE" \
+      && echo "$LOAD_MODULE" >> /tmp/simple_network_setup/udevmodulelist/"$MODULE"
 fi

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/macaddress_spoofing_functions
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/macaddress_spoofing_functions
@@ -1,0 +1,80 @@
+#!/bin/bash
+#Functions related to spoofing of MAC addresses
+#211215 v3.3: New SNS component
+
+macaddress_spoofing_enabled() {
+    #Return 0 if enabled -- enabled if macchanger installed
+    which macchanger >/dev/null 2>&1
+} #macaddress_spoofing_enabled
+
+set_active_interface_macaddresses() {
+    #Sets ACTIVE_INTERFACE_MACADDRESSES
+    #Format: [interface]_[current MAC]_[real MAC]
+    local ONEIFMAC NETDRIVER CURRREALMACADDRS CURRMACADDR REALMACADDR SEDSCRIPT
+    ACTIVE_INTERFACE_MACADDRESSES="$(ip link show | \
+      grep -B 1 'link/ether' | \
+      sed -n '/^[0-9]/ {N;s%^[0-9]\+: \([^:]*\).*link/ether \([^ ]*\).*%\1_\2_\2%p}')" #ex. wlan0 xx:xx:xx:xx:xx:xx, avoid using busybox 'ip -oneline' #210202 210208
+    for ONEIFMAC in $ACTIVE_INTERFACE_MACADDRESSES; do
+        #Because tethered phones can have dynamic MAC addresses, change their address to zeroes to match connection profile...
+        NETDRIVER="$(sed -n '/DRIVERS=="[^"]/ {s/[^"]*"\([^"]*\).*/\1/p ; q}' <<< "$(udevadm info -a -p /sys/class/net/"${ONEIFMAC%%_*}")")"
+        if [ "$NETDRIVER" = 'rndis_host' ]; then #USB-connected gadget
+#        if [ "$NETDRIVER" = 'forcedeth' ]; then #USB-connected gadget #DEBUG
+            #Assume only one "gadget" (e.g>, smart phone) tethered.
+            #For "gadgets" spoofing MAC, change profile real MAC to current MAC and avoid re-spoofing.
+            if grep "|Wired|$NETDRIVER|" <<< "$ALL_CONNECTION_PROFILES"; then
+                if ! grep -q "^${ONEIFMAC##*_}|Wired|$NETDRIVER|" <<< "$ALL_CONNECTION_PROFILES"; then #spoofing
+                    SEDSCRIPT="/|$NETDRIVER|/ s/^[^#][^|]*/${ONEIFMAC##*_}/"
+                    sed -i "$SEDSCRIPT" /etc/simple_network_setup/connections
+                    ALL_CONNECTION_PROFILES="$(sed "$SEDSCRIPT" <<< "$ALL_CONNECTION_PROFILES")"
+                fi
+                #Because gadgets can control their own spoofing, clear current MAC address to prevent re-spoofing.
+# shellcheck disable=SC2001
+                ACTIVE_INTERFACE_MACADDRESSES="$(sed "s/_${ONEIFMAC##*_}_/__/" <<< "$ACTIVE_INTERFACE_MACADDRESSES")"
+            fi
+        elif which macchanger >/dev/null 2>&1; then
+            #Use real MAC if MAC spoofed
+            CURRREALMACADDRS="$(macchanger -s "${ONEIFMAC%%_*}" | grep -Eow '[0-9a-f:]+')"
+            CURRMACADDR="$(head -n 1 <<< "$CURRREALMACADDRS")"
+            REALMACADDR="$(tail -n 1 <<< "$CURRREALMACADDRS")"
+            if [ "$CURRMACADDR" != "$REALMACADDR" ]; then #Spoofing MAC
+                SEDSCRIPT="/^${ONEIFMAC%%_*}_/ s/^\(.*_\).*/\1$REALMACADDR/"
+                ACTIVE_INTERFACE_MACADDRESSES="$(sed "$SEDSCRIPT" <<< "$ACTIVE_INTERFACE_MACADDRESSES")"
+            fi
+        fi
+    done
+} #set_active_interface_macaddresses
+
+spoof_macaddress() {
+    #Arguments: [(text prefix)]
+    #Returns log entries, for redirection
+    if which macchanger >/dev/null 2>&1; then #MAC changer installed, so...
+        #If using real MAC, spoof it.
+        local MACS
+        MACS="$(macchanger -s "$INTERFACE" | grep -Eow '[0-9a-f:]+')"
+        if [ "$(head -n 1 <<< "$MACS")" = "$(tail -n 1 <<< "$MACS")" ]; then
+            echo "${1}macchanger -e ${INTERFACE}"
+            macchanger -e "$INTERFACE" #Set random MAC for same vendor
+        fi
+    fi
+} #spoof_macaddress
+
+reset_macaddress() {
+    which macchanger >/dev/null 2>&1 \
+      && macchanger -p "$INTERFACE" >/dev/null #Undo spoofing
+} #reset_macaddress
+
+unspoof_macaddress() {
+    #Sets permanent MAC address in MACADDRESS
+    if which macchanger >/dev/null 2>&1; then #211215...
+        MACADDRESS="$(macchanger -s "$INTERFACE" | sed -n 's/Permanent MAC: \([0-9a-f:]\+\).*/\1/p')"
+    fi
+} #unspoof_macaddress
+
+set_dhcpcd_timeout() {
+    #Overrides the 30-second default wait time for getting  a lease
+    if grep -wq '^timeout' /etc/dhcpcd.conf; then
+        DHCPCD_TIMEOUT='' #timeout already set
+    else
+        DHCPCD_TIMEOUT='--timeout 40' #MAC spoofing may slow router response
+    fi
+} #set_dhcpcd_timeout

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -49,8 +49,9 @@
 #210703 v3.1 Accommodate EasyOS which does not use pup_event_backend_modprobe for module loading; change yaf-splash to gtkdialog-splash.
 #210915 Retry wired dhcpcd if nameserver not set; skip country regulation check for wired networks; change wired log to /tmp/simple_network_setup/rc_network_wired_connection_log, supporting multiple attempts.
 #211002 v3.2 Try interfaces in connection (list) order, but only once per interface.
+#211215 v3.3 Accommodate spoofed gadget (USB-tethered smartphone) MAC addresses; add spoofing if macchanger installed; override default dhcpcd response timeout if not already in conf file, to compensate for router possibly slowing due to MAC spoofing; improved some variable names; stop waiting for all connections if top-profile connection detected.
+#211231 v3.3 Replace ethtool with ip-show test for LOWER_UP; refine dhcpcd success check; refine module loading check; refine interface trials (re 211002), using grouped connection profiles; skip waiting for module loading and wired connection if not during boot-up.
 
-#set -x; exec >&2 #DEBUG
 #If version is changed, ensure that new VERSION is set in the sns script. #190525
 
 export TEXTDOMAIN=simple_network_setup
@@ -59,10 +60,13 @@ export OUTPUT_CHARSET=UTF-8
 LANGORIG=$LANG
 
 #Running?...
+# shellcheck disable=SC2009
 ps --no-headers -fC rc.network | grep '/usr/local/simple_network_setup' | grep -qvw "$$" \
   && sleep 5 \
   && ps --no-headers -fC rc.network | grep '/usr/local/simple_network_setup' | grep -qvw "$$" \
   && exit 1 #210209
+
+. /usr/local/simple_network_setup/macaddress_spoofing_functions #211215
 
 #each line of /etc/simple_network_setup/connections has everything needed about a connection:
 #(please ignore spaces, put here for readability only)
@@ -86,6 +90,7 @@ cancel_splash_and_exit() { #170505...
           && ps -C gtkdialog-splash -C yaf-splash | grep -wq "^ *$SPLASHPID" \
           && kill "$SPLASHPID" 2>/dev/null
     fi
+    touch /tmp/simple_network_setup/initialization_completed #211231
     exit 0
 } #170505 end
 
@@ -115,119 +120,99 @@ stop_interface() {
     exit
 } #stop_interface
 
-find_available_drivers() {
+ensure_driver_modules_loaded() {
     #181109 Collect driver names from saved connection profiles & make grep patterns...
-    local CONNECTION_DRIVER_LIST CONNECTION_DRIVER_COUNT
-    local PREFERRED_DRIVER PREFERRED_MODULE
-    CONNECTION_DRIVER_LIST="$(cut -f "$IF_DRIVER_FIELD" -d '|' /etc/simple_network_setup/connections | sort -u)"
-    [ -z "$CONNECTION_DRIVER_LIST" ] && exit
-    PREFERRED_DRIVER="$(head -n 1 /etc/simple_network_setup/connections | cut -f "$IF_DRIVER_FIELD" -d '|')"
-    PREFERRED_MODULE="$(cat /tmp/simple_network_setup/udevmodulelist/"$PREFERRED_DRIVER" 2>/dev/null)"
-    PREFERRED_MODULE="${PREFERRED_MODULE:-$PREFERRED_DRIVER}"
-    CONNECTION_DRIVER_COUNT="$(grep -vEc '^$' <<< "$CONNECTION_DRIVER_LIST")" #190525
-    local CONNECTION_DRIVER_PATTERNS CONNECTION_BUILTIN_DRIVERS
+    #Determine the modules to wait for to load... #211231...
+    local CONNECTION_DRIVER_LIST CONNECTION_DRIVER_PATTERNS CONNECTION_BUILTIN_DRIVER_LIST
+    CONNECTION_DRIVER_LIST="$(cut -f "$IF_DRIVER_FIELD" -d '|' <<< "$ALL_CONNECTION_PROFILES" | sort -u)"
 # shellcheck disable=SC2001
     CONNECTION_DRIVER_PATTERNS="$(sed 's%.*%/&.ko%' <<< "$CONNECTION_DRIVER_LIST")"
-    CONNECTION_BUILTIN_DRIVERS="$(grep -soF "${CONNECTION_DRIVER_PATTERNS}" /lib/modules/"$(uname -r)"/modules.builtin | sed 's%.*/\([^/]*\)\.ko%\1%')" #201017...
-    if [ -n "$CONNECTION_BUILTIN_DRIVERS" ]; then
-        local CONNECTION_MODULE_LIST
-        CONNECTION_MODULE_LIST="$(grep -vF "$CONNECTION_BUILTIN_DRIVERS" <<< "$CONNECTION_DRIVER_LIST")"
-    else
-        local CONNECTION_MODULE_LIST="$CONNECTION_DRIVER_LIST"
-    fi
-    if [ -n "$CONNECTION_MODULE_LIST" ]; then #201017
-        [ "$ARGUMENT" != 'start' ] && sleep 2 # Unless started by sns, allow time for all module loading to be initiated. #190525 210205
-        WAITCNT=0 ; WAITMAX=12 ; local WAITDRVRS=8 #180108 190525
-        #wait for interfaces to become available...
-        #note, do not test for wlan0 or wlan1 (etc) to become available, as these can change depending on plugged-in devices.
-        local ACTIVE_MODULE_LIST ACTIVE_MODULE_COUNT ACTIVE_MODULE_STRING
-        local ACTIVE_MODULE_STRING ONEDRIVER SUBSTITUTEDRIVER
-        local ACTIVE_CONNECTION_MODULE_LOAD_LIST
-        local ACTIVE_CONNECTION_MODULE_COUNT LOADED_CONNECTION_MODULE_PATTERNS LOADED_CONNECTION_MODULE_COUNT
-        local NETDRIVER SUBSTITUTEMODULE LOADMODULE
-        while true; do #190525
-            ACTIVE_MACADDRESSES="$(ip link show | sed -n '/link\/ether/ s/.*ether \([^ ]*\).*/\1/p')"
-            ACTIVE_DRIVER_LIST="$(grep -F "${ACTIVE_MACADDRESSES}" < /etc/simple_network_setup/connections | cut -f "$IF_DRIVER_FIELD" -d '|')"
-            ACTIVE_DRIVER_COUNT="$(sort -u <<< "$ACTIVE_DRIVER_LIST" | wc -l)"
-            if [ -n "$ACTIVE_DRIVER_LIST" ]; then
-                if grep -qw "$PREFERRED_DRIVER" <<< "$ACTIVE_DRIVER_LIST" \
-                  || [ "$ACTIVE_DRIVER_COUNT" -ge "$CONNECTION_DRIVER_COUNT" ] \
-                  || [ $WAITCNT -ge $WAITDRVRS ]; then
-                    ACTIVE_MODULE_STRING=''
-                    for ONEPATH in /sys/class/net/*; do
-                        [ "$(basename $ONEPATH)" = 'lo' ] && continue
-                        NETDRIVER="$(sed -n '/DRIVERS=="[^"]/ {s/[^"]*"\([^"]*\).*/\1/p ; q}' <<< "$(udevadm info -a -p "$ONEPATH")" | grep -xF "${CONNECTION_MODULE_LIST}")"
-                        if [ -n "$NETDRIVER" ]; then
-                            SUBSTITUTEMODULE="$(cat /tmp/simple_network_setup/udevmodulelist/"$NETDRIVER" 2>/dev/null)"
-                            LOADMODULE="${SUBSTITUTEMODULE:-"$NETDRIVER"}"
-                            grep -qxF "$ACTIVE_DRIVER_LIST" <<< "$NETDRIVER" && ACTIVE_MODULE_STRING="${ACTIVE_MODULE_STRING}${LOADMODULE}|"
-                        fi
-                    done
-                    ACTIVE_CONNECTION_MODULE_LOAD_LIST="$(tr '|' '\n' <<< "${ACTIVE_MODULE_STRING}")"
-                    if [ -n "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" ]; then #201017
-                        ACTIVE_CONNECTION_MODULE_COUNT="$(wc -l <<< "$ACTIVE_CONNECTION_MODULE_LOAD_LIST")" #201017
-                        if grep -qw "$PREFERRED_MODULE" <<< "$ACTIVE_CONNECTION_MODULE_LOAD_LIST" \
-                          || [ "$ACTIVE_CONNECTION_MODULE_COUNT" -ge "$CONNECTION_DRIVER_COUNT" ] \
-                          || [ $WAITCNT -ge $WAITDRVRS ]; then #190525
-                            LOADED_CONNECTION_MODULE_PATTERNS="$(lsmod | cut -f 1 -d ' ' | \
-                              grep -xF "${ACTIVE_CONNECTION_MODULE_LOAD_LIST}" | sed 's%^.*%|&|%')" #201017
-                            grep -qw "$PREFERRED_MODULE" <<< "$LOADED_CONNECTION_MODULE_PATTERNS" && break #preferred i/f present
-                            LOADED_CONNECTION_MODULE_COUNT="$(grep -vEc '^$' <<< "$LOADED_CONNECTION_MODULE_PATTERNS")"
-                            [ "$LOADED_CONNECTION_MODULE_COUNT" -ge "$ACTIVE_CONNECTION_MODULE_COUNT" ] && break
-                        fi
-                    fi
-                fi #190525
-            fi #201017
-            [ $WAITCNT -ge $WAITDRVRS ] && break #all modules may not be loaded or an i/f not present.
+    #Determine any built-in drivers to be used...
+    CONNECTION_BUILTIN_DRIVER_LIST="$(grep -soF "${CONNECTION_DRIVER_PATTERNS}" /lib/modules/"$(uname -r)"/modules.builtin | sed 's%.*/\([^/]*\)\.ko%\1%')" #global #201017...
+    WAITCNT=0 ; WAITMAX=12 ; local WAITDRVRS=8 #180108 190525
+    if [ ! -f /tmp/simple_network_setup/initialization_completed ]; then
+        while true; do #Wait until drivers identified by udev rules
+# shellcheck disable=SC2010
+            EXPECTED_DRIVER_LIST="$(ls -1 /tmp/simple_network_setup/udevmodulelist | grep -Fx "$CONNECTION_DRIVER_LIST")" #global
+            [ "$EXPECTED_DRIVER_LIST" = "$CONNECTION_DRIVER_LIST" ] \
+              || [ "$WAITCNT" -ge "$WAITDRVRS" ] && break
             sleep 1
             ((++WAITCNT))
         done
     fi
-    [ -n "$LOADED_CONNECTION_MODULE_PATTERNS" ] || [ -n "$CONNECTION_BUILTIN_DRIVERS" ] #set rc 0 = driver available 201017
-} #find_available_drivers
+# shellcheck disable=SC2010
+    EXPECTED_DRIVER_LIST="$(ls -1 /tmp/simple_network_setup/udevmodulelist | grep -Fx "$CONNECTION_DRIVER_LIST")" #to check for more drivers
+    local ONEDRIVER EXPECTED_MODULE_STRING='' EXPECTED_MODULE_LIST
+    for ONEDRIVER in $EXPECTED_DRIVER_LIST; do
+        EXPECTED_MODULE_STRING="$EXPECTED_MODULE_STRING$(cat /tmp/simple_network_setup/udevmodulelist/"$ONEDRIVER") "
+    done #Driver entry may have multiple module names from preferences.
+    EXPECTED_MODULE_LIST="$(tr ' ' '\n' <<< "${EXPECTED_MODULE_STRING%% }")"
+    [ -n "$EXPECTED_MODULE_LIST" ] && [ -n "$CONNECTION_BUILTIN_DRIVER_LIST" ] \
+      && EXPECTED_MODULE_LIST="$(grep -vF "$CONNECTION_BUILTIN_DRIVER_LIST" <<< "$EXPECTED_MODULE_LIST")"
+    if [ -n "$EXPECTED_MODULE_LIST" ]; then #201017
+        local EXPECTED_MODULE_COUNT LOADED_MODULE_COUNT
+        EXPECTED_MODULE_COUNT="$(wc -l <<< "$EXPECTED_MODULE_LIST")" #190525
+        #Wait until all expected modules are loaded...
+        while true; do #190525
+            LOADED_MODULE_COUNT="$(lsmod | cut -f 1 -d ' ' | \
+              grep -Fxc "${EXPECTED_MODULE_LIST}")"
+            [ "$LOADED_MODULE_COUNT" -eq "$EXPECTED_MODULE_COUNT" ] && break
+            [ "$WAITCNT" -ge "$WAITDRVRS" ] && break #all modules may not be loaded.
+            sleep 1
+            ((++WAITCNT))
+        done
+    elif [ -z "$CONNECTION_BUILTIN_DRIVER_LIST" ]; then return 1
+    fi
+    return 0
+} #ensure_driver_modules_loaded #211231 end
 
 find_available_interfaces() {
-    AVAILABLE_CONNECTIONS='' #190525...
-    local CONNECTION_MACADDRESS_COUNT
-    CONNECTION_MACADDRESS_COUNT="$(wc -l <<< "$ACTIVE_CONNECTION_MACADDRESSES")"
+    AVAILABLE_CONNECTIONS='' #global #190525...
+    local PREFERRED_MACADDR EXPECTED_DRIVER_PATTERNS CONNECTION_MACADDRESS_COUNT #190525...
+    PREFERRED_MACADDR="$(head -n 1 <<< "$ALL_CONNECTION_PROFILES" | cut -f "$MACADDRESS_FIELD" -d '|')" #211215
+# shellcheck disable=SC2001 #${variable//search/replace} not applicable for multiple lines
+    EXPECTED_DRIVER_PATTERNS="$(sed 's%^.*%|&|%' <<< "$EXPECTED_DRIVER_LIST")" #211215
+    CONNECTION_MACADDRESS_COUNT="$(grep -F "$EXPECTED_DRIVER_PATTERNS" <<< "$ALL_CONNECTION_PROFILES" | cut -f "$MACADDRESS_FIELD" -d '|' | sort -u | wc -l)" #211215
+    local ACTIVE_REAL_MACADDRESSES ACTIVE_MACADDRESS_PATTERNS
+    local AVAILABLE_CONNECTION_COUNT
     while true; do
-        local ACTIVE_MACADDRESS_PATTERNS
-# shellcheck disable=SC2060
-        ACTIVE_MACADDRESS_PATTERNS="$(sed 's%^.*%&|%' <<< "$ACTIVE_MACADDRESSES")"
-        AVAILABLE_CONNECTIONS="$(grep -iF "${ACTIVE_MACADDRESS_PATTERNS}" /etc/simple_network_setup/connections | grep '^..:')" #210202 201017
-        local AVAILABLE_CONNECTION_COUNT
-        AVAILABLE_CONNECTION_COUNT="$(wc -l <<< "$AVAILABLE_CONNECTIONS")"
-        [ "$AVAILABLE_CONNECTION_COUNT" -ge "$CONNECTION_MACADDRESS_COUNT" ] && break
-        [ $WAITCNT -ge $WAITMAX ] && break 
+        set_active_interface_macaddresses #211215...
+        if [ -n "$ACTIVE_INTERFACE_MACADDRESSES" ]; then
+            ACTIVE_REAL_MACADDRESSES="$(cut -f 3 -d _ <<< "$ACTIVE_INTERFACE_MACADDRESSES")"
+# shellcheck disable=SC2001 #${variable//search/replace} not applicable for appending a character
+            ACTIVE_MACADDRESS_PATTERNS="$(sed 's%^.*%&|%' <<< "$ACTIVE_REAL_MACADDRESSES")"
+            AVAILABLE_CONNECTIONS="$(grep -iF "${ACTIVE_MACADDRESS_PATTERNS}" <<< "$ALL_CONNECTION_PROFILES")" #210202 201017.
+            grep -q "$PREFERRED_MACADDR" <<< "$AVAILABLE_CONNECTIONS" && break #211215 end
+            AVAILABLE_CONNECTION_COUNT="$(wc -l <<< "$AVAILABLE_CONNECTIONS")"
+            [ "$AVAILABLE_CONNECTION_COUNT" -ge "$CONNECTION_MACADDRESS_COUNT" ] && break
+        fi
+        [ "$WAITCNT" -ge "$WAITMAX" ] && break 
         sleep 1
         ((++WAITCNT))
     done
-    [ $WAITCNT -gt 0 ] && echo "SNS rc.network: waited for ethernet interfaces: seconds=${WAITCNT}" #180115
+    [ "$WAITCNT" -gt 0 ] && echo "SNS rc.network: waited for ethernet interfaces: seconds=${WAITCNT}" #180115
     [ -z "$AVAILABLE_CONNECTIONS" ] && cancel_splash_and_exit #181109 end
-    local AVAILABLE_CONNECTION_MACADDRESSES
+    local AVAILABLE_CONNECTION_MACADDRESSES MACADDR MACINTERFACE
     AVAILABLE_CONNECTION_MACADDRESSES="$(cut -f "$MACADDRESS_FIELD" -d '|' <<< "$AVAILABLE_CONNECTIONS")"
-    local INTERFACE_MACADDRESSES
-    INTERFACE_MACADDRESSES="$(ip link show | \
-      grep -B 1 'link/ether' | \
-      grep -B 1 -iF "$AVAILABLE_CONNECTION_MACADDRESSES" | \
-      sed -n '/^[0-9]/ {N;s%^[0-9]\+: \([^:]*\).*link/ether\( [^ ]*\).*%\1\2%p}')" #ex. wlan0 xx:xx:xx:xx:xx:xx, avoid using busybox 'ip -online' #210202 210208
-    PRIORITIZED_INTERFACES='' #211002...
+    PRIORITIZED_INTERFACES='' #global #211002...
     for MACADDR in $AVAILABLE_CONNECTION_MACADDRESSES; do
-        PRIORITIZED_INTERFACES="$PRIORITIZED_INTERFACES$(grep -w "$MACADDR" <<< "$INTERFACE_MACADDRESSES" | cut -f 1 -d ' ') " #190525 end 210205
+        MACINTERFACE="$(grep "$MACADDR" <<< "$ACTIVE_INTERFACE_MACADDRESSES" | cut -f 1 -d _)"
+        grep -qw "$MACINTERFACE" <<< "$PRIORITIZED_INTERFACES" \
+          || PRIORITIZED_INTERFACES="${PRIORITIZED_INTERFACES}$MACINTERFACE " #190525 end 210205 #211215
     done
 } #find_available_interfaces
 
-initiate_wireless_connection() { #Exits from start_wireless_connection if successful
+initiate_wireless_connection() { #Exits if successful; returns if unsuccessful
     [ -x /usr/sbin/connectwizard_crd ] \
       && connectwizard_crd >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170612 #210915
     # For each interface beginning with that in the first profile, search for a network in profile order.
-    EBSSIDS_WANT="$(grep '|Wireless|' /etc/simple_network_setup/connections | \
-      cut -f "$CELL_ESSID_FIELD,$CELL_ADDRESS_FIELD" -d '|')"
+    EBSSIDS_WANT="$(grep '|Wireless|' <<< "$ALL_CONNECTION_PROFILES" | \
+      cut -f "$CELL_ESSID_FIELD,$CELL_ADDRESS_FIELD" -d '|')" #211215
     EBSSID_PATTERNS="$(sed -e 's/^[^|]*/SSID: &/' -e 's/[^|]*$/BSS &/' -e 's/|/\n/' <<< "$EBSSIDS_WANT")" #210202
     which iw >/dev/null 2>&1 || return 1 #skip wireless if 'iw' not installed #####
     rfkill unblock wlan #180125
-# shellcheck disable=SC2060
-    MACADDRESS="$(ip link show "$INTERFACE" | grep 'link/ether' | tr -s ' ' | cut -f 3 -d ' ')" #210202
+    MACADDRESS="$(grep "^${INTERFACE}_" <<< "$ACTIVE_INTERFACE_MACADDRESSES" | cut -f 2 -d _)" #211215
+    REALMACADDRESS="$(grep "^${INTERFACE}_" <<< "$ACTIVE_INTERFACE_MACADDRESSES" | cut -f 3 -d _)" #211215
     find_available_networks
     echo " EXECUTING: ip link set $INTERFACE down" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #110203 210202
     ip link set "$INTERFACE" down #210202
@@ -240,7 +225,10 @@ initiate_wireless_connection() { #Exits from start_wireless_connection if succes
         -e 's%signal: \([/0-9-]\+\)[^\|]*%\1%g' \
         -e 's%SSID: \([^\|]*\|\)%\1%g' | \
       sort -g -r -t '|' -k 3)" #170619 210202
-    while IFS='|' read -r WANTSSID WANTBSS; do
+    TRIED_WANTS=''  #211215
+    for ONEWANT in $EBSSIDS_WANT; do #211215
+        grep -wq "${ONEWANT}" <<< "${TRIED_WANTS}" && continue #211215
+        IFS='|' read -r WANTSSID WANTBSS <<< "$ONEWANT" #211215
         while IFS='|' read -r CELL_ADDRESS CELL_FREQUENCY _ CELL_ESSID _; do
             [ -z "$CELL_ESSID" ] && CELL_ESSID="$WANTSSID"
             if [ "$CELL_ADDRESS" = "$WANTBSS" ] \
@@ -250,8 +238,9 @@ initiate_wireless_connection() { #Exits from start_wireless_connection if succes
                 case "${SEC_MGMT:0:3}" in #210207...
                   WPA) RUNWPASUPP='yes' ;;
                   NON) [ -n "$SEC_KEY" ] && RUNWPASUPP='yes' ;; #WEP
-                esac 
-                ip link set "$INTERFACE" up #hmmm, it seems need to bring up after all the iwconfig operations! #210202
+                esac
+                spoof_macaddress '   EXECUTING: ' >> /tmp/simple_network_setup/rc_network_wireless_connection_log #If using real MAC, spoof it #211215
+                ip link set "$INTERFACE" up #210202
                 local RC=$? #170301
                 echo "     RESULT=$RC FOR: ip link set $INTERFACE up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170301 210202
                 if [ $RC -eq 0 ]; then #170301
@@ -263,10 +252,12 @@ initiate_wireless_connection() { #Exits from start_wireless_connection if succes
                         iw dev "$INTERFACE" connect "${CELL_ESSID}" "$CELL_FREQUENCY" "$CELL_ADDRESS" #210202
                     fi
                     start_wireless_connection #exits if connection successful
+                    reset_macaddress >> /tmp/simple_network_setup/rc_network_wireless_connection_log #Unsuccessful, so undo spoofing #211215
                 fi 
             fi 
         done <<< "$SRLINES"
-    done <<< "$EBSSIDS_WANT"
+        TRIED_WANTS="${TRIED_WANTS}${ONEWANT} " #211215
+    done
 } #initiate_wireless_connection
 
 find_available_networks() {
@@ -276,7 +267,7 @@ find_available_networks() {
     echo " SUCCESS: ip link set ${INTERFACE} up" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #210202
     sleep 0.1 #210205
     SECS=0 #210205
-    echo " EXECUTING SCAN: iw dev ${INTERFACE} scan | grep -E (messages & labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706 210202
+    echo " EXECUTING SCAN: iw dev ${INTERFACE} scan | grep -E (detail labels)" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #180706 210202
     for I in 1 2 3 4 5; do #210205
         SCANRESULT="$(iw dev "$INTERFACE" scan | \
           grep -E '^BSS |freq:|signal:|SSID:' | \
@@ -300,7 +291,8 @@ find_connection_profile_and_extract_content() {
     local essidPATTERN
     essidPATTERN='|'"${CELL_ESSID}"'|' #null or \x00... = hidden SSID
     local maPATTERN
-    maPATTERN="^$MACADDRESS|.*|$CELL_ADDRESS|" #interface & AP MAC addresses
+    REALMACADDRESS="$(grep "^${INTERFACE}_" <<< "$ACTIVE_INTERFACE_MACADDRESSES" | cut -f 3 -d _)" #211215
+    maPATTERN="^$REALMACADDRESS.*|$CELL_ADDRESS|" #interface & AP MAC addresses
     local CONNECTDATA
     CONNECTDATA="$(grep -i "$maPATTERN" <<< "$AVAILABLE_CONNECTIONS" | grep "$essidPATTERN")" #211002
     if [ -n "$CONNECTDATA" ]; then
@@ -319,7 +311,8 @@ find_connection_profile_and_extract_content() {
 
 run_wpa_supplicant() {
     local WPACONF
-    WPACONF="/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
+    REALMACADDRESS="$(grep "^${INTERFACE}_" <<< "$ACTIVE_INTERFACE_MACADDRESSES" | cut -f 3 -d _)" #211215
+    WPACONF="/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${REALMACADDRESS}" #211215
     [ -f "$WPACONF" ] || return 1 #210211
     wpa_supplicant -B -D"${WPA_DRIVER}" -i"${INTERFACE}" -c"$WPACONF"
     local RC=$? #210211
@@ -340,11 +333,12 @@ run_wpa_supplicant() {
 
 start_wireless_connection() {
     if [ "$wCNT" -le 20 ]; then #170402
+        echo -n '' > /etc/resolv.conf #211231
+        sleep 0.1 #timing precaution
         for ATTEMPT in 1 2 ; do
-            sleep 0.1 #timing precaution
-            echo "        EXECUTING: dhcpcd ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924
-# shellcheck disable=SC2086 #word-split $DHCPCDFIX
-            dhcpcd $DHCPCDFIX "$INTERFACE"
+            echo "        EXECUTING: dhcpcd ${DHCPCD_TIMEOUT} ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924 #211215
+# shellcheck disable=SC2086 #word-split $DHCPCD_TIMEOUT & $DHCPCDFIX
+            dhcpcd $DHCPCD_TIMEOUT $DHCPCDFIX "$INTERFACE" 2>&1 | tee -a /tmp/simple_network_setup/rc_network_wireless_connection_log #211231 #211215
             local RC=$? #170402
             echo "        dhcpcd return value: ${RC}" >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170924
             #need to wait awhile #210212...
@@ -355,84 +349,103 @@ start_wireless_connection() {
                 done
             fi
             if [ $RC -eq 0 ] \
-              && grep -q '^nameserver' /etc/resolv.conf; then #210212 end
-                echo "     SUCCESS" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
-                #in situation bring up interface from desktop icon...
-                [ "$DISPLAY" ] \
-                  &&  gtkdialog-splash -placement bottom -bg lightgreen -timeout 5 -text "$(eval_gettext "Network interface '\${INTERFACE}' has been activated")" >/dev/null &
-                cancel_splash_and_exit #one internet connection is enough! #170505
-            else
+              && grep -q '^nameserver' /etc/resolv.conf \
+              && grep -qw "Generated.* $INTERFACE" /etc/resolv.conf; then #210212 end #211231
+                break #211231
+            else #211231
                 echo "     FAIL" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+                GENDFROM="$(grep 'Generated by dhcpcd.' /etc/resolv.conf)" #211231
                 dhcpcd --release "$INTERFACE" 2>/dev/null
-                [ "$ATTEMPT" -eq 1 ] && continue
-                ps -C wpa_supplicant >/dev/null 2>&1 && wpa_cli terminate >/dev/null #kill wpa_supplicant.     #210202
-                ip link set "$INTERFACE" down #210202
-                iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid' && iw dev "$INTERFACE" disconnect #210202
-                ip route flush dev "$INTERFACE" #100703
-            fi #170402 #rerwin - moved
+                [ -n "$GENDFROM" ] && [ "${GENDFROM##* }" != "$INTERFACE" ] && break #211231
+                [ "$ATTEMPT" -eq 1 ] && sleep 8 #211231
+            fi #170402
         done
+        if grep -q '^nameserver' /etc/resolv.conf \
+          && grep -qw "Generated.* $INTERFACE" /etc/resolv.conf; then #210212 end #211231
+            echo "     SUCCESS" >> /tmp/simple_network_setup/rc_network_wireless_connection_log
+            #in situation bring up interface from desktop icon...
+            [ "$DISPLAY" ] \
+              &&  gtkdialog-splash -placement bottom -bg lightgreen -timeout 5 -text "$(eval_gettext "Network interface '\${INTERFACE}' has been activated")" >/dev/null &
+            cancel_splash_and_exit #one internet connection is enough! #170505
+        else
+            ps -C wpa_supplicant >/dev/null 2>&1 && wpa_cli terminate >/dev/null #kill wpa_supplicant.     #210202
+            ip link set "$INTERFACE" down #210202
+            iw dev "$INTERFACE" info 2>/dev/null | grep -qw 'ssid' && iw dev "$INTERFACE" disconnect #210202
+            ip route flush dev "$INTERFACE" #100703
+        fi #170402
     fi
 } #start_wireless_connection
 
-initiate_wired_connection() {
-    ip link set "$INTERFACE" up >> /tmp/simple_network_setup/rc_network_wired_connection_log 2>&1 || return 1 #210202
+initiate_wired_connection() { #Exits if successful; returns if unsuccessful
+    spoof_macaddress >> /tmp/simple_network_setup/rc_network_wired_connection_log #If using real MAC, spoof it #211215
+    if ip link set "$INTERFACE" up >> /tmp/simple_network_setup/rc_network_wired_connection_log 2>&1; then #210202
+        if ! ip link show "$INTERFACE" | grep -q 'LOWER_UP'; then #211231
+            TIMEOUT=15 #200412
+            if [ ! -f /tmp/simple_network_setup/initialization_completed ]; then #211231
+                while [ $TIMEOUT -ge 0 ]; do #200412
+                    ip link show "$INTERFACE" | grep -q 'LOWER_UP' && break #211231
+                    [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190212 200412
+                done
+            fi #211231
+            if [ -f /tmp/simple_network_setup/initialization_completed ] \
+              || [ $TIMEOUT -lt 0 ]; then #211231
+                ip link set "$INTERFACE" down #210202
+                return 1 #no network
+            fi
+        fi #211231
+        REALMACADDRESS="$(grep "^${INTERFACE}_" <<< "$ACTIVE_INTERFACE_MACADDRESSES" | cut -f 3 -d _)" #211215
+        maPATTERN='|'"$REALMACADDRESS"'|' #211215
+        DHCPCDFIX="$(grep -i "$maPATTERN" <<< "$AVAILABLE_CONNECTIONS" | \
+          head -n 1 | cut -f "$DHCPCDFIX_FIELD" -d '|')" #100325 ex: -I '' #210202 #211002
 
-    LINK_DETECTED=no
-    TIMEOUT=15 #200412
-    while [ $TIMEOUT -ge 0 ]; do #200412
-        if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
-            LINK_DETECTED="yes"
-            break
-        fi
-        [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190212 200412
-    done
-    if [ "$LINK_DETECTED" = "no" ] ; then
-        ip link set "$INTERFACE" down #210202
-        return 1 #no network
-    fi
-
-# shellcheck disable=SC2060
-    MACADDRESS="$(ip link show "$INTERFACE" | grep 'link/ether' | tr -s ' ' | cut -f 3 -d ' ')" #210202
-    maPATTERN='|'"$MACADDRESS"'|'
-    DHCPCDFIX="$(grep -i "$maPATTERN" <<< "$AVAILABLE_CONNECTIONS" | \
-      head -n 1 | cut -f "$DHCPCDFIX_FIELD" -d '|')" #100325 ex: -I '' #210202 #211002
-
-    sleep 0.1 #timing precaution #210915
-    for ATTEMPT in 1 2 3 ; do #210915
-        echo "EXECUTING: dhcpcd ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wired_connection_log #170924
-# shellcheck disable=SC2086
-        dhcpcd $DHCPCDFIX "$INTERFACE" >> /tmp/simple_network_setup/rc_network_wired_connection_log 2>&1
-        local RC=$? #170402
-        echo "dhcpcd return value: ${RC}" >> /tmp/simple_network_setup/rc_network_wired_connection_log #170924
-        #need to wait awhile #210212...
-        if [ $RC -eq 0 ]; then
-            for ONESLEEP in 0.2 1 2; do
-                sleep $ONESLEEP
-                grep -q '^nameserver' /etc/resolv.conf && break
-            done
-        fi
-        if grep -q '^nameserver' /etc/resolv.conf; then #210212 end
+        echo -n '' > /etc/resolv.conf #211231
+        sleep 0.1 #timing precaution #210915
+        for ATTEMPT in 1 2 ; do #210915
+            echo "EXECUTING: dhcpcd ${DHCPCD_TIMEOUT} ${DHCPCDFIX} ${INTERFACE}" >> /tmp/simple_network_setup/rc_network_wired_connection_log #170924 #211215
+# shellcheck disable=SC2086 #word-split $DHCPCD_TIMEOUT & $DHCPCDFIX
+            dhcpcd $DHCPCD_TIMEOUT $DHCPCDFIX "$INTERFACE" >> /tmp/simple_network_setup/rc_network_wired_connection_log 2>&1 #211215
+            local RC=$? #170402
+            echo "dhcpcd return value: ${RC}" >> /tmp/simple_network_setup/rc_network_wired_connection_log #170924
+            #need to wait awhile #210212...
+            if [ $RC -eq 0 ]; then
+                for ONESLEEP in 0.2 1 2; do
+                    sleep $ONESLEEP
+                    grep -q '^nameserver' /etc/resolv.conf && break
+                done
+            fi
+            if [ $RC -eq 0 ] \
+              && grep -q '^nameserver' /etc/resolv.conf \
+              && grep -qw "Generated.* $INTERFACE" /etc/resolv.conf; then #210212 end #211231
+                break #211231
+            else
+                GENDFROM="$(grep 'Generated by dhcpcd.' /etc/resolv.conf)" #211231
+                ip link set "$INTERFACE" down #210202
+                dhcpcd --release "$INTERFACE" 2>/dev/null
+                ip route flush dev "$INTERFACE" #100703
+                [ -n "$GENDFROM" ] && [ "${GENDFROM##* }" != "$INTERFACE" ] && break #211231
+                [ "$ATTEMPT" -eq 1 ] && sleep 8 #210915 #211231
+            fi
+        done #210915
+        if grep -q '^nameserver' /etc/resolv.conf \
+          && grep -qw "Generated.* $INTERFACE" /etc/resolv.conf; then #210212 end #211231
             [ "$DISPLAY" ] \
               &&  gtkdialog-splash -placement bottom -bg lightgreen -timeout 5 -text "$(eval_gettext "Network interface '\${INTERFACE}' has been activated")" >/dev/null &
             cancel_splash_and_exit #success. #170505
-        else
-            ip link set "$INTERFACE" down #210202
-            dhcpcd --release "$INTERFACE" 2>/dev/null
-            ip route flush dev "$INTERFACE" #100703
-            [ "$ATTEMPT" = '3' ] || sleep 5 #210915
         fi
-    done #210915
+    fi
+    reset_macaddress >> /tmp/simple_network_setup/rc_network_wired_connection_log #Unsuccessful, so undo spoofing #211215
 } #initiate_wired_connection
 
 
 ################# MAIN ####################
 
 export LANG='C'
-if [ "$1" ]; then #100325
-    case $1 in
-      stop) stop_interface ;;
-    esac
-fi
+#Argument: 'stop', 'start' from sns, null from network_default_connect or Connect/AppRun
+case "$1" in
+  stop) stop_interface ;; #100325
+  start) ;;
+  ?*) exit ;;
+esac
 [ ! -s /etc/simple_network_setup/connections ] && cancel_splash_and_exit #170505 171222
 
 if [ -z "$1" ] && [ -n "$DISPLAY" ]; then
@@ -440,7 +453,6 @@ if [ -z "$1" ] && [ -n "$DISPLAY" ]; then
     echo $! >/tmp/sns_splash_pid
 fi
 
-ARGUMENT="$1" #'start' from sns or null from network_default_connect or Connect/AppRun
 [ -f /root/.connectwizardrc ] \
   || echo 'CURRENT_EXEC=sns' > /root/.connectwizardrc #170309
 
@@ -450,22 +462,21 @@ if grep -q '|ndiswrapper|' /etc/simple_network_setup/connections; then #100314..
 fi
 
 mkdir -p /tmp/simple_network_setup
-find_available_drivers || cancel_splash_and_exit #201017
+set_dhcpcd_timeout #211215
+ALL_CONNECTION_PROFILES="$(grep -s '^..:' /etc/simple_network_setup/connections 2>/dev/null)" #211215
+ensure_driver_modules_loaded || cancel_splash_and_exit #201017
 find_available_interfaces
 
 echo -n "" > /tmp/simple_network_setup/rc_network_wireless_connection_log
 echo -n "" > /tmp/simple_network_setup/rc_network_wired_connection_log #210915
 
-TRIED_INTERFACES='' #211002
-for INTERFACE in $PRIORITIZED_INTERFACES; do #exs: wlan0 eth0 (may contain duplicate entries) #211002
-    grep -wq "${INTERFACE}" <<< "${TRIED_INTERFACES}" && continue #211002
+for INTERFACE in $PRIORITIZED_INTERFACES; do #exs: wlan0 eth0 #211002
     if [ -d "/sys/class/net/${INTERFACE}/wireless" ] \
       || grep -q "${INTERFACE}:" /proc/net/wireless; then
         initiate_wireless_connection #exits if successful #170924
     else
         initiate_wired_connection #exits if successful #170924
     fi
-    TRIED_INTERFACES="${TRIED_INTERFACES}${INTERFACE} " #211002
 done
 cancel_splash_and_exit #170505
 

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/rc.network
@@ -202,7 +202,7 @@ find_available_interfaces() {
     done
 } #find_available_interfaces
 
-initiate_wireless_connection() { #Exits if successful; returns if unsuccessful
+initiate_wireless_connection() { #Exits from start_wireless_connection if successful; returns if unsuccessful
     [ -x /usr/sbin/connectwizard_crd ] \
       && connectwizard_crd >> /tmp/simple_network_setup/rc_network_wireless_connection_log #170612 #210915
     # For each interface beginning with that in the first profile, search for a network in profile order.

--- a/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
+++ b/woof-code/rootfs-packages/simple_network_setup/usr/local/simple_network_setup/sns
@@ -63,9 +63,11 @@
 #210623 v3.0 (not annotated) Support hidden networks; remove unnecessary user selection of encryption protocols; use 'read' to extract fields from one-line entries; change profile format to omit unused fields; add wireless network name to status message; use eval_gettext where appropriate; rework connection wait splash messaging.
 #210703 v3.1 Accommodate EasyOS which does not use pup_event_backend_modprobe for module loading (udev rule, build_udevmodulelist, rc.network); change yaf-splash to gtkdialog-splash.
 #211002 v3.2 Add 'wired' profiles to top of connections list (as well as 'wireless' profiles); add splash message if 'iw' command not installed.
+#211215 v3.3 Accommodate spoofed gadget (USB-tethered smartphone) MAC addresses; add spoofing if macchanger installed; group same-MAC connections, so list shows connection priority; correct driver & interface searches and selection; override default dhcpcd response timeout if not already in conf file, to compensate for router possibly slowing due to MAC spoofing.
+#211231 v3.3 Replace ethtool with ip-show test for LOWER_UP.
+#220123 v3.3 Add iw-missing message to wireless configure dialog; remove unnecessary iw splash message (211002) and avoid iw-missing error messages, for clean support of wired interfaces when 'iw' is missing.
 
-#set -x; exec >&2 #DEBUG
-export VERSION='3.2'  #UPDATE this with each release!
+export VERSION='3.3'  #UPDATE this with each release!
 
 export TEXTDOMAIN=simple_network_setup
 export OUTPUT_CHARSET=UTF-8
@@ -73,13 +75,17 @@ export OUTPUT_CHARSET=UTF-8
 
 [ "$(whoami)" != "root" ] && exec sudo -A "${0}" "${@}" #110505
 
+# shellcheck disable=SC2009
 if ps --no-headers -C sns | grep -qwv "^ *$$"; then #170514... 190216
     sleep 1 #190525
+# shellcheck disable=SC2009
     if ps --no-headers -C sns | grep -qwv "^ *$$"; then #190525
         Xdialog --left --wmclass "sns" --title "$(gettext 'Simple Network Setup')"  --backtitle "\n$(gettext 'Simple Network Setup cannot start now because it is already active.')" --icon /usr/local/lib/X11/pixmaps/error.xpm --msgbox "\n$(gettext 'Please use the active SNS session or\nterminate it and start SNS again.')\n" 0 70
         exit 1
     fi #190525
 fi #170514 end
+
+. /usr/local/simple_network_setup/macaddress_spoofing_functions #211215
 
 #each line of /etc/simple_network_setup/connections has everything needed about a connection:
 #(please ignore spaces, put here for readability only)
@@ -176,8 +182,9 @@ find_usable_interfaces() {
         if [ "$(wc -w <<< "$WORKINGIF")" -gt 1 ]; then
             MSGSTATUS="$(eval_gettext "Current Internet connections are on interfaces \${MSGWIF}")"
         else
-            WORKSSID="$(iw dev "$WORKINGIF" link | sed -n 's%.*SSID: \(.*\)%\1%p')"
+            WORKSSID="$(iw dev "$WORKINGIF" link 2>/dev/null | sed -n 's%.*SSID: \(.*\)%\1%p')" #220123
             if [ -n "$WORKSSID" ]; then
+# shellcheck disable=SC2034 # Missed, but MSGWSSID used in eval_gettext.
                 MSGWSSID="<b>${WORKSSID:0:20}</b>"
                 MSGSTATUS="$(eval_gettext "Current Internet connection is on interface \${MSGWIF} network \${MSGWSSID}")"
             else
@@ -211,6 +218,7 @@ connect_button_splash() { #170505...
 export -f connect_button_splash #170505 end
 
 build_connection_display_list() {
+    set_active_interface_macaddresses #211215
     echo "" >/tmp/sns_CNT_P
     echo "<b>$(gettext 'Interface')</b>" >/tmp/sns_I_P
     echo "<b>$(gettext 'Type')</b>" >/tmp/sns_T_P
@@ -221,23 +229,33 @@ build_connection_display_list() {
     if grep -q '^..:.*|Wireless|' /etc/simple_network_setup/connections; then
         echo "<b>$(gettext 'Network')</b>" >/tmp/sns_S_P
         echo "<b>$(gettext 'Security')</b>" >/tmp/sns_SEC_P
+    else
+        echo "       " >/tmp/sns_S_P
+        echo "        " >/tmp/sns_SEC_P
     fi
     echo "" >/tmp/sns_DEL_BTN
     CNT=0
     while read -r ONECONNECTION; do
         IFS='|' read -r MAC_P TYPE_P DRIVER_P BUS_P _ _ SSID_P _ SEC_P _ <<< "$ONECONNECTION" #210211
         if [ "${#MAC_P}" -ge 17 ]; then #ignore old profile format
+            IF_CURR_REAL_MACS="$(grep -E "_${MAC_P}$" <<< "$ACTIVE_INTERFACE_MACADDRESSES")" #211215
+            [ -z "$IF_CURR_REAL_MACS" ] \
+              && IF_CURR_REAL_MACS=" _${MAC_P}_${MAC_P}" #space before first '_', for "no interface" #211215
             ((++CNT))
             echo "<b>$CNT</b>" >> /tmp/sns_CNT_P
-            INTERFACE_P="$(ip link show | grep -B 1 "link/ether $MAC_P" | sed -n "1 s/^[0-9]\+: \([^:]\+\).*/\1/p")" >> /tmp/sns_I_P #210211
-            echo "${INTERFACE_P:= }" >> /tmp/sns_I_P #i/f or space
+            INTERFACE_P="$(cut -f 1 -d _ <<< "$IF_CURR_REAL_MACS")" #211215
+            echo "$INTERFACE_P" >> /tmp/sns_I_P
             if [ "$TYPE_P" = "Wireless" ]; then
+# shellcheck disable=SC2005 #need newline by echo
                 echo "$(gettext 'Wireless')" >> /tmp/sns_T_P
             else
+# shellcheck disable=SC2005 #need newline by echo
                 echo "$(gettext 'Wired')" >> /tmp/sns_T_P
             fi
             echo "$DRIVER_P" >> /tmp/sns_D_P
             echo "$BUS_P" >> /tmp/sns_B_P
+            MAC_P="$(cut -f 2 -d _ <<< "$IF_CURR_REAL_MACS")" #211215
+            [ -z "$MAC_P" ] && MAC_P="$(cut -f 3 -d _ <<< "$IF_CURR_REAL_MACS")" #spoofed gadget #211215
             echo "$MAC_P" >> /tmp/sns_M_P
             if [ "$TYPE_P" = "Wireless" ]; then
                 echo "$SSID_P" >> /tmp/sns_S_P
@@ -259,7 +277,7 @@ build_connection_display_list() {
             <action>rm -f /etc/simple_network_setup/wpa_supplicant.conf-\"$WPACONFSFX\"</action>
             <action type=\"exit\">EXITRESTART></action></button>" >> /tmp/sns_DEL_BTN #170529 #210213
         fi
-    done <<< "$(grep -s '^..:' /etc/simple_network_setup/connections)"
+    done <<< "$ALL_CONNECTION_PROFILES" #211215
 } #build_connection_display_list
 
 build_display_connect_button() {
@@ -277,7 +295,10 @@ build_display_connect_button() {
     DISCONNECT_XML='' #190223
     grep -qswv 'sns' /root/.connectwizardrc \
       && DISCONNECT_XML="$(gettext '<b>Note:</b> The current connection was started by another network tool.  To control it with SNS, disconnect now, then re-connect or choose an interface.')" #190223
-    PROFILE_XML="$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Connection profiles have previously been created by SNS.')" "$(gettext "The <b>Connect</b> button will try to establish an internet connection by any of the available profiles.")" "${DISCONNECT_XML}")
+    SPOOFING_XML=''  #211215...
+    macaddress_spoofing_enabled \
+      && SPOOFING_XML="$(gettext '<b>Note:</b> Active interface hardware address is spoofed.')"
+    PROFILE_XML="$(/usr/lib/gtkdialog/xml_info fixed "internet_connect.svg" 60 "$(gettext 'Connection profiles have previously been created by SNS.')" "$(gettext "The <b>Connect</b> button will try to establish an internet connection by any of the available profiles.")" "${DISCONNECT_XML}" "${SPOOFING_XML}")
  <hbox border-width=\"7\" spacing=\"10\"><text use-markup=\"true\"><label>\"$(cat /tmp/sns_CNT_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_I_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_T_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_D_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_B_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_M_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_S_P)\"</label></text><text use-markup=\"true\"><label>\"$(cat /tmp/sns_SEC_P)\"</label></text></hbox>
  <hbox><text><label>$(gettext 'Delete:')</label></text>$(cat /tmp/sns_DEL_BTN)</hbox>
 " #190223
@@ -465,6 +486,7 @@ complete_the_wireless_connection() {
         show_wait_splash "$fuCNT"
         ((--fuCNT))
         [ "$CELL_ENCRYPTIONKEY" = "on" ] && configure_wpa_supplicant
+        spoof_macaddress 'STEP1d: ' >> /tmp/sns_wireless_log #If using real MAC, spoof it #211215
         echo "STEP5a: ip link set $INTERFACE up" >> /tmp/sns_wireless_log #210202
         ip link set "$INTERFACE" up #210202
         sleep 4
@@ -526,16 +548,20 @@ scan_for_wireless_networks() {
     if ! ip link set "$INTERFACE" up >> /tmp/sns_wireless_log 2>&1; then #210202
         FLAGERR=1
     else
-        sleep 0.1 #210205
-        echo "STEP1b: iw dev $INTERFACE scan | grep -E (messages & labels)" >> /tmp/sns_wireless_log #180706 210202
+        if which iw >/dev/null 2>&1; then #220123
+            sleep 0.1 #210205
+            echo "STEP1b: iw dev $INTERFACE scan | grep -E (messages & labels)" >> /tmp/sns_wireless_log #180706 210202
 # shellcheck disable=SC2034
-        for I in 1 2 3 4 5; do #210205
-            SCANRESULT="$(iw dev "$INTERFACE" scan | \
-              grep -E '^BSS |freq:|capability:|signal:|SSID:|DS Parameter set:|RSN:|Pairwise ciphers:|Authentication suites:|WPA:')" ###SCANNING### 110203 210203 210202
-            [ -n "$SCANRESULT" ] && break #210202
-            sleep 1 #210205
-        done #210205
-        echo "$SCANRESULT" >> /tmp/sns_wireless_log
+            for I in 1 2 3 4 5; do #210205
+                SCANRESULT="$(iw dev "$INTERFACE" scan | \
+                  grep -E '^BSS |freq:|capability:|signal:|SSID:|DS Parameter set:|RSN:|Pairwise ciphers:|Authentication suites:|WPA:')" ###SCANNING### 110203 210203 210202
+                [ -n "$SCANRESULT" ] && break #210202
+                sleep 1 #210205
+            done #210205
+            echo "$SCANRESULT" >> /tmp/sns_wireless_log
+        else #220123...
+            SCANRESULT=''
+        fi
     fi #210201
 } #scan_for_wireless_networks
 
@@ -662,7 +688,11 @@ build_display_radio_buttons() {
         FRAME1='<text space-expand="true" space-fill="true"><label>""</label></text>'
         HIDDENBOX=""
         FRAME2=""
-        WIN2MSG1="$(gettext 'No wireless networks found')"
+        if which iw >/dev/null 2>&1; then #220123...
+            WIN2MSG1="$(gettext 'No wireless networks found.')"
+        else
+            WIN2MSG1="$(gettext "Cannot scan for networks -- 'iw' command is missing.")"
+        fi
         WIN2BUT1=""
         WIN2BUT2=""
     else
@@ -768,7 +798,7 @@ build_and_display_wireless_setup_window() {
     <hbox space-expand="false" space-fill="false">
       <button space-expand="false" space-fill="false">
         <label>'$(gettext "Rescan")'</label>
-        '"`/usr/lib/gtkdialog/xml_button-icon refresh`"'
+        '"$(/usr/lib/gtkdialog/xml_button-icon refresh)"'
         <action type="exit">BUT_RESCAN</action>
       </button>
       '${WIN2BUT2}'
@@ -965,9 +995,9 @@ run_dhcpcd() {
     for iterDHCPCD in a b; do #100320
         [ "$iterDHCPCD" = "a" ] && DHCPCDFIX=""
         [ "$iterDHCPCD" = "b" ] && DHCPCDFIX="-I ''" #some dhcp servers require empty Client ID (default is macaddress).
-        echo "STEP6${iterDHCPCD}: dhcpcd $DHCPCDFIX $INTERFACE" >> /tmp/sns_wireless_log
-# shellcheck disable=SC2086 #word-split $DHCPCDFIX
-        dhcpcd $DHCPCDFIX "$INTERFACE" >> /tmp/sns_wireless_log 2>&1 ####DHCP CLIENT#### 121117
+        echo "STEP6${iterDHCPCD}: dhcpcd $DHCPCD_TIMEOUT $DHCPCDFIX $INTERFACE" >> /tmp/sns_wireless_log
+# shellcheck disable=SC2086 #word-split $DHCPCD_TIMEOUT & $DHCPCDFIX
+        dhcpcd $DHCPCD_TIMEOUT $DHCPCDFIX "$INTERFACE" >> /tmp/sns_wireless_log 2>&1 ####DHCP CLIENT#### 121117 #211215
         local RC=$? #170402
         [ $RC -eq 0 ] || break
         #need to wait awhile #210212...
@@ -997,9 +1027,14 @@ add_wireless_connection_profile_and_conf() { #211002
         blinky_tray & #210202
     fi
     [ "$SEC_MGMT" != 'open' ] && SEC_MGMT="$WPA_SEC_MGMT"
-    macssidPATTERN="^$MACADDRESS|.*|$CELL_ESSID|" #210208
+    unspoof_macaddress #Set MACADDRESS to permanent MAC address #211215
     touch /etc/simple_network_setup/connections
-    echo -e "${MACADDRESS}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}|${DHCPCDFIX}|${CELL_ESSID}|${CELL_ADDRESS}|${SEC_MGMT}|${SEC_KEY}|${WPA_DRIVER}|\n$(grep -v "$macssidPATTERN" /etc/simple_network_setup/connections)" > /tmp/sns_connections.tmp #210207 210208 #210428 #211002
+    ( #210207,210208,211215...
+        echo "${MACADDRESS}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}|${DHCPCDFIX}|\
+${CELL_ESSID}|${CELL_ADDRESS}|${SEC_MGMT}|${SEC_KEY}|${WPA_DRIVER}|"
+        grep "^$MACADDRESS|" < /etc/simple_network_setup/connections | grep -v "^$MACADDRESS.*|$CELL_ESSID|"
+        grep -v "^$MACADDRESS|" < /etc/simple_network_setup/connections
+    ) > /tmp/sns_connections.tmp
     mv  /tmp/sns_connections.tmp /etc/simple_network_setup/connections #211002
     mv -f /tmp/sns_wpa_supplicant_conf "/etc/simple_network_setup/wpa_supplicant.conf-${CELL_ESSID}-${MACADDRESS}"
 } #add_wireless_connection_profile_and_conf
@@ -1099,18 +1134,38 @@ build_and_display_wireless_error_window() {
     export SNS_error
     RETSTRING="$(gtkdialog -p SNS_error --center)"
 } #build_and_display_wireless_error_window
+    
+perform_wired_setup() {
+    gtkdialog-splash -placement center -bg orange -text "$(eval_gettext "Please wait, trying to connect to interface '\${INTERFACE}'...")" >/dev/null &
+    PIDXX=$!
+    echo "Information about this interface:
+ Interface: $INTERFACE  Driver: $IF_DRIVER  Bus: $IF_BUS  MacAddress: $MACADDRESS
+ Description: $IF_INFO
+ " > /tmp/sns_wired_log
+    spoof_macaddress >> /tmp/sns_wired_log #If using real MAC, spoof it #211215
+    if ip link set "$INTERFACE" up >> /tmp/sns_wired_log 2>&1; then #210202
+        check_and_connect_wired_link
+        kill $PIDXX 2>/dev/null
 
-detect_and_connect_wired_link() {
-    LINK_DETECTED=no
+        if grep -q '^nameserver' /etc/resolv.conf; then #210212
+            add_wired_connection_profile #211002
+            build_and_display_wired_success_window
+        else
+            build_and_display_wired_error_window
+            grep '^EXIT' <<< "$RETSTRING" | grep -q 'BUT_GOBACK' && exec sns
+        fi
+    else
+        kill $PIDXX 2>/dev/null
+    fi
+} #perform_wired_setup
+
+check_and_connect_wired_link() {
     TIMEOUT=15 #200412
     while [ $TIMEOUT -ge 0 ]; do #200412
-        if ethtool "$INTERFACE" | grep -Fq 'Link detected: yes' ; then
-            LINK_DETECTED="yes"
-            break
-        fi
+        ip link show "$INTERFACE" | grep -q 'LOWER_UP' && break #211231
         [ $((--TIMEOUT)) -ge 0 ] && sleep 1 #190209 190216 200412
     done
-    if [ "$LINK_DETECTED" = "no" ] ; then
+    if [ $TIMEOUT -lt 0 ]; then #211231
         ip link set "$INTERFACE" down #210202
         kill "$PIDXX" 2>/dev/null
         /usr/lib/gtkdialog/box_ok "$(gettext 'Simple Network Setup')" error "<b>$(eval_gettext "There does not seem to be any network connected to \${INTERFACE}")</b>" " " "$(gettext "Is the network cable unplugged? Modem router turned off? If you can fix it, great, otherwise try a different interface.")"
@@ -1118,7 +1173,8 @@ detect_and_connect_wired_link() {
         exit
     fi
     DHCPCDFIX=""
-    dhcpcd "$INTERFACE" >> /tmp/sns_wired_log 2>&1
+# shellcheck disable=SC2086 #word-split $DHCPCD_TIMEOUT
+    dhcpcd $DHCPCD_TIMEOUT "$INTERFACE" >> /tmp/sns_wired_log 2>&1 #211215
     RC=$? #170402
     #need to wait awhile #210212...
     if [ $RC -eq 0 ]; then
@@ -1132,7 +1188,8 @@ detect_and_connect_wired_link() {
         DHCPCDFIX="-I ''"
         dhcpcd --release "$INTERFACE"
         sleep 0.1
-        dhcpcd -I '' "$INTERFACE" >> /tmp/sns_wired_log 2>&1
+# shellcheck disable=SC2086 #word-split $DHCPCD_TIMEOUT
+        dhcpcd $DHCPCD_TIMEOUT -I '' "$INTERFACE" >> /tmp/sns_wired_log 2>&1 #211215
         RC=$? #170402
        #need to wait awhile #210212...
         if [ $RC -eq 0 ]; then
@@ -1142,7 +1199,7 @@ detect_and_connect_wired_link() {
             done
         fi
     fi
-} #detect_and_connect_wired_link
+} #check_and_connect_wired_link
 
 build_and_display_wired_success_window() {
     SNS_complete='
@@ -1180,8 +1237,9 @@ build_and_display_wired_success_window() {
 } #build_and_display_wired_success_window
 
 add_wired_connection_profile() { #211002...
-    MACADDRESS="$(ip link show "$INTERFACE" | grep 'link/ether' | tr -s ' ' | cut -f 3 -d ' ')" #210202
-    aPATTERN="^$MACADDRESS|"
+    #Use real address if using dynamic MAC addresses 
+    unspoof_macaddress #Set MACADDRESS to permanent MAC address #211215
+    aPATTERN="^$MACADDRESS.*|Wired|"
     touch /etc/simple_network_setup/connections
     echo -e "${MACADDRESS}|${IF_INTTYPE}|${IF_DRIVER}|${IF_BUS}|${IF_INFO}|${DHCPCDFIX}|\n$(grep -i -v "$aPATTERN" /etc/simple_network_setup/connections)" > /tmp/sns_connections.tmp #211002
     mv  /tmp/sns_connections.tmp /etc/simple_network_setup/connections #211002
@@ -1225,11 +1283,6 @@ build_and_display_wired_error_window() {
 
 ################# MAIN ####################
 
-if ! which iw; then #211002...
-    gtkdialog-splash -bg orange -close never -fontsize large -timeout 20 -text "$(gettext 'Simple_network_setup needs the command: iw.  Please install it.')" >/dev/null
-    exit
-fi
-
 #firewall
 if which firewall_ng >/dev/null 2>&1; then
     FW_EXEC=firewall_ng
@@ -1237,6 +1290,7 @@ else
     FW_EXEC="urxvt -e firewallinstallshell"
 fi
 
+set_dhcpcd_timeout #211215
 echo -n '' > /tmp/sns_interfaces
 INTERFACES="$(ip link show | grep -B 1 'link/ether' | grep '^[0-9]' | cut -f 2 -d ':' | tr -d '\n')" #210202
 for INTERFACE in $INTERFACES; do #exs: wlan0 eth0
@@ -1248,7 +1302,8 @@ find_usable_interfaces #sets WORKINGIF
 
 #120107 new 'Profile' frame...
 PROFILE_XML=""
-if grep -qs '^..:' /etc/simple_network_setup/connections; then
+ALL_CONNECTION_PROFILES="$(grep -s '^..:' /etc/simple_network_setup/connections)" #211215
+if [ -n "$ALL_CONNECTION_PROFILES" ]; then #211215
     build_connection_display_list
     build_display_connect_button
 fi
@@ -1273,33 +1328,10 @@ extract_interface_data
 ############ WIRELESS SETUP ###############
 if [ "$IF_INTTYPE" = "Wireless" ]; then
     perform_wireless_setup
-    exit
-fi
-
 ############ WIRED SETUP ###############
-if [ "$IF_INTTYPE" = "Wired" ]; then
-    gtkdialog-splash -placement center -bg orange -text "$(eval_gettext "Please wait, trying to connect to interface '\${INTERFACE}'...")" >/dev/null &
-    PIDXX=$!
-    echo "Information about this interface:
- Interface: $INTERFACE  Driver: $IF_DRIVER  Bus: $IF_BUS  MacAddress: $MACADDRESS
- Description: $IF_INFO
- " > /tmp/sns_wired_log
- 
-    if ip link set "$INTERFACE" up >> /tmp/sns_wired_log 2>&1; then #210202
-        detect_and_connect_wired_link
-        kill $PIDXX 2>/dev/null
-
-        if grep -q '^nameserver' /etc/resolv.conf; then #210212
-            add_wired_connection_profile #211002
-            build_and_display_wired_success_window
-        else
-            build_and_display_wired_error_window
-            grep '^EXIT' <<< "$RETSTRING" | grep -q 'BUT_GOBACK' && exec sns
-        fi
-    else
-        kill $PIDXX 2>/dev/null
-    fi
-    exit
+elif [ "$IF_INTTYPE" = "Wired" ]; then
+    perform_wired_setup
 fi
+exit
 
 ###END###


### PR DESCRIPTION
Accommodates spoofed gadget (USB-tethered smartphone) MAC addresses.

Adds MAC address spoofing for connections if 'macchanger' package installed.
    
Uses increased dhcpcd timeout value from the default 30 seconds to 40 seconds, if not specified in dhcpcd.conf, to avoid invalid IP address (169.254...) due to slow response from DNS possibly aggravated by MAC spoofing.

Replaces 'ethtool' for determining wired interface readiness, with ip-show test for LOWER_UP.

Refines checks for module loading, interface startup and successful connection, minimizing impact of unplugged ethernet cable.

For clean support of wired interfaces when 'iw' is missing, adds iw-missing message to wireless configure dialog, avoids iw-missing error messages.