### PR TITLE
Force children of JWM to use the X11 backend

### DIFF
--- a/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/cage/usr/bin/startxwayland
@@ -62,9 +62,6 @@ for F in $WAYLAND_DISPLAY $WAYLAND_DISPLAY.lock; do
 	mount --bind $XDG_RUNTIME_DIR/$F $SPOT_RUNTIME_DIR/$F
 done
 
-export GDK_BACKEND=x11
-unset SDL_VIDEODRIVER
-
 [ -e "$XDG_CONFIG_HOME/wmonitors/wmon_cmd" ] && . $XDG_CONFIG_HOME/wmonitors/wmon_cmd
 
 "$1"

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startxwayland
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startxwayland
@@ -62,9 +62,6 @@ for F in $WAYLAND_DISPLAY $WAYLAND_DISPLAY.lock; do
 	mount --bind $XDG_RUNTIME_DIR/$F $SPOT_RUNTIME_DIR/$F
 done
 
-export GDK_BACKEND=x11
-unset SDL_VIDEODRIVER
-
 [ -e "$XDG_CONFIG_HOME/wmonitors/wmon_cmd" ] && . $XDG_CONFIG_HOME/wmonitors/wmon_cmd
 
 "$1"

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -6,6 +6,10 @@
 #130525 old pc celeron 2ghz cpu, 256mb ram, CPUSPEED=1999, 1st bootup rox failed to start. try experiment.
 
 export XDG_SESSION_TYPE=x11
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	export GDK_BACKEND=x11
+	unset SDL_VIDEODRIVER
+fi
 
 [ -f /etc/desktop_app ] && read -r desktop < /etc/desktop_app
 [ "$desktop" = "" ] && desktop=rox


### PR DESCRIPTION
More preparation for #3010. This will be useful soon, once dwl is patched to take more of JWM's responsibilities, like keyboard shortcuts. The applications started by .xinitrc, JWM and their children must use their X11 backend to integrate with JWM (for example, tray icons), while native Wayland applications started via the compositor should use the Wayland backend, or the compositor's "rootless" Xwayland as fallback.
