### PR TITLE
Switch back to rox-filer in bullseye64

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray pcmanfm sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec pup-volume-monitor"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
After #3083, bullseye64 is 100% free from Wayland related stuff. I want to start a 9.2.x branch of dpup with apt and all the other goodies in 9.1.x, minus Wayland related stuff, because I won't be able to easily maintain a backport of dwl.