### PR TITLE
Make run-as-spot work with busybox from 2019 (fixes #3077)

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -45,7 +45,9 @@ if [ $(id -u) -eq 0 ]; then
 		case "$NAME" in
 		XDG_*) export $NAME="`echo "$VAL" | sed -e s~^$OLD_HOME~$USER_HOME~ -e s~:$OLD_HOME~:$USER_HOME~g`" ;;
 		esac
-	done < <(env)
+	done << EOF # hack for old busybox, which doesn't understand <() and <<<
+`env`
+EOF
 
 	export XDG_CONFIG_HOME=${USER_HOME}/.config
 	export XDG_CACHE_HOME=${USER_HOME}/.cache


### PR DESCRIPTION
It's an ugly hack and I think it's super bad to use an old and unreproducible package from 2019. That busybox is old, and it's statically linked against old libraries (could be affected by CVE-2020-28928, I haven't checked).