### PR TITLE
Add fonts-noto-color-emoji to bullseye64, sid64 and jammy64

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -143,6 +143,7 @@ yes|flex|flex|exe>dev,dev,doc,nls||deps:yes
 no|foomatic-db-engine|foomatic-db-engine|exe,dev,doc,nls
 no|foomatic-filters|foomatic-filters|exe,dev,doc,nls
 yes|fonts-liberation|fonts-liberation|exe,dev,doc,nls||deps:yes
+yes|fonts-noto-color-emoji|fonts-noto-color-emoji|exe,dev,doc,nls||deps:yes
 no|fpm2||exe,dev
 no|freeglut|freeglut3,freeglut3-dev|exe,dev,doc,nls
 no|freememapplet||exe

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -146,6 +146,7 @@ yes|flex|flex|exe>dev,dev,doc,nls||deps:yes
 no|foomatic-db-engine|foomatic-db-engine|exe,dev,doc,nls
 no|foomatic-filters|foomatic-filters|exe,dev,doc,nls
 yes|fonts-liberation|fonts-liberation|exe,dev,doc,nls||deps:yes
+yes|fonts-noto-color-emoji|fonts-noto-color-emoji|exe,dev,doc,nls||deps:yes
 no|fpm2||exe,dev
 no|freeglut|freeglut3,freeglut3-dev|exe,dev,doc,nls
 no|freememapplet||exe

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -146,6 +146,7 @@ yes|flex|flex|exe>dev,dev,doc,nls||deps:yes
 no|foomatic-db-engine|foomatic-db-engine|exe,dev,doc,nls
 no|foomatic-filters|foomatic-filters|exe,dev,doc,nls
 yes|fonts-liberation|fonts-liberation|exe,dev,doc,nls||deps:yes
+yes|fonts-noto-color-emoji|fonts-noto-color-emoji|exe,dev,doc,nls||deps:yes
 no|fpm2||exe,dev
 no|freeglut|freeglut3,freeglut3-dev|exe,dev,doc,nls
 no|freememapplet||exe


### PR DESCRIPTION
This is a big 10 MB package, but even some console applications use emojis nowadays, and I think the extra usability is worth it.