### PR TITLE
Start D-Bus after Xwayland

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -18,28 +18,6 @@ for F in $WAYLAND_DISPLAY $WAYLAND_DISPLAY.lock; do
 	mount --bind $XDG_RUNTIME_DIR/$F $SPOT_RUNTIME_DIR/$F
 done
 
-run-as-spot dbus-launch > /tmp/.spot-session-bus
-
-if [ -e /usr/bin/wireplumber ]; then
-    killall pipewire pipewire-pulse wireplumber
-    rm -f /tmp/runtime-spot/pipewire-0
-    run-as-spot pipewire &
-    (
-        while [ ! -e /tmp/runtime-spot/pipewire-0 ]; do sleep 0.1; done
-        run-as-spot pipewire-pulse &
-        run-as-spot wireplumber &
-    ) &
-    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
-    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
-elif [ -e /usr/bin/pulseaudio ]; then
-    PULSE_SERVER= run-as-spot sh -c "pulseaudio --kill > /dev/null 2>&1; pulseaudio --start --log-target=syslog"
-    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
-    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
-fi
-
-. /etc/rc.d/wl_func
-apply_pthemerc
-
 DISPLAY=:0
 XAUTHORITY=~/.Xauthority
 
@@ -74,6 +52,28 @@ done
 
 export GDK_BACKEND=x11
 unset SDL_VIDEODRIVER
+
+eval `dbus-launch --exit-with-x11 --sh-syntax`
+run-as-spot dbus-launch --exit-with-x11 > /tmp/.spot-session-bus
+
+if [ -e /usr/bin/wireplumber ]; then
+    rm -f /tmp/runtime-spot/pipewire-0
+    run-as-spot pipewire &
+    (
+        while [ ! -e /tmp/runtime-spot/pipewire-0 ]; do sleep 0.1; done
+        run-as-spot pipewire-pulse &
+        run-as-spot wireplumber &
+    ) &
+    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
+    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
+elif [ -e /usr/bin/pulseaudio ]; then
+    PULSE_SERVER= run-as-spot sh -c "pulseaudio --kill > /dev/null 2>&1; pulseaudio --start --log-target=syslog"
+    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
+    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
+fi
+
+. /etc/rc.d/wl_func
+apply_pthemerc
 
 /usr/sbin/delayedrun &
 

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -40,9 +40,9 @@ do
 	[ -n "$LIBINPUT_DEFAULT_LEFT_HANDED" ] && export LIBINPUT_DEFAULT_LEFT_HANDED
 
 	if [ /var/local/xwin_disable_xerrs_log_flag ]; then
-		dbus-launch dwl-kiosk -s ~/.dwlinitrc > /dev/null 2>&1
+		dwl-kiosk -s ~/.dwlinitrc > /dev/null 2>&1
 	else
-		dbus-launch dwl-kiosk -s ~/.dwlinitrc > /tmp/xerrs.log 2>&1
+		dwl-kiosk -s ~/.dwlinitrc > /tmp/xerrs.log 2>&1
 	fi
 
 	echo '--------'


### PR DESCRIPTION
This fixes two problems:
1) Some applications are "D-Bus activated", so sometimes the Blueman UI is started by a process started by D-Bus: this process doesn't have GDK_BACKEND=x11, so it's a native Wayland window that floats above the X desktop
2) The two D-Bus "session busses" are not terminated when dwl exits, but if we ask them to terminate when Xwayland exits, that's good enough for now