### PR TITLE
Allow browsers running as spot to access /dev/dri/renderD*

### DIFF
--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -129,6 +129,10 @@ find bdrv | tac | while read FILE; do
 	RELPATH=${FILE#bdrv/}
 	[ -e "rootfs-complete/$RELPATH" ] || continue
 
+	case "$RELPATH" in
+	etc/group|etc/passwd|etc/shadow) continue ;;
+	esac
+
 	if [ -L "bdrv/$RELPATH" -o -f "bdrv/$RELPATH" ]; then
 		rm -f "bdrv/$RELPATH"
 	elif [ -d "bdrv/$RELPATH" ]; then


### PR DESCRIPTION
Some browsers fall back to software rendering because the `render` group is missing and spot can't access /dev/dri/renderD*, which is belongs to the `root` group.

Happens at least on Wayland.