### PR TITLE
Make the VS Code .deb package work out-of-the-box

### DIFF
--- a/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
+++ b/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
@@ -12,7 +12,7 @@
 #include <regex.h>
 #include <stdio.h>
 
-#define SPOTLIST "^(firefox|firefox-[a-z]+|google-chrome-[a-z]+|chromium|vivaldi-[a-z]+|brave-browser|microsoft-edge-[a-z]+|transmission-[a-z]+|seamonkey|sylpheed|claws-mail|thunderbird|vlc|steam)$"
+#define SPOTLIST "^(firefox|firefox-[a-z]+|google-chrome-[a-z]+|chromium|vivaldi-[a-z]+|brave-browser|microsoft-edge-[a-z]+|transmission-[a-z]+|seamonkey|sylpheed|claws-mail|thunderbird|vlc|steam|code)$"
 
 static int
 sh(const char *cmd, const sigset_t *set)

--- a/woof-code/rootfs-skeleton/usr/sbin/setup-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/setup-spot
@@ -31,8 +31,35 @@ exec /usr/sbin/run-as-spot "'${1}'" "$@"
 	chmod 755 "$2"
 }
 
+#setup the app to run as spot or root...
 generic_func() {
- #setup the app to run as spot or root...
+ # if the executable is a symlink, replace the link target
+ if [ -h ${ONEAPPpath}/${ONEAPPname} ]; then
+  TARGET=`readlink -f ${ONEAPPpath}/${ONEAPPname}`
+  case $ONEAPPvalue in
+   true)
+    TARGET=`readlink -f ${ONEAPPpath}/${ONEAPPname}`
+    if [ ! -e ${TARGET}.bin ]; then
+     mv -f ${TARGET} ${TARGET}.bin
+    fi
+    case $RUNNINGPUP in
+     0)APPpath=${TARGET};;
+     1)APPpath=`echo ${TARGET}|sed "s%$PREFIXDIR%%"`;;
+    esac
+    run_as_spot ${TARGET}.bin ${TARGET}
+   ;;
+   false)
+    if [ -e ${TARGET}.bin ]; then
+     rm -f ${TARGET}
+     mv -f ${TARGET}.bin ${TARGET} #restore original.
+    fi
+   ;;
+  esac
+
+  return 0
+ fi
+
+ # if the executable is a file, replace the executable
  case $ONEAPPvalue in
   true)
    if [ ! -e ${ONEAPPpath}/${ONEAPPname}.bin ]; then

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -114,11 +114,11 @@ PROMPT='PS1="\w\$ "'
 ## Here add custom commands to be executed inside sandbox3/rootfs-complete
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
-[ -d ../adrv ] && sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i ../adrv/usr/share/applications/firefox-esr.desktop || sed s~Exec=/usr/lib/firefox-esr/firefox-esr~Exec=firefox-esr~ -i usr/share/applications/firefox-esr.desktop
 [ -d ../adrv ] && touch usr/bin/firefox-esr
 chroot . /usr/sbin/setup-spot firefox-esr=true
-[ -d ../adrv ] && mv -f ../adrv/usr/bin/firefox-esr{,.bin}
-[ -d ../adrv ] && mv -f usr/bin/firefox-esr ../adrv/usr/bin/
+[ -d ../adrv ] && mv -f ../adrv/usr/lib/firefox-esr/firefox-esr{,.bin}
+[ -d ../adrv ] && mv -f usr/bin/firefox-esr ../adrv/usr/lib/firefox-esr/firefox-esr
+[ -d ../adrv ] && sed s~/usr/bin/firefox-esr~/usr/lib/firefox-esr/firefox-esr~ -i ../adrv/usr/lib/firefox-esr/firefox-esr
 [ -d ../adrv ] && rm -f usr/bin/firefox-esr.bin
 [ -d ../adrv ] && touch usr/bin/sylpheed
 chroot . /usr/sbin/setup-spot sylpheed=true

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -114,11 +114,11 @@ PROMPT='PS1="\w\$ "'
 ## Here add custom commands to be executed inside sandbox3/rootfs-complete
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
-[ -d ../adrv ] && sed s~Exec=/usr/lib/firefox/firefox~Exec=firefox~ -i ../adrv/usr/share/applications/firefox.desktop || sed s~Exec=/usr/lib/firefox/firefox~Exec=firefox~ -i usr/share/applications/firefox.desktop
 [ -d ../adrv ] && touch usr/bin/firefox
 chroot . /usr/sbin/setup-spot firefox=true
-[ -d ../adrv ] && mv -f ../adrv/usr/bin/firefox{,.bin}
-[ -d ../adrv ] && mv -f usr/bin/firefox ../adrv/usr/bin/
+[ -d ../adrv ] && mv -f ../adrv/usr/lib/firefox/firefox{,.bin}
+[ -d ../adrv ] && mv -f usr/bin/firefox ../adrv/usr/lib/firefox/firefox
+[ -d ../adrv ] && sed s~/usr/bin/firefox~/usr/lib/firefox/firefox~ -i ../adrv/usr/lib/firefox/firefox
 [ -d ../adrv ] && rm -f usr/bin/firefox.bin
 [ -d ../adrv ] && touch usr/bin/transmission-gtk
 chroot . /usr/sbin/setup-spot transmission-gtk=true


### PR DESCRIPTION
```
Exec=/usr/share/code/code --new-window %F
```

*But*, if installed via apt, the package creates /usr/bin/code symlink, so if setup-spot replaces /usr/share/code/code with the run-as-spot script, and not /usr/bin/code, the menu entry works.

Firefox is similar to VS Code, the executable is somewhere under /usr, and the file under /usr/bin is a symlink.