### PR TITLE
More ROX-Filer-like default settings in PCManFM

### DIFF
--- a/woof-code/rootfs-petbuilds/pcmanfm/libfm-defaults.patch
+++ b/woof-code/rootfs-petbuilds/pcmanfm/libfm-defaults.patch
@@ -1,7 +1,7 @@
 diff -rupN libfm-1.3.2-orig/data/libfm.conf libfm-1.3.2/data/libfm.conf
---- libfm-1.3.2-orig/data/libfm.conf	2022-01-08 18:04:44.318354384 +0800
-+++ libfm-1.3.2/data/libfm.conf	2022-01-08 18:41:18.794283567 +0800
-@@ -1,13 +1,19 @@
+--- libfm-1.3.2-orig/data/libfm.conf	2022-03-29 09:48:23.721869744 +0300
++++ libfm-1.3.2/data/libfm.conf	2022-03-29 09:50:03.861511139 +0300
+@@ -1,13 +1,20 @@
  [config]
 -single_click=0
 +single_click=1
@@ -11,6 +11,7 @@ diff -rupN libfm-1.3.2-orig/data/libfm.conf libfm-1.3.2/data/libfm.conf
  thumbnail_local=1
  thumbnail_max=2048
 +force_startup_notify=0
++quick_exec=1
  
  [ui]
  big_icon_size=48
@@ -24,8 +25,8 @@ diff -rupN libfm-1.3.2-orig/data/libfm.conf libfm-1.3.2/data/libfm.conf
 +places_desktop=0
 +places_applications=0
 diff -rupN libfm-1.3.2-orig/data/terminals.list libfm-1.3.2/data/terminals.list
---- libfm-1.3.2-orig/data/terminals.list	2022-01-08 18:04:44.318354384 +0800
-+++ libfm-1.3.2/data/terminals.list	2022-01-08 18:41:07.690283925 +0800
+--- libfm-1.3.2-orig/data/terminals.list	2022-03-29 09:48:23.725869726 +0300
++++ libfm-1.3.2/data/terminals.list	2022-03-29 09:48:28.505847953 +0300
 @@ -75,3 +75,6 @@ desktop_id=terminology.desktop
  open_arg=-e
  noclose_arg=--hold -e

--- a/woof-code/rootfs-petbuilds/pcmanfm/pcmanfm-defaults.patch
+++ b/woof-code/rootfs-petbuilds/pcmanfm/pcmanfm-defaults.patch
@@ -1,6 +1,6 @@
 diff -rupN pcmanfm-1.3.2-orig/data/pcmanfm.conf pcmanfm-1.3.2/data/pcmanfm.conf
---- pcmanfm-1.3.2-orig/data/pcmanfm.conf	2022-03-03 17:47:09.716040023 +0200
-+++ pcmanfm-1.3.2/data/pcmanfm.conf	2022-03-03 17:47:21.400039646 +0200
+--- pcmanfm-1.3.2-orig/data/pcmanfm.conf	2022-03-28 19:43:22.688693759 +0300
++++ pcmanfm-1.3.2/data/pcmanfm.conf	2022-03-29 10:11:14.452689377 +0300
 @@ -15,7 +15,7 @@ show_wm_menu=0
  
  [ui]
@@ -10,9 +10,10 @@ diff -rupN pcmanfm-1.3.2-orig/data/pcmanfm.conf pcmanfm-1.3.2/data/pcmanfm.conf
  splitter_pos=150
  side_pane_mode=1
  view_mode=0
-@@ -23,3 +23,5 @@ show_hidden=0
+@@ -23,3 +23,6 @@ show_hidden=0
  sort_type=0
  sort_by=2
  max_tab_chars=32
 +show_statusbar=0
 +pathbar_mode_buttons=1
++desktop_folder_new_win=1


### PR DESCRIPTION
`quick_exec=1` makes pcmanfm start the application specified in the .desktop file, without showing a prompt first.

`desktop_folder_new_win=1` makes pcmanfm open a new window when clicking a desktop icon, instead of adding a new tab to the existing window.