### PR TITLE
Fix syntax error in /etc/shells

### DIFF
--- a/woof-code/rootfs-skeleton/etc/shells
+++ b/woof-code/rootfs-skeleton/etc/shells
@@ -1,3 +1,3 @@
 /bin/sh
 /bin/bash
-/bin/ash 
+/bin/ash


### PR DESCRIPTION
/bin/ash is not a valid login shell 😱 

Introduced in 406499aa3e16dc04982273c71badc7ee9e2091ac, 8 years ago 🤯 