### PR TITLE
Replace /root with /home/spot in XDG_* environment variables

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -38,6 +38,15 @@ if [ $(id -u) -eq 0 ]; then
 	touch ${USER_HOME}/.Xauthority
 	export XAUTHORITY=${USER_HOME}/.Xauthority
 
+	# replace all occurences of /root in XDG_* with /home/spot, because we don't
+	# run a login shell and source /etc/profile.d/*
+	OLD_HOME="$HOME"
+	while IFS='=' read NAME VAL; do
+		case "$NAME" in
+		XDG_*) export $NAME="`echo "$VAL" | sed -e s~^$OLD_HOME~$USER_HOME~ -e s~:$OLD_HOME~:$USER_HOME~g`" ;;
+		esac
+	done < <(env)
+
 	export XDG_CONFIG_HOME=${USER_HOME}/.config
 	export XDG_CACHE_HOME=${USER_HOME}/.cache
 	export XDG_DATA_HOME=${USER_HOME}/.local/share


### PR DESCRIPTION
Flatpak uses XDG_DATA_DIRS, and run-as-spot doesn't set this one.

(It's a file in /etc/profile.d that adds a directory under /root to XDG_DATA_DIRS, but we don't run a login shell inside run-as-spot, so this file doesn't get sourced again.)