### PR TITLE
Add GTK+ 4 theme support to ptheme

### DIFF
--- a/woof-code/rootfs-packages/ptheme/pinstall.sh
+++ b/woof-code/rootfs-packages/ptheme/pinstall.sh
@@ -121,6 +121,13 @@ gtk-toolbar-style = GTK_TOOLBAR_BOTH
 gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 fi
+if [ -d usr/share/themes/${PTHEME_GTK}/gtk-4.0 ]; then
+	mkdir -p root/.config/gtk-4.0
+	cat > root/.config/gtk-4.0/settings.ini << _EOF
+[Settings]
+gtk-theme-name = ${PTHEME_GTK}
+_EOF
+fi
 
 echo "gtk: ${PTHEME_GTK}"
 
@@ -145,6 +152,12 @@ gtk-button-images = 1
 gtk-enable-animations = 0
 EOF
 	fi
+	if [ -f root/.config/gtk-4.0/settings.ini ]; then
+		echo -e "gtk-icon-theme-name = $USE_ICON_THEME" >> root/.config/gtk-4.0/settings.ini
+		cat >> root/.config/gtk-4.0/settings.ini <<EOF
+gtk-enable-animations = 0
+EOF
+	fi
 	# then ROX
 	ROX_THEME_FILE="root/.config/rox.sourceforge.net/ROX-Filer/Options" # this could change in future
 	sed -i "s%<Option name=\"icon_theme\">.*%<Option name=\"icon_theme\">$USE_ICON_THEME</Option>%" $ROX_THEME_FILE
@@ -155,6 +168,10 @@ install -D -m 644 root/.gtkrc-2.0 etc/gtk-2.0/gtkrc
 if [ -f root/.config/gtk-3.0/settings.ini ]; then
 	install -D -m 644 root/.config/gtk-3.0/settings.ini etc/gtk-3.0/settings.ini
 	install -D -m 644 -o spot -g spot root/.config/gtk-3.0/settings.ini home/spot/.config/gtk-3.0/settings.ini
+fi
+if [ -f root/.config/gtk-4.0/settings.ini ]; then
+	install -D -m 644 root/.config/gtk-4.0/settings.ini etc/gtk-4.0/settings.ini
+	install -D -m 644 -o spot -g spot root/.config/gtk-4.0/settings.ini home/spot/.config/gtk-4.0/settings.ini
 fi
 
 ##### WALLPAPER #copy it as mv messes the themes

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -19,6 +19,35 @@ echo -n > $WORKDIR/ptheme_gtkfont
 export REAL_XDG_CONFIG_HOME="$HOME/.config"
 
 #functions
+set_gtk4_theme() {
+	if ls /usr/share/icons | grep -q "$1" ; then
+		if [ -e $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini ]; then
+			if grep -q "^gtk-icon-theme-name" $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini ;then
+				! grep -q "$1" $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini &&  \
+					sed -i "s/^gtk-icon-theme-name.*/gtk-icon-theme-name = $1/" $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
+			else
+				echo "gtk-icon-theme-name = $ICON_THEME" >> $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
+			fi
+		fi
+	else
+		PTHEME_GTK4="$1"
+		if [ -d "/usr/share/themes/${PTHEME_GTK4}/gtk-4.0" ]; then
+			mkdir -p $REAL_XDG_CONFIG_HOME/gtk-4.0
+			cat > $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini << _EOF
+[Settings]
+gtk-theme-name = ${PTHEME_GTK4}
+_EOF
+		fi
+	fi
+	if ! grep -qE "gtk-enable-animations" $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini ; then
+		cat >> $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini << EOF
+gtk-enable-animations = 0
+EOF
+	fi
+	install -D -m 644 $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini /etc/gtk-4.0/settings.ini
+	install -D -m 600 -o spot -g spot $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini /home/spot/.config/gtk-4.0/settings.ini
+}
+
 set_gtk3_theme() {
 	if ls /usr/share/icons | grep -q "$1" ; then
 		if [ -e $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini ]; then
@@ -41,7 +70,7 @@ gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 		fi
 	fi
-	if ! grep -qE "gtk-menu-images|gtk-button-images" $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini ; then
+	if ! grep -qE "gtk-menu-images|gtk-button-images|gtk-enable-animations" $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini ; then
 		cat >> $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini << EOF
 gtk-menu-images = 1
 gtk-button-images = 1		
@@ -60,9 +89,11 @@ set_theme_gtk (){
 		if [ "$(which gtk-theme-switch2)" ] ; then
 			gtk-theme-switch2 -f "$FONT" "/usr/share/themes/$THEME"
 			set_gtk3_theme "$THEME"
+			set_gtk4_theme "$THEME"
 		elif [ "$(which switch2)" ] ; then
 			switch2 -f "$FONT" "/usr/share/themes/$THEME"
 			set_gtk3_theme $THEME
+			set_gtk4_theme $THEME
 		else
 			# from upgrade_ptheme_fix
 			PTHEME_GTK=$THEME
@@ -85,6 +116,7 @@ gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF
 
 			set_gtk3_theme "$THEME"
+			set_gtk4_theme "$THEME"
 		fi
 	fi
 	#icon theme
@@ -92,12 +124,14 @@ _EOF
 		sed -i '/gtk-icon-theme-name/d' $HOME/.gtkrc-2.0
 		echo "gtk-icon-theme-name = \"$ICON_THEME\"" >> $HOME/.gtkrc-2.0
 		set_gtk3_theme "$ICON_THEME"
+		set_gtk4_theme "$ICON_THEME"
 		# rox "Options"
 		sed -i "s/  <Option name=\"icon_theme\">.*$/  <Option name=\"icon_theme\">$ICON_THEME<\/Option>/" $HOME/.config/rox.sourceforge.net/ROX-Filer/Options
 	elif [ "$ACTIVE_ICON_THEME" ]; then
 		sed -i '/gtk-icon-theme-name/d' $HOME/.gtkrc-2.0
 		echo "gtk-icon-theme-name = \"$ACTIVE_ICON_THEME\"" >> $HOME/.gtkrc-2.0
 		set_gtk3_theme "ACTIVE_$ICON_THEME"
+		set_gtk4_theme "ACTIVE_$ICON_THEME"
 		# rox "Options"
 		sed -i "s/  <Option name=\"icon_theme\">.*$/  <Option name=\"icon_theme\">$ICON_THEME<\/Option>/" $HOME/.config/rox.sourceforge.net/ROX-Filer/Options
 	fi
@@ -116,7 +150,7 @@ set_font (){
 	set_theme_gtk
 }
 
-export -f set_theme_gtk set_font set_gtk3_theme
+export -f set_theme_gtk set_font set_gtk3_theme set_gtk4_theme
 
 #parameters
 while [ $# != 0 ]; do


### PR DESCRIPTION
This will become useful once #2957 is fixed. For now, there are no GTK+ 4 themes, so this doesn't do anything.

Ubuntu 22.04 sticks with GTK+ 3, but some applications have moved on. It won't be long until the horrible visual inconsistency we had between GTK+ 2 and 3 returns, but this time, between GTK+ 3 and GTK+ 4.