### PR TITLE
Add a dummy notification daemon to prevent notifications

### DIFF
--- a/woof-code/packages-templates/blueman_FIXUPHACK
+++ b/woof-code/packages-templates/blueman_FIXUPHACK
@@ -9,6 +9,3 @@ EOF
 
 # the tray applet is written in Python and eats up precious RAM
 [ "$DISTRO_TARGETARCH" = "x86" ] && rm -vf etc/xdg/autostart/blueman.desktop
-
-# Puppy traditionally doesn't have desktop notifications, and Blueman's internal notifications mechanism doesn't have timeout
-rm -f usr/lib/python3/dist-packages/blueman/plugins/applet/ConnectionNotifier.py

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
@@ -1,0 +1,74 @@
+#include "generated-code.h"
+
+
+static gboolean
+on_get_capabilities (OrgFreedesktopNotifications *object,
+                     GDBusMethodInvocation       *invocation,
+                     gpointer                    user_data)
+{
+  static const gchar *capabilities[] = {"body", "actions", NULL};
+  org_freedesktop_notifications_complete_get_capabilities (object, invocation, capabilities);
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+
+static void
+on_bus_acquired (GDBusConnection *connection,
+                 const gchar     *name,
+                 gpointer         user_data)
+{
+  OrgFreedesktopNotifications *object;
+  gboolean exported;
+
+  object = org_freedesktop_notifications_skeleton_new();
+
+  g_signal_connect (object,
+                    "handle-get-capabilities",
+                    G_CALLBACK (on_get_capabilities),
+                    NULL);
+
+  exported = g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (object),
+                                               connection,
+                                               "/org/freedesktop/Notifications",
+                                               NULL);
+  if (!exported)
+    {
+      g_main_loop_quit((GMainLoop *)user_data);
+    }
+}
+
+
+static void
+on_name_lost (GDBusConnection *connection,
+              const gchar     *name,
+              gpointer         user_data)
+{
+  g_main_loop_quit((GMainLoop *)user_data);
+}
+
+
+gint
+main (gint argc, gchar *argv[])
+{
+  GMainLoop *loop;
+  guint id;
+
+  loop = g_main_loop_new (NULL, FALSE);
+
+  id = g_bus_own_name (G_BUS_TYPE_SESSION,
+                       "org.freedesktop.Notifications",
+                       G_BUS_NAME_OWNER_FLAGS_ALLOW_REPLACEMENT |
+                       G_BUS_NAME_OWNER_FLAGS_REPLACE,
+                       on_bus_acquired,
+                       NULL,
+                       on_name_lost,
+                       loop,
+                       NULL);
+
+  g_main_loop_run (loop);
+
+  g_bus_unown_name (id);
+  g_main_loop_unref (loop);
+
+  return 0;
+}

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "generated-code.h"
 
 
@@ -8,6 +9,24 @@ on_get_capabilities (OrgFreedesktopNotifications *object,
 {
   static const gchar *capabilities[] = {"body", NULL};
   org_freedesktop_notifications_complete_get_capabilities (object, invocation, capabilities);
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+
+static gboolean
+on_notify (OrgFreedesktopNotifications *object,
+           GDBusMethodInvocation       *invocation,
+           const gchar                 *app_name,
+           guint                        replaces_id,
+           const gchar                 *app_icon,
+           const gchar                 *summary,
+           const gchar                 *body,
+           const gchar *const          *actions,
+           GVariant                    *hints,
+           gint                         expire_timeout,
+           gpointer                     user_data)
+{
+  org_freedesktop_notifications_complete_notify (object, invocation, 0);
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }
 
@@ -25,6 +44,10 @@ on_bus_acquired (GDBusConnection *connection,
   g_signal_connect (object,
                     "handle-get-capabilities",
                     G_CALLBACK (on_get_capabilities),
+                    NULL);
+  g_signal_connect (object,
+                    "handle-notify",
+                    G_CALLBACK (on_notify),
                     NULL);
 
   exported = g_dbus_interface_skeleton_export (G_DBUS_INTERFACE_SKELETON (object),

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
@@ -6,7 +6,7 @@ on_get_capabilities (OrgFreedesktopNotifications *object,
                      GDBusMethodInvocation       *invocation,
                      gpointer                    user_data)
 {
-  static const gchar *capabilities[] = {"body", "actions", NULL};
+  static const gchar *capabilities[] = {"body", NULL};
   org_freedesktop_notifications_complete_get_capabilities (object, invocation, capabilities);
   return G_DBUS_METHOD_INVOCATION_HANDLED;
 }

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
@@ -2,6 +2,12 @@
 #include "generated-code.h"
 
 
+/* for < 2.68 */
+#ifndef G_DBUS_METHOD_INVOCATION_HANDLED
+#	define G_DBUS_METHOD_INVOCATION_HANDLED TRUE
+#endif
+
+
 static gboolean
 on_get_capabilities (OrgFreedesktopNotifications *object,
                      GDBusMethodInvocation       *invocation,

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/pet.specs
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/pet.specs
@@ -1,0 +1,1 @@
+notification-daemon-stub-1|notification-daemon-stub|1||BuildingBlock|348||notification-daemon-stub-1.pet||notification daemon stub|puppy|||

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/petbuild
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/petbuild
@@ -1,0 +1,18 @@
+download() {
+    :
+}
+
+build() {
+    cat << EOF > org.freedesktop.Notifications.xml
+<node>
+  <interface name="org.freedesktop.Notifications">
+    <method name="GetCapabilities">
+      <arg type="as" name="capabilities" direction="out" />
+    </method>
+  </interface>
+</node>
+EOF
+    gdbus-codegen --interface-prefix org.freedesktop.Notifications. --generate-c-code generated-code org.freedesktop.Notifications.xml
+
+    $CC $CFLAGS `pkg-config --cflags gio-2.0 gio-unix-2.0` generated-code.c main.c $LDFLAGS `pkg-config --libs gio-2.0 gio-unix-2.0` -o /usr/bin/notification-daemon-stub
+}

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/petbuild
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/petbuild
@@ -9,6 +9,17 @@ build() {
     <method name="GetCapabilities">
       <arg type="as" name="capabilities" direction="out" />
     </method>
+    <method name="Notify">
+      <arg type="s" name="app_name" direction="in" />
+      <arg type="u" name="replaces_id" direction="in" />
+      <arg type="s" name="app_icon" direction="in" />
+      <arg type="s" name="summary" direction="in" />
+      <arg type="s" name="body" direction="in" />
+      <arg type="as" name="actions" direction="in" />
+      <arg type="a{sv}" name="hints" direction="in" />
+      <arg type="i" name="expire_timeout" direction="in" />
+      <arg type="u" name="id" direction="out" />
+    </method>
   </interface>
 </node>
 EOF

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/usr/share/dbus-1/services/org.freedesktop.Notifications.service
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/usr/share/dbus-1/services/org.freedesktop.Notifications.service
@@ -1,0 +1,3 @@
+[D-BUS Service]
+Name=org.freedesktop.Notifications
+Exec=/usr/bin/notification-daemon-stub

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -487,6 +487,7 @@ no|network_roxapp_samba||exe
 yes|ninja|ninja-build|exe>dev,dev,doc,nls||deps:yes
 no|normalize|normalize-audio|exe,dev,doc,nls
 no|notecase||exe,dev,doc,nls
+yes|notification-daemon|notification-daemon|exe>null,dev>null,doc>null,nls>null
 no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 yes|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -494,6 +494,7 @@ no|network_roxapp_samba||exe
 yes|ninja|ninja-build|exe>dev,dev,doc,nls||deps:yes
 no|normalize|normalize-audio|exe,dev,doc,nls
 no|notecase||exe,dev,doc,nls
+yes|notification-daemon|notification-daemon|exe>null,dev>null,doc>null,nls>null
 no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 yes|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec pup-volume-monitor"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -491,6 +491,7 @@ no|network_roxapp_samba||exe
 yes|ninja|ninja-build|exe>dev,dev,doc,nls||deps:yes
 no|normalize|normalize-audio|exe,dev,doc,nls
 no|notecase||exe,dev,doc,nls
+yes|notification-daemon|notification-daemon|exe>null,dev>null,doc>null,nls>null
 no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 no|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec dwl-kiosk swaylock wlopm"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
This daemon lies that the capabilities Blueman looks for are present, so Blueman tries to use it to show a notification.

This is much lighter than the real notification-daemon (or any other widely-available implementation of desktop notifications), and behaves the same under Wayland 😉 

In the future, it should be easy to implement the missing Notify method, and simulate notifications with gtkdialog-splash. But as a first step, I want to prevent applications that show notifications from using some internal implementation.

(I wrote a blog post about this PR, in gemini://gemini.dimakrasner.com/blueman-notifications.gmi)