### PR TITLE
xorg-autoconf: Added nvidia kernel module for modesetting

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -621,7 +621,7 @@ drvfound=""
 [ -e $XORG_MODULE_PATH/drivers/${drv}_drv.so ] && drvfound="1"
 
 if [ "$drvfound" == "" ]; then
- if [ "$(echo "$MODLIST" | awk '{ print $1 }' | grep -E "^nouveau")" != "" ]; then
+ if [ "$(echo "$MODLIST" | awk '{ print $1 }' | grep -E "^nouveau|^nvidia")" != "" ]; then
   drv="modesetting"
  fi
 fi


### PR DESCRIPTION
Since the announcement of nvidia open source driver. Using modesetting might be feasible.