### PR TITLE
Apply security updates to bdrv

### DIFF
--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -82,6 +82,7 @@ EOF
 	;;
 esac
 chroot bdrv apt-get update
+chroot bdrv apt-get upgrade -y
 
 # blacklist packages that may conflict with packages in the main SFS
 chroot bdrv apt-mark hold busybox


### PR DESCRIPTION
0setup takes the latest security update, while apt thinks it's one security update behind because the debootstrap happens without security updates. In other words, the package is updated, but apt thinks it isn't and offers an update.