### PR TITLE
Add a dummy /bin/systemctl

### DIFF
--- a/woof-code/rootfs-skeleton/bin/systemctl
+++ b/woof-code/rootfs-skeleton/bin/systemctl
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Ignoring $0 $@"


### PR DESCRIPTION
Some Ubuntu packages try to `systemctl daemon-reload` during post-configuration, and installation fails. I assume this applies to any Puppy, because we don't have systemd.