### PR TITLE
cleanup cursor themeing re #3051

### DIFF
--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme
@@ -209,6 +209,7 @@ EOF
 	if [ "$PTHEME_MOUSE" ]; then
 		pcur -u -t "$PTHEME_MOUSE"
 		SWITCH_THEME=true
+		pidof labwc >/dev/null 2>&1 && . /etc/rc.d/wl_func && func_labwc "$PTHEME_MOUSE"
 	fi
 	#wallpaper
 	if [ "$PTHEME_WALL" ] && [ -f "/usr/share/backgrounds/$PTHEME_WALL" ]; then
@@ -419,6 +420,13 @@ echo -n > $WORKDIR/ptheme-mouse
 echo -n > $WORKDIR/ptheme-gtkdialog
 echo -n > $WORKDIR/ptheme-pwidgets_profile
 echo -n > $WORKDIR/ptheme-pwidgets_theme
+
+# link cursor themes in /usr/share/icons to $HOME
+while read -r ITHEME; do
+	ETHEME="${ITHEME/\/cursors/}"
+	XTHEME="${ETHEME##*\/}"
+	[ -e "$HOME/.icons/$XTHEME" ] || ln -sv "$ETHEME" $HOME/.icons
+done <<<$(find /usr/share/icons/ -maxdepth 2 -type d -name 'cursors')
 
 build_menus
 
@@ -656,8 +664,7 @@ S='
 
 ##  R O X   P I N
 
-   #[ "`grep -Fi 'rox' <<< $(ps -eo pid,command)`" ] &&
-    S=$S'
+   [ "`grep -Fi 'rox' <<< $(ps -eo pid,command)`" ] && S=$S'
    <hbox space-expand="true" space-fill="true">
     <menubar space-expand="true" space-fill="true">
       <menu label="'$(gettext 'Icons desktop arrangement (apps)')'" stock="gtk-go-down">

--- a/woof-code/rootfs-skeleton/etc/rc.d/wl_func
+++ b/woof-code/rootfs-skeleton/etc/rc.d/wl_func
@@ -40,10 +40,21 @@ apply_pthemerc() {
 	gsettings set org.gnome.desktop.interface font-name "Sans 10"
 	gsettings set org.gnome.desktop.interface gtk-theme "$PTHEME_GTK"
 	gsettings set org.gnome.desktop.interface icon-theme "$PTHEME_ICONS_GTK"
+	gsettings set org.gnome.desktop.interface cursor-theme "$PTHEME_MOUSE"
 	gsettings set org.gnome.desktop.interface enable-animations false
 
 	run-as-spot gsettings set org.gnome.desktop.interface font-name "Sans 10"
 	run-as-spot gsettings set org.gnome.desktop.interface gtk-theme "$PTHEME_GTK"
 	run-as-spot gsettings set org.gnome.desktop.interface icon-theme "$PTHEME_ICONS_GTK"
+	run-as-spot gsettings set org.gnome.desktop.interface cursor-theme "$PTHEME_MOUSE"
 	run-as-spot gsettings set org.gnome.desktop.interface enable-animations false
+}
+
+# sets the cursor theme in running labwc for pcur/ptheme
+func_labwc() {
+	gsettings set org.gnome.desktop.interface cursor-theme "$1"
+	[ `id -u` -eq 0 ] && run-as-spot gsettings set org.gnome.desktop.interface cursor-theme "$1"
+	grep -q 'XCURSOR_THEME' $XDG_CONFIG_HOME/labwc/environment && sed -i "s/XCURSOR_THEME.*/XCURSOR_THEME=$1/" $XDG_CONFIG_HOME/labwc/environment || \
+		echo "XCURSOR_THEME=$1" >> $XDG_CONFIG_HOME/labwc/environment
+	/usr/lib/gtkdialog/box_splash -bg orange -placement top -close box -timeout 7 -text "$(gettext 'To activate the new theme labwc needs to be restarted - just restart X')" &
 }

--- a/woof-code/rootfs-skeleton/usr/sbin/pcur
+++ b/woof-code/rootfs-skeleton/usr/sbin/pcur
@@ -19,14 +19,6 @@ func_switch (){
 		if [ `id -u` -eq 0 ] ; then
 			rm -f /home/spot/.icons/default
 		fi
-	elif [[ -d /usr/share/icons/"$1" ]]; then
-		mkdir -p $HOME/.icons/
-		ln -snf /usr/share/icons/"$1" $HOME/.icons/default
-		if [ `id -u` -eq 0 ] ; then
-			mkdir -p /home/spot/.icons/
-			ln -snf /usr/share/icons/"$1" /home/spot/.icons/default
-			chown -R spot:spot /home/spot/.icons
-		fi
 	elif [[ -d $HOME/.icons/"$1" ]]; then
 		ln -snf "$1" $HOME/.icons/default
 		if [ `id -u` -eq 0 ] ; then
@@ -40,6 +32,9 @@ func_switch (){
 			jwm -restart
 		elif pidof openbox >/dev/null 2>&1 ; then
 			openbox --restart
+		elif pidof labwc >/dev/null 2>&1 ; then
+			. /etc/rc.d/wl_func
+			func_labwc "$1"
 		fi
 	fi
 }
@@ -54,8 +49,8 @@ func_download (){
 	rm $PKG
 	/usr/lib/gtkdialog/box_ok "pCur - $(gettext 'Cursor theme setter')" complete "$(gettext 'New themes are installed. <b>Please restart pCur</b> - Cursor theme setter.')" && exit 0
 }
-export -f func_switch func_download
 
+export -f func_switch func_download
 
 #parameters
 while [ $# != 0 ]; do
@@ -83,27 +78,14 @@ if [ "$THEME" ]; then
 	exit
 fi
 #---
-
-for ONEITEM in `ls -1 /usr/share/icons | grep -Ev 'ROX|^default$'`; do
-	#precaution that 'cursors' subdir exists...
-	[ ! -d /usr/share/icons/${ONEITEM}/cursors ] && continue
-	if [ ! -f /usr/share/icons/${ONEITEM}.png ]; then
-		cd /usr/share/icons/${ONEITEM}/cursors
-		xcur2png -d /tmp/xcur2png left_ptr
-		mv -f /tmp/xcur2png/left_ptr_000.png /usr/share/icons/${ONEITEM}.png
-		rm -f /tmp/xcur2png/left_ptr_*.png
-	fi
-	if [ "$ONEITEM" = "$PREVTHEME" ]; then
-		FIRSTITEM="<item icon=\"${ONEITEM}\">${ONEITEM}</item>"
-	else
-		CURLIST="${CURLIST}<item icon=\"${ONEITEM}\">${ONEITEM}</item>"
-	fi
-	LISTHEIGHT=$(( $LISTHEIGHT + 25 ))
-done
+# link cursor themes in /usr/share/icons to $HOME
+while read -r ITHEME; do
+	ETHEME="${ITHEME/\/cursors/}"
+	XTHEME="${ETHEME##*\/}"
+	[ -e "$HOME/.icons/$XTHEME" ] || ln -sv "$ETHEME" $HOME/.icons
+done <<<$(find /usr/share/icons/ -maxdepth 2 -type d -name 'cursors')
 
 for ONEITEM in `ls -1 $HOME/.icons | grep -Ev 'ROX|^default$'`; do
-	#filter duplicates
-	[ -e /usr/share/icons/${ONEITEM} ] && continue
 	#precaution that 'cursors' subdir exists...
 	[ ! -d $HOME/.icons/${ONEITEM}/cursors ] && continue
 	if [ ! -f /usr/share/icons/${ONEITEM}.png ]; then


### PR DESCRIPTION
 - in normal pup allows installation of cursor themes to
/usr/share/icons for pcur and ptheme
 - for a wayland pup (labwc) uses gsettings to set cursor for root and spot
 - labwc environment variable XCURSOR_THEME is updated