### PR TITLE
Make Blueman desktop notifications work under X

### DIFF
--- a/woof-code/packages-templates/notification-daemon_FIXUPHACK
+++ b/woof-code/packages-templates/notification-daemon_FIXUPHACK
@@ -1,0 +1,7 @@
+BIN=`find . -name notification-daemon -type f`
+mkdir -p usr/share/dbus-1/services
+cat << EOF > usr/share/dbus-1/services/org.freedesktop.Notifications.service
+[D-BUS Service]
+Name=org.freedesktop.Notifications
+Exec=${BIN#.}
+EOF

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -487,6 +487,7 @@ no|network_roxapp_samba||exe
 yes|ninja|ninja-build|exe>dev,dev,doc,nls||deps:yes
 no|normalize|normalize-audio|exe,dev,doc,nls
 no|notecase||exe,dev,doc,nls
+yes|notification-daemon|notification-daemon|exe,dev,doc,nls||deps:yes
 no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 yes|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -491,6 +491,7 @@ no|network_roxapp_samba||exe
 yes|ninja|ninja-build|exe>dev,dev,doc,nls||deps:yes
 no|normalize|normalize-audio|exe,dev,doc,nls
 no|notecase||exe,dev,doc,nls
+yes|notification-daemon|notification-daemon|exe,dev,doc,nls||deps:yes
 no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 no|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.


### PR DESCRIPTION
Without this addition, Blueman uses its own implementation of notifications, and doesn't implement timeout, so the borderless window with the notification stays there forever.

The "pure Wayland" use case needs some other notification daemon, which supports Wayland. Maybe we should just implement a small D-Bus server that uses gtkdialog-splash.

Another problem is appearance, we don't have a mechanism to set the notification shape and colors.

![notification](https://user-images.githubusercontent.com/1471149/167999902-b904fa27-c855-4ae1-a2c4-d4bbdca3659f.png)
