### PR TITLE
If dev>exe, leave _DEV files untouched

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -404,6 +404,9 @@ do
 				rm -rf ${ONEDIR}
 				continue
 			fi
+			if [ -z "$DEV" ] ; then
+				continue
+			fi
 			if [ "$DEVX" ] ; then
 				continue
 			fi


### PR DESCRIPTION
```
yes|cpp|cpp,cpp-11,gcc-11-base,libisl23|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
```

Before:

```
Processing cpp
 processing cpp-11_11.2.0-18ubuntu1_amd64.deb
 processing cpp_11.2.0-1ubuntu1_amd64.deb
 processing gcc-11-base_11.2.0-18ubuntu1_amd64.deb
 processing libisl23_0.24-2_amd64.deb
cp: 'usr/lib/gcc/x86_64-linux-gnu' and '/root/woof-out_x86_64_x86_64_ubuntu_jammy64/packages-upup/cpp/usr/lib/gcc/x86_64-linux-gnu' are the same file
```

packages-upup/cpp/usr/lib/gcc/x86_64-linux-gnu/11/cc1 is missing, because we delete the directory after the failed `cp`.

After:

```
Processing cpp
 processing cpp-11_11.2.0-18ubuntu1_amd64.deb
 processing cpp_11.2.0-1ubuntu1_amd64.deb
 processing gcc-11-base_11.2.0-18ubuntu1_amd64.deb
 processing libisl23_0.24-2_amd64.deb
```

Now, packages-upup/cpp/usr/lib/gcc/x86_64-linux-gnu/11/cc1 exists.