### PR TITLE
Use memory_recursiveprot only if kernel is >= 5.7

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -195,7 +195,13 @@ busybox mount -t devpts -o dev,suid,gid=2,mode=620 none /dev/pts ;STATUS=$((STAT
 mkdir /sys 2>/dev/null
 busybox mount -t sysfs none /sys ;STATUS=$((STATUS+$?))
 
-busybox mount -t cgroup2 -o nsdelegate,memory_recursiveprot cgroup2 /sys/fs/cgroup ;STATUS=$((STATUS+$?))
+KERNVER="`uname -r`"
+
+if vercmp $KERNVER ge 5.7; then
+	busybox mount -t cgroup2 -o nsdelegate,memory_recursiveprot cgroup2 /sys/fs/cgroup ;STATUS=$((STATUS+$?))
+else
+	busybox mount -t cgroup2 -o nsdelegate cgroup2 /sys/fs/cgroup ;STATUS=$((STATUS+$?))
+fi
 
 # simulate what systemd does but only for /, podman needs this
 busybox mount --make-shared / 2>/dev/null
@@ -226,7 +232,6 @@ fi
 
 # kernel modules.builtin/order can also be found in /etc/modules
 # if somehow they're missing from /lib/modules, they will be copied back
-KERNVER="`uname -r`"
 [ ! -f /lib/modules/${KERNVER}/modules.builtin ] && \
 	cp -v /etc/modules/modules.builtin-${KERNVER} /lib/modules/${KERNVER}/modules.builtin
 [ ! -f /lib/modules/${KERNVER}/modules.order ] && \


### PR DESCRIPTION
This silences a harmless error introduced in 81f1c84, when using an old kernel.