### PR TITLE
Make setup-spot faster and safer

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/setup-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/setup-spot
@@ -20,8 +20,8 @@ SPOT_HOME=$(awk -F: '$1=="spot" {print $6}' ${PREFIXDIR}/etc/passwd)
 touch ${PREFIXDIR}/root/.spot-status
 
 run_as_spot() { #$1:app  $2:filename
-	cp ${PREFIXDIR}/usr/sbin/run-as-spot "$2"
-	sed -i "s%CMD=''%CMD=${1}%" "$2"
+	sed "s%CMD=''%CMD=${1}%" ${PREFIXDIR}/usr/sbin/run-as-spot > "$2"
+	chmod 755 "$2"
 }
 
 run_as_spot_2() { #$1:app  $2:filename
@@ -35,8 +35,9 @@ generic_func() {
  #setup the app to run as spot or root...
  case $ONEAPPvalue in
   true)
-   [ ! -e ${ONEAPPpath}/${ONEAPPname}.bin ] && cp -a -f ${ONEAPPpath}/${ONEAPPname} ${ONEAPPpath}/${ONEAPPname}.bin
-   rm -f ${ONEAPPpath}/${ONEAPPname} #in case it is a symlink.
+   if [ ! -e ${ONEAPPpath}/${ONEAPPname}.bin ]; then
+    mv -f ${ONEAPPpath}/${ONEAPPname} ${ONEAPPpath}/${ONEAPPname}.bin
+   fi
    case $RUNNINGPUP in
     0)APPpath=${ONEAPPpath};;
     1)APPpath=`echo ${ONEAPPpath}|sed "s%$PREFIXDIR%%"`;;
@@ -45,8 +46,8 @@ generic_func() {
   ;;
   false)
    if [ -e ${ONEAPPpath}/${ONEAPPname}.bin ];then
-    cp -a -f --remove-destination ${ONEAPPpath}/${ONEAPPname}.bin ${ONEAPPpath}/${ONEAPPname} #restore original.
-    rm -f ${ONEAPPpath}/${ONEAPPname}.bin
+    rm -f ${ONEAPPpath}/${ONEAPPname}
+    mv -f ${ONEAPPpath}/${ONEAPPname}.bin ${ONEAPPpath}/${ONEAPPname} #restore original.
    fi
   ;;
  esac


### PR DESCRIPTION
Copying is slow and not atomic like `rename()`.