### PR TITLE
Backport puppylinux-woof-CE/gtkdialog#126

### DIFF
--- a/woof-code/rootfs-petbuilds/gtkdialog/125.patch
+++ b/woof-code/rootfs-petbuilds/gtkdialog/125.patch
@@ -1,0 +1,110 @@
+From 9eecc5d9ba13275ae498079ccc6675131a73e889 Mon Sep 17 00:00:00 2001
+From: step- <step-@users.noreply.github.com>
+Date: Wed, 2 Feb 2022 22:43:59 +0100
+Subject: [PATCH 1/2] fix attributeset_get_first(): set is NULL (gtk3 terminal
+ widget) #125
+
+https://forum.puppylinux.com/viewtopic.php?p=39717#p39717
+This only fixes the "no exit" bug, not the VTE_CRITICAL color background
+error reported in the same thread.
+---
+ src/signals.c | 10 ++++++++++
+ src/signals.h | 11 +++++++++++
+ 2 files changed, 21 insertions(+)
+
+diff --git a/src/signals.c b/src/signals.c
+index 95e4bd5..d1a296b 100644
+--- a/src/signals.c
++++ b/src/signals.c
+@@ -633,8 +633,18 @@ void on_any_widget_icon_release_event(GtkWidget *widget,
+  *                                                                     *
+  ***********************************************************************/
+ 
++#if HAVE_VTE
++#if VTE_CHECK_VERSION(0,36,1)
++void on_any_widget_child_exited_event(GtkWidget *widget, int status, AttributeSet *Attr)
++{
++#else
++void on_any_widget_child_exited_event(GtkWidget *widget, AttributeSet *Attr)
++{
++#endif
++#else
+ void on_any_widget_child_exited_event(GtkWidget *widget, AttributeSet *Attr)
+ {
++#endif
+ #ifdef DEBUG_TRANSITS
+ 	fprintf(stderr, "%s(): Entering.\n", __func__);
+ #endif
+diff --git a/src/signals.h b/src/signals.h
+index 0b871d0..2907689 100644
+--- a/src/signals.h
++++ b/src/signals.h
+@@ -22,6 +22,9 @@
+ #ifndef SIGNALS_H
+ #define SIGNALS_H
+ 
++#if HAVE_VTE
++#include <vte/vte.h>
++#endif
+ /* Function prototypes */
+ void button_clicked_attr(GtkWidget *button, AttributeSet *Attr);
+ void button_entered_attr(GtkWidget *button, AttributeSet *Attr);
+@@ -57,7 +60,15 @@ void on_any_widget_icon_press_event(GtkWidget *widget,
+ void on_any_widget_icon_release_event(GtkWidget *widget,
+ 	GtkEntryIconPosition pos, GdkEvent *event, AttributeSet *Attr);
+ #endif
++#if HAVE_VTE
++#if VTE_CHECK_VERSION(0,36,1)
++void on_any_widget_child_exited_event(GtkWidget *widget, int status, AttributeSet *Attr);
++#else
++void on_any_widget_child_exited_event(GtkWidget *widget, AttributeSet *Attr);
++#endif
++#else
+ void on_any_widget_child_exited_event(GtkWidget *widget, AttributeSet *Attr);
++#endif
+ gboolean on_any_widget_key_press_event(GtkWidget *widget,
+ 	GdkEventKey *event, AttributeSet *Attr);
+ gboolean on_any_widget_key_release_event(GtkWidget*widget,
+-- 
+2.30.2
+
+
+From ac272076983da3bcbffa3e4c6935be709efabf1e Mon Sep 17 00:00:00 2001
+From: step- <step-@users.noreply.github.com>
+Date: Thu, 3 Feb 2022 10:03:58 +0100
+Subject: [PATCH 2/2] update VTE version check
+
+---
+ src/signals.c | 2 +-
+ src/signals.h | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/signals.c b/src/signals.c
+index d1a296b..fa90f01 100644
+--- a/src/signals.c
++++ b/src/signals.c
+@@ -634,7 +634,7 @@ void on_any_widget_icon_release_event(GtkWidget *widget,
+  ***********************************************************************/
+ 
+ #if HAVE_VTE
+-#if VTE_CHECK_VERSION(0,36,1)
++#if VTE_CHECK_VERSION(0,37,0)
+ void on_any_widget_child_exited_event(GtkWidget *widget, int status, AttributeSet *Attr)
+ {
+ #else
+diff --git a/src/signals.h b/src/signals.h
+index 2907689..d01b9e4 100644
+--- a/src/signals.h
++++ b/src/signals.h
+@@ -61,7 +61,7 @@ void on_any_widget_icon_release_event(GtkWidget *widget,
+ 	GtkEntryIconPosition pos, GdkEvent *event, AttributeSet *Attr);
+ #endif
+ #if HAVE_VTE
+-#if VTE_CHECK_VERSION(0,36,1)
++#if VTE_CHECK_VERSION(0,37,0)
+ void on_any_widget_child_exited_event(GtkWidget *widget, int status, AttributeSet *Attr);
+ #else
+ void on_any_widget_child_exited_event(GtkWidget *widget, AttributeSet *Attr);
+-- 
+2.30.2
+

--- a/woof-code/rootfs-petbuilds/gtkdialog/petbuild
+++ b/woof-code/rootfs-petbuilds/gtkdialog/petbuild
@@ -4,6 +4,7 @@ download() {
 
 build() {
     tar -xzf gtkdialog-0.8.4i.tar.gz
+    patch -d gtkdialog-0.8.4i -p1 < 125.patch
     if [ $PETBUILD_GTK -eq 3 ]; then
         cd gtkdialog-0.8.4i
         meson --buildtype=release --prefix=/usr --bindir=/usr/sbin -Dgtkver=3 build


### PR DESCRIPTION
This is temporary, until the next gtkdialog is out. Vanilla Dpup already has this fix backported, but it's always good to have consistency across Puppy releases.