### PR TITLE
Target i686 in petbuilds: libc targets i686 anyway

### DIFF
--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -1,7 +1,7 @@
 if [ -z "$WOOF_CFLAGS"]; then
     case "$DISTRO_TARGETARCH" in
     arm) WOOF_CFLAGS="-march=armv7-a -mfpu=neon-vfpv4 -mfloat-abi=hard" ;;
-    x86) WOOF_CFLAGS="-march=i486 -mtune=i686" ;;
+    x86) WOOF_CFLAGS="-march=i686 -mtune=i686" ;;
     x86_64) WOOF_CFLAGS="-march=x86-64 -mtune=generic" ;;
     esac
 fi


### PR DESCRIPTION
See https://github.com/puppylinux-woof-CE/woof-CE/issues/2873#issuecomment-1085556948.

Nobody runs a modern Puppy on an i486, i586 or K6, and the libc we take from other distros targets i686, so this `-march=i486` doesn't really make Puppy compatible with CPUs from the 90s.