### PR TITLE
Optionally, allow the updater to use prerelease and draft releases

### DIFF
--- a/woof-code/rootfs-packages/simple_updater/etc/simple_updater.conf
+++ b/woof-code/rootfs-packages/simple_updater/etc/simple_updater.conf
@@ -1,2 +1,8 @@
 # the repo to pull releases from
 UPDATE_REPO=puppylinux-woof-CE/woof-CE
+
+# skip draft releases?
+SKIP_DRAFTS=yes
+
+# skip prereleases?
+SKIP_PRERELEASES=yes

--- a/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
+++ b/woof-code/rootfs-packages/simple_updater/usr/sbin/simple_updater
@@ -22,10 +22,10 @@ fi
 RELEASE_CHOICE=-1
 for i in `seq 0 $(($COUNT - 1))`; do
 	DRAFT=`echo "$RELEASES" | jq -r ".[$i].draft"`
-	[ "$DRAFT" = true ] && continue
+	[ "$DRAFT" = true -a "$SKIP_DRAFTS" != no ] && continue
 
 	PRERELEASE=`echo "$RELEASES" | jq -r ".[$i].prerelease"`
-	[ "$PRERELEASE" = true ] && continue
+	[ "$PRERELEASE" = true -a "$SKIP_PRERELEASES" != no ] && continue
 
 	RELEASE_NAME=`echo "$RELEASES" | jq -r ".[$i].name"`
 	case "$RELEASE_NAME" in


### PR DESCRIPTION
I'd like to trigger a Vanilla Dpup 9.1.x build on every push to https://github.com/vanilla-dpup/woof-CE/commits/vanilladpup-9.1.x, to make it easy to test fixes I cherry-pick from testing.

Currently, the updater skips non-final releases, so existing users won't get updated to testing builds. But wit this PR, users who configure `SKIP_PRERELEASES=no` can update and receive individual fixes before anyone else.