### PR TITLE
Fix breakage of simple_installer introduced in a1525d9

### DIFF
--- a/woof-code/rootfs-petbuilds/lxterminal/urxvt.c
+++ b/woof-code/rootfs-petbuilds/lxterminal/urxvt.c
@@ -12,8 +12,11 @@ int main(int argc, char **argv)
 		"-e"
 	};
 	gchar *cmd;
-	int i;
+	int i, j;
 	gboolean hold = FALSE;
+
+	if (argc >= 32)
+		goto proxy;
 
 	for (i = 1; i < argc; ++i) {
 		if ((strcmp(argv[i], "-hold") == 0) || (strcmp(argv[1], "--hold") == 0)) {
@@ -24,11 +27,10 @@ int main(int argc, char **argv)
 
 	for (i = 1; i < argc; ++i) {
 		if ((strcmp(argv[i], "-e") == 0) && (i < (argc - 1))) {
-			cmd = g_strjoinv(" ", &argv[i + 1]);
-
 			if (hold) {
 				new_argv[3] = "/bin/sh";
 				new_argv[4] = "-c";
+				cmd = g_strjoinv(" ", &argv[i + 1]);
 				new_argv[5] = g_strdup_printf("%s; echo; echo -n \"FINISHED. PRESS ENTER KEY TO CLOSE THIS WINDOW: \"; read simuldone", cmd);
 				g_free(cmd);
 				new_argv[6] = NULL;
@@ -37,16 +39,17 @@ int main(int argc, char **argv)
 				g_free(new_argv[5]);
 			}
 			else {
-				new_argv[3] = cmd;
+				for (++i, j = 3; i < argc; ++i, ++j)
+					new_argv[j] = argv[i];
 
 				execvp(new_argv[0], new_argv);
-				g_free(cmd);
 			}
 
 			return EXIT_FAILURE;
 		}
 	}
 
+proxy:
 	argv[0] = new_argv[0];
 	execvp(argv[0], argv);
 	return EXIT_FAILURE;


### PR DESCRIPTION
When the arguments after `rxvt -e` are joined into one string, the shell behavior is different (because in shell syntax, `argv = ["a", "b", "c"]` is not the same as `argv = ["a b c"]` . We want to pass the arguments after `-e` to the shell, as-is.

0setup (via PPM's refresh button) and fsck (via pmount's file system check button) still work as expected.