### PR TITLE
sfs_load: Added handling of usrmerge

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -81,6 +81,9 @@ if [ -L /bin -o -L /sbin -o -L /lib -o -L /lib64 -o -L /lib32 -o -L /libx32 ]; t
      umount /mnt/$MNTFLD
      rm -rf /mnt/$MNTFLD
      inform_and_exit
+    else
+     umount /mnt/$MNTFLD
+     rm -rf /mnt/$MNTFLD
     fi
  
  fi

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -47,7 +47,47 @@
 
 #exec &>/tmp/sfsl.log ; set -x
 
+inform_and_exit() {
+	/usr/lib/gtkdialog/box_ok "sfs_load" error "$(gettext "this sfs should not be loaded because it has the wrong file structure")"
+	umount /mnt/"$SFSFILE"
+	rm -rf /mnt/"$SFSFILE"
+	exit 1
+}
+
 . /etc/rc.d/PUPSTATE
+
+if [ -L /bin -o -L /sbin -o -L /lib -o -L /lib64 -o -L /lib32 -o -L /libx32 ]; then
+
+ if [ "$1" ]; then
+ 
+   SFSFILE="$(basename "$1")"
+   MNTFLD="$(echo "${SFSFILE}-module" | sed -e 's#\ #_#g')"
+   mkdir -p /mnt/"$MNTFLD"
+   DEVLOOP="$(losetup -f)"
+   losetup "$DEVLOOP" "$1"
+   mount -t squashfs -o loop,ro "$DEVLOOP" /mnt/$MNTFLD
+  
+   FLD_INVALID=""
+  
+    for fld2 in bin sbin lib lib64 lib32 libx32
+    do
+    if [ -d /mnt/$MNTFLD/$fld2 -a ! -L /mnt/$MNTFLD/$fld2 ]; then
+      FLD_INVALID="y"
+      break
+     fi
+    done 
+       
+    if [ "$FLD_INVALID" != "" ]; then
+     umount /mnt/$MNTFLD
+     rm -rf /mnt/$MNTFLD
+     inform_and_exit
+    fi
+ 
+ fi
+ 
+fi 
+
+
 if [ "$PUNIONFS" = "overlay" ] ; then
 	exit
 fi

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -58,7 +58,7 @@ if [ -L /bin -o -L /sbin -o -L /lib -o -L /lib64 -o -L /lib32 -o -L /libx32 ]; t
    mkdir -p /mnt/"$MNTFLD"
    DEVLOOP="$(losetup -f)"
    losetup "$DEVLOOP" "$1"
-   mount -t squashfs -o loop,ro "$DEVLOOP" /mnt/$MNTFLD
+   mount -r -t squashfs -o loop,ro "$DEVLOOP" /mnt/$MNTFLD
   
    FLD_INVALID=""
   

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -47,13 +47,6 @@
 
 #exec &>/tmp/sfsl.log ; set -x
 
-inform_and_exit() {
-	/usr/lib/gtkdialog/box_ok "sfs_load" error "$(gettext "this sfs should not be loaded because it has the wrong file structure")"
-	umount /mnt/"$SFSFILE"
-	rm -rf /mnt/"$SFSFILE"
-	exit 1
-}
-
 . /etc/rc.d/PUPSTATE
 
 if [ -L /bin -o -L /sbin -o -L /lib -o -L /lib64 -o -L /lib32 -o -L /libx32 ]; then
@@ -75,15 +68,14 @@ if [ -L /bin -o -L /sbin -o -L /lib -o -L /lib64 -o -L /lib32 -o -L /libx32 ]; t
       FLD_INVALID="y"
       break
      fi
-    done 
+    done
+    
+    umount /mnt/$MNTFLD
+    rm -rf /mnt/$MNTFLD
        
     if [ "$FLD_INVALID" != "" ]; then
-     umount /mnt/$MNTFLD
-     rm -rf /mnt/$MNTFLD
-     inform_and_exit
-    else
-     umount /mnt/$MNTFLD
-     rm -rf /mnt/$MNTFLD
+      /usr/lib/gtkdialog/box_ok "sfs_load" error "$(gettext "This sfs should not be loaded because it has the wrong file structure")"
+      exit 1
     fi
  
  fi


### PR DESCRIPTION
Stop loading non-usrmerge file system hierarchy compliant SFS modules if the main puppy sfs was usrmerge compliant.

Fixes #3006 issue for sfs load