### PR TITLE
Add gplaces petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/gplaces/pet.specs
+++ b/woof-code/rootfs-petbuilds/gplaces/pet.specs
@@ -1,1 +1,1 @@
-gplaces-0.16.17|gplaces|0.16.17||Internet|6656K||gplaces-0.16.17.pet||A simple terminal based Gemini client|puppy|||
+gplaces-0.16.18|gplaces|0.16.18||Internet|6656K||gplaces-0.16.18.pet||A simple terminal based Gemini client|puppy|||

--- a/woof-code/rootfs-petbuilds/gplaces/pet.specs
+++ b/woof-code/rootfs-petbuilds/gplaces/pet.specs
@@ -1,0 +1,1 @@
+gplaces-0.16.17|gplaces|0.16.17||Internet|6656K||gplaces-0.16.17.pet||A simple terminal based Gemini client|puppy|||

--- a/woof-code/rootfs-petbuilds/gplaces/petbuild
+++ b/woof-code/rootfs-petbuilds/gplaces/petbuild
@@ -1,0 +1,16 @@
+download() {
+    if [ ! -f gplaces-0.16.17.tar.gz ]; then
+        git clone https://github.com/dimkr/gplaces gplaces-0.16.17
+        cd gplaces-0.16.17
+        git checkout v0.16.17
+        git submodule update --init --recursive
+        cd ..
+        tar -c gplaces-0.16.17 | gzip -9 > gplaces-0.16.17.tar.gz
+    fi
+}
+
+build() {
+    tar -xzf gplaces-0.16.17.tar.gz
+    cd gplaces-0.16.17
+    make PREFIX=/usr CONFDIR=/etc install
+}

--- a/woof-code/rootfs-petbuilds/gplaces/petbuild
+++ b/woof-code/rootfs-petbuilds/gplaces/petbuild
@@ -1,16 +1,16 @@
 download() {
-    if [ ! -f gplaces-0.16.17.tar.gz ]; then
-        git clone https://github.com/dimkr/gplaces gplaces-0.16.17
-        cd gplaces-0.16.17
-        git checkout v0.16.17
+    if [ ! -f gplaces-0.16.18.tar.gz ]; then
+        git clone https://github.com/dimkr/gplaces gplaces-0.16.18
+        cd gplaces-0.16.18
+        git checkout v0.16.18
         git submodule update --init --recursive
         cd ..
-        tar -c gplaces-0.16.17 | gzip -9 > gplaces-0.16.17.tar.gz
+        tar -c gplaces-0.16.18 | gzip -9 > gplaces-0.16.18.tar.gz
     fi
 }
 
 build() {
-    tar -xzf gplaces-0.16.17.tar.gz
-    cd gplaces-0.16.17
+    tar -xzf gplaces-0.16.18.tar.gz
+    cd gplaces-0.16.18
     make PREFIX=/usr CONFDIR=/etc install
 }

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -133,7 +133,7 @@ no|faac|libfaac0|exe,dev,doc,nls
 no|faad|faad,libfaad2,libfaad-dev|exe,dev,doc,nls
 no|ffconvert||exe,dev,doc,nls
 no|ffmpeg|ffmpeg,libaom0,libaom-dev,libavcodec58,libavcodec-extra58,libavcodec-dev,libavutil56,libavdevice58,libavdevice-dev,libswresample3,libswresample-dev,libavresample4,libavresample-dev,libavfilter-extra*,libpostproc55,libpostproc-dev,libavutil-dev,libavutil-dev,libavformat58,libavformat-dev,libavdevice-dev,libavfilter7,libavfilter-dev,libbs2b0,libbs2b-dev,libcodec2-0.8.1,libcodec2-dev,libflite1,libgme0,libiec61883-0,liblilv-0-0,liblilv-dev,libjack-jackd2-0,libjack-jackd2-dev,libnorm1,libnorm-dev,libnuma1,libnuma-dev,libopenal1,libopenal-data,libopenal-dev,libshine3,libshine-dev,libsnappy1v5,libsodium23,libsodium-dev,libsoxr0,libsoxr-dev,libssh-gcrypt-4,libssh-gcrypt-dev,libswscale5,libswscale-dev,libwavpack1,libwavpack-dev,libzmq5,libsndio7.0,libsndio-dev,libsdl2-2.0-0,libsdl2-dev,libavc1394-0,libtwolame0,libmodplug1,librubberband2,libebur128-1,libass9,libass-dev,libchromaprint1,libzvbi0,libzvbi-common,libwebpmux3,libwebp6,libcrystalhd3,libjson-c3,libjson-c-dev,libspeex1,libcaca0,libopenmpt0,libmpg123-0,libpgm-5.2-0,libmysofa0,libmysofa-dev,libvidstab1.1,libvidstab-dev|exe,dev,doc,nls
-yes|file|file,libmagic1,libmagic-mgc|exe,dev,doc,nls||deps:yes
+yes|file|file,libmagic1,libmagic-mgc,libmagic-dev|exe,dev,doc,nls||deps:yes
 no|file_sharing-curlftpfs-mpscan||exe
 yes|findutils|findutils|exe,dev>null,doc,nls||deps:yes
 yes|firefox-esr|firefox-esr,firefox-esr-l10n-all|exe,dev>null,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat gplaces"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -118,6 +118,7 @@ chroot . /usr/sbin/setup-spot firefox-esr=true
 chroot . /usr/sbin/setup-spot sylpheed=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true
+chroot . /usr/sbin/setup-spot gplaces=true
 mv -f root/.spot-status root/.spot-status.orig
 chroot . /usr/sbin/setup-spot powerapplet_tray=true
 mv -f root/.spot-status.orig root/.spot-status

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -135,7 +135,7 @@ no|faac|libfaac0|exe,dev,doc,nls
 no|faad|faad,libfaad2,libfaad-dev|exe,dev,doc,nls
 no|ffconvert||exe,dev,doc,nls
 no|ffmpeg|ffmpeg,libaom0,libaom-dev,libavcodec58,libavcodec-extra58,libavcodec-dev,libavutil56,libavdevice58,libavdevice-dev,libswresample3,libswresample-dev,libavresample4,libavresample-dev,libavfilter-extra*,libpostproc55,libpostproc-dev,libavutil-dev,libavutil-dev,libavformat58,libavformat-dev,libavdevice-dev,libavfilter7,libavfilter-dev,libbs2b0,libbs2b-dev,libcodec2-0.8.1,libcodec2-dev,libflite1,libgme0,libiec61883-0,liblilv-0-0,liblilv-dev,libjack-jackd2-0,libjack-jackd2-dev,libnorm1,libnorm-dev,libnuma1,libnuma-dev,libopenal1,libopenal-data,libopenal-dev,libshine3,libshine-dev,libsnappy1v5,libsodium23,libsodium-dev,libsoxr0,libsoxr-dev,libssh-gcrypt-4,libssh-gcrypt-dev,libswscale5,libswscale-dev,libwavpack1,libwavpack-dev,libzmq5,libsndio7.0,libsndio-dev,libsdl2-2.0-0,libsdl2-dev,libavc1394-0,libtwolame0,libmodplug1,librubberband2,libebur128-1,libass9,libass-dev,libchromaprint1,libzvbi0,libzvbi-common,libwebpmux3,libwebp6,libcrystalhd3,libjson-c3,libjson-c-dev,libspeex1,libcaca0,libopenmpt0,libmpg123-0,libpgm-5.2-0,libmysofa0,libmysofa-dev,libvidstab1.1,libvidstab-dev|exe,dev,doc,nls
-yes|file|file,libmagic1,libmagic-mgc|exe,dev,doc,nls||deps:yes
+yes|file|file,libmagic1,libmagic-mgc,libmagic-dev|exe,dev,doc,nls||deps:yes
 no|file_sharing-curlftpfs-mpscan||exe
 yes|findutils|findutils|exe,dev>null,doc,nls||deps:yes
 yes|firefox|firefox,firefox-l10n-all|exe,dev>null,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor weechat gplaces"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -117,6 +117,7 @@ chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot firefox=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true
+chroot . /usr/sbin/setup-spot gplaces=true
 mv -f root/.spot-status root/.spot-status.orig
 chroot . /usr/sbin/setup-spot powerapplet_tray=true
 mv -f root/.spot-status.orig root/.spot-status

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -136,7 +136,7 @@ no|faac|libfaac0|exe,dev,doc,nls
 no|faad|faad,libfaad2,libfaad-dev|exe,dev,doc,nls
 no|ffconvert||exe,dev,doc,nls
 no|ffmpeg|ffmpeg,libaom0,libaom-dev,libavcodec58,libavcodec-extra58,libavcodec-dev,libavutil56,libavdevice58,libavdevice-dev,libswresample3,libswresample-dev,libavresample4,libavresample-dev,libavfilter-extra*,libpostproc55,libpostproc-dev,libavutil-dev,libavutil-dev,libavformat58,libavformat-dev,libavdevice-dev,libavfilter7,libavfilter-dev,libbs2b0,libbs2b-dev,libcodec2-0.8.1,libcodec2-dev,libflite1,libgme0,libiec61883-0,liblilv-0-0,liblilv-dev,libjack-jackd2-0,libjack-jackd2-dev,libnorm1,libnorm-dev,libnuma1,libnuma-dev,libopenal1,libopenal-data,libopenal-dev,libshine3,libshine-dev,libsnappy1v5,libsodium23,libsodium-dev,libsoxr0,libsoxr-dev,libssh-gcrypt-4,libssh-gcrypt-dev,libswscale5,libswscale-dev,libwavpack1,libwavpack-dev,libzmq5,libsndio7.0,libsndio-dev,libsdl2-2.0-0,libsdl2-dev,libavc1394-0,libtwolame0,libmodplug1,librubberband2,libebur128-1,libass9,libass-dev,libchromaprint1,libzvbi0,libzvbi-common,libwebpmux3,libwebp6,libcrystalhd3,libjson-c3,libjson-c-dev,libspeex1,libcaca0,libopenmpt0,libmpg123-0,libpgm-5.2-0,libmysofa0,libmysofa-dev,libvidstab1.1,libvidstab-dev|exe,dev,doc,nls
-yes|file|file,libmagic1,libmagic-mgc|exe,dev,doc,nls||deps:yes
+yes|file|file,libmagic1,libmagic-mgc,libmagic-dev|exe,dev,doc,nls||deps:yes
 no|file_sharing-curlftpfs-mpscan||exe
 yes|findutils|findutils|exe,dev>null,doc,nls||deps:yes
 no|firmware_linux_module_b43||exe| #120919 have taken these out of woof, now pets.

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat gplaces"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -118,6 +118,7 @@ chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot netsurf-gtk=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true
+chroot . /usr/sbin/setup-spot gplaces=true
 mv -f root/.spot-status root/.spot-status.orig
 chroot . /usr/sbin/setup-spot powerapplet_tray=true
 mv -f root/.spot-status.orig root/.spot-status


### PR DESCRIPTION
Gemini (https://gemini.circumlunar.space/docs/faq.html) is a new protocol: a simplified and more text-oriented Gopher with TLS and extra flexibility (like arbitrary MIME types).

https://geminiquickst.art/ is a good place for new Gemini users. Geminispace is growing and Gemini blogs ("gemlogs") cover a range of topics, from science fiction to toki pona and bread baking. In addition, geminispace has "low tech" social networks, games and more.

Most content in geminispace is text and there's no client-side scripting, making Gemini a good fit for some use cases in a lightweight distro like Puppy:
- A lighter way to serve documentation (like the HTML files under /usr/share/doc), which can be easily translated to Gemtext and improved over time
- A secure and lightweight way to serve man pages (an alternative to pman); there are https://linux.die.net/man like Gemini servers

gplaces is a tiny (~80K) Gemini client (disclaimer: I'm the developer) which displays pages with `less`, making it instantly familiar to anyone used to `man`.

For example, gplaces can be used as a lightweight, `man`-like frontend to Wikipedia, via Gemipedia (gemini://gemi.dev/cgi-bin/wp.cgi) and the `whatis` alias in the default configuration file:

![gplaces](https://user-images.githubusercontent.com/1471149/170837061-21453905-ddf4-479b-baa7-8f471f8497bf.png)

There are other, much nicer Gemini clients (some of them are graphical and good looking, see https://gmi.skyjake.fi/lagrange/), but they're much bigger and gplaces is a good "gateway drug".