### PR TITLE
Use read-only loopback devices for ISO images

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/filemnt
+++ b/woof-code/rootfs-skeleton/usr/sbin/filemnt
@@ -177,7 +177,7 @@ if [ "$MNTEDLOOP" = "" ];then #not mounted on $MOUNTPOINT
   else #normal, no encryption... 130204 mavrothal: fix spaces in imgFile...
     case $Type in 
       iso|udf|iso9660) #iso img might have more than 1 fs. prefer udf..
-         mount -t udf -o loop "$imgFile" "$MOUNTPOINT" || mount -t iso9660 -o loop "$imgFile" "$MOUNTPOINT"
+         mount -r -t udf -o loop "$imgFile" "$MOUNTPOINT" || mount -r -t iso9660 -o loop "$imgFile" "$MOUNTPOINT"
          ;;
       exfat)
          mount -t exfat -o loop "$imgFile" "$MOUNTPOINT" || {


### PR DESCRIPTION
Files opened for writing get copied from pup_ro1 to pup_rw, making them super slow to mount. In addition, these large files get written to pup_ro1 later.