### PR TITLE
Allow the user to disable the firewall now and on boot (fixes #2883)

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1344,14 +1344,14 @@ if [ -f "$TMPFW" ];then
 	[ $state = 1 -a "$1" != "enable" ] && /etc/init.d/rc.firewall stop && sleep 1
 	echo "copying firewall"
 	cp -af "$TMPFW" /etc/init.d/rc.firewall
-	chmod 755 /etc/init.d/rc.firewall
+	[ "$MAIN" = "false" ] && chmod 644 /etc/init.d/rc.firewall || chmod 755 /etc/init.d/rc.firewall
 	rm -f "$TMPFW"
 else
 	echo "Something went wrong"
 	exit
 fi
 
-[ "$1" = "enable" ] && exit
+[ "$1" = "enable" -o "$MAIN" = "false" ] && exit
 
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &


### PR DESCRIPTION
I did my best to minimize changes to firewall_ng. It's messy and in bad shape.

EDIT: after looking the code again, I'm not sure I understand this UI. What does the "Your firewall is configured" checkbox do? If it's disabled, is it supposed to setup a firewall that blocks everything except the selected ports? That's not what it does.