### PR TITLE
If using ConnMan, prevent psync from synchronizing the clock on boot

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/psync
+++ b/woof-code/rootfs-skeleton/usr/sbin/psync
@@ -215,6 +215,7 @@ export psync_chkbox='
           <variable>PSYNC_ENABLED</variable>
           <action>if true enable_psync</action>
           <action>if false disable_psync</action>
+          <sensitive>'$([ -n "`pidof connmand`" ] && echo false || echo true)'</sensitive>
         </checkbox>
 '
 

--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -326,6 +326,11 @@ if [ "$MYBASE" = "quicksetup" ];then #120313 only allow in main quicksetup windo
           <action>help ntp</action>
         </button>
      </hbox>'
+    #if ConnMan takes care of NTP, hide the checkbox
+    if [ -n "`pidof connmand`" ]; then
+        CHKBOXNTP=""
+        CHECK_NTP="$DEFAULT_NTP"
+    fi
 
     #130701...
     SPOT_XML=''


### PR DESCRIPTION
There's no reason to synchronize the clock on **boot** and after the internet connection is established. (And synchronizing the clock early, possibly without an internet connection, is unlikely to work 100%.)