### PR TITLE
Add osmo petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/osmo/defaults.patch
+++ b/woof-code/rootfs-petbuilds/osmo/defaults.patch
@@ -1,0 +1,32 @@
+diff -rupN osmo-0.4.4-orig/src/options_prefs.c osmo-0.4.4/src/options_prefs.c
+--- osmo-0.4.4-orig/src/options_prefs.c	2022-05-23 22:05:17.851917650 +0800
++++ osmo-0.4.4/src/options_prefs.c	2022-05-23 22:06:26.487997273 +0800
+@@ -128,7 +128,7 @@ gint i;
+     config.toolbar_exit_button = FALSE;
+     config.date_format = DATE_YYYY_MM_DD;
+     config.time_format = TIME_24;
+-    config.enable_systray = TRUE;
++    config.enable_systray = FALSE;
+     config.start_minimised_in_systray = FALSE;
+     config.ignore_day_note_events = FALSE;
+     config.run_counter = 0;
+@@ -145,8 +145,8 @@ gint i;
+     g_strlcpy (config.spell_lang, g_getenv("LANG"), MAXNAME);
+     /* FIXME: DO NOT USE xdg-open AS IT CANNOT OPEN MULTIPLE LINKS AT ONCE */
+ 	/*g_strlcpy (config.web_browser, "xdg-open %s", MAXHELPERCMD);*/
+-	g_strlcpy (config.web_browser, "firefox %s", MAXHELPERCMD);
+-	g_strlcpy (config.email_client, "xdg-email %s", MAXHELPERCMD);
++	g_strlcpy (config.web_browser, "defaultbrowser %s", MAXHELPERCMD);
++	g_strlcpy (config.email_client, "defaultemail %s", MAXHELPERCMD);
+ 	/* play command requires SoX */
+ 	/*g_strlcpy (config.sound_player, "play %s", MAXHELPERCMD);*/
+ 	g_strlcpy (config.sound_player, "aplay %s", MAXHELPERCMD);
+@@ -160,7 +160,7 @@ gint i;
+     config.cb_window_size_y = 680;
+     config.ib_window_size_x = 550;
+     config.ib_window_size_y = 650;
+-    config.display_options = GUI_CALENDAR_SHOW_DAY_NAMES | GUI_CALENDAR_NO_MONTH_CHANGE | GUI_CALENDAR_WEEK_START_MONDAY;
++    config.display_options = GUI_CALENDAR_SHOW_DAY_NAMES | GUI_CALENDAR_NO_MONTH_CHANGE;
+     config.day_notes_visible = FALSE;
+     config.timeline_start = 8*60;
+     config.timeline_end = 15*60;

--- a/woof-code/rootfs-petbuilds/osmo/deps.patch
+++ b/woof-code/rootfs-petbuilds/osmo/deps.patch
@@ -1,0 +1,39 @@
+diff -rupN osmo-0.4.4-orig/configure osmo-0.4.4/configure
+--- osmo-0.4.4-orig/configure	2022-05-24 16:01:18.312892796 +0800
++++ osmo-0.4.4/configure	2022-05-24 16:01:48.557044142 +0800
+@@ -5986,7 +5986,7 @@ else
+ 	LIBICAL_LIBS=$pkg_cv_LIBICAL_LIBS
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+-	have_libical=true
++	have_libical=false
+ fi
+ if test "x$have_libical" = "xtrue"; then
+ 
+@@ -6164,7 +6164,7 @@ else
+ 	LIBNOTIFY_LIBS=$pkg_cv_LIBNOTIFY_LIBS
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+-	have_libnotify7=true
++	have_libnotify7=false
+ fi
+ if test "x$have_libnotify7" = "xtrue"; then
+ 
+@@ -6244,7 +6244,7 @@ else
+ 	LIBNOTIFY_LIBS=$pkg_cv_LIBNOTIFY_LIBS
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+-	have_libnotify=true
++	have_libnotify=false
+ fi
+     if test "x$have_libnotify" = "xtrue"; then
+ 
+@@ -6348,7 +6348,7 @@ else
+ 	LIBWEBKIT_LIBS=$pkg_cv_LIBWEBKIT_LIBS
+         { $as_echo "$as_me:${as_lineno-$LINENO}: result: yes" >&5
+ $as_echo "yes" >&6; }
+-	have_libwebkit=true
++	have_libwebkit=false
+ fi
+ if test "x$have_libwebkit" = "xtrue"; then
+     libwebkit="yes"

--- a/woof-code/rootfs-petbuilds/osmo/pet.specs
+++ b/woof-code/rootfs-petbuilds/osmo/pet.specs
@@ -1,0 +1,1 @@
+osmo-4.4|osmo|4.4||Personal|244||osmo-4.4.pet||Personal Organizer|puppy|||

--- a/woof-code/rootfs-petbuilds/osmo/petbuild
+++ b/woof-code/rootfs-petbuilds/osmo/petbuild
@@ -1,0 +1,12 @@
+download() {
+    [ -f osmo-0.4.4.tar.gz ] || wget -t 3 -T 60 -O osmo-0.4.4.tar.gz https://sourceforge.net/projects/osmo-pim/files/osmo-pim/osmo-0.4.4/osmo-0.4.4.tar.gz/download
+}
+
+build() {
+    tar -xzf osmo-0.4.4.tar.gz
+    cd osmo-0.4.4
+    patch -p1 < ../defaults.patch
+    patch -p1 < ../deps.patch
+    ./configure --prefix=/usr --enable-backup=no
+    make install
+}

--- a/woof-code/rootfs-petbuilds/osmo/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/osmo/pinstall.sh
@@ -1,0 +1,3 @@
+echo '#!/bin/sh
+exec osmo "$@"' > usr/local/bin/defaultcalendar
+chmod 755 usr/local/bin/defaultcalendar

--- a/woof-code/rootfs-petbuilds/osmo/sha256.sum
+++ b/woof-code/rootfs-petbuilds/osmo/sha256.sum
@@ -1,0 +1,1 @@
+1e8b11bd1baa0f6756326b58f87eb95a56b38a25d7336fdfb65c2dfca46d03a6  osmo-0.4.4.tar.gz

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/slackware64/15.0/DISTRO_PKGS_SPECS-slackware64-15.0
+++ b/woof-distro/x86_64/slackware64/15.0/DISTRO_PKGS_SPECS-slackware64-15.0
@@ -280,9 +280,9 @@ yes|libgnomeprintui||exe,dev,doc,nls
 yes|libgpg-error|libgpg-error|exe,dev,doc,nls
 yes|libgphoto2||exe,dev,doc,nls
 yes|libgsf|libgsf|exe,dev,doc,nls
-yes|libgtkhtml||exe,dev,doc,nls
+no|libgtkhtml||exe,dev,doc,nls
 yes|libgudev|libgudev|exe,dev,doc,nls
-yes|libical|libical|exe,dev,doc,nls
+no|libical|libical|exe,dev,doc,nls
 yes|libidl|libidl|exe,dev,doc,nls
 yes|libidn|libidn,libidn2|exe,dev,doc,nls
 yes|libieee1284|libieee1284|exe,dev,doc,nls
@@ -397,7 +397,7 @@ yes|openssh_server|openssh|exe,dev,doc,nls
 yes|openssl|openssl,openssl-solibs|exe,dev,doc,nls
 yes|opus|opus|exe,dev,doc,nls
 yes|orc|orc|exe,dev,doc,nls
-yes|osmo||exe,dev,doc,nls
+no|osmo||exe,dev,doc,nls
 yes|osxcart||exe,dev,doc,nls
 yes|p7zip||exe,dev,doc,nls
 yes|pam_slack|pam,cracklib,libpwquality|exe,dev,doc,nls

--- a/woof-distro/x86_64/slackware64/15.0/_00build.conf
+++ b/woof-distro/x86_64/slackware64/15.0/_00build.conf
@@ -50,7 +50,7 @@ BUILD_NLSX=no
 DEVX_IN_ISO=no
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons ram-saver"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce osmo pa-applet powerapplet_tray rox-filer rxvt-unicode sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons ram-saver"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
@@ -418,12 +418,12 @@ no|libgnome-keyring|libgnome-keyring-common,libgnome-keyring0|exe,dev,doc,nls|
 no|libgnomeui|libgnomeui-0,libgnomeui-common,libgnomeui-dev|exe,dev,doc,nls|
 yes|libgpg-error|libgpg-error0,libgpg-error-dev|exe,dev,doc,nls
 yes|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc,nls
-yes|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
+no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
 yes|libgsf|gir1.2-gsf-1,libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc,nls
-yes|libgtkhtml||exe,dev,doc,nls| #needed by my osmo pet.
+no|libgtkhtml||exe,dev,doc,nls| #needed by my osmo pet.
 yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc,nls
 yes|libhogweed|libhogweed5|exe,dev,doc,nls
-yes|libical|libical3,libical-dev,libical-dev|exe,dev,doc,nls
+no|libical|libical3,libical-dev,libical-dev|exe,dev,doc,nls
 yes|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls
 yes|libidl|libidl-2-0,libidl-dev|exe,dev,doc,nls
 yes|libidn|libidn11,libidn11-dev|exe,dev,doc,nls
@@ -502,7 +502,7 @@ yes|libstdc++9|libstdc++6,libstdc++-9-dev|exe,dev,doc,nls
 yes|libsystem||exe,dev,doc,nls
 yes|libsystemd|libsystemd0,libsystemd-dev|exe,dev,doc,nls
 yes|libtalloc|libtalloc2,libtalloc-dev|exe,dev,doc,nls
-yes|libtar|libtar0,libtar-dev|exe,dev,doc,nls| #needed by osmo.
+no|libtar|libtar0,libtar-dev|exe,dev,doc,nls| #needed by osmo.
 yes|libtasn1|libtasn1-6,libtasn1-6-dev|exe,dev,doc,nls
 yes|libthai|libthai0,libthai-data,libthai-dev|exe,dev,doc,nls| #MERGED 20150717-08
 yes|libtheora|libtheora0,libtheora-dev|exe,dev,doc,nls
@@ -612,7 +612,7 @@ yes|optipng|optipng|exe>dev,dev,doc,nls
 yes|opus|libopus0,libopus-dev,libopusfile0,libopusfile-dev,opus-tools|exe,dev,doc,nls| #needed by ffmpeg
 no|orbit2|liborbit2,liborbit-2-0,liborbit2-dev|exe,dev,doc,nls
 yes|orc|liborc-0.4-0,liborc-0.4-dev|exe,dev,doc,nls| #needed by mplayer.
-yes|osmo||exe,dev,doc,nls| #needs libnotify, libgtkhtml, libtar, libgringotts, libical.
+no|osmo||exe,dev,doc,nls| #needs libnotify, libgtkhtml, libtar, libgringotts, libical.
 yes|ots|libots0,libots-dev|exe,dev,doc,nls
 yes|p11-kit|libp11-kit0,libp11-kit-dev|exe,dev,doc,nls| #needed by cupsd (ubuntu cups pkg). 121210 need dev pkg for gnutls, refer forum t=82092&start=135
 yes|p7zip-full|p7zip-full|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -50,7 +50,7 @@ BUILD_NLSX=no
 DEVX_IN_ISO=no
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce pa-applet powerapplet_tray rox-filer rxvt-unicode transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog-legacy xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint netmon_wce osmo pa-applet powerapplet_tray rox-filer rxvt-unicode transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog-legacy xlockmore yad pmaterial_icons puppy_flat_icons puppy_standard_icons"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
slackware/15.0 uses PETBUILD_GTK=2 and stays with the old GTK+ 2 .pet package. Everything with PETBUILD_GTK=3 now uses the new petbuild.

The transition to the latest version, a good thing in its own right, allows some dependencies of older versions (like libtar and libgkhtml) to be dropped.

![menu](https://user-images.githubusercontent.com/1471149/169851706-87abdb4c-380e-4824-a224-8918ff212787.png)
![osmo](https://user-images.githubusercontent.com/1471149/169851713-4a7771a8-eead-4a99-b9c1-c3b89d2f8746.png)

