### PR TITLE
Move kernel-kit output to /usr

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -835,6 +835,7 @@ make DESTDIR=$CWD/output/${AUFS_UTIL_DIR} install
 		mv $CWD/output/${AUFS_UTIL_DIR}/usr/lib \
 			$CWD/output/${AUFS_UTIL_DIR}/usr/lib64
 	fi
+	mv $CWD/output/${AUFS_UTIL_DIR}/sbin $CWD/output/${AUFS_UTIL_DIR}/usr/
 	log_msg "aufs-util-${kernel_version} is in output"
 	#---
 	[ -z "$OLDPATH" ] || export PATH=$OLDPATH
@@ -855,7 +856,7 @@ else
 	export MAKE_TARGETS="bzImage modules"
 fi
 echo "$MAKE ${JOBS} ${MAKE_TARGETS}
-$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} modules_install" > compile ## debug
+$MAKE INSTALL_MOD_PATH=${linux_kernel_dir}/usr modules_install" > compile ## debug
 
 log_msg "Compiling the kernel"
 $MAKE ${JOBS} ${MAKE_TARGETS} >> ${BUILD_LOG} 2>&1
@@ -879,11 +880,11 @@ fi
 #---------------------------------------------------------------------
 
 log_msg "Creating the kernel package"
-$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} modules_install >> ${BUILD_LOG} 2>&1
+$MAKE INSTALL_MOD_PATH=${linux_kernel_dir}/usr modules_install >> ${BUILD_LOG} 2>&1
 if [ "$remove_sublevel" = "yes" ]; then
-	rm -f ${linux_kernel_dir}/lib/modules/${kernel_major_version}.0/{build,source}
+	rm -f ${linux_kernel_dir}/usr/lib/modules/${kernel_major_version}.0/{build,source}
 else
-	rm -f ${linux_kernel_dir}/lib/modules/${kernel_version}${custom_suffix}/{build,source}
+	rm -f ${linux_kernel_dir}/usr/lib/modules/${kernel_version}${custom_suffix}/{build,source}
 fi
 mkdir -p ${linux_kernel_dir}/boot
 mkdir -p ${linux_kernel_dir}/etc/modules
@@ -897,7 +898,7 @@ if [ "$kit_kernel" = "yes" ]; then
 else
 	cp .config ${linux_kernel_dir}/etc/modules/DOTconfig-${kernel_version}-${today}
 fi
-for i in `find ${linux_kernel_dir}/lib/modules -type f -name "modules.*"| grep -E 'order$|builtin$'`;do 
+for i in `find ${linux_kernel_dir}/usr/lib/modules -type f -name "modules.*"| grep -E 'order$|builtin$'`;do 
 	cp $i ${linux_kernel_dir}/etc/modules/${i##*/}-${kernel_version}${custom_suffix}
 	log_msg "copied ${i##*/} to ${linux_kernel_dir}/etc/modules/${i##*/}-${kernel_version}${custom_suffix}"
 done
@@ -961,13 +962,13 @@ if [ "$CREATE_SOURCES_SFS" != "no" ]; then
 	mkdir -p ${KERNEL_SOURCES_DIR}/usr/src
 	mv linux-${kernel_version} ${KERNEL_SOURCES_DIR}/usr/src/linux
 	if [ "$remove_sublevel" = "yes" ]; then
-		KERNEL_MODULES_DIR=${KERNEL_SOURCES_DIR}/lib/modules/${kernel_major_version}.0
+		KERNEL_MODULES_DIR=${KERNEL_SOURCES_DIR}/usr/lib/modules/${kernel_major_version}.0
 	else
-		KERNEL_MODULES_DIR=${KERNEL_SOURCES_DIR}/lib/modules/${kernel_version}${custom_suffix}
+		KERNEL_MODULES_DIR=${KERNEL_SOURCES_DIR}/usr/lib/modules/${kernel_version}${custom_suffix}
 	fi
 	mkdir -p ${KERNEL_MODULES_DIR}
-	ln -s ../../../usr/src/linux ${KERNEL_MODULES_DIR}/build
-	ln -s ../../../usr/src/linux ${KERNEL_MODULES_DIR}/source
+	ln -s ../../../src/linux ${KERNEL_MODULES_DIR}/build
+	ln -s ../../../src/linux ${KERNEL_MODULES_DIR}/source
 	if [ ! -f ${KERNEL_SOURCES_DIR}/usr/src/linux/include/linux/version.h ] ; then
 		ln -s /usr/src/linux/include/generated/uapi/linux/version.h \
 			${KERNEL_SOURCES_DIR}/usr/src/linux/include/linux/version.h
@@ -985,7 +986,7 @@ log_msg "Pausing here to add extra firmware."
 case ${FIRMWARE_OPT} in
 manual)
 	log_msg "once you have manually added firmware to "
-	log_msg "output/${linux_kernel_dir}/lib/firmware"
+	log_msg "output/${linux_kernel_dir}/usr/lib/firmware"
 	echo "hit ENTER to continue"
 	read firm
 ;;

--- a/kernel-kit/firmware_extra.sh
+++ b/kernel-kit/firmware_extra.sh
@@ -10,7 +10,7 @@
 export LANG=C
 
 TEMP=/tmp/fw$$
-OUT=$TEMP/lib/firmware
+OUT=$TEMP/usr/lib/firmware
 mkdir -p $OUT
 TOOLREPO=tools
 REPO=sources/firmware_extra

--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -15,7 +15,7 @@ CWD=`pwd`
 BUILD_LOG=${CWD}/build.log
 SRC_FW_DIR='../linux-firmware'
 FIRMWARE_SFS="output/${FDRV}"
-export FIRMWARE_RESULT_DIR='zfirmware_workdir/lib/firmware'
+export FIRMWARE_RESULT_DIR='zfirmware_workdir/usr/lib/firmware'
 
 ## functions
 log_msg()    { echo -e "$@" ; echo -e "$@" >> ${BUILD_LOG} ; }
@@ -73,7 +73,7 @@ cd ${CWD}
 
 [ -f "${FIRMWARE_SFS}" ] && rm -f ${FIRMWARE_SFS}
 
-export module_dir=output/${linux_kernel_dir}/lib/modules
+export module_dir=output/${linux_kernel_dir}/usr/lib/modules
 mkdir -p $FIRMWARE_RESULT_DIR
 firmware_list_dir=output/${linux_kernel_dir}/etc/modules/
 mkdir -p $firmware_list_dir
@@ -151,12 +151,12 @@ licence_func
 # copy firmwares to build
 case $1 in
 	f)[ -f "$FIRMWARE_SFS" ] && rm $FIRMWARE_SFS
-		[ -d "output/${linux_kernel_dir}/lib/firmware/" ] && rm -rf output/${linux_kernel_dir}/lib/firmware/ # redundant; also not in newer kernels
+		[ -d "output/${linux_kernel_dir}/usr/lib/firmware/" ] && rm -rf output/${linux_kernel_dir}/usr/lib/firmware/ # redundant; also not in newer kernels
 		mksquashfs zfirmware_workdir $FIRMWARE_SFS $COMP
 		(cd output/;md5sum ${FIRMWARE_SFS##*/} > ${FIRMWARE_SFS##*/}.md5.txt);;
-	b)[ -d "output/${linux_kernel_dir}/lib/firmware/" ] && rm -r output/${linux_kernel_dir}/lib/firmware/* ||\
-			mkdir -p output/${linux_kernel_dir}/lib/firmware/
-		cp -r -n $FIRMWARE_RESULT_DIR/* output/${linux_kernel_dir}/lib/firmware/ ;;
+	b)[ -d "output/${linux_kernel_dir}/usr/lib/firmware/" ] && rm -r output/${linux_kernel_dir}/usr/lib/firmware/* ||\
+			mkdir -p output/${linux_kernel_dir}/usr/lib/firmware/
+		cp -r -n $FIRMWARE_RESULT_DIR/* output/${linux_kernel_dir}/usr/lib/firmware/ ;;
 esac
 
 rm -rf zfirmware_workdir

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -189,7 +189,7 @@ and edit it to include your customised package list.
 			;;
 		change_kernels)
 			state=false
-			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" -a "$USR_SYMLINKS" != "yes" ] && state=true
+			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" ] && state=true
 			;;
 		simple_installer)
 			state=false
@@ -1022,42 +1022,6 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 	echo -e "\nNow building the main f.s., ${PUPPYSFS}..."
 	rm -f build/${PUPPYSFS} 2>/dev/null
 	mksquashfs rootfs-complete build/${PUPPYSFS} ${SFSCOMP} #100911 110713
-	###########
-	if [ "$USR_SYMLINKS" = "yes" ]; then
-		KSFSCOMP="$SFSCOMP"
-
-		if [ -f build/${ZDRVSFS} ]; then
-			echo -e "\nNow building the zdrv f.s., $ZDRVSFS ..."
-			rm -rf zdrv
-			unsquashfs -d zdrv build/${ZDRVSFS}
-			rm -f build/${ZDRVSFS}
-
-			# use the same mksquashfs options used by kernel-kit
-			KSFSCOMP=`sh -c '. $(ls zdrv/etc/modules/build.conf-* 2>/dev/null) 2>/dev/null && echo "$COMP"'`
-			[ -z "$KSFSCOMP" ] && KSFSCOMP="$SFSCOMP"
-
-			usrmerge zdrv 0
-
-			if [ "$ARCHDIR" = "x86_64-linux-gnu" -a -d zdrv/usr/lib64 -a ! -e zdrv/usr/lib/${ARCHDIR} ]; then
-				mkdir -vp zdrv/usr/lib
-				mv -v zdrv/usr/lib64 zdrv/usr/lib/${ARCHDIR}
-			fi
-
-			mksquashfs zdrv build/${ZDRVSFS} ${KSFSCOMP}
-			[ -n "$GITHUB_ACTIONS" ] && rm -rf zdrv
-		fi
-
-		if [ -f build/${FDRVSFS} ]; then
-			echo -e "\nNow building the fdrv f.s., $FDRVSFS ..."
-			rm -rf fdrv
-			unsquashfs -d fdrv build/${FDRVSFS}
-			rm -f build/${FDRVSFS}
-
-			usrmerge fdrv 0
-			mksquashfs fdrv build/${FDRVSFS} ${KSFSCOMP}
-			[ -n "$GITHUB_ACTIONS" ] && rm -rf fdrv
-		fi
-	fi
 	###########
 	if [ -d bdrv -o -d adrv -o -d fdrv -o -d ydrv ];then
 		#build the {a,f,y}drive sfs...

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -199,6 +199,18 @@ busybox mount -t sysfs none /sys ;STATUS=$((STATUS+$?))
 mkdir -p /dev/shm #120503 if kernel mounts a f.s. on /dev, removes my skeleton /dev
 busybox mount -t tmpfs -o size=${QTRFREERAM}k shmfs /dev/shm ;STATUS=$((STATUS+$?))
 
+# backward-compatibility for new kernel-kit output in /usr
+if [ -d /lib ];then
+	if [ -d /usr/lib/modules ];then
+		mkdir -p /lib/modules
+		mount --bind /usr/lib/modules /lib/modules
+	fi
+	if [ -d /usr/lib/firmware ];then
+		mkdir -p /lib/firmware
+		mount --bind /usr/lib/firmware /lib/firmware
+	fi
+fi
+
 # kernel modules.builtin/order can also be found in /etc/modules
 # if somehow they're missing from /lib/modules, they will be copied back
 KERNVER="`uname -r`"


### PR DESCRIPTION
This PR addresses the concerns raised in https://github.com/puppylinux-woof-CE/woof-CE/pull/2445#issuecomment-904604701 and https://github.com/puppylinux-woof-CE/woof-CE/pull/2771#pullrequestreview-853536828.

Today, woof-CE can build a Puppy with the traditional directory layout, or with /bin, /sbin and /lib* symlinks to /usr/. But for this to work, 3builddistro needs to 1) rebuild fdrv+zdrv, after moving everything to /usr and 2) remove change_kernels, because it won't work unless somebody performed (1) on the new kernel.

The old directory layout is creating compatibility issues with Ubuntu and Debian packages (for example, see #2857), and Debian 11 is the last to officially support it. It's time to have proper support for it in Puppy, and clean up the mess.

This PR 1) makes kernel-kit output compatible with both the traditional and new directory layouts 2) removes the ugly unpacking+packing of fdrv+zdrv and 3) restores change_kernels, when using the new directory layout.

**However, this comes at a price: this PR makes kernel-kit output incompatible with any old Puppy** that doesn't have the rc.sysinit change.

I don't see a cleaner way to make kernel-kit output work for both directory layouts, using a single package.