### PR TITLE
Fix breakage of bionic64 introduced in 2bf56f5

### DIFF
--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -251,10 +251,10 @@ yes|gtklp|gtklp|exe,dev,doc,nls| #stupid deb has no .desktop file -- need a temp
 yes|gtkmm|libgtkmm-2.4-1v5,libgtkmm-2.4-dev|exe,dev,doc,nls
 yes|gtk_theme_stark||exe
 yes|gtk_theme_flatbluecontrast||exe
-no|gtk_theme_flat_grey_rounded||exe
+yes|gtk_theme_flat_grey_rounded||exe
 yes|gtk_theme_numix||exe
-no|gtk_theme_stardust_zigbert||exe
-no|gtk_theme_stark-blueish||exe
+yes|gtk_theme_stardust_zigbert||exe
+yes|gtk_theme_stark-blueish||exe
 yes|gtk-update-icon-cache|gtk-update-icon-cache|exe,dev,doc,nls
 yes|gtksourceview|libgtksourceview2.0-0,libgtksourceview2.0-common,libgtksourceview2.0-dev|exe,dev,doc,nls
 yes|gtkspell|libgtkspell0,libgtkspell-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -39,7 +39,7 @@ BUILD_DEVX=no
 DEVX_IN_ISO=no
 
 ## packages to build from source
-PETBUILDS="pmaterial_icons puppy_flat_icons puppy_standard_icons gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish"
+PETBUILDS="pmaterial_icons puppy_flat_icons puppy_standard_icons"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=2


### PR DESCRIPTION
No devx, no make, can't install themes.