### PR TITLE
Drop libllvm11 from sid64

### DIFF
--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -440,7 +440,7 @@ yes|libzstd|libzstd1|exe,dev,doc,nls||deps:yes
 no|linux_firmware_dvb||exe
 yes|linux-header|linux-libc-dev|exe>dev,dev,doc,nls||deps:yes
 no|lirc|liblircclient0,liblircclient-dev|exe,dev,doc,nls
-yes|llvm|libllvm11|exe,dev||deps:yes #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
+no|llvm|libllvm11|exe,dev||deps:yes #needed by libgl1-mesa-dri, but huge 7MB deb. i left out dev components. 120605 removed. 120902 back.
 yes|login|login|exe>null,dev>null,doc>null,nls>null
 yes|lsb-base|lsb-base|exe,dev,doc,nls||deps:yes
 no|lxrandr||exe,dev,doc,nls


### PR DESCRIPTION
mesa needs libllvm13, and dependency resolution makes sure it's there. Huge library, huge waste of space.