### PR TITLE
Fix more cursor theme inconsistency in applications running as spot

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/pcur
+++ b/woof-code/rootfs-skeleton/usr/sbin/pcur
@@ -73,10 +73,6 @@ Options
 		I=$[$I+1]
 	done
 done
-if [ "$THEME" ]; then
-	func_switch "$THEME" &
-	exit
-fi
 #---
 # link cursor themes in /usr/share/icons to $HOME
 while read -r ITHEME; do
@@ -85,6 +81,11 @@ while read -r ITHEME; do
 	[ -e "$HOME/.icons/$XTHEME" ] || ln -sv "$ETHEME" $HOME/.icons
 	[ -e "/home/spot/.icons/$XTHEME" ] || ln -sv "$ETHEME" /home/spot/.icons
 done <<<$(find /usr/share/icons/ -maxdepth 2 -type d -name 'cursors')
+
+if [ "$THEME" ]; then
+	func_switch "$THEME" &
+	exit
+fi
 
 for ONEITEM in `ls -1 $HOME/.icons | grep -Ev 'ROX|^default$'`; do
 	#precaution that 'cursors' subdir exists...


### PR DESCRIPTION
Yet another fix is required after #3102 and #3052. This time, the cursor theme runs out of sync after changing the theme.

After clean boot, everything looks fine and the cursor theme is consistent:

![before](https://user-images.githubusercontent.com/1471149/171007535-97f469da-0e7f-4577-8a12-dc61bc53ba34.png)

But, after the theme is changed, pcur fails to set the cursor theme because the symlinks are missing:

![bug](https://user-images.githubusercontent.com/1471149/171007597-dc99b6a4-8d7c-4693-b6b8-3d692bd247eb.png)

With this PR, pcur creates the symlinks even when it's triggered by ptheme:

![fix](https://user-images.githubusercontent.com/1471149/171007756-8e33763c-46a6-43fe-bba9-df52cb6fe6e7.png)

