### PR TITLE
Bump the dpup bullseye version to 9.2.0

### DIFF
--- a/woof-distro/arm/debian/bullseye-veyron-speedy/DISTRO_SPECS
+++ b/woof-distro/arm/debian/bullseye-veyron-speedy/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Vanilla Dpup'
 #version number of this distribution:
-DISTRO_VERSION=9.1.0
+DISTRO_VERSION=9.2.0
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='debian'
 #Prefix for some filenames: exs: bullseyesave.2fs, bullseye-8.0.sfs

--- a/woof-distro/x86/debian/bullseye/DISTRO_SPECS
+++ b/woof-distro/x86/debian/bullseye/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Vanilla Dpup'
 #version number of this distribution:
-DISTRO_VERSION=9.1.0
+DISTRO_VERSION=9.2.0
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='debian'
 #Prefix for some filenames: exs: bullseyesave.2fs, bullseye-8.0.sfs

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_SPECS
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_SPECS
@@ -1,7 +1,7 @@
 #One or more words that identify this distribution:
 DISTRO_NAME='Vanilla Dpup'
 #version number of this distribution:
-DISTRO_VERSION=9.1.0
+DISTRO_VERSION=9.2.0
 #The distro whose binary packages were used to build this distribution:
 DISTRO_BINARY_COMPAT='debian'
 #Prefix for some filenames: exs: bullseyesave.2fs, bullseye-8.0.sfs


### PR DESCRIPTION
9.1.x is built from https://github.com/vanilla-dpup/woof-CE/commits/vanilladpup-9.1.x, branched from testing about two weeks ago. There's one fix (https://github.com/vanilla-dpup/woof-CE/commit/7ba365a5f61a1d72b3e9f9dda1b6e155a23aaf19) that still hasn't made it into testing, so it's time to bump the version number and reflect this difference.