### PR TITLE
Change to remove_sublevel=no and let DKMS rebuild out-of-tree drivers

### DIFF
--- a/kernel-kit/4.19.x-x86-build.conf
+++ b/kernel-kit/4.19.x-x86-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/4.19.x-x86_64-build.conf
+++ b/kernel-kit/4.19.x-x86_64-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.10.x-x86-build.conf
+++ b/kernel-kit/5.10.x-x86-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.10.x-x86_64-build.conf
+++ b/kernel-kit/5.10.x-x86_64-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.13.x-x86_64-build.conf
+++ b/kernel-kit/5.13.x-x86_64-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.15.x-x86-build.conf
+++ b/kernel-kit/5.15.x-x86-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.15.x-x86_64-build.conf
+++ b/kernel-kit/5.15.x-x86_64-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.4.x-veyron-speedy-build.conf
+++ b/kernel-kit/5.4.x-veyron-speedy-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.4.x-x86-build.conf
+++ b/kernel-kit/5.4.x-x86-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/kernel-kit/5.4.x-x86_64-build.conf
+++ b/kernel-kit/5.4.x-x86_64-build.conf
@@ -57,7 +57,7 @@ package_name_suffix=kernel-kit
 ##-----------------------------------------------------------------------
 
 ## remove kernel sublevel, or not : set yes or no
-remove_sublevel=yes
+remove_sublevel=no
 
 ## aufs version (git branch) - see README -> AUFS GIT BRANCHES
 ## the script automatically detects the aufs version, but when it does not

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -383,6 +383,9 @@ if [ -e /lib/systemd/systemd-udevd ] ; then
   ln -s /proc/self/fd/2 /dev/stderr
 fi
 
+#rebuild out-of-tree modules if the kernel has changed
+[ -e /usr/lib/dkms/dkms_autoinstaller ] && PATH="$PATH" /usr/lib/dkms/dkms_autoinstaller start 2>/dev/console
+
 #110502 change 'never' to 'early', fixes device nodes created with correct owner:group...
 if [ "$BOOT_UDEVDCHILDREN" ];then #120709
    udevd --daemon --resolve-names=early --children-max=${BOOT_UDEVDCHILDREN} #BOOT_UDEVDCHILDREN=1 good idea?


### PR DESCRIPTION
Tested by installing the kernel sources SFS, `apt install broadcom-sta-dkms`, `modprobe wl`, poweroff, kernel+sources SFS swap and reboot. `wl.ko` got rebuilt before udev was started, and loaded properly.

~~This PR will break automated builds, unless #2866 is merged first.~~