### PR TITLE
Add gtk2dialog symlink

### DIFF
--- a/woof-code/support/rootfs-hacks.sh
+++ b/woof-code/support/rootfs-hacks.sh
@@ -17,7 +17,7 @@ if [ ! -e ${SR}/usr/bin/rxvt-unicode ] && [ -f ${SR}/usr/bin/urxvt ] ; then
 fi
 
 # gtk2dialog symlink
-if [ ! -e ${SR}/usr/sbin/gtk2dialog ] && [ -f ${SR}/usr/sbin/gtkdialog ] ; then
+if [ ! -e ${SR}/usr/sbin/gtk2dialog ] && [ -e ${SR}/usr/sbin/gtkdialog ] ; then
 	ln -snfv gtkdialog ${SR}/usr/sbin/gtk2dialog
 fi
 

--- a/woof-code/support/rootfs-hacks.sh
+++ b/woof-code/support/rootfs-hacks.sh
@@ -16,6 +16,11 @@ if [ ! -e ${SR}/usr/bin/rxvt-unicode ] && [ -f ${SR}/usr/bin/urxvt ] ; then
 	ln -snfv urxvt ${SR}/usr/bin/rxvt-unicode
 fi
 
+# gtk2dialog symlink
+if [ ! -e ${SR}/usr/sbin/gtk2dialog ] && [ -f ${SR}/usr/sbin/gtkdialog ] ; then
+	ln -snfv gtkdialog ${SR}/usr/sbin/gtk2dialog
+fi
+
 # zenity symlink
 if [ ! -L ${SR}/usr/bin/zenity ] && [ -f ${SR}/usr/bin/yad ] ; then
 	ln -snfv yad ${SR}/usr/bin/zenity


### PR DESCRIPTION
/rootfs-packages/jwm_config/usr/local/jwm_config/tray
now unconditionally uses gtk2dialog - see #2965
this change ensures gtk2dialog is present in a build - as a link to gtkdialog if necessary