### PR TITLE
Allow the new hostname to be resolved over IPv4

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -295,10 +295,7 @@ if [ "`cat /etc/hostname`" = "puppypc" ];then
  echo -n "Updating unique hostname..." >/dev/console #hostname
  echo "puppypc${RANDOM}" > /etc/hostname
  PUPHOSTNAME="`cat /etc/hostname`"
- HOSTSFILEFIRST="`grep -w 'puppypc' /etc/hosts|sed 's% puppypc%%'`"
- HOSTSFILEREST="`grep -v 'puppypc' /etc/hosts`"
- echo "$HOSTSFILEFIRST $PUPHOSTNAME" > /etc/hosts
- echo "$HOSTSFILEREST" >> /etc/hosts
+ sed "s/ puppypc\$/ $PUPHOSTNAME/g" -i /etc/hosts
  status_func 0
 fi
 


### PR DESCRIPTION
Regression introduced in https://github.com/puppylinux-woof-CE/woof-CE/pull/2892/files#diff-85b7ed0ea80f2994bae7fc1c5e1da9c3617e078bb48c4bf9f02eca297c936355R2:

```
~$ head -n 3 /etc/hosts
127.0.0.1 localhost                           <- no puppypc29527 here
::1 localhost puppypc29527
# pup-advert-blocker IPs below
```

This happens because rc.sysinit assumes the new hostname appears only once in /etc/hosts.

While I'm already here, I made this function more efficient - instead of reading the entire file to RAM before we write it to /etc/hosts (and it's 3 MB here if the ad blocker is enabled!), we just modify it in-place with sed, and this time, replace all occurrences of the old hostname.