### PR TITLE
Make lsb_release -sc work

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -538,6 +538,7 @@ HOME_URL="http://puppylinux.com/"
 SUPPORT_URL="http://www.murga-linux.com/puppy/index.php"
 BUG_REPORT_URL="https://github.com/puppylinux-woof-CE/woof-CE"
 _EOF
+rm -f etc/os-release
 ln -s ../usr/lib/os-release etc/
 
 cd $WKGDIR

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -525,7 +525,8 @@ if [ -n "$PROMPT" ]; then
 fi
 
 echo "Now setting /etc/os-release file"
-cat > etc/os-release << _EOF
+mkdir -p usr/lib
+cat > usr/lib/os-release << _EOF
 NAME=Puppy
 VERSION="$DISTRO_VERSION"
 ID=puppy_$DISTRO_FILE_PREFIX
@@ -537,6 +538,7 @@ HOME_URL="http://puppylinux.com/"
 SUPPORT_URL="http://www.murga-linux.com/puppy/index.php"
 BUG_REPORT_URL="https://github.com/puppylinux-woof-CE/woof-CE"
 _EOF
+ln -s ../usr/lib/os-release etc/
 
 cd $WKGDIR
 

--- a/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
+++ b/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
@@ -12,7 +12,7 @@
 #include <regex.h>
 #include <stdio.h>
 
-#define SPOTLIST "^(firefox|firefox-[a-z]+|google-chrome-[a-z]+|chromium|vivaldi-[a-z]+|brave-browser|microsoft-edge-[a-z]+|transmission-[a-z]+|seamonkey|sylpheed|claws-mail|thunderbird|vlc|steam|code)$"
+#define SPOTLIST "^(firefox|firefox-[a-z]+|google-chrome-[a-z]+|chromium|vivaldi-[a-z]+|brave-browser|microsoft-edge-[a-z]+|transmission-[a-z]+|seamonkey|sylpheed|claws-mail|thunderbird|vlc|steam|code|librewolf)$"
 
 static int
 sh(const char *cmd, const sigset_t *set)

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -155,6 +155,12 @@ cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSIO
 	rm -f /tmp/$NAME-sorted.list
 done
 
+# impersonate the distro we're compatible with, so tools like software-properties-gtk work
+mkdir -p bdrv/usr/lib
+sed "s/^ID=.*/ID=${DISTRO_BINARY_COMPAT}/" rootfs-complete/usr/lib/os-release > bdrv/usr/lib/os-release
+echo "VERSION_CODENAME=${DISTRO_COMPAT_VERSION}" >> bdrv/usr/lib/os-release
+chmod 644 bdrv/usr/lib/os-release
+
 # open .deb files with gdebi
 if [ -e rootfs-complete/usr/local/bin/rox ]; then
 	mkdir -p bdrv/etc/xdg/rox.sourceforge.net/MIME-types


### PR DESCRIPTION
This makes tools like software-properties-gtk work (because they check what distro they're running on).

![props](https://user-images.githubusercontent.com/1471149/157042244-aa7ab5c2-1195-459a-9e99-1bc560b8a991.png)

Without the distro ID or codename:

![miss1](https://user-images.githubusercontent.com/1471149/157042153-eb46b5e0-03dc-44d4-be80-a7e12ddfb938.png)
![miss2](https://user-images.githubusercontent.com/1471149/157042157-b17964ef-2dc9-45f8-974d-fee9cb67a59f.png)

And now the instructions in https://librewolf.net/installation/debian, which use `sudo` and `lsb_release -sc`, "just work":

![librewolf](https://user-images.githubusercontent.com/1471149/157042785-6ed36d65-ba30-4d1c-958f-c2900b867fb5.png)