### PR TITLE
Basic Flatpak support with JWM

### DIFF
--- a/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
+++ b/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
@@ -38,12 +38,15 @@ sh(const char *cmd, const sigset_t *set)
 }
 
 static void
-setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *event, const sigset_t *set)
+setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *event, const sigset_t *set, const int force)
 {
 	static char orig[NAME_MAX + sizeof(".bin")];
 	struct stat stbuf;
 	size_t len;
 	char *cmd;
+
+	if (force)
+		goto doit;
 
 	if (regexec(re, event->name, 0, NULL, 0) != 0)
 		return;
@@ -55,6 +58,7 @@ setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *even
 	    (S_ISREG(stbuf.st_mode) && (stbuf.st_size == 0)))
 		return;
 
+doit:
 	len = strlen(event->name);
 	memcpy(orig, event->name, len);
 	memcpy(orig + len, ".bin", sizeof(".bin") - 1);
@@ -70,7 +74,7 @@ setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *even
 }
 
 static int
-handle_events(const regex_t *re, const int fd, const int appwd, const int binwd, const int usrbin, const sigset_t *set)
+handle_events(const regex_t *re, const int fd, const int appwd, const int flatpakappwd, const int binwd, const int flatpakwd, const int usrbin, const sigset_t *set)
 {
 	char buf[sizeof(struct inotify_event) + NAME_MAX + 1];
 	const struct inotify_event *event;
@@ -90,8 +94,10 @@ handle_events(const regex_t *re, const int fd, const int appwd, const int binwd,
 		     (char *)event < (buf + out);
 		     event = (const struct inotify_event *)((char *)event + sizeof(*event) + event->len)) {
 			if (event->wd == binwd)
-				setup_spot(re, usrbin, event, set);
-			else if (event->wd != appwd)
+				setup_spot(re, usrbin, event, set, 0);
+			else if (event->wd == flatpakwd)
+				setup_spot(re, usrbin, event, set, 1);
+			else if ((event->wd != appwd) && (event->wd != flatpakappwd))
 				continue;
 
 			if (!(event->mask & (IN_DELETE | IN_CLOSE_WRITE | IN_MOVED_TO)))
@@ -114,7 +120,7 @@ main(int argc, char* argv[])
 {
 	regex_t re;
 	sigset_t set, oset;
-	int fd, appwd, binwd, usrbin, sig;
+	int fd, appwd, flatpakappwd, binwd, flatpakwd, usrbin, sig;
 
 	if (argc != 2)
 		return EXIT_FAILURE;
@@ -145,17 +151,24 @@ main(int argc, char* argv[])
 		return EXIT_FAILURE;
 	}
 
+	flatpakappwd = inotify_add_watch(fd, "/var/lib/flatpak/exports/share/applications", IN_CREATE | IN_DELETE | IN_MOVED_TO | IN_EXCL_UNLINK);
+
 	binwd = inotify_add_watch(fd, "/usr/bin", IN_CLOSE_WRITE | IN_CREATE | IN_MOVED_TO | IN_EXCL_UNLINK);
 	if (binwd < 0) {
+		inotify_rm_watch(fd, flatpakappwd);
 		inotify_rm_watch(fd, appwd);
 		close(fd);
 		regfree(&re);
 		return EXIT_FAILURE;
 	}
 
+	flatpakwd = inotify_add_watch(fd, "/var/lib/flatpak/exports/bin", IN_CREATE | IN_CREATE | IN_MOVED_TO | IN_EXCL_UNLINK);
+
 	usrbin = open("/usr/bin", O_DIRECTORY | O_RDONLY);
 	if (usrbin < 0) {
+		inotify_rm_watch(fd, flatpakwd);
 		inotify_rm_watch(fd, binwd);
+		inotify_rm_watch(fd, flatpakappwd);
 		inotify_rm_watch(fd, appwd);
 		close(fd);
 		regfree(&re);
@@ -166,7 +179,9 @@ main(int argc, char* argv[])
 	    (fcntl(fd, F_SETSIG, SIGRTMIN) < 0) ||
 	    (fcntl(fd, F_SETOWN, getpid()) < 0)) {
 		close(usrbin);
+		inotify_rm_watch(fd, flatpakwd);
 		inotify_rm_watch(fd, binwd);
+		inotify_rm_watch(fd, flatpakappwd);
 		inotify_rm_watch(fd, appwd);
 		close(fd);
 		regfree(&re);
@@ -175,13 +190,15 @@ main(int argc, char* argv[])
 
 	while ((sigwait(&set, &sig) == 0) &&
 	       (((sig == SIGRTMIN) &&
-	         (handle_events(&re, fd, appwd, binwd, usrbin, &oset) == 0)) ||
+	         (handle_events(&re, fd, appwd, flatpakappwd, binwd, flatpakwd, usrbin, &oset) == 0)) ||
 	        ((sig == SIGALRM) &&
 	         (sh(argv[1], &oset) == 0)) ||
 	        (sig == SIGCHLD)));
 
 	close(usrbin);
+	inotify_rm_watch(fd, flatpakwd);
 	inotify_rm_watch(fd, binwd);
+	inotify_rm_watch(fd, flatpakappwd);
 	inotify_rm_watch(fd, appwd);
 	close(fd);
 	regfree(&re);

--- a/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
+++ b/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
@@ -38,7 +38,7 @@ sh(const char *cmd, const sigset_t *set)
 }
 
 static void
-setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *event, const sigset_t *set, const int force)
+setup_spot(const regex_t *re, const int bin, const struct inotify_event *event, const sigset_t *set, const int force)
 {
 	static char orig[NAME_MAX + sizeof(".bin")];
 	struct stat stbuf;
@@ -51,7 +51,7 @@ setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *even
 	if (regexec(re, event->name, 0, NULL, 0) != 0)
 		return;
 
-	if (fstatat(usrbin, event->name, &stbuf, AT_SYMLINK_NOFOLLOW) < 0)
+	if (fstatat(bin, event->name, &stbuf, AT_SYMLINK_NOFOLLOW) < 0)
 		return;
 
 	if (((event->mask & IN_CREATE) && !S_ISLNK(stbuf.st_mode)) ||
@@ -63,7 +63,7 @@ doit:
 	memcpy(orig, event->name, len);
 	memcpy(orig + len, ".bin", sizeof(".bin") - 1);
 
-	if ((fstatat(usrbin, orig, &stbuf, AT_SYMLINK_NOFOLLOW) == 0) ||
+	if ((fstatat(bin, orig, &stbuf, AT_SYMLINK_NOFOLLOW) == 0) ||
 	    (errno != ENOENT))
 		return;
 
@@ -74,7 +74,7 @@ doit:
 }
 
 static int
-handle_events(const regex_t *re, const int fd, const int appwd, const int flatpakappwd, const int binwd, const int flatpakwd, const int usrbin, const sigset_t *set)
+handle_events(const regex_t *re, const int fd, const int appwd, const int flatpakappwd, const int binwd, const int flatpakwd, const int flatpakbin, const int usrbin, const sigset_t *set)
 {
 	char buf[sizeof(struct inotify_event) + NAME_MAX + 1];
 	const struct inotify_event *event;
@@ -96,7 +96,7 @@ handle_events(const regex_t *re, const int fd, const int appwd, const int flatpa
 			if (event->wd == binwd)
 				setup_spot(re, usrbin, event, set, 0);
 			else if (event->wd == flatpakwd)
-				setup_spot(re, usrbin, event, set, 1);
+				setup_spot(re, flatpakbin, event, set, 1);
 			else if ((event->wd != appwd) && (event->wd != flatpakappwd))
 				continue;
 
@@ -120,7 +120,7 @@ main(int argc, char* argv[])
 {
 	regex_t re;
 	sigset_t set, oset;
-	int fd, appwd, flatpakappwd, binwd, flatpakwd, usrbin, sig;
+	int fd, appwd, flatpakappwd, binwd, flatpakwd, flatpakbin, usrbin, sig;
 
 	if (argc != 2)
 		return EXIT_FAILURE;
@@ -164,8 +164,22 @@ main(int argc, char* argv[])
 
 	flatpakwd = inotify_add_watch(fd, "/var/lib/flatpak/exports/bin", IN_CREATE | IN_CREATE | IN_MOVED_TO | IN_EXCL_UNLINK);
 
+	if (flatpakwd != -1) {
+		flatpakbin = open("/var/lib/flatpak/exports/bin", O_DIRECTORY | O_RDONLY);
+		if (flatpakbin < 0) {
+			inotify_rm_watch(fd, flatpakwd);
+			inotify_rm_watch(fd, binwd);
+			inotify_rm_watch(fd, flatpakappwd);
+			inotify_rm_watch(fd, appwd);
+			close(fd);
+			regfree(&re);
+			return EXIT_FAILURE;
+		}
+	}
+
 	usrbin = open("/usr/bin", O_DIRECTORY | O_RDONLY);
 	if (usrbin < 0) {
+		close(flatpakbin);
 		inotify_rm_watch(fd, flatpakwd);
 		inotify_rm_watch(fd, binwd);
 		inotify_rm_watch(fd, flatpakappwd);
@@ -179,6 +193,7 @@ main(int argc, char* argv[])
 	    (fcntl(fd, F_SETSIG, SIGRTMIN) < 0) ||
 	    (fcntl(fd, F_SETOWN, getpid()) < 0)) {
 		close(usrbin);
+		close(flatpakbin);
 		inotify_rm_watch(fd, flatpakwd);
 		inotify_rm_watch(fd, binwd);
 		inotify_rm_watch(fd, flatpakappwd);
@@ -190,12 +205,13 @@ main(int argc, char* argv[])
 
 	while ((sigwait(&set, &sig) == 0) &&
 	       (((sig == SIGRTMIN) &&
-	         (handle_events(&re, fd, appwd, flatpakappwd, binwd, flatpakwd, usrbin, &oset) == 0)) ||
+	         (handle_events(&re, fd, appwd, flatpakappwd, binwd, flatpakwd, flatpakbin, usrbin, &oset) == 0)) ||
 	        ((sig == SIGALRM) &&
 	         (sh(argv[1], &oset) == 0)) ||
 	        (sig == SIGCHLD)));
 
 	close(usrbin);
+	close(flatpakbin);
 	inotify_rm_watch(fd, flatpakwd);
 	inotify_rm_watch(fd, binwd);
 	inotify_rm_watch(fd, flatpakappwd);

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/3055.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/3055.patch
@@ -1,0 +1,31 @@
+diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2022-04-29 22:10:11.701935725 +0800
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2022-04-29 22:12:40.906103926 +0800
+@@ -217,11 +217,25 @@ process_entry(GMenuTreeEntry *entry)
+ 
+   if (gmenu_tree_entry_get_launch_in_terminal (entry))
+   {
+-    cmd = g_strdup_printf("rxvt -title '%s' -e sh -c '%s'", name, exec);
++    if (g_str_has_prefix(exec, "/usr/bin/flatpak run"))
++    {
++      cmd = g_strdup_printf("rxvt -title '%s' -e sh -c 'run-as-spot %s'", name, exec);
++    }
++    else
++    {
++      cmd = g_strdup_printf("rxvt -title '%s' -e sh -c '%s'", name, exec);
++    }
+   }
+   else
+   {
+-    cmd = exec;
++    if (g_str_has_prefix(exec, "/usr/bin/flatpak run"))
++    {
++      cmd = g_strdup_printf("run-as-spot %s", exec);
++    }
++    else
++    {
++      cmd = exec;
++    }
+   }
+ 
+   comment = gmenu_tree_entry_get_comment (entry);

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/3055.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/3055.patch
@@ -20,7 +20,7 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 -    cmd = exec;
 +    if (g_str_has_prefix(exec, "/usr/bin/flatpak run"))
 +    {
-+      cmd = g_strdup_printf("run-as-spot %s", exec);
++      cmd = g_strdup_printf("WAYLAND_DISPLAY= run-as-spot %s", exec);
 +    }
 +    else
 +    {

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/petbuild
@@ -20,6 +20,7 @@ build() {
     patch -p1 < ../empty-menus.patch
     patch -p1 < ../2089.patch
     patch -p1 < ../unique.patch
+    patch -p1 < ../3055.patch
     $CC $CFLAGS -DGMENU_I_KNOW_THIS_IS_UNSTABLE `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --cflags glib-2.0 libgnome-menu` jwm-xdgmenu/jwm-xdgmenu.c $LDFLAGS `PKG_CONFIG_PATH="/usr/lib/pkgconfig:$PKG_CONFIG_PATH" pkg-config --libs glib-2.0 libgnome-menu` -o /usr/bin/jwm-xdgmenu
 
     # we don't need these

--- a/woof-code/rootfs-skeleton/etc/profile.d/flatpak-bindir.sh
+++ b/woof-code/rootfs-skeleton/etc/profile.d/flatpak-bindir.sh
@@ -1,0 +1,1 @@
+[ -e /var/lib/flatpak/exports/bin ] && export PATH="$PATH:/var/lib/flatpak/exports/bin"


### PR DESCRIPTION
After `flatpak install org.gnome.gedit`, with a workaround for #3057:

![gedit](https://user-images.githubusercontent.com/1471149/166096193-b539c709-ca09-4be2-9fb0-5511aab7d94d.png)
