### PR TITLE
umount.crypto_LUKS: Use initrd cryptsetup first

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/umount.crypto_LUKS
+++ b/woof-code/rootfs-skeleton/sbin/umount.crypto_LUKS
@@ -7,6 +7,10 @@
 
 #set -x
 
+CRYPTINITRD=""
+[ -e "/initrd/bin/cryptsetup" ] && CRYPTINITRD="/initrd/bin/cryptsetup"
+[ -e "/initrd/sbin/cryptsetup" ] && CRYPTINITRD="/initrd/sbin/cryptsetup"
+
 CRYPTSETUP=cryptsetup
 [ -x /bin/cryptsetup ] && CRYPTSETUP=/bin/cryptsetup
 [ -x /initrd/files/bin/cryptsetup ] && CRYPTSETUP=/initrd/files/bin/cryptsetup
@@ -22,7 +26,10 @@ luks_umount() {
 		# /dev/mapper/luksfile11171
 		mntinfo=$(mount | grep "^${1} ")
 		if [ -z "$mntinfo" ] ; then
-			$CRYPTSETUP luksClose ${1##*/} #basename
+		        #Try cryptsetup from initrd
+			[ "$CRYPTINITRD" != "" ] && $CRYPTINITRD luksClose ${1##*/} 2>/dev/null #basename
+			#If fails use cryptsetup from main puppy sfs
+			[ "$(mount | grep "^${1} ")" != "" ] && $CRYPTSETUP luksClose ${1##*/} #basename
 			return $?
 		fi
 	elif [ -d $1 ] ; then # mountpoint


### PR DESCRIPTION
Try to unmount luks block devices using static build from initrd first in response on merged PR #2680 if unmount fails use the cryptsetup from main puppy sfs file