### PR TITLE
Keep the Xwayland window below Wayland windows

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/kiosk.patch
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/kiosk.patch
@@ -1,14 +1,14 @@
-From 9f2cf0b7fe44ab0eb62a9512023d0382b82bad6b Mon Sep 17 00:00:00 2001
+From 1c9161728cd11a1343a585e9861748b525a8bf31 Mon Sep 17 00:00:00 2001
 From: Dima Krasner <dima@dimakrasner.com>
-Date: Sun, 3 Apr 2022 00:46:47 +0800
+Date: Tue, 5 Apr 2022 13:35:12 +0800
 Subject: [PATCH] maximize the first window and make all others float
 
 ---
- dwl.c | 31 +++++++++++++++++++++++++++++++
- 1 file changed, 31 insertions(+)
+ dwl.c | 33 ++++++++++++++++++++++++++++++++-
+ 1 file changed, 32 insertions(+), 1 deletion(-)
 
 diff --git a/dwl.c b/dwl.c
-index 529dbf8..5f657b1 100644
+index 529dbf88..b71577a6 100644
 --- a/dwl.c
 +++ b/dwl.c
 @@ -207,6 +207,7 @@ static void applybounds(Client *c, struct wlr_box *bbox);
@@ -70,3 +70,12 @@ index 529dbf8..5f657b1 100644
  	wlr_scene_node_reparent(c->scene, layers[c->isfloating ? LyrFloat : LyrTile]);
  	setmon(c, mon, newtags);
  }
+@@ -1126,7 +1157,7 @@ focusclient(Client *c, int lift)
+ 	int i;
+ 
+ 	/* Raise client in stacking order if requested */
+-	if (c && lift)
++	if (c && lift && c->isfloating)
+ 		wlr_scene_node_raise_to_top(c->scene);
+ 
+ 	if (c && client_surface(c) == old)


### PR DESCRIPTION
When a Wayland window is clicked and becomes focused, it's raised to the top of the stack. This makes sense for all windows except the fullscreen Xwayland window at the bottom of the stack, which should stay at the bottom. Otherwise, Wayland windows disappear and cannot be restored, as they don't appear in the JWM window list.