### PR TITLE
Ignore /etc/profile.d/*.csh

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile
+++ b/woof-code/rootfs-skeleton/etc/profile
@@ -90,7 +90,7 @@ export PREFIX='/usr' #convenient to set this i think...
 # Append any additional sh scripts found in /etc/profile.d/:
 #for profile_script in /etc/profile.d/*.sh ; do
 for profile_script in /etc/profile.d/* ; do #w482 any files.
-	case "$profile_script" in *txt) continue ;; esac
+	case "$profile_script" in *txt|*.csh) continue ;; esac
 	. $profile_script
 done
 unset profile_script


### PR DESCRIPTION
Ubuntu has these, and they're not meant to be sourced by bash. They cause syntax errors in every new terminal tab or window.