### PR TITLE
Always strip debugging symbols from kernel modules

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -855,7 +855,7 @@ else
 	export MAKE_TARGETS="bzImage modules"
 fi
 echo "$MAKE ${JOBS} ${MAKE_TARGETS}
-$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} modules_install" > compile ## debug
+$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} INSTALL_MOD_STRIP=1 modules_install" > compile ## debug
 
 log_msg "Compiling the kernel"
 $MAKE ${JOBS} ${MAKE_TARGETS} >> ${BUILD_LOG} 2>&1
@@ -879,7 +879,7 @@ fi
 #---------------------------------------------------------------------
 
 log_msg "Creating the kernel package"
-$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} modules_install >> ${BUILD_LOG} 2>&1
+$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} INSTALL_MOD_STRIP=1 modules_install >> ${BUILD_LOG} 2>&1
 if [ "$remove_sublevel" = "yes" ]; then
 	rm -f ${linux_kernel_dir}/lib/modules/${kernel_major_version}.0/{build,source}
 else


### PR DESCRIPTION
This is not the same as forcing `STRIP_KMODULES=yes`, because the latter removes more symbols.

This PR makes it possible to build a kernel with debugging symbols, which supports `bpftrace`, but without making /lib/modules huge (6 GB with 5.15.x). This tool is extremely useful, and can be used for many things: for example, I'd like to explore the possibility of using it to detect frequently accessed files on pup_ro1 and copy them to pup_rw, or replace snapmergepuppy with a more efficient solution.

EDIT: work great, a debugging-enabled kernel is 2 MB bigger, and zdrv is only 15 MB bigger. All bpftrace examples I tried worked. Kernels without debugging symbols (= all Puppy kernels today) are unaffected by this PR, because there's nothing to strip.