### PR TITLE
Before checking if a device supports TRIM, strip the partition number

### DIFF
--- a/woof-code/rootfs-skeleton/etc/init.d/trim
+++ b/woof-code/rootfs-skeleton/etc/init.d/trim
@@ -37,6 +37,12 @@ case $1 in
   [ -z "$DEV" ] && exit 0
   DEV="${DEV#/dev/}"
   DEV="${DEV%% *}"
+  case "$DEV" in
+  sd*[0-9]*) DEV="${DEV%%[0-9]*}" ;;
+  mmcblk[0-9]*p[0-9]*) DEV="${DEV%p[0-9]*}" ;;
+  nvme[0-9]*n[0-9]*p[0-9]*) DEV="${DEV%p[0-9]*}" ;;
+  *) exit 0 ;;
+  esac
   N="`cat /sys/block/$DEV/queue/discard_granularity 2>/dev/null`"
   [ -z "$N" ] && exit 0
   [ $N -eq 0 ] && exit 0


### PR DESCRIPTION
The check should be done using the device name, not the partition name (i.e. /sys/block/sda/queue/discard_granularity, not /sys/block/sda1/queue/discard_granularity):

```
nvme123n456p789 -> nvme123n456
mmcblk123p456 -> mmcblk123
sda123 -> sda 
```