### PR TITLE
Add spot to the render group

### DIFF
--- a/woof-code/rootfs-skeleton/etc/group.debian
+++ b/woof-code/rootfs-skeleton/etc/group.debian
@@ -49,3 +49,4 @@ plugdev:x:46:root,spot
 staff:x:50:
 games:x:60:
 nogroup:x:65533:
+render:x:106:root,spot


### PR DESCRIPTION
Looks like 52eb84e is not enough. The device node ownership is now correct, but the post-installation script that adds the `render` group doesn't add spot to it.