### PR TITLE
Shrink bdrv

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -68,7 +68,7 @@ rm -rf sandbox3/rootfs-complete
 rm -rf sandbox3/devx
 rm -rf sandbox3/docx ${DOCXSFS}
 rm -rf sandbox3/nlsx ${NLSXSFS}
-rm -rf sandbox3/bdrv sandbox3/adrv sandbox3/ydrv sandbox3/fdrv
+rm -rf sandbox3/bdrv sandbox3/bdrv_NLS sandbox3/bdrv_DOC sandbox3/adrv sandbox3/ydrv sandbox3/fdrv
 mkdir -p sandbox3/rootfs-complete/etc
 mkdir -p sandbox3/devx
 cp DISTRO_SPECS sandbox3/rootfs-complete/etc/

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -129,13 +129,17 @@ cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSIO
 	LIST=bdrv/var/lib/dpkg/info/$NAME:$ARCH.list
 	[ -f "$LIST" ] || LIST=bdrv/var/lib/dpkg/info/$NAME.list
 
+	sort -r $LIST > /tmp/$NAME-sorted.list
+
 	while read FILE; do
 		[ -d "bdrv/$FILE" ] || rm -f "bdrv/$FILE" 2>/dev/null
-	done < $LIST
+	done < /tmp/$NAME-sorted.list
 
 	while read FILE; do
 		[ ! -d "bdrv/$FILE" ] || rmdir "bdrv/$FILE" 2>/dev/null || :
-	done < $LIST
+	done < /tmp/$NAME-sorted.list
+
+	rm -f /tmp/$NAME-sorted.list
 done
 
 # open .deb files with gdebi
@@ -169,4 +173,14 @@ if [ -e rootfs-complete/usr/share/applications/mimeapps.list ]; then
 			esac
 		done < rootfs-complete/usr/share/applications/mimeapps.list
 	) > bdrv/usr/share/applications/mimeapps.list
+fi
+
+# move large directories to docx and nlsx
+mkdir -p bdrv_NLS/usr/share bdrv_DOC/usr/share
+mv bdrv/usr/share/locale bdrv_NLS/usr/share/
+mv bdrv/usr/share/doc bdrv/usr/share/info bdrv/usr/share/man bdrv_DOC/usr/share/
+if [ -d bdrv/usr/share/gnome/help ]; then
+	mkdir -p bdrv_DOC/usr/share/gnome
+	mv bdrv/usr/share/gnome/help bdrv_DOC/usr/share/gnome/
+	rmdir bdrv/usr/share/gnome 2>/dev/null
 fi

--- a/woof-code/support/docx_nlsx.sh
+++ b/woof-code/support/docx_nlsx.sh
@@ -30,6 +30,10 @@ if [ "$BUILD_DOCX" = "yes" ] ; then
 			cp -a --remove-destination ../packages-${DISTRO_FILE_PREFIX}/${i}_DOC/* docx/
 		fi
 	done
+	if [ -d bdrv_DOC ] ; then
+		echo -n " bdrv_DOC"
+		cp -a --remove-destination bdrv_DOC/* docx/
+	fi
 	echo
 	rm -f docx/pet.specs
 	[ "$USR_SYMLINKS" = "yes" ] && usrmerge docx 0
@@ -49,6 +53,10 @@ if [ "$BUILD_NLSX" = "yes" ] ; then
 			cp -a --remove-destination ../packages-${DISTRO_FILE_PREFIX}/${i}_NLS/* nlsx/
 		fi
 	done
+	if [ -d bdrv_NLS ] ; then
+		echo -n " bdrv_NLS"
+		cp -a --remove-destination bdrv_NLS/* nlsx/
+	fi
 	echo
 	rm -f nlsx/pet.specs
 	mkdir -p nlsx/var/local


### PR DESCRIPTION
This PR makes bdrv much smaller, by fixing the order in which directories are removed, and by moving large directories to nlsx and docx.