### PR TITLE
Set the GTK+ 3 theme for native Wayland applications

### DIFF
--- a/woof-code/rootfs-packages/ptheme/pinstall.sh
+++ b/woof-code/rootfs-packages/ptheme/pinstall.sh
@@ -38,6 +38,11 @@ echo "that you can specify in build.conf: PTHEME=<theme>"
 
 . usr/share/ptheme/globals/"${theme}"
 
+cat << EOF > root/.pthemerc
+PTHEME_GTK="$PTHEME_GTK"
+PTHEME_ICONS_GTK="$PTHEME_ICONS_GTK"
+EOF
+
 ##### JWM
 [ ! -d root/.jwm ] && mkdir -p root/.jwm
 cp -af usr/share/jwm/themes/"${PTHEME_JWM_COLOR}-jwmrc" root/.jwm/jwmrc-theme

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme
@@ -146,6 +146,12 @@ set_theme (){
 	XPID=$!
 	
 	LANG=C
+
+	cat << EOF > $HOME/.pthemerc
+PTHEME_GTK="$PTHEME_GTK"
+PTHEME_ICONS_GTK="$PTHEME_ICONS_GTK"
+EOF
+
 	#icons
 	if [ "$PTHEME_ICONS" ] && [ -d /usr/local/lib/X11/themes/"$PTHEME_ICONS" ]; then
 		icon_switcher -a "$PTHEME_ICONS"

--- a/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/autostart
+++ b/woof-code/rootfs-petbuilds/labwc/root/.config/labwc/autostart
@@ -9,6 +9,9 @@ esac
 
 swaybg -i `cat ~/.config/wallpaper/bg_img` -m $mode &
 
+. /etc/rc.d/wl_func
+apply_pthemerc
+
 # allow applications running as spot to talk to labwc
 SPOT_RUNTIME_DIR=`run-as-spot sh -c 'mkdir -p $XDG_RUNTIME_DIR && echo $XDG_RUNTIME_DIR'`
 for F in $WAYLAND_DISPLAY $WAYLAND_DISPLAY.lock; do

--- a/woof-code/rootfs-skeleton/etc/rc.d/wl_func
+++ b/woof-code/rootfs-skeleton/etc/rc.d/wl_func
@@ -31,3 +31,17 @@ pozi() {
 exit_error() {
 	echo "$1" && exit 1
 }
+
+# sets the GTK+ 3 theme
+apply_pthemerc() {
+	[ -f ~/.pthemerc ] || return
+	. ~/.pthemerc
+
+	gsettings set org.gnome.desktop.interface gtk-theme "$PTHEME_GTK"
+	gsettings set org.gnome.desktop.interface icon-theme "$PTHEME_ICONS_GTK"
+	gsettings set org.gnome.desktop.interface enable-animations false
+
+	run-as-spot gsettings set org.gnome.desktop.interface gtk-theme "$PTHEME_GTK"
+	run-as-spot gsettings set org.gnome.desktop.interface icon-theme "$PTHEME_ICONS_GTK"
+	run-as-spot gsettings set org.gnome.desktop.interface enable-animations false
+}

--- a/woof-code/rootfs-skeleton/etc/rc.d/wl_func
+++ b/woof-code/rootfs-skeleton/etc/rc.d/wl_func
@@ -37,10 +37,12 @@ apply_pthemerc() {
 	[ -f ~/.pthemerc ] || return
 	. ~/.pthemerc
 
+	gsettings set org.gnome.desktop.interface font-name "Sans 10"
 	gsettings set org.gnome.desktop.interface gtk-theme "$PTHEME_GTK"
 	gsettings set org.gnome.desktop.interface icon-theme "$PTHEME_ICONS_GTK"
 	gsettings set org.gnome.desktop.interface enable-animations false
 
+	run-as-spot gsettings set org.gnome.desktop.interface font-name "Sans 10"
 	run-as-spot gsettings set org.gnome.desktop.interface gtk-theme "$PTHEME_GTK"
 	run-as-spot gsettings set org.gnome.desktop.interface icon-theme "$PTHEME_ICONS_GTK"
 	run-as-spot gsettings set org.gnome.desktop.interface enable-animations false

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -64,6 +64,11 @@ elif [ -e /usr/bin/pulseaudio ]; then
     export PULSE_COOKIE=/home/spot/.config/pulse/cookie
 fi
 
+if [ -n "$WAYLAND_DISPLAY" ]; then
+	. /etc/rc.d/wl_func
+	apply_pthemerc
+fi
+
 CURRENTWM="`cat /etc/windowmanager`"
 if [ "$CURRENTWM" = "startkde" ];then
  /sbin/pup_event_frontend_d & #130525

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -138,7 +138,7 @@ mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop
-for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
+for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
 for i in usr/share/ptheme/globals/*; do case \"\$i\" in \"usr/share/ptheme/globals/Dark Gray\"|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -133,7 +133,7 @@ mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop
-for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
+for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
 for i in usr/share/ptheme/globals/*; do case \"\$i\" in \"usr/share/ptheme/globals/Dark Gray\"|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -125,7 +125,7 @@ mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop
-for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
+for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
 for i in usr/share/ptheme/globals/*; do case \"\$i\" in \"usr/share/ptheme/globals/Dark Gray\"|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf


### PR DESCRIPTION
See https://github.com/swaywm/sway/wiki/GTK-3-settings-on-Wayland.

![theme](https://user-images.githubusercontent.com/1471149/161382287-866cb5fc-d06f-4631-9472-fe5df9632591.png)


