### PR TITLE
If not using ROX-Filer, replaces the Drives menu with pmount

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/usr/local/jwm_config/menu_build_places
+++ b/woof-code/rootfs-packages/jwm_config/usr/local/jwm_config/menu_build_places
@@ -10,9 +10,13 @@ echo '
 	<Program label="'$(gettext 'System')'" icon="/usr/local/lib/X11/pixmaps/pc48.png">rox /</Program>
 	<Program label="'$(gettext 'Network')'" icon="/usr/local/lib/X11/pixmaps/connect48.png">rox $HOME/network</Program>'
 	[ -d $HOME/Downloads ] && echo '<Program label="'$(gettext 'Downloads')'" icon="/usr/local/lib/X11/pixmaps/folder48.png">rox $HOME/Downloads</Program>'
-	echo '<Separator/>
-	<Dynamic label="'$(gettext 'Drives')'" icon="/usr/local/lib/X11/pixmaps/drive48.png">exec:/usr/local/jwm_config/menu_build_places_drives</Dynamic>
-	<Dynamic label="'$(gettext 'Recently used')'" icon="file.svg">exec:/usr/local/jwm_config/menu_build_recent_docs</Dynamic>
+	echo '<Separator/>'
+	if [ -n "`pidof ROX-Filer`" ]; then
+		echo '<Dynamic label="'$(gettext 'Drives')'" icon="/usr/local/lib/X11/pixmaps/drive48.png">exec:/usr/local/jwm_config/menu_build_places_drives</Dynamic>'
+	else
+		echo '<Program label="'$(gettext 'Drives')'" icon="/usr/local/lib/X11/pixmaps/drive48.png">pmount</Program>'
+	fi
+	echo '<Dynamic label="'$(gettext 'Recently used')'" icon="file.svg">exec:/usr/local/jwm_config/menu_build_recent_docs</Dynamic>
 	<Separator/>
 	<Program label="'$(gettext 'Web')'" icon="/usr/local/lib/X11/pixmaps/www48.png">defaultbrowser</Program>
 	<Program label="'$(gettext 'Help')'" icon="/usr/local/lib/X11/pixmaps/help48.png">/usr/sbin/puppyhelp</Program>


### PR DESCRIPTION
There's no easy to unmount a drive without the ROX-Filer desktop icons. Therefore, it makes more sense to put a menu entry that leads to some tool that allows one to mount, unmount and browse partitions.

![pmount](https://user-images.githubusercontent.com/1471149/156231895-66ecda7e-3bc2-4317-b585-e0d140d854a1.png)

@01micko In Vanilla Dpup 9.2.x, I want to get rid of ROX-Filer. The combination of JWM and pcmanfm should be a good stepping stone towards a pure Wayland desktop with pcmanfm. Without the drives menu, we have a pretty static menu layout and it should be much easier to build a 1:1 equivalent of this jwm+pcmanfm combo, using labwc+sfwbar+pcmanfm.

