### PR TITLE
Backport jammy64 package list cleanup to dpup

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -79,6 +79,7 @@ yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc,nls||deps:yes
 no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
+yes|cpp|cpp|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
 yes|crda|crda,wireless-regdb|exe,dev,doc,nls||deps:yes
 no|ctorrent|ctorrent|exe,dev>null,doc,nls
 no|cryptsetup||exe # must use wce static binary
@@ -96,12 +97,12 @@ yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1|exe,dev,doc,nls||deps
 yes|debconf|debconf|exe,dev,doc,nls
 yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
 yes|debootstrap|debootstrap|exe>dev,dev,doc,nls||deps:yes
-yes|dejavu_fonts|fonts-dejavu-core,fonts-dejavu-extra|exe,dev,doc,nls||deps:yes
+yes|dejavu_fonts|fonts-dejavu|exe,dev,doc,nls||deps:yes
 no|desk_icon_theme_uniform||exe
 no|desk_icon_theme_neon||exe
 no|desktop-file-utils|desktop-file-utils|exe,dev,doc,nls
 no|devmapper|libdevmapper1.02.1,libdevmapper-dev,libdevmapper-event1.02.1|exe,dev,doc,nls
-yes|dhcpcd|dhcpcd5|exe,dev>null,doc,nls||deps:yes
+no|dhcpcd|dhcpcd5|exe,dev>null,doc,nls||deps:yes
 yes|dialog|dialog|exe,dev>null,doc,nls||deps:yes
 no|dictd||exe,dev>null,doc,nls
 no|dietlibc|dietlibc-dev|exe>dev,dev,doc,nls
@@ -153,7 +154,8 @@ no|gail|libgail18,libgail-common,libgail-dev|exe,dev,doc,nls
 yes|galculator|galculator|exe,dev>null,doc,nls||deps:yes
 no|gamin|gamin,libgamin0,libgamin-dev|exe,dev,doc,nls
 yes|gawk|gawk|exe,dev>null,doc,nls||deps:yes
-yes|gcc_dev|gcc-10-base,gcc,gcc-10,g++,g++-10,cpp,cpp-10|exe>dev,dev,doc,nls||deps:yes #cloog-isl removed
+yes|gcc_dev|gcc,g++|exe>dev,dev,doc,nls||deps:yes
+yes|gcc_lib|libatomic1,libgcc-s1,libgomp1,libquadmath0|exe,dev,doc,nls||deps:yes
 no|gconf|gconf2-common,gconf2,libgconf-2-4,libgconf2-dev,libgconf-2-4,gconf-service|exe,dev,doc,nls||deps:yes
 yes|gdb|gdb,libboost-regex1.74.0|exe>dev,dev,doc,nls||deps:yes
 yes|gdbm|libgdbm6|exe,dev,doc,nls||deps:yes
@@ -162,8 +164,9 @@ no|gdmap|gdmap|exe,dev>null,doc,nls
 no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
 no|getflash||exe
 no|get_libreoffice||exe
-yes|gettext_devxonly|gettext-base,gettext|exe>dev,dev,doc,nls||deps:yes
-yes|gettext|gettext-base,gettext|exe,dev>null,doc,nls||deps:yes
+no|gettext_devxonly|gettext-base,gettext|exe>dev,dev,doc,nls||deps:yes
+no|gettext|gettext-base,gettext|exe,dev>null,doc,nls||deps:yes
+yes|gettext-full|gettext-base,gettext|exe,dev,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
 no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls
@@ -196,7 +199,7 @@ no|gpptp||exe,dev>null,doc,nls
 no|gptfdisk||exe,doc,dev,nls
 yes|graphite2|libgraphite2-3,libgraphite2-dev|exe,dev,doc,nls||deps:yes #needed by harfbuzz.
 yes|grep|grep|exe,dev>null,doc,nls||deps:yes
-yes|groff|groff|exe>dev,dev,doc,nls||deps:yes
+yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
 no|grub4dos||exe,dev>null,doc,nls
@@ -292,11 +295,12 @@ yes|libdb|libdb5.3,libdb5.3-dev|exe>dev,dev,doc,nls||deps:yes
 no|libdbusmenu|libdbusmenu-gtk3-4,libdbusmenu-glib4|exe,dev,doc,nls #needed by libappindicator. left off dev debs.
 no|libdc1394|libdc1394-22,libdc1394-22-dev|exe,dev,doc,nls #ffmpeg3 compiled in luci needs this
 no|libdca|libdca0,libdca-dev|exe,dev,doc,nls #mplayer needs this.
-yes|libdeflate|libdeflate0|exe,dev,doc,nls||deps:yes
+no|libdeflate|libdeflate0|exe,dev,doc,nls||deps:yes
 no|libdmx|libdmx1,libdmx-dev|exe,dev,doc,nls||deps:yes #this is actaully part of xorg.
 no|libdvdcss||exe,dev,doc,nls
 no|libdvdnav|libdvdnav4|exe,dev,doc,nls #needed by mplayer.
 no|libdvdread|libdvdread4,libdvdread-dev|exe,dev,doc,nls
+yes|libdw|libdw1|exe,dev,doc,nls||deps:yes #needed by gnome-software
 yes|libedit|libedit2|exe,dev,doc,nls||deps:yes
 yes|libelf|libelf1,libelf-dev|exe,dev,doc,nls||deps:yes
 no|libenca|libenca0,libenca-dev|exe,dev,doc,nls
@@ -401,12 +405,13 @@ no|libtheora|libtheora0,libtheora-dev|exe,dev,doc,nls
 yes|libtiff|libtiff5|exe,dev,doc,nls||deps:yes
 yes|libtool|libtool,autotools-dev|exe>dev,dev,doc,nls||deps:yes
 yes|libtirpc|libtirpc3,libtirpc-common,libtirpc-dev|exe,dev,doc,nls||deps:yes
+yes|libuchardet|libuchardet0|exe,dev,doc,nls||deps:yes
 yes|libudev|libudev1,libudev-dev|exe,dev,doc,nls||deps:yes
 yes|libunbound|libunbound8|exe,dev,doc,nls||deps:yes
 yes|libunistring|libunistring2|exe,dev,doc,nls||deps:yes
 no|libusb|libusb-0.1-4,libusb-dev|exe,dev,doc,nls
 yes|libusb1|libusb-1.0-0|exe,dev,doc,nls||deps:yes #libusb1 necesssary for ffmpeg3
-yes|libutf8proc|libutf8proc2|exe>dev,dev,doc,nls||deps:yes
+no|libutf8proc|libutf8proc2|exe>dev,dev,doc,nls||deps:yes
 no|libv4l|libv4l-0,libv4l-dev,libv4lconvert0|exe,dev,doc,nls
 yes|libva|libva2,libva-drm2,libva-x11-2,vainfo,va-driver-all|exe,dev,doc,nls||deps:yes #needed by mplayer.
 no|libvdpau|libvdpau1,mesa-vdpau-drivers,vdpau-va-driver,libvdpau-dev|exe,dev,doc,nls #needed by mplayer. no, this has another big dep: Failed to open VDPAU backend libvdpau_nvidia.so missing.
@@ -417,7 +422,7 @@ no|libwmf|libwmf0.2-7,libwmf-dev|exe,dev,doc,nls
 no|libwpg|libwpg-0.3-3|exe,dev>null,doc,nls
 no|libwpd|libwpd-0.10-10,libwpd-dev|exe,dev,doc,nls
 no|libxatracker2|libxatracker2,libxatracker-dev|exe,dev,doc,nls
-yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-xinput0,libxcb-xinput-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-res0,libxcb-res0-dev|exe,dev,doc,nls||deps:yes
+yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri3-0,libxcb-dri3-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-render0,libxcb-render0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-render0,libxcb-render0-dev|exe,dev,doc,nls||deps:yes
 yes|libz3|libz3-4|exe,dev,doc,nls||deps:yes
 no|libzip|libzip4,libzip-dev|exe,dev,doc,nls
 yes|xcb-util|libxcb-util1,libxcb-util-dev|exe,dev,doc,nls||deps:yes
@@ -426,7 +431,7 @@ yes|libxkbcommon|libxkbcommon0,libxkbcommon-dev,libxkbcommon-x11-0,libxkbcommon-
 yes|libxml2|libxml2,libxml2-dev|exe,dev,doc,nls||deps:yes
 yes|libxml2-utils|libxml2-utils|exe>dev,dev,doc,nls||deps:yes
 yes|libxshmfence|libxshmfence1,libxshmfence-dev|exe,dev,doc,nls||deps:yes #xorg needs this.
-yes|libxslt|libxslt1.1|exe,dev,doc,nls||deps:yes
+yes|libxslt|libxslt1.1|exe>dev,dev,doc,nls||deps:yes
 no|libxvmc|libxvmc1,libxvmc-dev|exe,dev,doc,nls||deps:yes #this is actually part of xorg.
 yes|libxxhash|libxxhash0|exe,dev,doc,nls||deps:yes
 yes|libzstd|libzstd1|exe,dev,doc,nls||deps:yes
@@ -451,13 +456,13 @@ yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls||deps:yes
 yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
-yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,mesa-va-drivers,libglu1-mesa,libglu1-mesa-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
+yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
 yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls
 no|mhwaveedit|mhwaveedit|exe,dev>null,doc,nls
 no|miniupnpc|libminiupnpc*,libminiupnpc-dev|exe,dev,doc,nls #needed by transmission.
 no|mirdir||exe
-yes|mpclib3|libmpc3|exe>dev,dev,doc,nls||deps:yes #needed by gcc.
+yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
 yes|mpfr|libmpfr6|exe>dev,dev,doc,nls||deps:yes
 no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
@@ -515,7 +520,7 @@ yes|pavucontrol|pavucontrol|exe,dev,doc,nls||deps:yes
 no|pbackup||exe
 yes|pciutils|pciutils,libpci3|exe,dev,doc,nls||deps:yes
 no|pcmciautils|pcmciautils|exe,dev,doc,nls
-yes|pcre|libpcre2-8-0,libpcre2-dev,libpcre3,libpcre3-dev,libpcre16-3,libpcrecpp0v5|exe,dev,doc,nls||deps:yes
+yes|pcre|libpcre3,libpcre3-dev,libpcre2-8-0,libpcre16-3,libpcrecpp0v5|exe,dev,doc,nls||deps:yes
 no|pdiag||exe| #diagnostic tool created by rerwin.
 no|pdvdrsab||exe
 no|peasydisc||exe
@@ -581,12 +586,12 @@ no|sane-backends||exe,dev,doc,nls
 no|scale2x||exe
 no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc,nls
 yes|sed|sed|exe,dev>null,doc,nls||deps:yes
-yes|sensible-utils|sensible-utils|exe>null,dev>null,doc>null,nls>null
+yes|sensible-utils|sensible-utils|exe,dev,doc,nls||deps:yes
 yes|serf|libserf-1-1|exe>dev,dev,doc,nls||deps:yes #needed by svn.
 no|setserial|setserial|exe,dev>null,doc,nls
 yes|sgml-base|sgml-base|exe,dev,doc,nls||deps:yes
 yes|sgml-data|sgml-data|exe>dev,dev,doc,nls||deps:yes
-yes|shared-mime-info|shared-mime-info|exe,dev,doc,nls||deps:yes
+yes|shared-mime-info|shared-mime-info|exe,dev>exe,doc,nls||deps:yes
 no|simple-mtpfs||exe,dev,doc,nls #pupmtp
 yes|sqlite|libsqlite3-0|exe,dev,doc,nls||deps:yes
 yes|squashfs-tools|squashfs-tools|exe,dev,doc,nls||deps:yes
@@ -629,7 +634,8 @@ no|vobcopy|vobcopy|exe,dev,doc,nls
 no|vorbis-tools|vorbis-tools|exe,dev,doc,nls
 yes|vboot-kernel-utils|vboot-kernel-utils|exe->dev,dev,doc,nls||deps:yes
 yes|vte|libvte-2.91-0,libvte-2.91-common,libvte-2.91-dev|exe,dev,doc,nls||deps:yes
-yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0,libwayland-dev,wayland-protocols,libwayland-bin|exe,dev,doc,nls||deps:yes
+yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0|exe,dev,doc,nls||deps:yes
+yes|wayland-dev|libwayland-dev,wayland-protocols,libwayland-bin|exe>dev,dev,doc,nls||deps:yes
 no|wcpufreq||exe,dev| #using this instead of cpu-scaling-ondemand.
 yes|wget|wget|exe,dev>null,doc,nls||deps:yes
 yes|wireless-tools|wireless-tools,libiw30,libiw-dev|exe,dev,doc,nls||deps:yes
@@ -681,6 +687,7 @@ fi
 case $DISTRO_TARGETARCH in
 x86)
     PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|dhcpcd|dhcpcd5|exe,dev>null,doc,nls||deps:yes
 yes|gcc_lib|libatomic1,libcc1-0,libgcc-s1,libgomp1,libisl23,libitm1,libquadmath0|exe,dev,doc,nls||deps:yes #libcloog-isl4 and libisl15 removed for Bullseye
 yes|mtools|mtools|exe,dev,doc,nls||deps:yes
 yes|syslinux|syslinux,syslinux-common,syslinux-utils,syslinux-efi,extlinux,isolinux|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -80,6 +80,7 @@ yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc,nls||deps:yes
 no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
+yes|cpp|cpp|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
 no|ctorrent|ctorrent|exe,dev>null,doc,nls
 no|cryptsetup||exe # must use wce static binary
@@ -97,12 +98,12 @@ yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1|exe,dev,doc,nls||deps
 yes|debconf|debconf|exe,dev,doc,nls
 yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
 yes|debootstrap|debootstrap|exe>dev,dev,doc,nls||deps:yes
-yes|dejavu_fonts|fonts-dejavu-core,fonts-dejavu-extra|exe,dev,doc,nls||deps:yes
+yes|dejavu_fonts|fonts-dejavu|exe,dev,doc,nls||deps:yes
 no|desk_icon_theme_uniform||exe
 no|desk_icon_theme_neon||exe
 no|desktop-file-utils|desktop-file-utils|exe,dev,doc,nls
 no|devmapper|libdevmapper1.02.1,libdevmapper-dev,libdevmapper-event1.02.1|exe,dev,doc,nls
-yes|dhcpcd|dhcpcd5|exe,dev>null,doc,nls||deps:yes
+no|dhcpcd|dhcpcd5|exe,dev>null,doc,nls||deps:yes
 yes|dialog|dialog|exe,dev>null,doc,nls||deps:yes
 no|dictd||exe,dev>null,doc,nls
 no|dietlibc|dietlibc-dev|exe>dev,dev,doc,nls
@@ -166,8 +167,7 @@ no|gdmap|gdmap|exe,dev>null,doc,nls
 no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
 no|getflash||exe
 no|get_libreoffice||exe
-yes|gettext_devxonly|gettext-base,gettext|exe>dev,dev,doc,nls||deps:yes
-yes|gettext|gettext-base,gettext|exe,dev>null,doc,nls||deps:yes
+yes|gettext-full|gettext-base,gettext|exe,dev,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
 no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls
@@ -202,7 +202,7 @@ no|gpptp||exe,dev>null,doc,nls
 no|gptfdisk||exe,doc,dev,nls
 yes|graphite2|libgraphite2-3,libgraphite2-dev|exe,dev,doc,nls||deps:yes #needed by harfbuzz.
 yes|grep|grep|exe,dev>null,doc,nls||deps:yes
-yes|groff|groff|exe>dev,dev,doc,nls||deps:yes
+yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
 no|grub4dos||exe,dev>null,doc,nls
@@ -298,11 +298,12 @@ yes|libdb|libdb5.3,libdb5.3-dev|exe>dev,dev,doc,nls||deps:yes
 no|libdbusmenu|libdbusmenu-gtk3-4,libdbusmenu-glib4|exe,dev,doc,nls #needed by libappindicator. left off dev debs.
 no|libdc1394|libdc1394-22,libdc1394-22-dev|exe,dev,doc,nls #ffmpeg3 compiled in luci needs this
 no|libdca|libdca0,libdca-dev|exe,dev,doc,nls #mplayer needs this.
-yes|libdeflate|libdeflate0|exe,dev,doc,nls||deps:yes
+no|libdeflate|libdeflate0|exe,dev,doc,nls||deps:yes
 no|libdmx|libdmx1,libdmx-dev|exe,dev,doc,nls||deps:yes #this is actaully part of xorg.
 no|libdvdcss||exe,dev,doc,nls
 no|libdvdnav|libdvdnav4|exe,dev,doc,nls #needed by mplayer.
 no|libdvdread|libdvdread4,libdvdread-dev|exe,dev,doc,nls
+yes|libdw|libdw1|exe,dev,doc,nls||deps:yes #needed by gnome-software
 yes|libedit|libedit2|exe,dev,doc,nls||deps:yes
 yes|libelf|libelf1,libelf-dev|exe,dev,doc,nls||deps:yes
 no|libenca|libenca0,libenca-dev|exe,dev,doc,nls
@@ -408,12 +409,13 @@ no|libtheora|libtheora0,libtheora-dev|exe,dev,doc,nls
 yes|libtiff|libtiff5|exe,dev,doc,nls||deps:yes
 yes|libtool|libtool,autotools-dev|exe>dev,dev,doc,nls||deps:yes
 yes|libtirpc|libtirpc3,libtirpc-common,libtirpc-dev|exe,dev,doc,nls||deps:yes
+yes|libuchardet|libuchardet0|exe,dev,doc,nls||deps:yes
 yes|libudev|libudev1,libudev-dev|exe,dev,doc,nls||deps:yes
 yes|libunbound|libunbound8|exe,dev,doc,nls||deps:yes
 yes|libunistring|libunistring2|exe,dev,doc,nls||deps:yes
 no|libusb|libusb-0.1-4,libusb-dev|exe,dev,doc,nls
 yes|libusb1|libusb-1.0-0|exe,dev,doc,nls||deps:yes #libusb1 necesssary for ffmpeg3
-yes|libutf8proc|libutf8proc2|exe>dev,dev,doc,nls||deps:yes
+no|libutf8proc|libutf8proc2|exe>dev,dev,doc,nls||deps:yes
 no|libv4l|libv4l-0,libv4l-dev,libv4lconvert0|exe,dev,doc,nls
 yes|libva|libva2,libva-drm2,libva-x11-2,vainfo,va-driver-all|exe,dev,doc,nls||deps:yes #needed by mplayer.
 no|libvdpau|libvdpau1,mesa-vdpau-drivers,vdpau-va-driver,libvdpau-dev|exe,dev,doc,nls #needed by mplayer. no, this has another big dep: Failed to open VDPAU backend libvdpau_nvidia.so missing.
@@ -424,7 +426,7 @@ no|libwmf|libwmf0.2-7,libwmf-dev|exe,dev,doc,nls
 no|libwpg|libwpg-0.3-3|exe,dev>null,doc,nls
 no|libwpd|libwpd-0.10-10,libwpd-dev|exe,dev,doc,nls
 no|libxatracker2|libxatracker2,libxatracker-dev|exe,dev,doc,nls
-yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri3-0,libxcb-dri3-dev,libxcb-icccm4,libxcb-icccm4-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-render-util0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-composite0,libxcb-composite0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-xinput0,libxcb-xinput-dev,libxcb-render0,libxcb-render0-dev,libxcb-render-util0,libxcb-res0,libxcb-res0-dev|exe,dev,doc,nls||deps:yes
+yes|libxcb_base|libxcb1,libxcb1-dev,libxcb-dri2-0,libxcb-dri3-0,libxcb-dri3-dev,libxcb-xkb1,libxcb-xkb-dev,libxcb-present0,libxcb-present-dev,libxcb-render0,libxcb-render0-dev,libxcb-shape0,libxcb-shape0-dev,libxcb-shm0,libxcb-shm0-dev,libxcb-sync1,libxcb-sync-dev,libxcb-glx0,libxcb-glx0-dev,libxcb-xfixes0,libxcb-xfixes0-dev,libxcb-damage0,libxcb-damage0-dev,libxcb-render0,libxcb-render0-dev|exe,dev,doc,nls||deps:yes
 yes|libz3|libz3-4|exe,dev,doc,nls||deps:yes
 no|libzip|libzip4,libzip-dev|exe,dev,doc,nls
 yes|xcb-util|libxcb-util1,libxcb-util-dev|exe,dev,doc,nls||deps:yes
@@ -433,7 +435,7 @@ yes|libxkbcommon|libxkbcommon0,libxkbcommon-dev,libxkbcommon-x11-0,libxkbcommon-
 yes|libxml2|libxml2,libxml2-dev|exe,dev,doc,nls||deps:yes
 yes|libxml2-utils|libxml2-utils|exe>dev,dev,doc,nls||deps:yes
 yes|libxshmfence|libxshmfence1,libxshmfence-dev|exe,dev,doc,nls||deps:yes #xorg needs this.
-yes|libxslt|libxslt1.1|exe,dev,doc,nls||deps:yes
+yes|libxslt|libxslt1.1|exe>dev,dev,doc,nls||deps:yes
 no|libxvmc|libxvmc1,libxvmc-dev|exe,dev,doc,nls||deps:yes #this is actually part of xorg.
 yes|libyaml|libyaml-0-2,libyaml-dev|exe,dev,doc,nls||deps:yes
 yes|libxxhash|libxxhash0|exe,dev,doc,nls||deps:yes
@@ -459,13 +461,13 @@ yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls||deps:yes
 yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
-yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,mesa-va-drivers,libglu1-mesa,libglu1-mesa-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
+yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
 yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls
 no|mhwaveedit|mhwaveedit|exe,dev>null,doc,nls
 no|miniupnpc|libminiupnpc*,libminiupnpc-dev|exe,dev,doc,nls #needed by transmission.
 no|mirdir||exe
-yes|mpclib3|libmpc3|exe>dev,dev,doc,nls||deps:yes #needed by gcc.
+yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
 yes|mpfr|libmpfr6|exe>dev,dev,doc,nls||deps:yes
 no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
@@ -523,7 +525,7 @@ yes|pavucontrol|pavucontrol|exe,dev,doc,nls||deps:yes
 no|pbackup||exe
 yes|pciutils|pciutils,libpci3|exe,dev,doc,nls||deps:yes
 no|pcmciautils|pcmciautils|exe,dev,doc,nls
-yes|pcre|libpcre2-8-0,libpcre2-dev,libpcre3,libpcre3-dev,libpcre16-3,libpcrecpp0v5|exe,dev,doc,nls||deps:yes
+yes|pcre|libpcre3,libpcre3-dev,libpcre2-8-0,libpcre16-3,libpcrecpp0v5|exe,dev,doc,nls||deps:yes
 no|pdiag||exe| #diagnostic tool created by rerwin.
 no|pdvdrsab||exe
 no|peasydisc||exe
@@ -591,12 +593,12 @@ no|scale2x||exe
 no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc,nls
 yes|scdoc|scdoc|exe>dev,dev,doc,nls||deps:yes
 yes|sed|sed|exe,dev>null,doc,nls||deps:yes
-yes|sensible-utils|sensible-utils|exe>null,dev>null,doc>null,nls>null
+yes|sensible-utils|sensible-utils|exe,dev,doc,nls||deps:yes
 yes|serf|libserf-1-1|exe>dev,dev,doc,nls||deps:yes #needed by svn.
 no|setserial|setserial|exe,dev>null,doc,nls
 yes|sgml-base|sgml-base|exe,dev,doc,nls||deps:yes
 yes|sgml-data|sgml-data|exe>dev,dev,doc,nls||deps:yes
-yes|shared-mime-info|shared-mime-info|exe,dev,doc,nls||deps:yes
+yes|shared-mime-info|shared-mime-info|exe,dev>exe,doc,nls||deps:yes
 no|simple-mtpfs||exe,dev,doc,nls #pupmtp
 yes|sqlite|libsqlite3-0|exe,dev,doc,nls||deps:yes
 yes|squashfs-tools|squashfs-tools|exe,dev,doc,nls||deps:yes
@@ -640,7 +642,8 @@ no|vobcopy|vobcopy|exe,dev,doc,nls
 no|vorbis-tools|vorbis-tools|exe,dev,doc,nls
 yes|vboot-kernel-utils|vboot-kernel-utils|exe->dev,dev,doc,nls||deps:yes
 yes|vte|libvte-2.91-0,libvte-2.91-common,libvte-2.91-dev|exe,dev,doc,nls||deps:yes
-yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0,libwayland-dev,wayland-protocols,libwayland-bin|exe,dev,doc,nls||deps:yes
+yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0|exe,dev,doc,nls||deps:yes
+yes|wayland-dev|libwayland-dev,wayland-protocols,libwayland-bin|exe>dev,dev,doc,nls||deps:yes
 no|wcpufreq||exe,dev| #using this instead of cpu-scaling-ondemand.
 yes|wget|wget|exe,dev>null,doc,nls||deps:yes
 yes|wireless-tools|wireless-tools,libiw30,libiw-dev|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
This PR makes devx obsolete, by moving the _DEV part of development packages and _DEV dependencies of packages in the main SFS into the main SFS. Now, `apt install build-essential` "just works".