### PR TITLE
Fix IPv6 connectivity when firewall is enabled (fixes #3121)

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -999,22 +999,25 @@ fi
 #if [ "\$LOGGING" = "true" ];then
 #	\$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 8 -j LOG \
 #--log-prefix "Ping detected: "
-#	\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 8 -j LOG \
+#	\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 128 -j LOG \
 #--log-prefix "Ping detected: "
 #fi
 # \$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 8 -j ACCEPT
-# \$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 8 -j ACCEPT
+# \$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 128 -j ACCEPT
 
 # By default, however, drop pings without logging. Blaster
 # and other worms have infected systems blasting pings.
 # Comment the line below if you want pings logged, but it
 # will likely fill your logs.
 \$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 8 -j DROP
-\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 8 -j DROP
+\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 128 -j DROP
 
 # Time Exceeded
 \$IPT -A icmp_packets -p ICMP -s 0/0 --icmp-type 11 -j ACCEPT
-\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 11 -j ACCEPT
+\$IP6T -A icmp_packets -p ICMPV6 --icmpv6-type 3 -j ACCEPT
+
+# Neighbour Discovery
+\$IP6T -A icmp_packets -p ICMPV6 -s fe80::/10 -j ACCEPT
 
 # Not matched, so return so it will be logged
 \$IPT -A icmp_packets -p ICMP -j RETURN


### PR DESCRIPTION
ICMP packet types are different between IPv4 and IPv6, and Neighbour Discovery (the alternative to ARP) is done over ICMPv6. This PR only fixes internet connectivity over IPv6.