### PR TITLE
Suspend on lid close even if a USB device is mounted

### DIFF
--- a/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
+++ b/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
@@ -26,17 +26,21 @@ PS=$(ps)
 [ ! -f /tmp/suspend ] && echo "$PS"| grep -qE 'sh[ ].*poweroff' && rm -f "$LOCKFILE" && exit 0
 rm -f /tmp/suspend
 
+. /etc/DISTRO_SPECS
+
 # do not suspend if usb media mounted
-USBS=$(probedisk2|grep '|usb' | cut -d'|' -f1 )
-for USB in $USBS
-do
-	mount | grep -q "^$USB" && rm -f "$LOCKFILE" && exit 0
-done
+if [ "$DISTRO_TARGETARCH" = "x86" ]; then
+	USBS=$(probedisk2|grep '|usb' | cut -d'|' -f1 )
+	for USB in $USBS
+	do
+		mount | grep -q "^$USB" && rm -f "$LOCKFILE" && exit 0
+	done
+fi
 
 # process before suspend
 # sync for non-usb drives
 sync
-rmmod ehci_hcd
+[ "$DISTRO_TARGETARCH" = "x86" ] && rmmod ehci_hcd
 
 #suspend
 case "$DISABLE_LOCK" in
@@ -55,7 +59,7 @@ esac
 
 # process at recovery from suspend
 #restartwm
-modprobe ehci_hcd
+[ "$DISTRO_TARGETARCH" = "x86" ] && modprobe ehci_hcd
 #/etc/rc.d/rc.network restart
 
 rm -f "$LOCKFILE"


### PR DESCRIPTION
This thing is driving me crazy!

It's been years since the last time I had a flash drive that complains it's disconnected and doesn't properly resume from suspend. Is this still a problem in 2022?

It takes a very long time for Puppy to boot from USB, and constantly shutting down, only because my laptop doesn't suspend when Puppy is booted from a flash drive, is not an option.