### PR TITLE
Treat empty .xlockrc like a missing file and do not prompt for a password if -startCmd is specified

### DIFF
--- a/woof-code/rootfs-petbuilds/xlockmore/null.patch
+++ b/woof-code/rootfs-petbuilds/xlockmore/null.patch
@@ -1,0 +1,60 @@
+diff -rupN xlockmore-5.66-orig/xlock/passwd.c xlockmore-5.66/xlock/passwd.c
+--- xlockmore-5.66-orig/xlock/passwd.c	2022-03-06 13:27:50.906407728 +0200
++++ xlockmore-5.66/xlock/passwd.c	2022-03-06 14:16:34.069494306 +0200
+@@ -55,6 +55,7 @@ extern Bool inwindow;
+ extern Bool grabmouse;
+ extern Bool nolock;
+ extern char *cpasswd;
++extern char *startCmd;
+ 
+ #ifdef USE_PAM
+ #include <X11/Xlib.h>
+@@ -731,7 +732,19 @@ gpass(void)
+ 		(void) strncpy(xlockrc, home, MAXPATHLEN);
+ 		xlockrc[MAXPATHLEN] = '\0';
+ 		(void) strncat(xlockrc, "/.xlockrc", MAXPATHLEN);
+-		if ((fp = my_fopen(xlockrc, "r")) == NULL) {
++		fp = my_fopen(xlockrc, "r");
++		if (fp != NULL) {
++			if ((fseek(fp, 0, SEEK_END) != 0) || (ftell(fp) == 0)) {
++				fclose(fp);
++				fp = NULL;
++			} else {
++				rewind(fp);
++			}
++		}
++		if (fp == NULL) {
++			if (startCmd && startCmd[0])
++				return;
++
+ 			if ((fp = my_fopen(xlockrc, "w")) != NULL)
+ 				(void) fchmod(fileno(fp), 0600);
+ #if defined(HAVE_KRB4) || defined(HAVE_KRB5)
+@@ -739,7 +752,7 @@ gpass(void)
+ #else
+ 			if (!gpasskey(userpass)) {
+ 				remove(xlockrc); /* else creates annoying null file */
+-				exit(1);
++				goto fail;
+ 			}
+ #endif /* KRB4 || KRB5 */
+ 			if (fp)
+@@ -761,15 +774,16 @@ gpass(void)
+ #if defined(HAVE_KRB4) || defined(HAVE_KRB5)
+ 				if (!gpasskey(buf)) {
+ 					remove(xlockrc); /* else creates annoying null file */
+-					exit(1);
++					goto fail;
+ 				}
+ #else
+-				exit(1);
++				goto fail;
+ #endif
+ 			}
+ 			buf[CPASSLENGTH - 1] = '\0';
+ 			(void) strncpy(userpass, buf, CPASSLENGTH);
+ 		}
++fail:
+ 		if (fp)
+ 			(void) fclose(fp);
+ 	} else {

--- a/woof-code/rootfs-petbuilds/xlockmore/petbuild
+++ b/woof-code/rootfs-petbuilds/xlockmore/petbuild
@@ -6,6 +6,7 @@ build() {
     tar -xJf xlockmore-5.66.tar.xz
     cd xlockmore-5.66
     patch -p1 < ../small.patch
+    patch -p1 < ../null.patch
     ./configure --prefix=/usr --enable-def-play=no --enable-xlockrc --disable-setuid --without-editres --without-xpm --without-libpng --without-gltt --without-ttf --without-ftgl --without-freetype --without-opengl --without-mesa --without-dtsaver --without-esound --enable-nice-only --without-nas --without-gtk2
     # TODO: figure out why linking fails on x86_64
     make -j1 || :


### PR DESCRIPTION
When xlock runs for the first time, it asks the user to enter a password.

If the user used Super+L, that's probably fine, because the user sees the screen. But if the user closes the laptop lid (which triggers `xlock -startCmd ...` via acpid) and never used Super+L before, xlock should run the -startCmd command without waiting for the user to enter a password (because the user can't do that).

In addition, xlock has a reliability issue - xlock creates ~/.xlock, then writes to it, but refuses to run if it's an empty file. And it doesn't ever prompt you for a password again if the file exists, so you're stuck with a broken xlock. A power failure or file system corruption after the creation of the file and before the password is written and flushed to disk (for example, nightly battery drain) can result in an empty file, so it's a real problem.