### PR TITLE
Fix bashism in /etc/init.d/trim

### DIFF
--- a/woof-code/rootfs-skeleton/etc/init.d/trim
+++ b/woof-code/rootfs-skeleton/etc/init.d/trim
@@ -24,7 +24,7 @@ BEFORELAST=$LAST" > /etc/rc.d/TRIMSTATE.tmp
     LAST=`date +%s`
     echo "# `date`
 LAST=$LAST" >> /etc/rc.d/TRIMSTATE.tmp
-    mv -f /etc/rc.d/TRIMSTATE{.tmp,}
+    mv -f /etc/rc.d/TRIMSTATE.tmp /etc/rc.d/TRIMSTATE
    fi
   fi
   sleep $POLL


### PR DESCRIPTION
Looks like ash doesn't understand this syntax, so TRIM happens too often.