### PR TITLE
When centering a large window, make sure (0,0) is within the active monitor

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/kiosk.patch
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/kiosk.patch
@@ -1,14 +1,14 @@
-From c0bb5943e0cd2b0e05b99297fedd39759151c6fa Mon Sep 17 00:00:00 2001
+From 9f2cf0b7fe44ab0eb62a9512023d0382b82bad6b Mon Sep 17 00:00:00 2001
 From: Dima Krasner <dima@dimakrasner.com>
-Date: Sat, 2 Apr 2022 17:40:10 +0800
+Date: Sun, 3 Apr 2022 00:46:47 +0800
 Subject: [PATCH] maximize the first window and make all others float
 
 ---
- dwl.c | 24 ++++++++++++++++++++++++
- 1 file changed, 24 insertions(+)
+ dwl.c | 31 +++++++++++++++++++++++++++++++
+ 1 file changed, 31 insertions(+)
 
 diff --git a/dwl.c b/dwl.c
-index 529dbf8..d82e3a7 100644
+index 529dbf8..5f657b1 100644
 --- a/dwl.c
 +++ b/dwl.c
 @@ -207,6 +207,7 @@ static void applybounds(Client *c, struct wlr_box *bbox);
@@ -19,19 +19,26 @@ index 529dbf8..d82e3a7 100644
  static void applyrules(Client *c);
  static void arrange(Monitor *m);
  static void arrangelayer(Monitor *m, struct wl_list *list,
-@@ -449,6 +450,19 @@ applyexclusive(struct wlr_box *usable_area,
+@@ -449,6 +450,26 @@ applyexclusive(struct wlr_box *usable_area,
  	}
  }
  
 +void
 +center(Client *c, struct wlr_output *wlr_output)
 +{
-+	struct wlr_output_layout_output *ol_output = wlr_output_layout_get(output_layout, wlr_output);
-+	if (!ol_output)
-+		return;
++	struct wlr_box *box = wlr_output_layout_get_box(output_layout, wlr_output);
 +
-+	c->geom.x = ol_output->x + wlr_output->width / wlr_output->scale / 2 - c->geom.width / 2;
-+	c->geom.y = ol_output->y + wlr_output->height / wlr_output->scale / 2 - c->geom.height / 2;
++	c->geom.x = cursor->x - c->geom.width / 2;
++	if (c->geom.x + c->geom.width > box->x + box->width)
++		c->geom.x = box->x + box->width - c->geom.width;
++	if (c->geom.x < box->x || c->geom.width > box->width)
++		c->geom.x = box->x;
++
++	c->geom.y = cursor->y - c->geom.height / 2;
++	if (c->geom.y + c->geom.height > box->y + box->height)
++		c->geom.y = box->y + box->height - c->geom.height;
++	if (c->geom.y < box->y || c->geom.height > box->height)
++		c->geom.y = box->y;
 +
 +	wlr_scene_node_set_position(c->scene, c->geom.x, c->geom.y);
 +}
@@ -39,7 +46,7 @@ index 529dbf8..d82e3a7 100644
  void
  applyrules(Client *c)
  {
-@@ -457,6 +471,7 @@ applyrules(Client *c)
+@@ -457,6 +478,7 @@ applyrules(Client *c)
  	unsigned int i, newtags = 0;
  	const Rule *r;
  	Monitor *mon = selmon, *m;
@@ -47,7 +54,7 @@ index 529dbf8..d82e3a7 100644
  
  	c->isfloating = client_is_float_type(c);
  	if (!(appid = client_get_appid(c)))
-@@ -475,6 +490,15 @@ applyrules(Client *c)
+@@ -475,6 +497,15 @@ applyrules(Client *c)
  					mon = m;
  		}
  	}


### PR DESCRIPTION
A new Wayland window is centered around the cursor, but if it's bigger than the active monitor or if the cursor is near one of the monitor's edges, the window is moved to `x=0` or `x=$monitor_width-$window_width` to make it fit within the monitor. If the window is too big to fit in the screen, it's positioned at 0,0, making it possible to resize it using the title bar, or double-click the title bar to maximize the window (fill this monitor).

This minimizes the need for mouse movement when trying to interact with a new window, and feels more natural compared to windows that get centered on the screen.