### PR TITLE
Add /usr merge compatible kernel packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,6 +102,16 @@ jobs:
       run: |
         cd ../woof-out_*
         echo | sudo -E ./2createpackages
+    - name: Choose kernel variant
+      id: choose_kernel_variant
+      run: |
+        cd ../woof-out_*
+        . _00build.conf
+        [ ! -e _00build_2.conf ] || . _00build_2.conf
+        name="kernel-kit-output-usrmerge-${{ matrix.kernel }}"
+        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-${{ matrix.kernel }}"
+        echo "::set-output name=artifact_name::$name"
+      shell: bash
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
       with:
@@ -109,7 +119,7 @@ jobs:
         branch: testing
         workflow: kernel-kit.yml
         workflow_conclusion: success
-        name: kernel-kit-output-${{ matrix.kernel }}
+        name: ${{ steps.choose_kernel_variant.outputs.artifact_name }}
         path: output
     - name: Move cached kernel-kit output
       run: sudo mv output ../woof-out_*/kernel-kit/

--- a/.github/workflows/kernel-kit.yml
+++ b/.github/workflows/kernel-kit.yml
@@ -69,3 +69,41 @@ jobs:
           name: kernel-kit-output-${{ matrix.kernel-kit-config }}
           path: kernel-kit/small-output
           retention-days: 14
+  usrmerge:
+    if: github.event_name != 'schedule' || (github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing')
+    needs: build
+    runs-on: ubuntu-20.04
+    container:
+      image: ${{ matrix.image }}
+    strategy:
+      matrix:
+        include:
+          - kernel-kit-config: 5.10.x-x86
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.10.x-x86_64
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.15.x-x86
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.15.x-x86_64
+            image: debian:bullseye-slim
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          apt-get update -qq
+          apt-get install -y --no-install-recommends squashfs-tools bzip2
+      - name: Get build output
+        uses: actions/download-artifact@v2
+        with:
+          name: kernel-kit-output-${{ matrix.kernel-kit-config }}
+          path: kernel-kit/output
+      - name: Repackage kernel
+        run: |
+          cd kernel-kit
+          ./usrmerge.sh
+      - name: Upload kernel
+        uses: actions/upload-artifact@v2
+        with:
+          name: kernel-kit-output-usrmerge-${{ matrix.kernel-kit-config }}
+          path: kernel-kit/output
+          retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,16 @@ jobs:
       run: |
         cd ../woof-out_*
         echo | sudo -E ./2createpackages
+    - name: Choose kernel variant
+      id: choose_kernel_variant
+      run: |
+        cd ../woof-out_*
+        . _00build.conf
+        [ ! -e _00build_2.conf ] || . _00build_2.conf
+        name="kernel-kit-output-usrmerge-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}"
+        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}"
+        echo "::set-output name=artifact_name::$name"
+      shell: bash
     - name: Get cached kernel-kit output
       uses: dawidd6/action-download-artifact@v2
       with:
@@ -84,7 +94,7 @@ jobs:
         branch: testing
         workflow: kernel-kit.yml
         workflow_conclusion: success
-        name: kernel-kit-output-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}
+        name: ${{ steps.choose_kernel_variant.outputs.artifact_name }}
         path: output
     - name: Move cached kernel-kit output
       run: sudo mv output ../woof-out_*/kernel-kit/

--- a/kernel-kit/usrmerge.sh
+++ b/kernel-kit/usrmerge.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -e
+
+. ../woof-code/_00func
+cd output
+
+TAR=`ls huge-*.tar.bz2`
+tar xf $TAR
+rm -f $TAR
+
+ZDRV=`ls kernel-modules-*.sfs`
+unsquashfs -d zdrv $ZDRV
+rm -f $ZDRV
+. zdrv/etc/modules/build.conf-*
+usrmerge zdrv 0
+mksquashfs zdrv $ZDRV $COMP
+rm -rf zdrv
+
+FDRV=`ls fdrv-*.sfs`
+unsquashfs -d fdrv $FDRV
+rm -f $FDRV
+usrmerge fdrv 0
+mksquashfs fdrv $FDRV $COMP
+rm -rf fdrv
+
+tar -cjf $TAR vmlinuz-* $ZDRV $FDRV
+md5sum $TAR > $TAR.md5.txt
+sha256sum $TAR > $TAR.sha256.txt
+
+rm -f vmlinuz-* $ZDRV $FDRV
+
+KSRC=`ls kernel_sources-*.sfs`
+unsquashfs -d ksrc $KSRC
+rm -f $KSRC
+rm -vf ksrc/lib/modules/*/{build,source}
+usrmerge ksrc 0
+MODULES=`echo ksrc/usr/lib/modules/*`
+ln -sv ../../../src/linux ${MODULES}/build
+ln -sv ../../../src/linux ${MODULES}/source
+mksquashfs ksrc $KSRC $COMP
+rm -rf ksrc
+
+md5sum $KSRC > $KSRC.md5.txt
+sha256sum $KSRC > $KSRC.sha256.txt

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -76,41 +76,6 @@ cp DISTRO_SPECS sandbox3/rootfs-complete/etc/
 #copy the skeleton...
 cp -a rootfs-skeleton/* sandbox3/rootfs-complete/
 
-mergedir() {
-	if [ ! -e ${2} ]; then
-		mkdir -vp `dirname ${2}`
-		mv -v ${1} ${2} || exit 1
-		return
-	fi
-
-	echo "Merging ${1} with ${2}"
-
-	for NAME in `ls ${1} 2>/dev/null`; do
-		if [ -d ${1}/${NAME} ]; then
-			mergedir ${1}/${NAME} ${2}/${NAME}
-		else
-			rm -f ${2}/${NAME}
-			mv -vf ${1}/${NAME} ${2}/ || exit 1
-		fi
-	done
-
-	rmdir -v ${1} || exit 1
-}
-
-usrmerge() {
-	USRDIRS="bin sbin lib"
-	[ "$DISTRO_TARGETARCH" = "x86_64" ] && USRDIRS="$USRDIRS lib64 lib32 libx32"
-
-	for USRDIR in $USRDIRS; do
-		[ -d ${1}/${USRDIR} ] && mergedir ${1}/${USRDIR} ${1}/usr/${USRDIR}
-
-		if [ $2 -eq 1 ]; then
-			[ ! -e ${1}/usr/${USRDIR} ] && mkdir -v ${1}/usr/${USRDIR}
-			ln -vs usr/${USRDIR} ${1}/${USRDIR} || exit 1
-		fi
-	done
-}
-
 if [ "$XAUTOCONF" = 'yes' ];then
 	echo 'enabling xorg-autoconf'; sleep 1
 	chmod 755 sandbox3/rootfs-complete/usr/sbin/xorg-autoconf
@@ -189,7 +154,7 @@ and edit it to include your customised package list.
 			;;
 		change_kernels)
 			state=false
-			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" -a "$USR_SYMLINKS" != "yes" ] && state=true
+			[ "$DISTRO_KERNEL_PET" = 'Huge_Kernel' -a "$ISOFLAG" ] && state=true
 			;;
 		simple_installer)
 			state=false
@@ -1022,42 +987,6 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 	echo -e "\nNow building the main f.s., ${PUPPYSFS}..."
 	rm -f build/${PUPPYSFS} 2>/dev/null
 	mksquashfs rootfs-complete build/${PUPPYSFS} ${SFSCOMP} #100911 110713
-	###########
-	if [ "$USR_SYMLINKS" = "yes" ]; then
-		KSFSCOMP="$SFSCOMP"
-
-		if [ -f build/${ZDRVSFS} ]; then
-			echo -e "\nNow building the zdrv f.s., $ZDRVSFS ..."
-			rm -rf zdrv
-			unsquashfs -d zdrv build/${ZDRVSFS}
-			rm -f build/${ZDRVSFS}
-
-			# use the same mksquashfs options used by kernel-kit
-			KSFSCOMP=`sh -c '. $(ls zdrv/etc/modules/build.conf-* 2>/dev/null) 2>/dev/null && echo "$COMP"'`
-			[ -z "$KSFSCOMP" ] && KSFSCOMP="$SFSCOMP"
-
-			usrmerge zdrv 0
-
-			if [ "$ARCHDIR" = "x86_64-linux-gnu" -a -d zdrv/usr/lib64 -a ! -e zdrv/usr/lib/${ARCHDIR} ]; then
-				mkdir -vp zdrv/usr/lib
-				mv -v zdrv/usr/lib64 zdrv/usr/lib/${ARCHDIR}
-			fi
-
-			mksquashfs zdrv build/${ZDRVSFS} ${KSFSCOMP}
-			[ -n "$GITHUB_ACTIONS" ] && rm -rf zdrv
-		fi
-
-		if [ -f build/${FDRVSFS} ]; then
-			echo -e "\nNow building the fdrv f.s., $FDRVSFS ..."
-			rm -rf fdrv
-			unsquashfs -d fdrv build/${FDRVSFS}
-			rm -f build/${FDRVSFS}
-
-			usrmerge fdrv 0
-			mksquashfs fdrv build/${FDRVSFS} ${KSFSCOMP}
-			[ -n "$GITHUB_ACTIONS" ] && rm -rf fdrv
-		fi
-	fi
 	###########
 	if [ -d bdrv -o -d adrv -o -d fdrv -o -d ydrv ];then
 		#build the {a,f,y}drive sfs...

--- a/woof-code/_00func
+++ b/woof-code/_00func
@@ -283,6 +283,41 @@ function remove_unneeded_compat_pkgs() {
 	rm -f /tmp/compatpkgs$$
 }
 
+mergedir() {
+	if [ ! -e ${2} ]; then
+		mkdir -vp `dirname ${2}`
+		mv -v ${1} ${2} || exit 1
+		return
+	fi
+
+	echo "Merging ${1} with ${2}"
+
+	for NAME in `ls ${1} 2>/dev/null`; do
+		if [ -d ${1}/${NAME} ]; then
+			mergedir ${1}/${NAME} ${2}/${NAME}
+		else
+			rm -f ${2}/${NAME}
+			mv -vf ${1}/${NAME} ${2}/ || exit 1
+		fi
+	done
+
+	rmdir -v ${1} || exit 1
+}
+
+usrmerge() {
+	USRDIRS="bin sbin lib"
+	[ "$DISTRO_TARGETARCH" = "x86_64" ] && USRDIRS="$USRDIRS lib64 lib32 libx32"
+
+	for USRDIR in $USRDIRS; do
+		[ -d ${1}/${USRDIR} ] && mergedir ${1}/${USRDIR} ${1}/usr/${USRDIR}
+
+		if [ $2 -eq 1 ]; then
+			[ ! -e ${1}/usr/${USRDIR} ] && mkdir -v ${1}/usr/${USRDIR}
+			ln -vs usr/${USRDIR} ${1}/${USRDIR} || exit 1
+		fi
+	done
+}
+
 if [ "${0##*/}" = "_00func" ] ; then
 	$@
 fi

--- a/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
+++ b/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
@@ -9,5 +9,6 @@
 #FDRV_SFS_URL=
 
 ADRV_INC=
+USR_SYMLINKS=no
 BUILD_CROS_IMAGE=yes
 BOOT_BOARD='veyron-speedy'


### PR DESCRIPTION
This is an alternative to #2863 that doesn't upset anyone, but also doesn't address all concerns (the user must use the right package, otherwise the system won't boot).

This PR adds a second build step, which re-packages some kernels after moving everything to /usr:

~~Still testing.~~ Works great! All builds passed and every build uses the right kernel package.

![matrix](https://user-images.githubusercontent.com/1471149/153741881-288b6d81-19ea-4712-a75c-6c7a9c255fff.png)
![artifacts](https://user-images.githubusercontent.com/1471149/153741884-df33373f-0ad0-4017-aadd-254766a555cb.png)

Then, the other jobs check `USR_SYMLINKS` to decide which build artifact to use: `kernel-kit-output-x-y` or `kernel-kit-output-usrmerge-x-y`.