### PR TITLE
Never start seatd, so it cannot slow down shutdown

### DIFF
--- a/woof-code/packages-templates/seatd_FIXUPHACK
+++ b/woof-code/packages-templates/seatd_FIXUPHACK
@@ -1,0 +1,2 @@
+# force libseatd to use the builtin backend, we don't have logind anyway
+rm -rf etc/init.d

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -592,6 +592,7 @@ no|rxvt-unicode||exe,dev>null,doc,nls
 no|sane-backends||exe,dev,doc,nls
 no|scale2x||exe
 no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc,nls
+yes|seatd|seatd|exe,dev,doc,nls||deps:yes
 yes|scdoc|scdoc|exe>dev,dev,doc,nls||deps:yes
 yes|sed|sed|exe,dev>null,doc,nls||deps:yes
 yes|sensible-utils|sensible-utils|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -589,6 +589,7 @@ no|rxvt-unicode||exe,dev>null,doc,nls
 no|sane-backends||exe,dev,doc,nls
 no|scale2x||exe
 no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc,nls
+yes|seatd|seatd|exe,dev,doc,nls||deps:yes
 yes|sed|sed|exe,dev>null,doc,nls||deps:yes
 yes|sensible-utils|sensible-utils|exe,dev,doc,nls||deps:yes
 yes|serf|libserf-1-1|exe>dev,dev,doc,nls||deps:yes #needed by svn.


### PR DESCRIPTION
There is some problem with the init script in jammy64, for some reason it hangs for a very long time trying to stop seatd. It could be a bug, either in the init script or seatd itself, and it probably affects only Puppy because Ubuntu uses systemd. Puppy is probably the only user of the init script.

But Puppy doesn't need seatd and the logind integration anyway, so let's just disable that daemon and let libseat use its "builtin" backend instead.