### PR TITLE
Make petbuilds.sh compatible with BUILD_DEVX=no

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -336,6 +336,7 @@ if [ -n "$PETBUILDS" ]; then
 		echo "Building without qemu-user-static"
 	fi
 
+	[ "$BUILD_DEVX" = "yes" ] && PETBUILD_ENABLE="enabled"
 	cd sandbox3
 	. ../support/petbuilds.sh
 	cd ..

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -336,7 +336,7 @@ if [ -n "$PETBUILDS" ]; then
 		echo "Building without qemu-user-static"
 	fi
 
-	[ "$BUILD_DEVX" = "yes" ] && PETBUILD_ENABLE="enabled"
+	[ ! "$BUILD_DEVX" = "yes" ] && echo "WARNING - petbuilds require BUILD_DEVX=yes"
 	cd sandbox3
 	. ../support/petbuilds.sh
 	cd ..

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -52,8 +52,11 @@ fi
 
 HERE=`pwd`
 PKGS=
+COPYPKGS="$PETBUILDS"
 
 # busybox must be first, so other petbuilds can use coreutils commands
+# PETBUILD_ENABLE is set in 3builddistro from BUILD_DEVX and can also be set in _00build.conf
+if [ "$PETBUILD_ENABLE" = "enabled" ]; then
 for NAME in $PETBUILDS; do
     HASH=`cat ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_COMPAT_REPOS ../DISTRO_COMPAT_REPOS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_PET_REPOS ../rootfs-petbuilds/${NAME}/petbuild 2>/dev/null | md5sum | awk '{print $1}'`
     if [ ! -d "../petbuild-output/${NAME}-${HASH}" ]; then
@@ -284,14 +287,16 @@ for NAME in $PETBUILDS; do
 
     PKGS="$PKGS $NAME"
 done
+COPYPKGS="$PKGS"
 
 [ $HAVE_ROOTFS -eq 1 ] && rm -rf petbuild-rootfs-complete
+fi
 
 echo "Copying petbuilds to rootfs-complete"
 
 MAINPKGS=
 
-for NAME in $PKGS; do
+for NAME in $COPYPKGS; do
     rm -rf ../packages-${DISTRO_FILE_PREFIX}/${NAME} ../packages-${DISTRO_FILE_PREFIX}/${NAME}_NLS ../packages-${DISTRO_FILE_PREFIX}/${NAME}_DOC
 
     mkdir ../packages-${DISTRO_FILE_PREFIX}/${NAME}

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -55,9 +55,8 @@ PKGS=
 COPYPKGS="$PETBUILDS"
 
 # busybox must be first, so other petbuilds can use coreutils commands
-# PETBUILD_ENABLE is set in 3builddistro from BUILD_DEVX and can also be set in _00build.conf
-if [ "$PETBUILD_ENABLE" = "enabled" ]; then
-for NAME in $PETBUILDS; do
+if [ "$BUILD_DEVX" = "yes" ]; then
+  for NAME in $PETBUILDS; do
     HASH=`cat ../DISTRO_PKGS_SPECS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_COMPAT_REPOS ../DISTRO_COMPAT_REPOS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} ../DISTRO_PET_REPOS ../rootfs-petbuilds/${NAME}/petbuild 2>/dev/null | md5sum | awk '{print $1}'`
     if [ ! -d "../petbuild-output/${NAME}-${HASH}" ]; then
         if [ $HAVE_ROOTFS -eq 0 ]; then
@@ -286,10 +285,10 @@ for NAME in $PETBUILDS; do
     ln -s ${NAME}-${HASH} ../petbuild-output/${NAME}-latest
 
     PKGS="$PKGS $NAME"
-done
-COPYPKGS="$PKGS"
+  done
+  COPYPKGS="$PKGS"
 
-[ $HAVE_ROOTFS -eq 1 ] && rm -rf petbuild-rootfs-complete
+  [ $HAVE_ROOTFS -eq 1 ] && rm -rf petbuild-rootfs-complete
 fi
 
 echo "Copying petbuilds to rootfs-complete"


### PR DESCRIPTION
All automated Woof-CE builds have BUILD_DEVX=yes so behaviour is unchanged.

Only applies to manual builds where BUILD_DEVX=no