### PR TITLE
Switch to prebuilt initrd.gz binaries from GitHub

### DIFF
--- a/initrd-progs/build.sh
+++ b/initrd-progs/build.sh
@@ -2,8 +2,8 @@
 
 ARCH_LIST="i686 x86_64 arm aarch64"
 
-INITRD_STATIC='initrd_progs-20210401-static.tar.xz'
-PREBUILT_BINARIES="http://distro.ibiblio.org/puppylinux/initrd_progs/${INITRD_STATIC}"
+INITRD_STATIC='initrd_progs-static.tar.xz'
+PREBUILT_BINARIES="https://github.com/puppylinux-woof-CE/initrd_progs/releases/latest/download/${INITRD_STATIC}"
 
 ARCH=`uname -m`
 


### PR DESCRIPTION
Depends on:

https://github.com/puppylinux-woof-CE/initrd_progs/pull/15
https://github.com/puppylinux-woof-CE/initrd_progs/pull/16

Everything is built on a clean Ubuntu container with the latest musl.cc toolchain, and the tarball contains exactly the same selection of binaries as the old one. Nothing is updated, except libgpg-error, because the old version required an old version of gawk.

By automating the process of building these old magic binaries, it should be easier to add features to initrd.gz and fix years-old issues (for example, update busybox to a newer one, to add support for a new filesystem).