### PR TITLE
Show only one menu entry for each .desktop file

### DIFF
--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
@@ -19,6 +19,7 @@ build() {
     cd xdg_puppy-0.7.6-9
     patch -p1 < ../empty-menus.patch
     patch -p1 < ../2089.patch
+    patch -p1 < ../unique.patch
     $CC $CFLAGS -DGMENU_I_KNOW_THIS_IS_UNSTABLE `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --cflags glib-2.0 libgnome-menu` jwm-xdgmenu/jwm-xdgmenu.c $LDFLAGS `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --libs glib-2.0 libgnome-menu` -o /usr/bin/jwm-xdgmenu
 
     # we don't need these

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
@@ -1,0 +1,73 @@
+diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2022-02-24 21:02:10.059689993 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2022-02-25 03:35:24.503675651 +0200
+@@ -22,7 +22,7 @@
+  * Declarations
+  */
+ static void show_help();
+-static void process_directory(GMenuTreeDirectory *directory, char *menheight);
++static void process_directory(GMenuTreeDirectory *directory, char *menheight, GHashTable *history);
+ static void process_entry(GMenuTreeEntry *entry);
+ static void process_separator(GMenuTreeSeparator *entry);
+ char *menheight;
+@@ -72,10 +72,13 @@ main (int argc, char **argv)
+   }
+   
+   GMenuTree *menuTree = gmenu_tree_lookup (argv[1],  GMENU_TREE_FLAGS_NONE );
++  GHashTable *history = g_hash_table_new_full(g_str_hash, g_str_equal, g_free, NULL);
+ 
+   GMenuTreeDirectory *rootDirectory = gmenu_tree_get_root_directory(menuTree);
+ 
+-  process_directory(rootDirectory, menheight);
++  process_directory(rootDirectory, menheight, history);
++
++  g_hash_table_destroy(history);
+ 
+   gmenu_tree_item_unref (rootDirectory);
+ 
+@@ -106,7 +109,7 @@ show_help()
+  * This function processes a directory entry and all it's child nodes
+  */
+ void
+-process_directory(GMenuTreeDirectory *directory, char *menheight)
++process_directory(GMenuTreeDirectory *directory, char *menheight, GHashTable *history)
+ {
+ 	int hasSeparator = 0, first = 1;
+ 	char *mheight = menheight;
+@@ -117,6 +120,10 @@ process_directory(GMenuTreeDirectory *di
+ 
+   GSList *l;
+ 
++  GMenuTreeEntry *entry;
++
++  const char *path;
++
+   /* if the menu has no items, don't show an empty menu */
+   for (l = entryList; l; l = l->next)
+   {
+@@ -154,7 +161,7 @@ start:
+ 				}
+ 				hasSeparator = 0;
+ 		  }
+-			process_directory(GMENU_TREE_DIRECTORY(item),menheight);
++			process_directory(GMENU_TREE_DIRECTORY(item),menheight,history);
+ 			first = 0;
+ 			break;
+ 		case GMENU_TREE_ITEM_ENTRY:
+@@ -166,8 +173,14 @@ start:
+ 				}
+ 				hasSeparator = 0;
+ 		  }
+-			process_entry(GMENU_TREE_ENTRY(item));
+-			first = 0;
++			entry = GMENU_TREE_ENTRY(item);
++			path = gmenu_tree_entry_get_desktop_file_path(entry);
++			if (!g_hash_table_lookup(history, path))
++			{
++				process_entry(entry);
++				first = 0;
++				g_hash_table_insert(history, g_strdup(path), (gpointer)1);
++			}
+ 			break;
+ 		case GMENU_TREE_ITEM_SEPARATOR:
+ 			hasSeparator = 1;


### PR DESCRIPTION
`apt install -y gimp vlc`

Before:

![gimp](https://user-images.githubusercontent.com/1471149/155536444-84e0e6a7-f469-4d70-9bc7-ef126255cb05.png)

After:

![gimp2](https://user-images.githubusercontent.com/1471149/155536437-03291f5f-4ca4-4507-9311-5536addb8d44.png)

Before:

![vlc](https://user-images.githubusercontent.com/1471149/155536452-f4b09b17-068c-413a-9242-a9278a7dbdac.png)

After:

![vlc2](https://user-images.githubusercontent.com/1471149/155536449-df4914fc-df4a-47d6-8f77-25b639c0f813.png)

Some applications appear in more than one category, and that's fine IMHO. For example, Wireshark appears under the monitoring submenu of System, and under Network.