### PR TITLE
Restore the Firefox titlebar until joewing/jwm#540 is fixed

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -8,8 +8,6 @@ cat << EOF > ${FFDIR}/puppy.cfg
 
 // use less vertical space
 defaultPref("browser.compactmode.show", true);
-defaultPref("browser.tabs.drawInTitlebar", true);
-defaultPref("browser.tabs.inTitlebar", 1);
 defaultPref("browser.uidensity", 1);
 
 // render website text while fetching images


### PR DESCRIPTION
This eats precious vertical space and I hate this, but it can take time until this issue is fixed.