### PR TITLE
Remove development packages from bdrv

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1142,7 +1142,7 @@ if [ "$SDFLAG" = "" -a "$CROSFLAG" = "" ] ; then #120506
 		echo "Running ../support/mk_iso.sh"
 		../support/mk_iso.sh || exit 1
 	else
-		[ "$BUILD_DEVX" = "yes" -a -f ${DEVXSFS} ] && mv -f ${DEVXSFS} ./build/
+		[ "$BUILD_DEVX" = "yes" -a -f ${DEVXSFS} -a ! -f build/${BDRVSFS} ] && mv -f ${DEVXSFS} ./build/
 		[ -f ${DOCXSFS} ] && mv -f ${DOCXSFS} ./build/
 		[ -f ${NLSXSFS} ] && mv -f ${NLSXSFS} ./build/
 		KBUILDSFS="`ls ../kernel-kit/output/kbuild-*.sfs 2>/dev/null`"

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -89,8 +89,16 @@ chroot bdrv apt-mark hold busybox-static
 # snap is broken without systemd
 chroot bdrv apt-mark hold snapd
 
-# install all packages included in the woof-CE build
-chroot bdrv apt-get install -y `cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 5 -d \| | tr '\n' ' '`
+# install all packages that didn't get fully redirected to devx
+PKGS=`cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 1,5 -d \| |
+while IFS=\| read GENERICNAME NAME; do
+	case "$NAME" in
+	*-dev) continue ;;
+	esac
+
+	[ -d ../packages-${DISTRO_FILE_PREFIX}/${GENERICNAME//:}_DEV -a ! -e ../packages-${DISTRO_FILE_PREFIX}/${GENERICNAME//:} ] || echo "$NAME"
+done`
+chroot bdrv apt-get install -y $PKGS
 
 # add missing package recommendations, Synaptic and gdebi
 chroot bdrv apt-get install -y command-not-found synaptic gdebi
@@ -131,6 +139,7 @@ done
 cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 5 -d \| | while read NAME; do
 	LIST=bdrv/var/lib/dpkg/info/$NAME:$ARCH.list
 	[ -f "$LIST" ] || LIST=bdrv/var/lib/dpkg/info/$NAME.list
+	[ -f "$LIST" ] || continue
 
 	sort -r $LIST > /tmp/$NAME-sorted.list
 

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -93,7 +93,7 @@ chroot bdrv apt-mark hold snapd
 PKGS=`cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 1,5 -d \| |
 while IFS=\| read GENERICNAME NAME; do
 	case "$NAME" in
-	*-dev) continue ;;
+	*-dev|*-dev-bin|*-devtools) continue ;;
 	esac
 
 	[ -d ../packages-${DISTRO_FILE_PREFIX}/${GENERICNAME//:}_DEV -a ! -e ../packages-${DISTRO_FILE_PREFIX}/${GENERICNAME//:} ] || echo "$NAME"

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -93,7 +93,7 @@ chroot bdrv apt-mark hold snapd
 PKGS=`cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 1,5 -d \| |
 while IFS=\| read GENERICNAME NAME; do
 	case "$NAME" in
-	*-dev|*-dev-bin|*-devtools) continue ;;
+	*-dev|*-dev-bin|*-devtools|*-headers) continue ;;
 	esac
 
 	[ -d ../packages-${DISTRO_FILE_PREFIX}/${GENERICNAME//:}_DEV -a ! -e ../packages-${DISTRO_FILE_PREFIX}/${GENERICNAME//:} ] || echo "$NAME"


### PR DESCRIPTION
Right now, apt is configured to *think* that all packages in devx are installed. This means that if the user installs a package that depends on a package in devx, but devx is not loaded, that package is broken.

This PR will make `apt install gcc`, among other instructions you can find online, work. Users who use PPM can always load devx, and get development tools the old way. This makes life easier for users, because if something needs GCC, it will get installed automatically (while loading devx requires manual intervention).

Also, this should make bdrv even smaller, because a big portion of its size is the apt state directory, where it stores which packages are installed and remembers which files belong to each package.