### PR TITLE
Check the firewall state before the tray icon appears

### DIFF
--- a/woof-code/rootfs-petbuilds/firewallstatus/firewallstatus-0.7/firewallstatus.c
+++ b/woof-code/rootfs-petbuilds/firewallstatus/firewallstatus-0.7/firewallstatus.c
@@ -185,6 +185,7 @@ int main(int argc, char **argv) {
 	gtk_init(&argc, &argv);
 		
 	tray_icon = create_tray_icon();
+	Firestate(NULL);
                         
 	g_timeout_add(interval, Firestate, NULL);
 	gtk_main();


### PR DESCRIPTION
Even if the firewall is currently active, the tray icon always starts in its "disabled" state and switches to the "enabled" state after 2s. I want less lies and less changes on the screen!