### PR TITLE
Disable set_wl_monsleep when using X

### DIFF
--- a/woof-code/rootfs-skeleton/root/Startup/set_wl_monsleep
+++ b/woof-code/rootfs-skeleton/root/Startup/set_wl_monsleep
@@ -1,1 +1,4 @@
-../../usr/sbin/set_wl_monsleep
+#!/bin/sh
+
+[ "$XDG_SESSION_TYPE" != "wayland" ] && exit 0
+exec set_wl_monsleep


### PR DESCRIPTION
This mitigates #2897, until it's fixed. And there's no reason to run set_wl_monsleep when using X.Org, anyway.