### PR TITLE
quicksetup: make it work in pure wayland and improve gtk3 performance

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -70,10 +70,9 @@ PARAM1=""
 [ $1 ] && PARAM1="$1"
 PARAM2=""
 [ $2 ] && PARAM2="$2"
-TABCHAR="`echo -n -e '\t'`"
 
-[ "$PARAM1" = "composeonly" ] && unset DISPLAY
-[ "$PARAM1" = "cli" ] && unset DISPLAY
+[ "$PARAM1" = "composeonly" ] && unset DISPLAY && unset WAYLAND_DISPLAY
+[ "$PARAM1" = "cli" ] && unset DISPLAY && unset WAYLAND_DISPLAY
 
 MYBASE=$(basename $0)
 WINICON="gtk-preferences"; HELPICON="gtk-index" #gtk-info
@@ -134,17 +133,44 @@ case $MYBASE in
  ;;
 esac
 [ "$SET_LOCALE" -o "$SET_TIMEZONE" -o "$SET_KEYBOARD" ] && SET_COUNTRY="yes"
-#[ "$SET_XRES" -o "$SET_XWIZARD" ] && SET_X="yes"
-#[ -n "$WAYLAND_DISPLAY" ] && SET_XRES=
 
 XPID=0
-if [ $DISPLAY ];then
+if [ -n "$DISPLAY" -o -n "$WAYLAND_DISPLAY" ];then
  if [ "$PARAM1" != "nosplash" -a $NOSPLASH -eq 0 ];then
   WELCOMEMSG=$(printf "$(gettext 'Welcome to %s!')" "$DISTRO_NAME $DISTRO_VERSION")
   /usr/lib/gtkdialog/box_splash -placement center -close never -fontsize large -icon_width 60 -icon /usr/share/pixmaps/puppy/puppy.svg -text "$WELCOMEMSG" &
   XPID=$!
  fi
 fi
+
+###### functions
+# locale list
+get_locales() {
+	PLACES=`sed -e 's% on$%%' -e 's% off$%%' -e 's%"%%g' /usr/share/i18n/dialog_table_x`
+	printf "%s\n" "en_US English, USA"
+	printf "%s\n" "$PLACES"
+}
+
+# timezone list
+get_zones() {
+	ZONES=`grep -v ' on$' /var/local/quicksetup-timezone-table-x | sed -e 's/\(["\.]\)//g' -e 's/ o.*$//'`
+	printf "%s\n" "GMT+8 (Perth, Singapore, Hongkong)"
+	printf "%s\n" "$ZONES"
+}
+
+# keyboard list
+get_kbs() {
+	KBS=`sed -e 's% o.*$%%' -e 's%"%%g'  /var/tmp/xkblayout-table | sort -u`
+	printf "%s\n" "us English (US)"
+	printf "%s\n" "$KBS"
+}
+
+# crdw list
+get_crd() {
+	ITEMS="$(cat /etc/iso3166-1-alpha2)"
+	printf "%s\n" "00 Unset"
+	printf "%s\n" "$ITEMS"
+}
 
 #help dialogs
 help (){
@@ -155,9 +181,6 @@ help (){
 
 <b>Note:</b> After making a choice here, clicking the <b>OK</b> button will update the layout in X (graphical desktop) but not the console (when X not running) -- that requires a reboot.
 
-<b>Tip</b>
-This list is large. To speed up navigation of the list use keyboard keys Page Down, Page Up, Home and End.
-
 <b>Technical</b>
 The choice made here is saved in /etc/keymap. The value specifies a console layout, from the directory /lib/keymaps. When X starts, the startup script /usr/bin/xwin translates that to the equivalent for X, from directory /etc/X11/xkb/symbols -- note, if no match is found, X falls back to using <b>us</b> layout -- please report if that happens to you.')" > /tmp/box_help
    ;;
@@ -165,18 +188,15 @@ The choice made here is saved in /etc/keymap. The value specifies a console layo
    HEADING="`gettext 'Keyboard Numlock'`"
    echo "$(gettext 'Most keyboards have a group of keys on the right side of the keyboard that are labeled <b>0</b> to <b>9</b>. These are intended for when heavy entry of numbers is required. They are dual-purpose, that is can also serve as arrow-keys, Home, End, PgUp, PgDn -- and the latter is usually the default. That is, numlock defaults to off.
 
-If the checkbox is ticked, numlock will be on when X starts.
+If the checkbox is ticked, numlock will be on when the graphical server starts.
 
 <b>Technical</b>
-The file ~/Startup/numlockx specifies whether numlock is on or off. if the file attribute is executable, then it will execute when X starts. The file contains either <b>numlockx on</b> or <b>numlockx off</b>, and may be edited directly if desired.')" > /tmp/box_help
+The file ~/Startup/numlockx specifies whether numlock is on or off. if the file attribute is executable, then it will execute when X starts. The file contains either <b>numlockx on</b> or <b>numlockx off</b>, and may be edited directly if desired. If running Wayland the file ~/Startup/numlockt is a link to an executable that simply switches numlock on when executed.')" > /tmp/box_help
    ;;
   timezone)
    HEADING="`gettext 'Time Zone'`"
    echo "`gettext 'This needs to be set to ensure that Puppy knows the correct time and date.
 If you cannot find an entry for your location, choose one of the <b>GMT</b> entries. Finding the correct entry is best, as it automatically applies DST (Daylight Saving Time), whereas the GMT entries are fixed offsets from the GMT (UTC) reference.
-
-<b>Tip</b>
-This list is large. To speed up navigation of the list use keyboard keys Page Down, Page Up, Home and End.
 
 <b>Technical</b>
 After making a choice, /etc/localtime will point to the appropriate timezone file in /usr/share/zoneinfo.'`" > /tmp/box_help
@@ -212,9 +232,6 @@ Spanish (es): vicmz</i>")
 $(gettext 'Currently installed langpack:') <b>${INSTLANGPACK}</b>
 
 $(gettext "Note: Even if no langpack is available for your language and country, choosing the correct locale does provide some useful localization. However, all the applications, menus and documentation will be in English.")
-
-$(gettext "<b>Tip</b>
-This list is large. To speed up navigation of the list use keyboard keys Page Down, Page Up, Home and End.")
 
 $(gettext "<b>Technical</b>
 The chosen locale file is generated in /usr/lib/locale (if not already) and LANG variable set in /etc/profile.")" > /tmp/box_help
@@ -270,7 +287,54 @@ A list of country codes is in /etc/iso3166-1-alpha2, and /etc/modprobe.d/crdw.co
  esac
  /usr/lib/gtkdialog/box_help "$HEADING" dialog-info.svg &
 }
-export -f help
+
+text2svg() {
+	W=680
+	case $2 in
+	crd)W=180;;
+	esac
+	
+	echo '<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="'$W'" height="24">
+  <path d="m 3,0 '$(($W - 6))',0 a 3 3 0 0 1 3,3 l 0,18 a 3 3 0 0 1 -3,3 l -'$(($W - 6))',0 a 3 3 0 0 1 -3,-3 l 0 -18 a 3 3 0 0 1 3,-3 z"
+     style="fill:#FFF;fill-opacity:0.3;fill-rule:evenodd;stroke-width:3pt;" id="rect1" />
+  <text text-anchor="middle" x="50%" y="70%" style="font-size:12pt;fill:#000;stroke-width:3pt;" id="text1">
+    <tspan id="tspan1">'"${1}"'</tspan>
+  </text>
+</svg>' > /tmp/def-${2}.svg
+}
+export -f get_locales get_zones get_kbs get_crd help text2svg
+
+###### end functions
+
+# get height of screen
+OLDLANG=$LANG
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	WVAL0=$(LANG=C;while read a ; do echo $a | grep -q 'preferred'  && b=${a%% *} && echo ${b%x*} && break; done <<<$(wlr-randr))
+	HVAL0=$(LANG=C;while read a ; do echo $a | grep -q 'preferred'  && b=${a%% *} && echo ${b#*x} && break; done <<<$(wlr-randr))
+elif [ -n "$DISPLAY" ]; then
+	WVAL0=$(LANG=C; while read a ; do [ "${a:0:5}" = 'Width' ] && echo ${a#* } ; done <<<$(xwininfo -root))
+	HVAL0=$(LANG=C; while read b ; do [ "${b:0:6}" = 'Height' ] && echo ${b#* } ; done <<<$(xwininfo -root))
+fi
+LANG=$OLDLANG
+HVAL0=$(($HVAL0 - 60)) # allow for horizontal taskbar
+WVAL0=$(($WVAL0 - 5)) # allow for WM borders
+HVAL=590 # 585 is the height in gtk2, a little less in gtk3
+WVAL=820 # 820 is width close enough in gtk2 and gtk3
+if [ $HVAL0 -le $HVAL ];then
+	HVAL=$HVAL0
+fi
+if [ $WVAL0 -le $WVAL ];then
+	WVAL=$WVAL0
+fi
+# ensure we get a value if xwininfo/wlr-randr failed
+[ -z "$HVAL" ] && HVAL=580
+[ -z "$WVAL" ] && WVAL=820
+
+if [ "$GTKDIALOG_BUILD" = 'GTK2' ]; then
+ HVAL=$(($HVAL + 20))
+ WVAL=$(($WVAL + 20))
+fi
 
 ###Network###
 #120227 hostname set but only if network connection already available on 1st boot...
@@ -288,16 +352,7 @@ if [ "$SET_NETWORK" ];then
 fi
 
 if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup window.
-
-   # check connectivity for state of firewall checkbox
-   if wget -q --spider -T 4 http://distro.ibiblio.org ;then # returns other than 0 we're not connected
-     ONLINE='true'
-     FWTT=$(gettext "Tick checkbox to activate the firewall (recommended)")
-   else
-     ONLINE='false'
-     FWTT=$(gettext "Firewall can not be activated until you are connected")
-   fi
-
+	FWTT=$(gettext "Tick checkbox to activate the firewall (recommended)")
     #130701 removed this condition, always display network frame...
     SET_NETWORK="yes"
     HOSTNAME="`cat /etc/hostname`" #do not use $HOSTNAME, as hostname-set may have just been run.
@@ -332,20 +387,34 @@ if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup windo
     HOMEUSER="`whoami`"
     if [ "$HOMEUSER" = "root" ];then
      SPOT_XML='
-     <hbox space-expand="false" space-fill="false">
-       <hbox space-expand="true" space-fill="true">
-       <text space-expand="true" space-fill="true"><label>""</label></text>
-       </hbox>
-       <checkbox tooltip-text="'$(gettext 'Tick this if interested in running Internet applications as non-root user spot, for extra security')'" space-expand="false" space-fill="false">
+     <hbox>
+       <checkbox tooltip-text="'$(gettext 'Tick this if interested in running Internet applications as non-root user spot, for extra security')'" xalign="0" space-expand="false" space-fill="false">
          <label>'$(gettext 'Run Internet apps as spot')'</label>
          <variable>CHECK_SPOT</variable>
          <default>false</default>
        </checkbox>
          <button space-expand="false" space-fill="false">
          '"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
-         <action>basichtmlviewer /usr/share/doc/root.htm & </action>
+         <action>defaultbrowser /usr/share/doc/root.htm & </action>
        </button>
      </hbox>'
+    fi
+	
+	# change root password
+	PASS_XML=''
+	if [ "$HOMEUSER" = "root" ];then
+	PASS_XML='
+	<hbox>
+		<checkbox tooltip-text="'$(gettext 'Tick this to change the root password')'" xalign="0" space-expand="true" space-fill="true">
+			<label>'$(gettext 'Change root password')'</label>
+			<variable>CHECK_PASS</variable>
+			<default>false</default>
+		</checkbox>
+		<button space-expand="false" space-fill="false">
+			'"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
+			<action>defaultbrowser /usr/share/doc/root.htm & </action>
+		</button>
+	</hbox>'
     fi
 
     CRDW_XML=''
@@ -353,27 +422,47 @@ if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup windo
       && which crda >/dev/null 2>&1;then #170609...
      DEFAULT_2CH='00'
      [ -f /etc/modprobe.d/crdw.conf ] && DEFAULT_2CH="$(cat /etc/modprobe.d/crdw.conf | grep '^options cfg80211' | cut -f 2 -d '=')" #created by quicksetup
-     [ ! "$DEFAULT_2CH" ] && DEFAULT_2CH='00'
+     [ -z "$DEFAULT_2CH" ] && DEFAULT_2CH='00'
      DEFAULT_CRDW="$(grep "^${DEFAULT_2CH} " /etc/iso3166-1-alpha2)" #ex: AU Australia
-     [ ! "$DEFAULT_CRDW" ] && DEFAULT_CRDW='00 UNSET'
-     DEFAULT_CRDW_ITEM="<item>${DEFAULT_CRDW}</item>"
-     if [ "$DEFAULT_2CH" == "00" ];then
-      ITEMS="$(sed -e 's%^%<item>%' -e 's%$%</item>%' /etc/iso3166-1-alpha2)"
-     else
-      ITEMS="<item>00 UNSET</item>$(sed -e 's%^%<item>%' -e 's%$%</item>%' /etc/iso3166-1-alpha2)"
-     fi
+     [ -z "$DEFAULT_CRDW" ] && DEFAULT_CRDW='00 UNSET'
+     text2svg "$DEFAULT_CRDW" crd
      TT_crdw="$(gettext 'To use WiFi channels 12-14 where legal or to avoid using them where illegal, choose the country where you are using WiFi -- if your WiFi device(s) cannot use those channels, you can leave it unset (00)')"
      T_crdw="$(gettext 'CRD:')"
+     export CH_CRD='<window title="'$(gettext "Set Wireless Channel Zone - Current: $DEFAULT_CRDW")'" window-position="1">
+	<vbox>
+		'`/usr/lib/gtkdialog/xml_info fixed "wireless.svg" 60 "$(gettext "If needed, you can change your wireless network frequency to suit your zone and press OK, or close the window to make no change.")"`'
+		<tree hscrollbar-policy="1" vscrollbar-policy="1">
+			<height>'$HVAL'</height>
+			<variable>EX_CRD</variable>
+			<label>'$DEFAULT_CRDW' (default)</label>
+			<input>get_crd</input>
+		</tree>
+		<hbox>
+			<button>
+				<label>'$(gettext "Ok")'</label>
+				'"`/usr/lib/gtkdialog/xml_button-icon ok`"'
+				<action>echo -n $EX_CRD >/tmp/xcrd</action>
+				<action>text2svg "$EX_CRD" crd</action>
+				<action function="refresh">COMBO_CRDW</action>
+				<action function="closewindow">CH_CRD</action>
+			</button>
+		</hbox>
+	</vbox>
+	<variable>CH_CRD</variable>
+</window>'
+
      CRDW_XML='<hbox space-expand="false" space-fill="false">
-     <text><label>'${T_crdw}'</label></text>
-     <comboboxtext tooltip-text="'${TT_crdw}'" width-request="143">
-     '${DEFAULT_CRDW_ITEM}'
-     '${ITEMS}'
-     <variable>COMBO_CRDW</variable></comboboxtext>
-     <button>
-       '"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
-       <action>help crdw</action>
-     </button></hbox>'
+	<text><label>'${T_crdw}'</label></text>
+		<button space-expand="true" space-fill="true" tooltip-text="'${TT_crdw}'" relief="2">
+			<input file>/tmp/def-crd.svg</input>
+			<variable>COMBO_CRDW</variable>
+			<action function="launch">CH_CRD</action>
+		</button>
+		<button>
+			'"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
+			<action>help crdw</action>
+		</button>
+	</hbox>'
     fi #170609 end
     
     NETWORK_XML='
@@ -385,7 +474,6 @@ if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup windo
               <label>'$(gettext "Firewall enabled")'</label>
               <variable>CHECK_FIREWALL</variable>
               <default>'${DEFAULT_FIREWALL}'</default>
-              <sensitive>'${ONLINE}'</sensitive>
             </checkbox>
             <button space-expand="false" space-fill="false">
               '"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
@@ -398,6 +486,7 @@ if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup windo
 
         <vbox space-expand="false" space-fill="false">
           '${SPOT_XML}'
+          '${PASS_XML}'
         </vbox>
         <text space-expand="true" space-fill="true"><label>""</label></text>
         <vbox space-expand="false" space-fill="false">
@@ -416,7 +505,6 @@ if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup windo
         </vbox>
       </hbox>
     </frame>' #170609 170610
- #fi
 fi
 
 ###Country localization###
@@ -717,12 +805,33 @@ if [ "$SET_COUNTRY" ];then
   onPTN="s%^${BASELANG} \"(.*)\" off$%${BASELANG} \"\1\" on%"
   sed -i -e 's% on$% off%' -r -e "$onPTN" /usr/share/i18n/dialog_table_x
 
-  DEFAULTXML=""
-  DEFAULT=`grep ' on$' /usr/share/i18n/dialog_table_x | sed -e 's% on$%%' -e 's%"%%g' -e "s% %  ${TABCHAR}%"`
-  [ "$DEFAULT" ] && DEFAULTXML="<item>${DEFAULT}</item>" #111107 combobox does not support default tag.
-  ITEMS=`sed -e 's% on$%%' -e 's% off$%%' -e 's%"%%g' -e "s% %  ${TABCHAR}%" -e 's%^%<item>%' -e 's%$%</item>%' /usr/share/i18n/dialog_table_x`
+  DEFAULT_LOC=`grep ' on$' /usr/share/i18n/dialog_table_x | sed -e 's% on$%%' -e 's%"%%g'`
+  text2svg "${DEFAULT_LOC}" loc
 
-  DEFAULT_UTF8='false'
+  export CH_LOC='<window title="'$(gettext "Set Locale - Current: $DEFAULT_LOC")'" window-position="1">
+	<vbox>
+		'`/usr/lib/gtkdialog/xml_info fixed "country.svg" 60 "$(gettext "Please choose your locale.")"`'
+		<tree hscrollbar-policy="1" vscrollbar-policy="1">
+			<height>'$HVAL'</height>
+			<variable>EX_LOC</variable>
+			<label>'${DEFAULT_LOC/_/__}'</label>
+			<input>get_locales</input>
+		</tree>
+		<hbox>	
+			<button>
+				<label>'$(gettext "Ok")'</label>
+				'"`/usr/lib/gtkdialog/xml_button-icon ok`"'
+				<action>echo -n $EX_LOC >/tmp/xloc</action>
+				<action>text2svg "$EX_LOC" loc</action>
+				<action function="refresh">COMBO_LOCALE</action>
+				<action function="closewindow">CH_LOC</action>
+			</button>
+		</hbox>
+	</vbox>
+	<variable>CH_LOC</variable>
+</window>' # strange bug with <label> tag but the double underscore is a reasonable work around
+
+DEFAULT_UTF8='false'
   [ "$UTF8" ] && DEFAULT_UTF8='true'
   CHECKUTF8XML='
   <hbox tooltip-text="'$(gettext 'Tick checkbox to support UTF-8 encoding')'" space-expand="true" space-fill="true">
@@ -737,37 +846,39 @@ if [ "$SET_COUNTRY" ];then
        <action>help utf8</action>
     </button>
   </hbox>'
-  LOCALEXML='
-  <vbox space-expand="false" space-fill="false">
-    <hbox tooltip-text="'$(gettext "Main Language")'" space-expand="true" space-fill="true">
-      '"`/usr/lib/gtkdialog/xml_pixmap country_language.svg icon`"'
-      <text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
-      <vbox space-expand="true" space-fill="true">'
-        [ "$(grep -E "countrywizard|quickcountry" <<< "$MYBASE")" ] && LOCALEXML=$LOCALEXML'<text use-markup="true" xalign="0" yalign="1" height-request="20" space-expand="true" space-fill="true"><label>"<b>'$(gettext "Main language")'</b>"</label></text>'
-        LOCALEXML=$LOCALEXML'
-        <hbox tooltip-text="'$(gettext "Choose main language")'" space-expand="true" space-fill="true">
-          <comboboxtext space-expand="true" space-fill="true">
-            '${DEFAULTXML}'
-            '${ITEMS}'
-            <variable>COMBO_LOCALE</variable>
-          </comboboxtext>
-          <button space-expand="false" space-fill="false">
-            '"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
-            <action>help locale</action>
-          </button>
-        </hbox>
-        '${CHECKUTF8XML}'
-      </vbox>
-    </hbox>
-  </vbox>'
+
+   LOCALEXML='
+	<vbox space-expand="false" space-fill="false">
+		<hbox tooltip-text="'$(gettext "Main Language")'" space-expand="true" space-fill="true">
+			'"`/usr/lib/gtkdialog/xml_pixmap country_language.svg icon`"'
+			<text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
+			<vbox space-expand="true" space-fill="true">'
+			[ "$(grep -E "countrywizard|quickcountry" <<< "$MYBASE")" ] && LOCALEXML=$LOCALEXML'<text use-markup="true" xalign="0" yalign="1" height-request="20" space-expand="true" space-fill="true"><label>"<b>'$(gettext "Main language")'</b>"</label></text>'
+			LOCALEXML=$LOCALEXML'
+				<hbox tooltip-text="'$(gettext "Choose main language")'" space-expand="true" space-fill="true">
+					<button space-expand="true" space-fill="true" relief="2">
+						<input file>/tmp/def-loc.svg</input>
+						<variable>COMBO_LOCALE</variable>
+						<action function="launch">CH_LOC</action>
+					</button>
+					<button space-expand="false" space-fill="false">
+						'"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
+						<action>help locale</action>
+					</button>
+				</hbox>
+			'${CHECKUTF8XML}'
+			</vbox>
+		</hbox>
+	</vbox>'
  fi #end SET_LOCALE
 
  ###Choose timezone###
  TIMEZONEXML=""
  if [ "$SET_TIMEZONE" ];then
   [ -L /etc/localtime -a ! -e /etc/localtime ] && rm -f /etc/localtime
-  CZONE='/usr/share/zoneinfo/GMT0'
-  DEF_TIMEZONE='GMT0'
+  [ -d /etc/localtime ] && rm -rf /etc/localtime 
+  CZONE='/usr/share/zoneinfo/Etc/GMT-8'
+  DEF_TIMEZONE='GMT+8 (Perth, Singapore, Hongkong)'
   if [ -L /etc/localtime ] ; then
    CZONE="`readlink /etc/localtime`"
    DEF_TIMEZONE="`readlink /etc/localtime | sed -e 's%/usr/share/zoneinfo/%%'`"
@@ -827,18 +938,13 @@ if [ "$SET_COUNTRY" ];then
    done
   fi
   ZONECHOICES_CLI="`cat /var/local/quicksetup-timezone-table-cli`" #111113
-
   #table already exist, but may need to reselect 'on' item...
   echo "$xDEF_TIMEZONE" | grep "GMT" | grep -q "[+-]" && xDEF_TIMEZONE=$(fix_gmt $xDEF_TIMEZONE)
   echo "$DEF_TIMEZONE" | grep -q "GMT[+-]" && DEF_TIMEZONE=$(fix_gmt $DEF_TIMEZONE)
   onPTN="s%^${xDEF_TIMEZONE} \"(.*)\" off$%${DEF_TIMEZONE} \"\1\" on%"
   sed -i -e 's% on$% off%' -r -e "$onPTN" /var/local/quicksetup-timezone-table-x
-
-  DEFAULTXML=""
-  DEFAULT=`grep ' on$' /var/local/quicksetup-timezone-table-x | sed -e 's% on$%%' -e 's%"%%g' -e "s% %${TABCHAR}%"`
-  [ "$DEFAULT" ] && DEFAULTXML="<item>${DEFAULT}</item>" #111107 combobox does not support default tag.
-  ITEMS=`sed -e 's% on$%%' -e 's% off$%%' -e 's%"%%g' -e "s% %${TABCHAR}%" -e 's%^%<item>%' -e 's%$%</item>%' /var/local/quicksetup-timezone-table-x`
-
+  DEFAULT_TZ=`grep ' on$' /var/local/quicksetup-timezone-table-x | sed -e 's/\(["\.]\)//g' -e 's/ on$/ (default)/'`
+  text2svg "${DEFAULT_TZ}" tz
   DEFAULT_UTC="false"
   [ "$HWCLOCKTIME" = "utc" ] && DEFAULT_UTC="true" #see /etc/clock
   CHECKUTCXML='
@@ -855,29 +961,52 @@ if [ "$SET_COUNTRY" ];then
     </button>
   </hbox>'
 
+  export CH_TZ='<window title="'$(gettext "Set Timezone - Current: $DEFAULT_TZ")'" window-position="1">
+	<vbox>
+		'`/usr/lib/gtkdialog/xml_info fixed "country_timezone.svg" 60 "$(gettext "Please choose the timezone to suit your location.")"`'
+		<tree hscrollbar-policy="1" vscrollbar-policy="1">
+			<height>'$HVAL'</height>
+			<variable>EX_TZ</variable>
+			<label>'$DEFAULT_TZ'</label>
+			<input>get_zones</input>
+		</tree>
+		<hbox>
+			<button>
+				<label>'$(gettext "Ok")'</label>
+				'"`/usr/lib/gtkdialog/xml_button-icon ok`"'
+				<action>echo -n $EX_TZ >/tmp/xtz</action>
+				<action>text2svg "${EX_TZ}" tz</action>
+				<action function="refresh">COMBO_TIMEZONE</action>
+				<action function="closewindow">CH_TZ</action>
+			</button>
+		</hbox>
+	</vbox>
+	<variable>CH_TZ</variable>
+</window>'
+
   TIMEZONEXML='
-  <vbox space-expand="false" space-fill="false">
-    <hbox tooltip-text="'$(gettext "Time Zone")'" space-expand="true" space-fill="true">
-      '"`/usr/lib/gtkdialog/xml_pixmap country_timezone.svg icon`"'
-      <text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
-      <vbox space-expand="true" space-fill="true">'
-         [ "$(grep -E "countrywizard|quickcountry" <<< "$MYBASE")" ] && TIMEZONEXML=$TIMEZONEXML'<hseparator></hseparator><text use-markup="true" xalign="0" yalign="1" height-request="30" space-expand="true" space-fill="true"><label>"<b>'$(gettext "Time zone")'</b>"</label></text>'
-        TIMEZONEXML=$TIMEZONEXML'
-        <hbox tooltip-text="'$(gettext "Choose time zone")'" space-expand="true" space-fill="true">
-          <comboboxtext space-expand="true" space-fill="true">
-            '${DEFAULTXML}'
-            '${ITEMS}'
-            <variable>COMBO_TIMEZONE</variable>
-          </comboboxtext>
-          <button space-expand="false" space-fill="false">
-            '"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
-            <action>help timezone</action>
-          </button>
-        </hbox>
-        '${CHECKUTCXML}'
-      </vbox>
-    </hbox>
-  </vbox>'
+  	<vbox space-expand="false" space-fill="false">
+		<hbox tooltip-text="'$(gettext "Time Zone")'" space-expand="true" space-fill="true">
+			'"`/usr/lib/gtkdialog/xml_pixmap country_timezone.svg icon`"'
+			<text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
+			<vbox space-expand="true" space-fill="true">'
+				[ "$(grep -E "countrywizard|quickcountry" <<< "$MYBASE")" ] && TIMEZONEXML=$TIMEZONEXML'<hseparator></hseparator><text use-markup="true" xalign="0" yalign="1" height-request="30" space-expand="true" space-fill="true"><label>"<b>'$(gettext "Time zone")'</b>"</label></text>'
+				TIMEZONEXML=$TIMEZONEXML'
+				<hbox tooltip-text="'$(gettext "Choose time zone")'" space-expand="true" space-fill="true">
+					<button space-expand="true" space-fill="true" relief="2">
+						<input file>/tmp/def-tz.svg</input>
+						<variable>COMBO_TIMEZONE</variable>
+						<action function="launch">CH_TZ</action>
+					</button>
+					<button space-expand="false" space-fill="false">
+						'"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
+						<action>help timezone</action>
+					</button>
+				</hbox>
+				'${CHECKUTCXML}'
+			</vbox>
+		</hbox>
+	</vbox>'
  fi #end SET_TIMEZONE
 
  ###keyboard layout###
@@ -886,17 +1015,15 @@ if [ "$SET_COUNTRY" ];then
   # Check if the keyboard needs any kernel modules
   [ "$(which initmodules)" -a ! -f /mnt/home${PSUBDIR}/${DISTRO_FILE_PREFIX}initmodules.txt ] && initmodules -q & # [ ... -a "$PUPMODE" = "5" ] could do instead
   xkbconfigmanager layouttable #creates /var/tmp/xkblayout-table
-  DEFAULTXML=""
-  DEFAULT=`grep ' on$' /var/tmp/xkblayout-table | sed -e 's% on$%%' -e 's%"%%g' -e "s% %    ${TABCHAR}%"`
-  [ "$DEFAULT" ] && DEFAULTXML="<item>${DEFAULT}</item>" #111107 combobox does not support default tag.
-  ITEMS=`sed -e 's% on$%%' -e 's% off$%%' -e 's%"%%g' -e "s% %    ${TABCHAR}%" -e 's%^%<item>%' -e 's%$%</item>%' /var/tmp/xkblayout-table`
-
+  DEFAULT_KB=`grep ' on$' /var/tmp/xkblayout-table | sed -e 's%"%%g'  -e 's/ o.*$//'`
+  [ -z "$DEFAULT_KB" ] && DEFAULT_KB='us English (US)'
+  text2svg "$DEFAULT_KB" kbl
   DEFAULT_NUMLOCK="false"
   CHECKNUMLOCKXML=""
   SENS="true"
-  [ -n "$WAYLAND_DISPLAY" ] && SENS="false"
-  if which numlockx >/dev/null;then
+  if which numlockx >/dev/null || which numlockt >/dev/null;then
    [ -x $HOME/Startup/numlockx ] && [ "`grep '^numlockx on' $HOME/Startup/numlockx`" != "" ] && DEFAULT_NUMLOCK="true"
+   readlink ~/Startup/numlockt >/dev/null 2>&1 && DEFAULT_NUMLOCK="true"
    CHECKNUMLOCKXML='
    <hbox tooltip-text="'$(gettext 'Tick checkbox to turn on keyboard numlock')'" space-expand="true" space-fill="true">
      <checkbox space-expand="false" space-fill="false">
@@ -914,28 +1041,51 @@ if [ "$SET_COUNTRY" ];then
   fi
   CHECK_NUMLOCK="$DEFAULT_NUMLOCK"
 
+  export CH_KBL='<window title="'$(gettext "Set Keyboard - Current: $DEFAULT_KB")'" window-position="1">
+	<vbox>
+		'`/usr/lib/gtkdialog/xml_info fixed "country_keyboard.svg" 60 "$(gettext "Please choose a suitable keyboard layout.")"`'
+		<tree hscrollbar-policy="1" vscrollbar-policy="1">
+			<height>'$HVAL'</height>
+			<variable>EX_KBL</variable>
+			<label>'$DEFAULT_KB'</label>
+			<input>get_kbs</input>
+		</tree>
+		<hbox>
+			<button>
+				<label>'$(gettext "Ok")'</label>
+				'"`/usr/lib/gtkdialog/xml_button-icon ok`"'
+				<action>echo -n $EX_KBL >/tmp/xkbl</action>
+				<action>text2svg "$EX_KBL" kbl</action>
+				<action function="refresh">COMBO_KEYBOARD</action>
+				<action function="closewindow">CH_KBL</action>
+			</button>
+		</hbox>
+	</vbox>
+	<variable>CH_KBL</variable>
+</window>'
+
   KEYBOARDXML='
-  <vbox space-expand="false" space-fill="false">
-    <hbox tooltip-text="'$(gettext "Keyboard Layout")'" space-expand="true" space-fill="true">
-      '"`/usr/lib/gtkdialog/xml_pixmap country_keyboard.svg icon`"'
-      <text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
-      <vbox space-expand="true" space-fill="true">'
-         [ "$(grep -E "countrywizard|quickcountry" <<< "$MYBASE")" ] && KEYBOARDXML=$KEYBOARDXML'<hseparator></hseparator><text use-markup="true" xalign="0" yalign="1" height-request="30" space-expand="true" space-fill="true"><label>"<b>'$(gettext "Keyboard Layout")'</b>"</label></text>'
-        KEYBOARDXML=$KEYBOARDXML'<hbox tooltip-text="'$(gettext "Choose keyboard layout")'" space-expand="true" space-fill="true">
-          <comboboxtext space-expand="true" space-fill="true">
-            '${DEFAULTXML}'
-            '${ITEMS}'
-            <variable>COMBO_KEYBOARD</variable>
-          </comboboxtext>
-          <button space-expand="false" space-fill="false">
-            '"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
-            <action>help keyboard</action>
-          </button>
-        </hbox>
-        '${CHECKNUMLOCKXML}'
-      </vbox>
-    </hbox>
-  </vbox>'
+	<vbox space-expand="false" space-fill="false">
+		<hbox tooltip-text="'$(gettext "Keyboard Layout")'" space-expand="true" space-fill="true">
+			'"`/usr/lib/gtkdialog/xml_pixmap country_keyboard.svg icon`"'
+			<text width-request="10" space-expand="false" space-fill="false"><label>""</label></text>
+			<vbox space-expand="true" space-fill="true">'
+				[ "$(grep -E "countrywizard|quickcountry" <<< "$MYBASE")" ] && KEYBOARDXML=$KEYBOARDXML'<hseparator></hseparator><text use-markup="true" xalign="0" yalign="1" height-request="30" space-expand="true" space-fill="true"><label>"<b>'$(gettext "Keyboard Layout")'</b>"</label></text>'
+				KEYBOARDXML=$KEYBOARDXML'<hbox tooltip-text="'$(gettext "Choose keyboard layout")'" space-expand="true" space-fill="true">
+				<button space-expand="true" space-fill="true" relief="2">
+					<input file>/tmp/def-kbl.svg</input>
+					<variable>COMBO_KEYBOARD</variable>
+					<action function="launch">CH_KBL</action>
+				</button>
+				<button space-expand="false" space-fill="false">
+					'"`/usr/lib/gtkdialog/xml_button-icon info mini`"'
+					<action>help keyboard</action>
+				</button>
+			</hbox>
+			'${CHECKNUMLOCKXML}'
+			</vbox>
+		</hbox>
+	</vbox>'
  fi #end SET_KEYBOARD
 
  COUNTRYXML='
@@ -951,16 +1101,16 @@ fi #end SET_COUNTRY
 ###setup x###
 if [ "$SET_XWIZARD" ];then
   #put up a button to launch xorgwizard...
-  if [ -z "$WAYLAND_DISPLAY" ];then
-    XDRIVERSUCCESS=$(report-video driver)
-    TT_xorg=$(gettext 'Xorg Video Wizard')
-    XMSGX=$(gettext "The <b>${XDRIVERSUCCESS}</b> video driver is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
-    XMSGRES=$(gettext "Current resolution:<b> $(report-video res) </b> ($(report-video depth) bit)")
-  else
+  if [ -n "$WAYLAND_DISPLAY" ];then
     XDRIVERSUCCESS=true
     TT_xorg=$(gettext 'Wayland Video Wizard')
     XMSGX=$(gettext "The <b>Wayland Display Server</b> is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
     XMSGRES=$(gettext "Current resolution:<b> $(while read a ; do echo $a | grep -q 'preferred'  && echo ${a%% *} && break; done <<<$(wlr-randr)) </b> ($(report-video depth) bit)")
+  elif [ -n "DISPLAY" ];then
+    XDRIVERSUCCESS=$(report-video driver)
+    TT_xorg=$(gettext 'Xorg Video Wizard')
+    XMSGX=$(gettext "The <b>${XDRIVERSUCCESS}</b> video driver is currently being used. Ok, if you need to adjust screen resolution or displacement, run the Video Wizard.")
+    XMSGRES=$(gettext "Current resolution:<b> $(report-video res) </b> ($(report-video depth) bit)")
   fi
   if [ "$XDRIVERSUCCESS" ];then #precaution.
     B_xwiz=$(gettext 'Run Video Wizard')
@@ -979,7 +1129,11 @@ if [ "$SET_XWIZARD" ];then
 fi #end SET_XWIZARD
 
 if [ "$SET_XRES" -a ! "$SET_XWIZARD" ];then
-  echo > /var/tmp/xrandrlist
+  case $XDG_SESSION_TYPE in
+  wayland)
+  exec wmonitors.sh
+  ;;
+  *)echo > /var/tmp/xrandrlist
   while read line ; do 
 		#      $F1			$F2		 $F3      $F4
 		#   800x600        75.0     72.0*    60.0 
@@ -1020,6 +1174,8 @@ $(cat /var/tmp/xrandrlist | grep -v "${DEF_XYRES}.*${DEF_VFREQ}\*")"
        </button>
      </hbox>
    </vbox>'
+  ;;
+  esac
 fi #end SET_XRES
 
 if [ "$SET_XRES" ] ; then
@@ -1030,6 +1186,13 @@ if [ "$SET_XRES" ] ; then
      '${XYRESXML}'
    </frame>
  </vbox>'
+elif [ "$MYBASE" = "quicksetup" ]; then
+ XXML='
+ <vbox>
+   <frame '${XFRAMETITLE}'>
+     '${XWIZARDXML}'
+   </frame>
+ </vbox>' 
 fi #end SET_XRES
 
 #120714 alternate audio/video frame for arm board... create $XXML...
@@ -1076,34 +1239,8 @@ esac' > /etc/init.d/11alsa_raspi
  </vbox>"
 fi
 
-
-
 ####main window####
 ###################
-# get height of screen
-OLDLANG=$LANG
-if [ -n "$WAYLAND_DISPLAY" ]; then
-	WVAL0=$(LANG=C;while read a ; do echo $a | grep -q 'preferred'  && b=${a%% *} && echo ${b%x*} && break; done <<<$(wlr-randr))
-	HVAL0=$(LANG=C;while read a ; do echo $a | grep -q 'preferred'  && b=${a%% *} && echo ${b#*x} && break; done <<<$(wlr-randr))
-else
-	WVAL0=$(LANG=C; while read a ; do [ "${a:0:5}" = 'Width' ] && echo ${a#* } ; done <<<$(xwininfo -root))
-	HVAL0=$(LANG=C; while read b ; do [ "${b:0:6}" = 'Height' ] && echo ${b#* } ; done <<<$(xwininfo -root))
-fi
-LANG=$OLDLANG
-HVAL0=$(($HVAL0 - 60)) # allow for horizontal taskbar
-WVAL0=$(($WVAL0 - 5)) # allow for WM borders
-HVAL=590 # 585 is the height in gtk2, a little less in gtk3
-WVAL=820 # 820 is width close enough in gtk2 and gtk3
-if [ $HVAL0 -le $HVAL ];then
-	HVAL=$HVAL0
-fi
-if [ $WVAL0 -le $WVAL ];then
-	WVAL=$WVAL0
-fi
-# ensure we get a value if xwininfo/wlr-randr failed
-[ -z "$HVAL" ] && HVAL=580
-[ -z "$WVAL" ] && WVAL=820
-
 [ $XPID -ne 0 ] && kill $XPID 2> /dev/null
 BACKTITLEXML=""
 [ "$BACKTITLE" ] && BACKTITLEXML="`/usr/lib/gtkdialog/xml_info fixed "$ICON.svg" 60 "$(gettext "${BACKTITLE}")"`"
@@ -1132,11 +1269,11 @@ export QUICKSETUP_DIALOG='
 
 ###display main window###
 wPID=0
-if [ $DISPLAY ];then
+if [ -n "$DISPLAY" -o -n "$WAYLAND_DISPLAY" ];then
  . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
  RETVALS="`gtkdialog -p QUICKSETUP_DIALOG --styles=/tmp/gtkrc_xml_info.css --geometry="${WVAL}x${HVAL}" 2>/dev/null`"
  eval "$RETVALS"
- [ "$EXIT" != "OK" -a "$EXIT" != "NVIDIA" ] && exit
+ [ "$EXIT" != "OK" ] && exit
 
  #get rid of this, as causes xorgwizard to run at next boot (see $HOME/.profile)...
  [ -f $HOME/.xorgwizard-reenter ] && rm -f $HOME/.xorgwizard-reenter
@@ -1181,33 +1318,45 @@ FLAG_CHANGED=""
 
 if [ "$SET_KEYBOARD" ];then
  #two variables COMBO_KEYBOARD and CHECK_NUMLOCK
- XKB_LAYOUT="`echo -n "$COMBO_KEYBOARD" | cut -f 1 -d ' ' | cut -f 1 -d "$TABCHAR"`"
+ [ -z "$COMBO_KEYBOARD" -a -f /tmp/xkbl ] && read COMBO_KEYBOARD </tmp/xkbl
+ read XKB_LAYOUT c <<<$COMBO_KEYBOARD
  FONTMAP=""; CODEPAGE=""
- FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard Layout'):yes|" #111020 no need to restart X.
  if [ -f /etc/X11/xorg.conf ]; then
   sed -i "s%.*Option.*XkbLayout.*%	Option      \"XkbLayout\" \"${XKB_LAYOUT}\"%" /etc/X11/xorg.conf
- fi
- if [ -f ~/.Xwaylandrc ]; then
-   sed -i "s%^XKB_DEFAULT_LAYOUT=.*%XKB_DEFAULT_LAYOUT=$XKB_LAYOUT%" ~/.Xwaylandrc
- fi
- if [ -f "$XDG_CONFIG_HOME/labwc/environment" ]; then
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard Layout'):yes|" #111020 no need to restart X.
+ elif [ -f ~/.Xwaylandrc ]; then
+  sed -i "s%^XKB_DEFAULT_LAYOUT=.*%XKB_DEFAULT_LAYOUT=$XKB_LAYOUT%" ~/.Xwaylandrc
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard Layout'):restart|" #111020 no need to restart X.
+ elif [ -f "$XDG_CONFIG_HOME/labwc/environment" ]; then
   sed -i "s%^XKB_DEFAULT_LAYOUT=.*%XKB_DEFAULT_LAYOUT=$XKB_LAYOUT%" $XDG_CONFIG_HOME/labwc/environment
+  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard Layout'):restart|" #111020 no need to restart X.
  fi
  xkbconfigmanager apply
- #-
+ 
+  #-
  #120224 fontmap will be handled in locale code below.
  if [ "$DEFAULT_NUMLOCK" != "$CHECK_NUMLOCK" ];then
   FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'Keyboard numlock'):yes|"
   STATUS_NUMLOCK=off
   [ "$CHECK_NUMLOCK" = "true" ] && STATUS_NUMLOCK=on
-  echo -e "#!/bin/sh\nnumlockx ${STATUS_NUMLOCK}" > $HOME/Startup/numlockx
-  chmod 755 $HOME/Startup/numlockx
-  numlockx ${STATUS_NUMLOCK} #do it now.
+  if type numlockx >/dev/null 2>&1 ; then
+   echo -e "#!/bin/sh\nnumlockx ${STATUS_NUMLOCK}" > $HOME/Startup/numlockx
+   chmod 755 $HOME/Startup/numlockx
+   numlockx ${STATUS_NUMLOCK} #do it now.
+  elif type numlockt >/dev/null 2>&1 ; then
+   if [ "$CHECK_NUMLOCK" = "true" ] ;then
+    ( cd ~/Startup; ln -sf `which numlockt` . )
+    numlockt #do it now.
+   else
+    rm -f ~/Startup/numlockt
+   fi
+  fi
  fi
 fi #end SET_KEYBOARD
 
 if [ "$SET_LOCALE" ];then
  #two variables, COMBO_LOCALE and CHECK_UTF8
+ [ -z "$COMBO_LOCALE" -a -f /tmp/xloc ] && read COMBO_LOCALE </tmp/xloc
  LANGCHOICE="`echo -n "$COMBO_LOCALE" | cut -f 1 -d ' ' | cut -f 1 -d '@'`" #nl_BE@euro, need to chop.
  UTF8=""
  [ "$CHECK_UTF8" = "true" ] && UTF8='.UTF-8'
@@ -1287,7 +1436,7 @@ if [ "$SET_LOCALE" ];then
    LANG12=${LANGCHOICE%.*} #"`echo -n $LANGCHOICE | cut -f 1 -d '.'`" #ex: de_DE
    l1PTN="|langpack_${LANG1}|"
    l12PTN="|langpack_${LANG12}|"
-   if [ "$LANG1" != "en" ];then
+   if [ "$LANG1" != "en" -a "$LANG1" != "C" ];then
     LANGFLAG='no'
     [ "`grep "$l12PTN" /root/.packages/woof-installed-packages`" != "" ] && LANGFLAG='yes'
     [ "`grep "$l12PTN" /root/.packages/user-installed-packages`" != "" ] && LANGFLAG='yes'
@@ -1366,7 +1515,7 @@ Note: Before downloading the langpack, you will have to make an Internet connect
      [ "`grep "$l12PTN" /root/.packages/Packages-puppy-noarch-official`" != "" ] && AVAILPACK="langpack_${LANG12}"
      [ "`grep "$l1PTN" /root/.packages/Packages-puppy-noarch-official`" != "" ] && AVAILPACK="langpack_${LANG1}"
      [ "$AVAILPACK" ] && AVAILMSG="$AVAILMSG1"
-     if [ "$DISPLAY" ];then
+     if [ -n "$DISPLAY" -o -n "$WAYLAND_DISPLAY" ];then
       [ $wPID -ne 0 ] && kill $wPID #120524
       wPID=0
       LANG=${NEWLANG} pupdialog --background '#8080FF' --colors --backtitle "${AVAILTITLE}" --msgbox "${AVAILMSG3}\n\n${AVAILMSG}" 0 0
@@ -1374,22 +1523,21 @@ Note: Before downloading the langpack, you will have to make an Internet connect
       dialog --msgbox "`eval_gettext \"Note, you will need to install langpack_\\\${LANG12} or langpack_\\\${LANG1} PET package to more fully translate Puppy to your language. Run the Puppy Package Manager after connection to the Internet, to download and install this package.\"`" 0 0 >/dev/console
      fi
     fi
-   fi
-
    #120209 scripts fixdesk and fixmenus translate files to new language (as specified in /usr/share/sss/menu_strings and desk_strings).
    #so need to call them here...
    #note, these are also called in /etc/rc.d/rc.update ...
    LANG=${LANGCHOICE}${UTF8} fixdesk
    LANG=${LANGCHOICE}${UTF8} fixmenus
    #...no need to refresh screen, as changing locale requires restart of X.
-
+   fi
   fi
  fi
 fi #end SET_LOCALE
 
 if [ "$SET_TIMEZONE" ];then
  #two variables, COMBO_TIMEZONE and CHECK_UTC
- ZONERETVAL="`echo -n "$COMBO_TIMEZONE" | cut -f 1 -d ' ' | cut -f 1 -d "$TABCHAR"`"
+ [ -z "$COMBO_TIMEZONE" -a -f /tmp/xtz ] && read COMBO_TIMEZONE </tmp/xtz
+ read ZONERETVAL xx <<< "$COMBO_TIMEZONE"
  NEW_HWCLOCKTIME="localtime"
  [ "$CHECK_UTC" = "true" ] && NEW_HWCLOCKTIME="utc"
  [ ! -e /etc/localtime ] && DEF_TIMEZONE="" #111027 precaution.
@@ -1403,7 +1551,7 @@ if [ "$SET_TIMEZONE" ];then
   [ "$ZONERETVAL" = "UTC" ] && ZONERETVAL="Etc/$ZONERETVAL"
   [ "$ZONERETVAL" = "Zulu" ] && ZONERETVAL="Etc/$ZONERETVAL"
   ln -snf /usr/share/zoneinfo/$ZONERETVAL /etc/localtime
-  which xset >/dev/null 2>&1 && xset s noblank s noexpose -dpms  #shinobar 30jan11: avoid the screen go to blank
+  [ -z "$WAYLAND_DISPLAY" ] && which xset >/dev/null 2>&1 && xset s noblank s noexpose -dpms  #shinobar 30jan11: avoid the screen go to blank
 
   #need to set Linux system time/date, from hardware clock...
   set_hwclock_type -q --hctosys ${NEW_HWCLOCKTIME}
@@ -1527,7 +1675,7 @@ if [ "$SET_NETWORK" ];then #120227
     chmod 755 /etc/init.d/rc.firewall #ugh
     /etc/init.d/rc.firewall start
    else
-    [ $(which firewallinstallshell) ] && rxvt -bg LightYellow -title "Firewall setup" -e firewallinstallshell
+    [ $(which firewallinstallshell) ] && xterm -e firewallinstallshell
     [ $(which firewall_ng) ] && firewall_ng
    fi
   fi
@@ -1554,28 +1702,34 @@ if [ "$SET_NETWORK" ];then #120227
    fi
   fi
  fi
-
+ [ -z "$COMBO_CRDW" -a -f /tmp/xcrd ] && read COMBO_CRDW </tmp/xcrd
  if [ "$DEFAULT_CRDW" != "$COMBO_CRDW" ];then #170609...
   NEW_CRDW="$(echo -n "$COMBO_CRDW" | cut -f 1 -d ' ')" #ex: AU
-  echo "options cfg80211 ieee80211_regdom=${NEW_CRDW}" > /etc/modprobe.d/crdw.conf #set at the next bootup.
-  #...at bootup, after module cfg80211 loads, can confirm setting by running 'iw reg get'
-  #BK: had taken this out, but seems still need it on my laptop. may need to expand this script, with a loop, keep plugging away until the setting gets forced. but for now, just do it once...
-  echo "#!/bin/ash
-  iw reg set ${NEW_CRDW}" > /etc/init.d/z-wifi-puppy
-  chmod 755 /etc/init.d/z-wifi-puppy
-  iw reg set ${NEW_CRDW} #set now.
-  FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'CRD changed to') ${NEW_CRDW}:yes|"
+  if [ -n "$NEW_CRDW" ]; then
+   echo "options cfg80211 ieee80211_regdom=${NEW_CRDW}" > /etc/modprobe.d/crdw.conf #set at the next bootup.
+   #...at bootup, after module cfg80211 loads, can confirm setting by running 'iw reg get'
+   #BK: had taken this out, but seems still need it on my laptop. may need to expand this script, with a loop, keep plugging away until the setting gets forced. but for now, just do it once...
+   echo "#!/bin/ash
+   iw reg set ${NEW_CRDW}" > /etc/init.d/z-wifi-puppy
+   chmod 755 /etc/init.d/z-wifi-puppy
+   iw reg set ${NEW_CRDW} #set now.
+   FLAG_CHANGED="${FLAG_CHANGED}$(gettext 'CRD changed to') ${NEW_CRDW}:yes|"
+  fi
  fi #170609 end
 
  #130701...
- if [ $DISPLAY ];then
+ if [ -n "$DISPLAY" -o -n "$WAYLAND_DISPLAY" ];then
   if [ "$CHECK_SPOT" = "true" ];then
    [ $wPID -ne 0 ] && kill $wPID
    wPID=0
    loginmanager
   fi
+  if [ "$CHECK_PASS" = "true" ];then
+   [ $wPID -ne 0 ] && kill $wPID
+   wPID=0
+   loginmanager
+  fi
  fi
-
 fi
 
 #120714 raspberry pi support...
@@ -1604,7 +1758,7 @@ if [ "$SET_RP_AUDIO" -o "$SET_RP_VIDEO" ];then
  fi
 fi
 
-[ ! $DISPLAY ] && exit
+[ -z "$DISPLAY" -a -z "$WAYLAND_DISPLAY" ] && exit
 
 if [ "`echo -n "$FLAG_CHANGED" | grep "restart"`" != "" ];then
 


### PR DESCRIPTION
re: #2903

This is a big commit so I will provide the file for testing in a zip

Changes:
- fix some actions on 'OK' press
- suppress 'xset' under wayland
- test for DISPLAY and WAYLAND_DISPLAY for GUI
- add test for numlockt (alternative to numlockx)
- fix LANG=C bug asking for translation
- add 'change root password' checkbox
- fix numerous logic bugs
- remove comboboxtext in favour of a button to launch a 'tree' widget
for locale, timezone, keyboard and crdw choices. It is much better under
gtk3, fixes quicksetup under wayland, and works great in gtk2
- remove redundant, useless stuff