### PR TITLE
Add command-not-found support to bdrv

### DIFF
--- a/woof-code/rootfs-skeleton/root/.bashrc
+++ b/woof-code/rootfs-skeleton/root/.bashrc
@@ -1,2 +1,12 @@
 . /etc/profile
 [ -f /etc/bash_completion ] && . /etc/bash_completion
+if [ -x /usr/lib/command-not-found ]; then
+ command_not_found_handle() {
+  if [ -f /var/lib/command-not-found/commands.db ]; then
+   /usr/lib/command-not-found -- "$1"
+  else
+   echo "bash: $1: command not found" >&2
+  fi
+  return 127
+ }
+fi

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -89,8 +89,8 @@ chroot bdrv apt-mark hold busybox-static
 # install all packages included in the woof-CE build
 chroot bdrv apt-get install -y `cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 5 -d \| | tr '\n' ' '`
 
-# add Synaptic and gdebi
-chroot bdrv apt-get install -y synaptic gdebi
+# add missing package recommendations, Synaptic and gdebi
+chroot bdrv apt-get install -y command-not-found synaptic gdebi
 sed -e 's/^Categories=.*/Categories=X-Setup-puppy/' -i bdrv/usr/share/applications/synaptic.desktop
 echo "NoDisplay=true" >> bdrv/usr/share/applications/gdebi.desktop
 


### PR DESCRIPTION
![vlc](https://user-images.githubusercontent.com/1471149/154638757-840f72e6-9984-4bf2-91fe-ee2e7180c4f3.png)

This works nicely with shell completion:

![abiword](https://user-images.githubusercontent.com/1471149/154663737-debac6ed-6f91-4fb1-adb9-b7c11c70fd07.png)

And it starts working immediately after the first `apt update`, so users who don't use apt won't be bothered by it:

![update](https://user-images.githubusercontent.com/1471149/154664396-143624d5-5d33-44e1-ad41-aed00293bf97.png)