### PR TITLE
Fix double setup-spot

### DIFF
--- a/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
+++ b/woof-code/rootfs-petbuilds/fixmenusd/fixmenusd.c
@@ -57,7 +57,7 @@ setup_spot(const regex_t *re, const int usrbin, const struct inotify_event *even
 
 	len = strlen(event->name);
 	memcpy(orig, event->name, len);
-	memcpy(orig + len, ".bin", sizeof(".bin") - 1);
+	memcpy(orig + len, ".bin", sizeof(".bin"));
 
 	if ((fstatat(usrbin, orig, &stbuf, AT_SYMLINK_NOFOLLOW) == 0) ||
 	    (errno != ENOENT))


### PR DESCRIPTION
fixmenusd has a bug: it checks if setup-spot ran in the past, by concatenating the executable path and ".bin", but doesn't terminate the string. It's a problem, because this string is a static buffer, reused in later invocations of setup_spot(). Therefore, if you install application x and then application y, and the executable name of x is longer, the garbage at the end of the executable name prevents this protection against double setup-spot from working.

This is super important to have before #3064 is merged, because Flatpak executables have long names and make this statistical bug much more likely to happen in the real world.

To reproduce:

```
flatpak install com.github.dimkr.gplaces
apt install hexchat
```

```
~$ strace -s 999 -p `pidof fixmenusd`
...
newfstatat(4, "com.github.dimkr.gplaces.bin", 0x7ffc3498f9f0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
...
newfstatat(5, "hexchat.bindimkr.gplaces.bin", 0x7ffc3498f9f0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)             <- The static string is not terminated after the first invocation of setup_spot()
```

With the fix:

```
~$ strace -s 999 -p `pidof fixmenusd`
...
newfstatat(4, "com.github.dimkr.gplaces.bin", 0x7ffe6a8fc8f0, AT_SYMLINK_NOFOLLOW) = -1 ENOENT (No such file or directory)
...
newfstatat(5, "hexchat.bin", {st_mode=S_IFREG|0755, st_size=1015376, ...}, AT_SYMLINK_NOFOLLOW) = 0
```