### PR TITLE
When building an ISO image, unify bdrv and rootfs-complete

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,7 +127,7 @@ jobs:
         sudo mv -f woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}.iso $GITHUB_WORKSPACE/
         sudo mv -f kernel-kit/output/kbuild-*.sfs woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}/
         cd woof-output-${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}
-        sudo tar -f $GITHUB_WORKSPACE/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}-extra.tar -c *{x,drv}_${{ github.event.inputs.prefix }}_${{ github.event.inputs.version }}.sfs kbuild-*.sfs
+        sudo tar -f $GITHUB_WORKSPACE/${{ github.event.inputs.prefix }}-${{ github.event.inputs.version }}-extra.tar -c `ls *{x,drv}_${{ github.event.inputs.prefix }}_${{ github.event.inputs.version }}.sfs 2>/dev/null` kbuild-*.sfs
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -985,6 +985,12 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 			if [ "$ISOFLAG" -o "$FRUGALIFY" ]; then
 				echo "Now building sandbox3/bdrv"
 				$MWD/support/bdrv.sh || exit 1
+
+				if [ "$ISOFLAG" ]; then
+					echo "Unifying bdrv with rootfs-complete"
+					cp -av bdrv/* rootfs-complete/ || exit 1
+					rm -rf bdrv
+				fi
 			fi
 			;;
 		esac


### PR DESCRIPTION
initrd.gz doesn't auto-load bdrv, so let's just unify them! Before #2930, the jammy64 bdrv is only 12 MB and its contribution to ISO size is even smaller when compressed together with the main SFS.