### PR TITLE
Add a tiny kernel sources SFS for building out-of-tree drivers

### DIFF
--- a/.github/workflows/kernel-kit.yml
+++ b/.github/workflows/kernel-kit.yml
@@ -60,9 +60,9 @@ jobs:
         run: |
           cd kernel-kit
           cp -f ${{ matrix.kernel-kit-config }}-build.conf build.conf
-          ./build.sh
+          CREATE_KBUILD_SFS=yes ./build.sh
           mkdir small-output
-          mv `ls output/kernel_sources-*.sfs* output/*.tar* 2>/dev/null` small-output
+          mv `ls output/kernel_sources-*.sfs* output/kbuild-*.sfs* output/*.tar* 2>/dev/null` small-output
       - name: Upload kernel
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,9 +119,9 @@ jobs:
         cd ../woof-out_*
         sudo -E HOME=/root XDG_CONFIG_HOME=/root/.config ./3builddistro release
         sudo mv -f woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}.iso $GITHUB_WORKSPACE/
-        sudo mv -f kernel-kit/output/kernel_sources-*.sfs woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/
+        sudo mv -f kernel-kit/output/kbuild-*.sfs woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/
         cd woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}
-        sudo tar -f $GITHUB_WORKSPACE/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}-extra.tar -c *{x,drv}_${{ github.event.inputs.prefix }}_${{ github.event.inputs.version }}.sfs kernel_sources-*.sfs
+        sudo tar -f $GITHUB_WORKSPACE/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}-extra.tar -c *{x,drv}_${{ github.event.inputs.prefix }}_${{ github.event.inputs.version }}.sfs kbuild-*.sfs
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/kernel-kit/kbuild.sh
+++ b/kernel-kit/kbuild.sh
@@ -1,0 +1,13 @@
+#!/bin/sh -xe
+
+for FILE in tools scripts Makefile include .config Module.symvers; do
+	cp -a ${1}/${FILE} ${2}/
+done
+
+find ${1}/arch -name Makefile -or -name include |
+while read FILE; do
+	DIR=`dirname ${FILE}`
+	DIR=${DIR#${1}/}
+	mkdir -p ${2}/${DIR}
+	cp -a ${FILE} ${2}/${DIR}
+done

--- a/kernel-kit/usrmerge.sh
+++ b/kernel-kit/usrmerge.sh
@@ -41,3 +41,18 @@ rm -rf ksrc
 
 md5sum $KSRC > $KSRC.md5.txt
 sha256sum $KSRC > $KSRC.sha256.txt
+
+KBUILD=`ls kbuild-*.sfs`
+unsquashfs -d kbuild $KBUILD
+rm -f $KBUILD
+TARGET="../../../src/`basename $(readlink kbuild/lib/modules/*/build)`"
+rm -vf kbuild/lib/modules/*/{build,source}
+usrmerge kbuild 0
+MODULES=`echo kbuild/usr/lib/modules/*`
+ln -sv ${TARGET} ${MODULES}/build
+ln -sv ${TARGET} ${MODULES}/source
+mksquashfs kbuild $KBUILD $COMP
+rm -rf kbuild
+
+md5sum $KBUILD > $KSRC.md5.txt
+sha256sum $KBUILD > $KSRC.sha256.txt

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1133,8 +1133,8 @@ if [ "$SDFLAG" = "" -a "$CROSFLAG" = "" ] ; then #120506
 		[ "$BUILD_DEVX" = "yes" -a -f ${DEVXSFS} ] && mv -f ${DEVXSFS} ./build/
 		[ -f ${DOCXSFS} ] && mv -f ${DOCXSFS} ./build/
 		[ -f ${NLSXSFS} ] && mv -f ${NLSXSFS} ./build/
-		KSRCSFS="`ls ../kernel-kit/output/kernel_sources-*.sfs 2>/dev/null`"
-		[ -n "${KSRCSFS}" ] && cp -f ${KSRCSFS} ./build/ksrc_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs
+		KBUILDSFS="`ls ../kernel-kit/output/kbuild-*.sfs 2>/dev/null`"
+		[ -n "${KBUILDSFS}" ] && cp -f ${KBUILDSFS} ./build/kbuild_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs
 
 		WOOF_OUTPUT="woof-output-${DISTRO_FILE_PREFIX}-${DISTRO_VERSION}"
 		mkdir -p ../$WOOF_OUTPUT


### PR DESCRIPTION
Should be ~15 MB, compared to ~150 MB for the entire kernel sources SFS. ~~I'm currently testing the build pipeline and want to make sure both Broadcom and NVIDIA drivers build fine with it, on a clean system, and test automatic rebuild on kernel upgrade.~~ Works great!