### PR TITLE
Basic IPv6 support

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -512,8 +512,11 @@ SYSCTL="/sbin/sysctl -w"
 # IPTables Location
 IPT_PATH="\$(dirname \$(which iptables))"
 IPT="\$IPT_PATH/iptables"
+IP6T="\$IPT_PATH/ip6tables"
 IPTS="\$IPT_PATH/iptables-save"
+IP6TS="\$IPT_PATH/iptables-save"
 IPTR="\$IPT_PATH/iptables-restore"
+IP6TR="\$IPT_PATH/iptables-restore"
 EOF_FWSTART
 
 # generic or interface
@@ -541,18 +544,21 @@ INET_IFACE="$IFACE"
 
 LO_IFACE="lo"
 LO_IP="127.0.0.1"
+LO_IP6="::1"
 
 # Save and Restore arguments handled here
 if [ "\$1" = "save" ]
 then
 	echo -n "Saving firewall to /etc/sysconfig/iptables ... "
 	\$IPTS > /etc/sysconfig/iptables
+	\$IP6TS > /etc/sysconfig/ip6tables
 	echo "done"
 	exit 0
 elif [ "\$1" = "restore" ]
 then
 	echo -n "Restoring firewall from /etc/sysconfig/iptables ... "
 	\$IPTR < /etc/sysconfig/iptables
+	\$IP6TR < /etc/sysconfig/ip6tables
 	echo "done"
 	exit 0
 fi
@@ -762,15 +768,32 @@ echo "Flushing Tables ..."
 \$IPT -t mangle -P PREROUTING ACCEPT
 \$IPT -t mangle -P OUTPUT ACCEPT
 
+\$IP6T -P INPUT ACCEPT
+\$IP6T -P FORWARD ACCEPT
+\$IP6T -P OUTPUT ACCEPT
+\$IP6T -t nat -P PREROUTING ACCEPT
+\$IP6T -t nat -P POSTROUTING ACCEPT
+\$IP6T -t nat -P OUTPUT ACCEPT
+\$IP6T -t mangle -P PREROUTING ACCEPT
+\$IP6T -t mangle -P OUTPUT ACCEPT
+
 # Flush all rules
 \$IPT -F
 \$IPT -t nat -F
 \$IPT -t mangle -F
 
+\$IP6T -F
+\$IP6T -t nat -F
+\$IP6T -t mangle -F
+
 # Erase all non-default chains
 \$IPT -X
 \$IPT -t nat -X
 \$IPT -t mangle -X
+
+\$IP6T -X
+\$IP6T -t nat -X
+\$IP6T -t mangle -X
 
 if [ "\$1" = "stop" ]
 then
@@ -795,6 +818,10 @@ fi
 \$IPT -P OUTPUT DROP
 \$IPT -P FORWARD DROP
 
+\$IP6T -P INPUT DROP
+\$IP6T -P OUTPUT DROP
+\$IP6T -P FORWARD DROP
+
 ###############################################################################
 #
 # User-Specified Chains
@@ -807,18 +834,22 @@ echo "Create and populate custom rule chains ..."
 # Create a chain to filter INVALID packets
 
 \$IPT -N bad_packets
+\$IP6T -N bad_packets
 
 # Create another chain to filter bad tcp packets
 
 \$IPT -N bad_tcp_packets
+\$IP6T -N bad_tcp_packets
 
 # Create separate chains for icmp, tcp (incoming and outgoing),
 # and incoming udp packets.
 
 \$IPT -N icmp_packets
+\$IP6T -N icmp_packets
 
 # Used for UDP packets inbound from the Internet
 \$IPT -N udp_inbound
+\$IP6T -N udp_inbound
 
 # Used to block outbound UDP services from internal network
 # Default to allow all
@@ -844,15 +875,20 @@ echo "Create and populate custom rule chains ..."
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_packets -p ALL -m conntrack --ctstate INVALID -j LOG \
 --log-prefix "Invalid packet: "
+	\$IP6T -A bad_packets -p ALL -m conntrack --ctstate INVALID -j LOG \
+--log-prefix "Invalid packet: "
 fi
 
 \$IPT -A bad_packets -p ALL -m conntrack --ctstate INVALID -j DROP
+\$IP6T -A bad_packets -p ALL -m conntrack --ctstate INVALID -j DROP
 
 # Then check the tcp packets for additional problems
 \$IPT -A bad_packets -p tcp -j bad_tcp_packets
+\$IP6T -A bad_packets -p tcp -j bad_tcp_packets
 
 # All good, so return
 \$IPT -A bad_packets -p ALL -j RETURN
+\$IP6T -A bad_packets -p ALL -j RETURN
 
 # bad_tcp_packets chain
 #
@@ -866,47 +902,69 @@ fi
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp ! --syn -m conntrack --ctstate NEW -j LOG \
 --log-prefix "New not syn: "
+	\$IP6T -A bad_tcp_packets -p tcp ! --syn -m conntrack --ctstate NEW -j LOG \
+--log-prefix "New not syn: "
 fi
 \$IPT -A bad_tcp_packets -p tcp ! --syn -m conntrack --ctstate NEW -j DROP
+\$IP6T -A bad_tcp_packets -p tcp ! --syn -m conntrack --ctstate NEW -j DROP
 
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL NONE -j LOG \
 --log-prefix "Stealth scan: "
+	\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL NONE -j LOG \
+--log-prefix "Stealth scan: "
 fi
 \$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL NONE -j DROP
+\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL NONE -j DROP
 
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL ALL -j LOG \
 --log-prefix "Stealth scan: "
+	\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL ALL -j LOG \
+--log-prefix "Stealth scan: "
 fi
 \$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL ALL -j DROP
+\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL ALL -j DROP
 
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL FIN,URG,PSH -j LOG \
 --log-prefix "Stealth scan: "
+	\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL FIN,URG,PSH -j LOG \
+--log-prefix "Stealth scan: "
 fi
 \$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL FIN,URG,PSH -j DROP
+\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL FIN,URG,PSH -j DROP
 
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j LOG \
 --log-prefix "Stealth scan: "
+	\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j LOG \
+--log-prefix "Stealth scan: "
 fi
 \$IPT -A bad_tcp_packets -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP
+\$IP6T -A bad_tcp_packets -p tcp --tcp-flags ALL SYN,RST,ACK,FIN,URG -j DROP
 
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp --tcp-flags SYN,RST SYN,RST -j LOG \
 --log-prefix "Stealth scan: "
+	\$IP6T -A bad_tcp_packets -p tcp --tcp-flags SYN,RST SYN,RST -j LOG \
+--log-prefix "Stealth scan: "
 fi
 \$IPT -A bad_tcp_packets -p tcp --tcp-flags SYN,RST SYN,RST -j DROP
+\$IP6T -A bad_tcp_packets -p tcp --tcp-flags SYN,RST SYN,RST -j DROP
 
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A bad_tcp_packets -p tcp --tcp-flags SYN,FIN SYN,FIN -j LOG \
 --log-prefix "Stealth scan: "
+	\$IP6T -A bad_tcp_packets -p tcp --tcp-flags SYN,FIN SYN,FIN -j LOG \
+--log-prefix "Stealth scan: "
 fi
 \$IPT -A bad_tcp_packets -p tcp --tcp-flags SYN,FIN SYN,FIN -j DROP
+\$IP6T -A bad_tcp_packets -p tcp --tcp-flags SYN,FIN SYN,FIN -j DROP
 
 # All good, so return
 \$IPT -A bad_tcp_packets -p tcp -j RETURN
+\$IP6T -A bad_tcp_packets -p tcp -j RETURN
 
 # icmp_packets chain
 #
@@ -929,8 +987,11 @@ fi
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A icmp_packets --fragment -p ICMP -j LOG \
 --log-prefix "ICMP Fragment: "
+	\$IP6T -A icmp_packets -m frag --fragmore -p ICMP -j LOG \
+--log-prefix "ICMP Fragment: "
 fi
 \$IPT -A icmp_packets --fragment -p ICMP -j DROP
+\$IP6T -A icmp_packets -m frag --fragmore -p ICMP -j DROP
 
 # Echo - uncomment to allow your system to be pinged.
 # Uncomment the LOG command if you also want to log PING attempts
@@ -938,20 +999,26 @@ fi
 #if [ "\$LOGGING" = "true" ];then
 #	\$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 8 -j LOG \
 #--log-prefix "Ping detected: "
+#	\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 8 -j LOG \
+#--log-prefix "Ping detected: "
 #fi
 # \$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 8 -j ACCEPT
+# \$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 8 -j ACCEPT
 
 # By default, however, drop pings without logging. Blaster
 # and other worms have infected systems blasting pings.
 # Comment the line below if you want pings logged, but it
 # will likely fill your logs.
 \$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 8 -j DROP
+\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 8 -j DROP
 
 # Time Exceeded
 \$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 11 -j ACCEPT
+\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 11 -j ACCEPT
 
 # Not matched, so return so it will be logged
 \$IPT -A icmp_packets -p ICMP -j RETURN
+\$IP6T -A icmp_packets -p ICMPV6 -j RETURN
 
 # TCP & UDP
 # Identify ports at:
@@ -1002,6 +1069,8 @@ cat >> $TMPFW << EOF_FWCOMMENT
 # If you receive your dynamic address by a different means, you
 # can probably comment this line.
 \$IPT -A udp_inbound -p UDP -s 0/0 --source-port 67 --destination-port 68 \
+-j ACCEPT
+\$IP6T -A udp_inbound -p UDP -d fe80::/64 --destination-port 546 -m state --state NEW \
 -j ACCEPT
 # User specified allowed UDP protocol
 EOF_FWCOMMENT
@@ -1111,6 +1180,7 @@ cat >> $TMPFW << EOF_MID
 
 # Not matched, so return for logging
 \$IPT -A udp_inbound -p UDP -j RETURN
+\$IP6T -A udp_inbound -p UDP -j RETURN
 
 # udp_outbound chain
 #
@@ -1213,9 +1283,11 @@ echo "Process INPUT chain ..."
 
 # Allow all on localhost interface
 \$IPT -A INPUT -p ALL -i \$LO_IFACE -j ACCEPT
+\$IP6T -A INPUT -p ALL -i \$LO_IFACE -j ACCEPT
 
 # Drop bad packets
 \$IPT -A INPUT -p ALL -j bad_packets
+\$IP6T -A INPUT -p ALL -j bad_packets
 
 # DOCSIS compliant cable modems
 # Some DOCSIS compliant cable modems send IGMP multicasts to find
@@ -1239,21 +1311,28 @@ echo "Process INPUT chain ..."
 # Accept Established Connections
 \$IPT -A INPUT -p ALL $IOPT -m conntrack --ctstate ESTABLISHED,RELATED \
 -j ACCEPT
+\$IP6T -A INPUT -p ALL $IOPT -m conntrack --ctstate ESTABLISHED,RELATED \
+-j ACCEPT
 
 # Route the rest to the appropriate user chain
 \$IPT -A INPUT -p TCP $IOPT -j tcp_inbound
 \$IPT -A INPUT -p UDP $IOPT -j udp_inbound
+\$IP6T -A INPUT -p UDP $IOPT -j udp_inbound
 \$IPT -A INPUT -p ICMP $IOPT -j icmp_packets
+\$IP6T -A INPUT -p ICMPV6 $IOPT -j icmp_packets
 
 # Drop without logging broadcasts that get this far.
 # Cuts down on log clutter.
 # Comment this line if testing new rules that impact
 # broadcast protocols.
 \$IPT -A INPUT -m pkttype --pkt-type broadcast -j DROP
+\$IP6T -A INPUT -m pkttype --pkt-type broadcast -j DROP
 
 # Log packets that still don't match
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A INPUT -m limit --limit 3/minute --limit-burst 3 -j LOG \
+--log-prefix "INPUT packet died: "
+	\$IP6T -A INPUT -m limit --limit 3/minute --limit-burst 3 -j LOG \
 --log-prefix "INPUT packet died: "
 fi
 
@@ -1279,17 +1358,23 @@ echo "Process OUTPUT chain ..."
 # However, invalid icmp packets need to be dropped
 # to prevent a possible exploit.
 \$IPT -A OUTPUT -p icmp -m conntrack --ctstate INVALID -j DROP
+\$IP6T -A OUTPUT -p ICMPV6 -m conntrack --ctstate INVALID -j DROP
 
 # Localhost
 \$IPT -A OUTPUT -p ALL -s \$LO_IP -j ACCEPT
+\$IP6T -A OUTPUT -p ALL -s \$LO_IP6 -j ACCEPT
 \$IPT -A OUTPUT -p ALL -o \$LO_IFACE -j ACCEPT
+\$IP6T -A OUTPUT -p ALL -o \$LO_IFACE -j ACCEPT
 
 # To internet
 \$IPT -A OUTPUT -p ALL $OOPT -j ACCEPT
+\$IP6T -A OUTPUT -p ALL $OOPT -j ACCEPT
 
 # Log packets that still don't match
 if [ "\$LOGGING" = "true" ];then
 	\$IPT -A OUTPUT -m limit --limit 3/minute --limit-burst 3 -j LOG \
+--log-prefix "OUTPUT packet died: "
+	\$IP6T -A OUTPUT -m limit --limit 3/minute --limit-burst 3 -j LOG \
 --log-prefix "OUTPUT packet died: "
 fi
 

--- a/woof-code/rootfs-skeleton/etc/hosts
+++ b/woof-code/rootfs-skeleton/etc/hosts
@@ -1,4 +1,2 @@
 127.0.0.1 localhost puppypc
-192.168.1.1 pc2
-192.168.1.2 pc3
-192.168.1.3 pc4
+::1 localhost puppypc

--- a/woof-code/rootfs-skeleton/usr/sbin/hostname-set
+++ b/woof-code/rootfs-skeleton/usr/sbin/hostname-set
@@ -93,6 +93,7 @@ $(gettext '<b>NOTE:</b> There did appear to be an active network connection, tha
  hostname $NEW_HOSTNAME
  echo -n $NEW_HOSTNAME > /etc/hostname
  echo "127.0.0.1 localhost $NEW_HOSTNAME" > /tmp/hostname-set-hosts
+ echo "::1 localhost $NEW_HOSTNAME" >> /tmp/hostname-set-hosts
  grep -vw 'localhost'  /etc/hosts >> /tmp/hostname-set-hosts
  [ -s /tmp/hostname-set-hosts ] && mv -f /tmp/hostname-set-hosts /etc/hosts
  M_h1="$(gettext 'Set Hostname: done')"

--- a/woof-code/support/rootfs-hacks.sh
+++ b/woof-code/support/rootfs-hacks.sh
@@ -239,6 +239,9 @@ fi
 if [ -h ${SR}/usr/sbin/iptables-legacy ] ; then
 	ln -sv /usr/sbin/iptables-legacy ${SR}/usr/sbin/iptables
 fi
+if [ -h ${SR}/usr/sbin/ip6tables-legacy ] ; then
+	ln -sv /usr/sbin/ip6tables-legacy ${SR}/usr/sbin/ip6tables
+fi
 
 echo ----
 

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -244,7 +244,7 @@ no|inkscapelite||exe,dev,doc,nls
 no|inotify-tools|inotify-tools,libinotifytools0|exe,dev,doc,nls
 yes|installwatch|checkinstall|exe>dev,dev,doc,nls||deps:yes
 yes|intltool|intltool|exe>dev,dev,doc,nls||deps:yes #previously only in devx, but need in main f.s. to run momanager without devx.
-yes|iptables|iptables,libip4tc2,libip6tc2,libxtables12,libnftnl11|exe,dev,doc,nls||deps:yes
+yes|iptables|iptables,libip4tc2,libip6tc2,libxtables12,libnftnl11|exe,dev>exe,doc,nls||deps:yes
 no|iso-codes|iso-codes|exe,dev,doc,nls #needed by gstreamer. very big. GSTREAMER1.0 GSTREAMER0.10
 no|isomaster|isomaster|exe,dev,doc,nls
 yes|iw|iw|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -250,7 +250,7 @@ no|inkscapelite||exe,dev,doc,nls
 no|inotify-tools|inotify-tools,libinotifytools0|exe,dev,doc,nls
 yes|installwatch|checkinstall|exe>dev,dev,doc,nls||deps:yes
 yes|intltool|intltool|exe>dev,dev,doc,nls||deps:yes #previously only in devx, but need in main f.s. to run momanager without devx.
-yes|iptables|iptables,libip4tc2,libip6tc2,libxtables12,libnftnl11|exe,dev,doc,nls||deps:yes
+yes|iptables|iptables,libip4tc2,libip6tc2,libxtables12,libnftnl11|exe,dev>exe,doc,nls||deps:yes
 no|iso-codes|iso-codes|exe,dev,doc,nls #needed by gstreamer. very big. GSTREAMER1.0 GSTREAMER0.10
 no|isomaster|isomaster|exe,dev,doc,nls
 yes|iw|iw|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
This PR fixes #2891.

It adds ::1 to /etc/hosts, so IPv6-capable applications that resolve `localhost` don't fail.

And it blocks all incoming IPv6 traffic, with some exceptions (like DHCPv6). The hardcoded sets of exceptions offered by the UI (SMB, HTTP, etc') are not supported, because things behave differently under IPv6 (ports, special IP addresses, etc') and this needs more research.

For now, IPv6 is nothing but an attack vector when using Puppy in untrusted networks, most home routers support both IPv4 and IPv6 (at least, in the LAN), and most people use IPv4 to talk to home servers. Therefore, for now, it's good enough to block incoming traffic and allow all outgoing traffic.