### PR TITLE
Restore missing delay on x86

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -392,7 +392,7 @@ if [ "$BOOT_UDEVDCHILDREN" ];then #120709
 else
    udevd --daemon --resolve-names=early
 fi
-[ "$WOOF_TARGETARCH" = "x86" ] && sleep 0.3
+[ "$DISTRO_TARGETARCH" = "x86" ] && sleep 0.3
 
 # kernel polling - https://lwn.net/Articles/423619/
 echo 5000 > /sys/module/block/parameters/events_dfl_poll_msecs
@@ -403,7 +403,7 @@ do
  ONEPATH="`dirname $ONEMODALIAS`"
  if [ -e ${ONEPATH}/uevent ];then
   echo add > ${ONEPATH}/uevent #generates an 'add' uevent.
-  [ "$WOOF_TARGETARCH" = "x86" ] && sleep 0.02
+  [ "$DISTRO_TARGETARCH" = "x86" ] && sleep 0.02
  fi
 done
 


### PR DESCRIPTION
rc.sysinit doesn't source /etc/rc.d/WOOFMERGEVARS, so `$WOOF_TARGETARCH` is always empty. But it does source DISTRO_SPECS, so let's just use DISTRO_TARGETARCH instead.