### PR TITLE
If present, add the kernel sources SFS to ext4 images

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1204,6 +1204,8 @@ if [ "$SDFLAG" = "" -a "$CROSFLAG" = "" ] ; then #120506
 		[ "$BUILD_DEVX" = "yes" -a -f ${DEVXSFS} ] && mv -f ${DEVXSFS} ./build/
 		[ -f ${DOCXSFS} ] && mv -f ${DOCXSFS} ./build/
 		[ -f ${NLSXSFS} ] && mv -f ${NLSXSFS} ./build/
+		KSRCSFS="`ls ../kernel-kit/output/kernel_sources-*.sfs 2>/dev/null`"
+		[ -n "${KSRCSFS}" ] && cp -f ${KSRCSFS} ./build/ksrc_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs
 
 		WOOF_OUTPUT="woof-output-${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}"
 		mkdir -p ../$WOOF_OUTPUT


### PR DESCRIPTION
This PR complements #2868, which tries to rebuild out-of-tree drivers. It will fail, unless the user downloads the matching kernel sources SFS after each update.

With both PRs, it's possible to `apt install some-non-free-driver-dkms` and let dkms rebuild it on each system update, with zero manual intervention.