### PR TITLE
petbuilds/geany/defaults.patch: use defaultterminal

### DIFF
--- a/woof-code/rootfs-petbuilds/geany/defaults.patch
+++ b/woof-code/rootfs-petbuilds/geany/defaults.patch
@@ -18,7 +18,7 @@ diff -rup geany-1.37.1-orig/src/keyfile.c geany-1.37.1/src/keyfile.c
  #define GEANY_DEFAULT_TOOLS_TERMINAL	"open -a terminal %c"
  #else
 -#define GEANY_DEFAULT_TOOLS_TERMINAL	"xterm -e \"/bin/sh %c\""
-+#define GEANY_DEFAULT_TOOLS_TERMINAL	"urxvt -e /bin/sh %c"
++#define GEANY_DEFAULT_TOOLS_TERMINAL	"defaultterminal -e /bin/sh %c"
  #endif
  #ifdef __APPLE__
  #define GEANY_DEFAULT_TOOLS_BROWSER		"open -a safari"


### PR DESCRIPTION
`urxvt` may not be available, especially on wayland