### PR TITLE
Make pupswap work under PUPMODE 6

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -897,6 +897,7 @@ fi
 if [ "$FRUGALIFY" ]; then
 	echo "PUPMODE='6'" > rootfs-complete/etc/rc.d/PUPSTATE
 	echo "PUNIONFS='overlay'" >> rootfs-complete/etc/rc.d/PUPSTATE
+	echo "PUP_HOME=''" >> rootfs-complete/etc/rc.d/PUPSTATE
 fi
 
 if grep -q '^spot:' rootfs-complete/etc/passwd ; then

--- a/woof-code/rootfs-skeleton/usr/sbin/pupswap
+++ b/woof-code/rootfs-skeleton/usr/sbin/pupswap
@@ -116,7 +116,7 @@ TOTAL_SWAP_SIZES=$X
 if [ "$MOUNTED_PARTITIONS" = "" ] ; then #MOUNTED_PARTITIONS can be exported
 	MOUNTED_PARTITIONS="`mount | grep -E "/(s|h)d[a-z][0-9]" | awk '{print $3}' | sort -u`"
 fi
-if [ $PUPMODE -eq 2 -o $PUPMODE -eq 6 ] ; then #full install
+if [ $PUPMODE -eq 2 ] ; then #full install
 	MOUNTED_PARTITIONS="/
 $MOUNTED_PARTITIONS"
 fi


### PR DESCRIPTION
It works, but not if the swap file is under /, and that's the default.