### PR TITLE
If only Xwayland is present, start Xwayland and hide the X.Org button

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -31,11 +31,14 @@ fi
 
 if [ -f /var/local/xwin_enable_xwayland ] ; then
 	XWAYLAND=1
+elif [ -e /usr/bin/startxwayland -a ! -e /usr/bin/Xorg ]; then
+	XWAYLAND=1
+	touch /var/local/xwin_enable_xwayland
 else
 	XWAYLAND=0
 fi
 
-if [ $XWAYLAND -eq 0 -a `id -u` -eq 0 -a -h /usr/bin/X ] ; then
+if [ $XWAYLAND -eq 0 -a `id -u` -eq 0 -a ! -e /usr/bin/X ] ; then
 	ln -snf Xorg /usr/bin/X
 fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorgwizard
@@ -489,7 +489,7 @@ if which nvidia-settings >/dev/null 2>&1 && NRATE=$(nvidia-settings -q RefreshRa
 	USING_NVIDIA=1
 fi
 
-if [ -f /var/local/xwin_enable_xwayland ]; then
+if [ -f /var/local/xwin_enable_xwayland -o ! -e /usr/bin/Xorg ]; then
 	USING_XORG=false
 else
 	USING_XORG=true
@@ -699,11 +699,11 @@ fi
 
 
 xXSERVER=""
-if [ -f /usr/bin/startxwayland -a ! -f /var/local/xwin_enable_xwayland ]; then
+if [ -e /usr/bin/Xorg -a -f /usr/bin/startxwayland -a ! -f /var/local/xwin_enable_xwayland ]; then
  xXSERVER="<hseparator></hseparator>
 $(gui_opt "setxserver xwayland" wm_restart.svg "$(gettext '<b>X Server</b>
 Change to Xwayland..')" true)"
-elif [ -f /usr/bin/startxwayland -a -f /var/local/xwin_enable_xwayland ]; then
+elif [ -e /usr/bin/Xorg -a -f /usr/bin/startxwayland -a -f /var/local/xwin_enable_xwayland ]; then
  xXSERVER="<hseparator></hseparator>
 $(gui_opt "setxserver xorg" wm_restart.svg "$(gettext '<b>X Server</b>
 Change to X.Org..')" true)"


### PR DESCRIPTION
X.Org is much bigger than Cage+Xwayland, and I'd like to try to build a Puppy without X.Org.