### PR TITLE
Disable Blueman notifications (fixes #3060)

### DIFF
--- a/woof-code/packages-templates/blueman_FIXUPHACK
+++ b/woof-code/packages-templates/blueman_FIXUPHACK
@@ -9,3 +9,6 @@ EOF
 
 # the tray applet is written in Python and eats up precious RAM
 [ "$DISTRO_TARGETARCH" = "x86" ] && rm -vf etc/xdg/autostart/blueman.desktop
+
+# Puppy traditionally doesn't have desktop notifications, and Blueman's internal notifications mechanism doesn't have timeout
+rm -f usr/lib/python3/dist-packages/blueman/plugins/applet/ConnectionNotifier.py


### PR DESCRIPTION
This is a cheaper alternative to #3081. I think I like this one better. I hate notifications myself, and traditionally, Puppy doesn't have them because there's no notifications daemon to display them. This is more consistent with Puppy tradition.