### PR TITLE
If sudo is not installed, provide a dummy sudo

### DIFF
--- a/woof-code/rootfs-skeleton/root/.bashrc
+++ b/woof-code/rootfs-skeleton/root/.bashrc
@@ -10,3 +10,12 @@ if [ -x /usr/lib/command-not-found ]; then
   return 127
  }
 fi
+if [ ! -e /usr/bin/sudo ]; then
+ sudo() {
+  if [ -e /usr/bin/sudo ]; then
+   /usr/bin/sudo "$@"
+  else
+   "$@"
+  fi
+ }
+fi


### PR DESCRIPTION
The internet is full of instructions that ask users to `sudo apt install`, but Puppy has no sudo. So let's provide a dummy sudo that works only through an interactive shell and doesn't break anything!

![sudo](https://user-images.githubusercontent.com/1471149/156914113-d2bac441-6854-4b39-93d9-0071a56c5441.png)