### PR TITLE
Clear FIXUPHACK_FILE before processing a package

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -200,6 +200,9 @@ do
  PKG_DIR=${EXE_DIR}
  #------------------------------------------------------------------------
 
+ FIXUPHACK_FILE=""
+ DISABLE_POST_INSTALL_SCRIPT=""
+
  #inject $FNDIT at end of do-done, runs faster...
  #==== extract packages ======
  while read ONEDBENTRY
@@ -260,8 +263,6 @@ do
 	case $DB_fullfilename in
 	*.pet) echo -n ;;
 	*)
-		FIXUPHACK_FILE=""
-		DISABLE_POST_INSTALL_SCRIPT=""
 		if [ -f packages-templates/${GENERICNAME}/FIXUPHACK ] ; then
 			FIXUPHACK_FILE="packages-templates/${GENERICNAME}/FIXUPHACK"
 		elif [ -f packages-templates/${GENERICNAME}_FIXUPHACK ] ; then


### PR DESCRIPTION
```
yes|udev|udev|exe,dev,doc,nls||deps:yes                                   
yes|ubuntu-mono|ubuntu-mono|exe>null,dev>null,doc>null,nls>null||deps:yes
```

Results in:

```
Processing udev
 processing udev_249.10-0ubuntu1_amd64.deb
 executing packages-templates/udev_FIXUPHACK

Processing ubuntu-mono
 executing packages-templates/udev_FIXUPHACK                 <--
```