### PR TITLE
Change the default ConnMan settings

### DIFF
--- a/woof-code/packages-templates/connman_FIXUPHACK
+++ b/woof-code/packages-templates/connman_FIXUPHACK
@@ -6,3 +6,13 @@ if [ -e etc/init.d/unscd ]; then
 fi
 EOF
 esac
+
+if [ -e etc/connman/main.conf ]; then
+	cat << EOF >> etc/connman/main.conf
+
+# Puppy customization
+BackgroundScanning = false
+FallbackTimeservers = pool.ntp.org
+EnableOnlineCheck = false
+EOF
+fi


### PR DESCRIPTION
1. Disable background scanning - connman-ui starts a scan when clicked and this is a waste of energy
2. Synchronize the clock, so the user doesn't have to run psync (for HTTPS and `apt update` to work) if no NTP server is specified by the DHCP server
3. Disable the HTTP request to ipv4.connman.net, in the name of privacy