### PR TITLE
Switch to XDG_SESSION_TYPE=wayland under dwl

### DIFF
--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -5,10 +5,11 @@
 #130212 removed glipper code, see latest glipper pet.
 #130525 old pc celeron 2ghz cpu, 256mb ram, CPUSPEED=1999, 1st bootup rox failed to start. try experiment.
 
-export XDG_SESSION_TYPE=x11
 if [ -n "$WAYLAND_DISPLAY" ]; then
 	export GDK_BACKEND=x11
 	unset SDL_VIDEODRIVER
+else
+	export XDG_SESSION_TYPE=x11
 fi
 
 [ -f /etc/desktop_app ] && read -r desktop < /etc/desktop_app

--- a/woof-code/rootfs-skeleton/root/.xinitrc
+++ b/woof-code/rootfs-skeleton/root/.xinitrc
@@ -8,6 +8,7 @@
 if [ -n "$WAYLAND_DISPLAY" ]; then
 	export GDK_BACKEND=x11
 	unset SDL_VIDEODRIVER
+	export XDG_SESSION_TYPE=wayland
 else
 	export XDG_SESSION_TYPE=x11
 fi

--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -18,6 +18,7 @@ if [ "$XDG_SESSION_TYPE" != 'wayland' ]; then
 	ROOTY=${geometry#*x}
 else
 	ROOTX=1000; ROOTY=1000 # to keep this happy
+	export GDK_BACKEND=wayland # force a native Wayland window to activate layer-shell support
 fi
 
 MAX_CHAR_WIDTH=40 #Maximum number of chars in one line


### PR DESCRIPTION
Once again, it's time to steer the ship towards the Wayland destination.

(The next step is to add a `startdwl` script that skips .xinitrc, sets `GDK_BACKEND=wayland` and starts a Wayland panel)

With this PR, box_splash joins applications that insist on using their Wayland backend (like mpv) and becomes a native Wayland window in the correct layer:

![native](https://user-images.githubusercontent.com/1471149/163329182-8e6ee037-dffc-4439-915f-23b1450ccd9c.png)

