### PR TITLE
Auto-load bdrv and kbuild and hide them in sfs_load

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -80,6 +80,7 @@ export DISTRODESC="${DISTRO_NAME} ${DISTRO_VERSION} - Linux ${KERNELVER} - `unam
 [ ! "$DISTRO_FDRVSFS" ] && DISTRO_FDRVSFS="fdrv_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs"
 [ ! "$DISTRO_ADRVSFS" ] && DISTRO_ADRVSFS="adrv_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs"
 [ ! "$DISTRO_YDRVSFS" ] && DISTRO_YDRVSFS="ydrv_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs"
+[ ! "$DISTRO_BDRVSFS" ] && DISTRO_BDRVSFS="bdrv_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs"
 [ ! "$DISTRO_PUPPYSFS" ] && DISTRO_PUPPYSFS="puppy_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs"
 
 # filenames specified in DISTRO_SPECS: DISTRO_ZDRVSFS, DISTRO_PUPPYSFS...
@@ -87,7 +88,9 @@ Z_DEF_FN="$DISTRO_ZDRVSFS"
 F_DEF_FN="$DISTRO_FDRVSFS"
 A_DEF_FN="$DISTRO_ADRVSFS"
 Y_DEF_FN="$DISTRO_YDRVSFS"
+B_DEF_FN="$DISTRO_BDRVSFS"
 P_DEF_FN="$DISTRO_PUPPYSFS"
+KBUILD_DEF_FN="kbuild-$KERNELVER.sfs"
 
 if [ ! "$LOGLEVEL" ] ; then
   echo '3' > /proc/sys/kernel/printk # '3' is the standard loglevel.
@@ -230,6 +233,8 @@ decode_other_ids() {
  [ "$ONE_PART" ] && { A_PART="$ONE_PART"; A_BP_ID=""; }
  decode_id "$Y_BP_ID"
  [ "$ONE_PART" ] && { Y_PART="$ONE_PART"; Y_BP_ID=""; }
+ decode_id "$B_BP_ID"
+ [ "$ONE_PART" ] && { B_PART="$ONE_PART"; B_BP_ID=""; }
  decode_id "$SAVE_BP_ID"
  [ "$ONE_PART" ] && { SAVEPART="$ONE_PART"; PSAVEPART="$ONE_PART"; SAVE_BP_ID=""; }
 }
@@ -772,6 +777,7 @@ echo -e "\\033[0;34m ***\\033[0;39m"
 [ $fdrv ] && FDRV=$fdrv
 [ $adrv ] && ADRV=$adrv
 [ $ydrv ] && YDRV=$ydrv
+[ $bdrv ] && BDRV=$bdrv
 #<partition>:<filename>, for savefile/savefolder. <partition> can be a name or Label or UUID
 [ $psave ] && PSAVE=$psave #ex: sdb4:/puppy/tahr/tahrsave or smark or 49baa82d-8c69:tahrsave
 #list of kernel modules to load, ex: pimod=hid-logitech-dj.ko,kernel/drivers/hid/hid-multitouch.ko 
@@ -828,6 +834,7 @@ fi
 [ "$FDRV" ] && { decode_spec "$FDRV"; F_BP_ID="$ONE_BP_ID"; F_BP_FN="$ONE_BP_FN"; FDRV=""; }	
 [ "$ADRV" ] && { decode_spec "$ADRV"; A_BP_ID="$ONE_BP_ID"; A_BP_FN="$ONE_BP_FN"; ADRV=""; }
 [ "$YDRV" ] && { decode_spec "$YDRV"; Y_BP_ID="$ONE_BP_ID"; Y_BP_FN="$ONE_BP_FN"; YDRV=""; }
+[ "$BDRV" ] && { decode_spec "$BDRV"; B_BP_ID="$ONE_BP_ID"; B_BP_FN="$ONE_BP_FN"; BDRV=""; }
 [ "$PSAVE" ] && { decode_spec "$PSAVE"; SAVE_BP_ID="$ONE_BP_ID"; SAVE_BP_FN="$ONE_BP_FN"; }
 SAVE_BP_DIR=""
 [ "$SAVE_BP_FN" ] && [ "${SAVE_BP_FN:$((${#SAVE_BP_FN} - 1))}" = "/" ] && SAVE_BP_DIR="$SAVE_BP_FN" #last char
@@ -839,6 +846,7 @@ SAVE_BP_DIR=""
 [ -f /${F_DEF_FN} ] && { FDRV="rootfs,rootfs,/$F_DEF_FN"; F_DEF_FN=""; }
 [ -f /${A_DEF_FN} ] && { ADRV="rootfs,rootfs,/$A_DEF_FN"; A_DEF_FN=""; }
 [ -f /${Y_DEF_FN} ] && { YDRV="rootfs,rootfs,/$Y_DEF_FN"; Y_DEF_FN=""; }
+[ -f /${B_DEF_FN} ] && { BDRV="rootfs,rootfs,/$B_DEF_FN"; B_DEF_FN=""; }
 
 #setup wireless
 [ "$PWIRELESS" ] && echo -e "SSID=${PWIRELESS%:*}\nPSWD=${PWIRELESS#*:}" > /tmp/wireless.conf
@@ -949,6 +957,7 @@ PUP_LAYER="$SFS_MP"
 [ "$F_BP_ID" ] && log_part_id "$F_BP_ID"
 [ "$A_BP_ID" ] && log_part_id "$A_BP_ID"
 [ "$Y_BP_ID" ] && log_part_id "$Y_BP_ID"
+[ "$B_BP_ID" ] && log_part_id "$B_BP_ID"
 [ "$SAVE_BP_ID" ] && log_part_id "$SAVE_BP_ID"
 
 #have basic system, now try to add optional stuff
@@ -964,9 +973,17 @@ find_onepupdrv "$Y_PART" "$Y_BP_FN" "$Y_DEF_FN" "y"
 [ "$ONE_FN" ] && YDRV="$ONE_PART,$ONE_FS,$ONE_FN"
 [ "$YDRV" ] && { LOADMSG="ydrv"; setup_onepupdrv "$YDRV" "y" "p"; }
 
+find_onepupdrv "$B_PART" "$B_BP_FN" "$B_DEF_FN" "b"
+[ "$ONE_FN" ] && BDRV="$ONE_PART,$ONE_FS,$ONE_FN"
+[ "$BDRV" ] && { LOADMSG="bdrv"; setup_onepupdrv "$BDRV" "b" "p"; }
+
 find_onepupdrv "$A_PART" "$A_BP_FN" "$A_DEF_FN" "a"
 [ "$ONE_FN" ] && ADRV="$ONE_PART,$ONE_FS,$ONE_FN"
 [ "$ADRV" ] && { LOADMSG="adrv"; setup_onepupdrv "$ADRV" "a" "p"; }
+
+find_onepupdrv "" "" "$KBUILD_DEF_FN" "k"
+[ "$ONE_FN" ] && KBUILD="$ONE_PART,$ONE_FS,$ONE_FN"
+[ "$KBUILD" ] && { LOADMSG="kbuild"; setup_onepupdrv "$KBUILD" "k" "p"; }
 
 #process SAVESPEC - takes precedence - written by shutdownconfig
 if [ -f "${P_MP}${PSUBDIR}/SAVESPEC" ];then
@@ -1252,6 +1269,7 @@ echo "ZDRV='$ZDRV'"
 echo "FDRV='$FDRV'"
 echo "ADRV='$ADRV'"
 echo "YDRV='$YDRV'"
+echo "BDRV='$BDRV'"
 echo '#Partition no. override on boot drive to which session is (or will be) saved...'
 echo "PSAVEMARK='$PSAVEMARK'"
 echo "PSAVEPART='$PSAVEPART'"

--- a/initrd-progs/0initrd/sbin/init-bootmenu
+++ b/initrd-progs/0initrd/sbin/init-bootmenu
@@ -35,6 +35,7 @@ decode_entry() {
  Z_FDRV=""
  Z_ADRV=""
  Z_YDRV=""
+ Z_BDRV=""
  Z_SEARCH_DIR=""
  Z_SEARCH_DRIVE=""
  Z_DISTRO_SPECS=""
@@ -59,6 +60,7 @@ decode_entry() {
    FDRV) Z_FDRV=${VALUE} ;;
    ADRV) Z_ADRV=${VALUE} ;;
    YDRV) Z_YDRV=${VALUE} ;;
+   BDRV) Z_BDRV=${VALUE} ;;
    SEARCH_DIR)   Z_SEARCH_DIR=${VALUE}   ;;
    SEARCH_DRIVE) Z_SEARCH_DRIVE=${VALUE} ;;
    DISTRO_SPECS) Z_DISTRO_SPECS=${VALUE} ;;
@@ -159,6 +161,7 @@ exec_init() {
  [ "$Z_FDRV" ]      && export fdrv=$Z_FDRV
  [ "$Z_ADRV" ]      && export adrv=$Z_ADRV
  [ "$Z_YDRV" ]      && export ydrv=$Z_YDRV
+ [ "$Z_BDRV" ]      && export bdrv=$Z_BDRV
  clear
 }
 

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -26,6 +26,7 @@ for i in $@ ; do
 			BUILD_DOCX=yes
 			BUILD_NLSX=yes
 			BUILD_BDRV=yes
+			ADD_KBUILD=yes
 			;;
 	esac
 done
@@ -988,12 +989,6 @@ if [ "$BUILD_SFS" = 'yes' ]; then
 			if [ "$ISOFLAG" -o "$FRUGALIFY" ]; then
 				echo "Now building sandbox3/bdrv"
 				$MWD/support/bdrv.sh || exit 1
-
-				if [ "$ISOFLAG" ]; then
-					echo "Unifying bdrv with rootfs-complete"
-					cp -av bdrv/* rootfs-complete/ || exit 1
-					rm -rf bdrv
-				fi
 			fi
 			;;
 		esac
@@ -1141,9 +1136,9 @@ if [ "$SDFLAG" = "" -a "$CROSFLAG" = "" ] ; then #120506
 			mv -f ${NLSXSFS} ../${WOOF_OUTPUT}/
 			( cd ../${WOOF_OUTPUT} ; md5sum ${NLSXSFS} > ${NLSXSFS}.md5.txt )
 		fi
-		if [ -f build/${BDRVSFS} ] ; then
-			mv -f build/${BDRVSFS} ../${WOOF_OUTPUT}/
-			( cd ../${WOOF_OUTPUT} ; md5sum ${BDRVSFS} > ${BDRVSFS}.md5.txt )
+		if [ "$ADD_KBUILD" = "yes" ]; then
+			KBUILDSFS="`ls ../kernel-kit/output/kbuild-*.sfs 2>/dev/null`"
+			[ -n "${KBUILDSFS}" ] && cp -f ${KBUILDSFS} ./build/
 		fi
 
 		echo "Running ../support/mk_iso.sh"

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -649,7 +649,7 @@ add_new_sfs_list() {
 	local Q=$2
 	[ "$Q" ] && Q="@($QUEUED)"
 	case "$F" in
-		$SFSBASE|$ZDRBASE|$ADRBASE|$YDRBASE|$FDRBASE) return 1 ;;
+		$SFSBASE|$ZDRBASE|$ADRBASE|$YDRBASE|$BDRBASE|$FDRBASE|kbuild-*.sfs) return 1 ;;
 		*.sfs|*.sb|*.lzm|*.xzm|*.squashfs|*.filesystem) ok=1 ;;
 		*) return 1 ;; #only allow sfs files
 	esac
@@ -731,16 +731,18 @@ $ALLSFSLIST"
 	for ONESFS in $ALLSFSLIST
 	do
 		BASEONESFS="`basename $ONESFS`" #100711
-		[ "`echo "$BASEONESFS" | grep -E '^adrv_|^fdrv_|^ydrv_|^zdrv_|^pup_'`" != "" ] && continue
+		[ "`echo "$BASEONESFS" | grep -E '^adrv_|^fdrv_|^ydrv_|^bdrv_|^zdrv_|^pup_|^kbuild-'`" != "" ] && continue
 		[ "`echo "$BASEONESFS" | grep "^${DISTRO_PUPPYSFS}"`" != "" ] && continue #100913
 		[ "${DISTRO_ZDRVSFS}" ] && [ "`echo "$BASEONESFS" | grep "^${DISTRO_ZDRVSFS}"`" != "" ] && continue #100913
 		[ "${DISTRO_ADRVSFS}" ] && [ "`echo "$BASEONESFS" | grep "^${DISTRO_ADRVSFS}"`" != "" ] && continue #v1.9.2: saluki
 		[ "${DISTRO_YDRVSFS}" ] && [ "`echo "$BASEONESFS" | grep "^${DISTRO_YDRVSFS}"`" != "" ] && continue #v2.0.11
+		[ "${DISTRO_BDRVSFS}" ] && [ "`echo "$BASEONESFS" | grep "^${DISTRO_BDRVSFS}"`" != "" ] && continue
 		[ "${DISTRO_FDRVSFS}" ] && [ "`echo "$BASEONESFS" | grep "^${DISTRO_FDRVSFS}"`" != "" ] && continue #v1.9.2: saluki
 		[ "`echo "$BASEONESFS" | grep "^${SFSBASE}"`" != "" ] && continue #100913
 		[ "${ZDRBASE}" ] && [ "`echo "$BASEONESFS" | grep "^${ZDRBASE}"`" != "" ] && continue #100913
 		[ "${ADRBASE}" ] && [ "`echo "$BASEONESFS" | grep "^${ADRBASE}"`" != "" ] && continue #v1.9.2: saluki
 		[ "${YDRBASE}" ] && [ "`echo "$BASEONESFS" | grep "^${YDRBASE}"`" != "" ] && continue #v2.0.11
+		[ "${BDRBASE}" ] && [ "`echo "$BASEONESFS" | grep "^${BDRBASE}"`" != "" ] && continue
 		[ "${FDRBASE}" ] && [ "`echo "$BASEONESFS" | grep "^${FDRBASE}"`" != "" ] && continue #v1.9.2: saluki
 		BASEFIXEDSFSLIST="$BASEFIXEDSFSLIST
 $BASEONESFS"
@@ -1330,8 +1332,9 @@ append_sfs() {
 	#v1.9.1, #v2.0: do not register zdrv #v2.0.11: ditto adrv and ydrv
 	#v2.1.8: avoid dup. in EXTRASFSLIST
 	case "$FILENAME" in
-		$DISTRO_PUPPYSFS|$DISTRO_ZDRVSFS|$DISTRO_ADRVSFS|$DISTRO_YDRVSFS|$DISTRO_FDRVSFS) :;;
-		$SFSBASE|$ZDRBASE|$ADRBASE|$YDRBASE|$FDRBASE) :;;
+		$DISTRO_PUPPYSFS|$DISTRO_ZDRVSFS|$DISTRO_ADRVSFS|$DISTRO_YDRVSFS|$DISTRO_BDRVSFS|$DISTRO_FDRVSFS) :;;
+		$SFSBASE|$ZDRBASE|$ADRBASE|$YDRBASE|$BDRBASE|$FDRBASE) :;;
+		kbuild-*.sfs) :;;
 		*) echo $EXTRASFSLIST | grep -qw "$FILENAME" || EXTRASFSLIST="$EXTRASFSLIST $FILENAME";;
 	esac
 	save_bootconfig
@@ -1746,6 +1749,7 @@ SFSBASE=$(basename "$SFSFILE")
 ZDRBASE=${ZDRV##*/}
 ADRBASE=${ADRV##*/}
 YDRBASE=${YDRV##*/}
+BDRBASE=${BDRV##*/}
 FDRBASE=${FDRV##*/}
 
 KERNVER="`uname -r | cut -f 1 -d \-`" #20151004
@@ -2032,7 +2036,7 @@ ALINE=$(echo $LASTUNIONRECORD | grep -o -w "$PATTERN")
 if [ "$ALINE" ]; then
 	#v2.0: fix zdrv, adrv #2.0.8 ydrv
 	case "$FILENAME" in
-		$SFSBASE|$ZDRBASE|$ADRBASE|$YDRBASE|$FDRBASE) fatal $(printf "$(gettext "'%s' is the system file and cannot be removed.")" "$FILENAME");;
+		$SFSBASE|$ZDRBASE|$ADRBASE|$YDRBASE|$BDRBASE|$FDRBASE|kbuild-*.sfs) fatal $(printf "$(gettext "'%s' is the system file and cannot be removed.")" "$FILENAME");;
 	esac
 	FILENAME=$(keyword $ALINE)
 	EXTRASFS="$DIRNAME/$FILENAME"


### PR DESCRIPTION
This PR complements #2963.

- [x] Allow sfs_load to re-add a SFS to EXTRASFSLIST if removed but still loaded - fixed in 2ee35c8