### PR TITLE
Use relative paths in efilinux.cfg

### DIFF
--- a/woof-code/rootfs-packages/simple_installer/usr/sbin/simple_installer
+++ b/woof-code/rootfs-packages/simple_installer/usr/sbin/simple_installer
@@ -93,16 +93,16 @@ if [ -n "$ESP" ]; then
 
 		if [ -e /mnt/efi/EFI/BOOT/ucode.cpio ]; then
 			install -m 644 /mnt/efi/EFI/BOOT/ucode.cpio /mnt/targetp1/EFI/BOOT/ucode.cpio
-			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio initrd=0:\EFI\BOOT\initrd.gz root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz initrd=\EFI\BOOT\ucode.cpio initrd=\EFI\BOOT\initrd.gz root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
 		else
-			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\initrd.gz root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz initrd=\EFI\BOOT\initrd.gz root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
 		fi
 	else
 		if [ -e /mnt/efi/EFI/BOOT/ucode.cpio ]; then
 			install -m 644 /mnt/efi/EFI/BOOT/ucode.cpio /mnt/targetp1/EFI/BOOT/ucode.cpio
-			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz initrd=\EFI\BOOT\ucode.cpio root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
 		else
-			echo "-f 0:\EFI\BOOT\vmlinuz root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz root=PARTUUID=${PARTUUID} init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/targetp1/EFI/BOOT/efilinux.cfg
 		fi
 	fi
 	busybox umount /mnt/targetp1 2>/dev/null

--- a/woof-code/support/pc_image.sh
+++ b/woof-code/support/pc_image.sh
@@ -100,16 +100,16 @@ if [ "$WOOF_TARGETARCH" = "x86_64" ]; then
 	if [ "$FRUGALIFY" = "yes" ]; then
 		if [ -e build/ucode.cpio ]; then
 			install -m 644 build/ucode.cpio /mnt/uefiimagep1/EFI/BOOT/ucode.cpio
-			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio root=PARTUUID=$PARTUUID init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz initrd=\EFI\BOOT\ucode.cpio root=PARTUUID=$PARTUUID init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
 		else
-			echo "-f 0:\EFI\BOOT\vmlinuz root=PARTUUID=$PARTUUID init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz root=PARTUUID=$PARTUUID init=/frugalify rootfstype=ext4 rootwait rw" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
 		fi
 	else
 		if [ -e build/ucode.cpio ]; then
 			install -m 644 build/ucode.cpio /mnt/uefiimagep1/EFI/BOOT/ucode.cpio
-			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\ucode.cpio initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz initrd=\EFI\BOOT\ucode.cpio initrd=\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
 		else
-			echo "-f 0:\EFI\BOOT\vmlinuz initrd=0:\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
+			echo "-f \EFI\BOOT\vmlinuz initrd=\EFI\BOOT\initrd.gz" > /mnt/uefiimagep1/EFI/BOOT/efilinux.cfg
 		fi
 
 		install -m 644 build/initrd.gz /mnt/uefiimagep1/EFI/BOOT/initrd.gz


### PR DESCRIPTION
If you have version X installed on sda2 with an EFI partition in sda1, but try to boot version Y from sdb, it will use the older kernel and initramfs from sda1.