### PR TITLE
Run init scripts immediately on x86_64 and optimize rc.services

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.services
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.services
@@ -1,19 +1,24 @@
 #!/bin/ash
 #(c) Copyright Barry Kauler Nov. 2010. License GPL v3 /usr/share/doc/legal.
 
+. /etc/DISTRO_SPECS
+
 #wait for snd_ modules to complete loading...
 #this sleep benefits all slow peripherals.
-sleep 6
+[ "$DISTRO_TARGETARCH" = "x86" ] && sleep 6
+
+DBUS_PID=`pidof dbus-daemon`
 
 for service_script in /etc/init.d/*
 do
  if [ -x $service_script ]; then
   #Check if the script contains dbus-daemon
-  if [ "$(cat $service_script | grep "dbus-daemon")" == "" ]; then
+  if [ -z "$(fgrep dbus-daemon $service_script)" ]; then
    $service_script start
-  elif [ "$(pidof dbus-daemon)" == "" ]; then
+  elif [ -z "$DBUS_PID" ]; then
    #run dbus-daemon script if the dbus-daemon is not running
    $service_script start
+   DBUS_PID=`pidof dbus-daemon`
   fi
  fi
 done


### PR DESCRIPTION
Vanilla Dpup 9.1.x boots very quickly on my laptop, and I've noticed that sometimes the WiFi connection isn't established by the time I reach the desktop. I wondered why, and found this hardcoded 6s delay.

It's probably some legacy x86/PCI/ISA/whatever thing, and I see no reason for this, especially since we have `udevadm settle` in rc.sysinit.