### PR TITLE
.xinitrc: Pipewire improvements

### DIFF
--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -55,6 +55,7 @@ if [ -e /usr/bin/wireplumber ]; then
         while [ ! -e /tmp/runtime-spot/pipewire-0 ]; do sleep 0.1; done
         run-as-spot pipewire-pulse &
         run-as-spot wireplumber &
+	run-as-spot pipewire-media-session &
     ) &
     export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
     export PULSE_COOKIE=/home/spot/.config/pulse/cookie


### PR DESCRIPTION
Run pipewire-media-session on login, pipewire cannot detect the audio device if pipewire-media-session is not running.