### PR TITLE
Set the default icon for windows without an icon

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
@@ -100,6 +100,8 @@
 <Key key="Super_R">root:9</Key>
 <Key mask="C" key="Super_L">root:9</Key>
 
+<DefaultIcon>/usr/share/pixmaps/puppy/execute.svg</DefaultIcon>
+
 <ButtonClose>/root/.jwm/window_buttons/close.png</ButtonClose>
 <ButtonMax>/root/.jwm/window_buttons/max.png</ButtonMax>
 <ButtonMaxActive>/root/.jwm/window_buttons/maxact.png</ButtonMaxActive>


### PR DESCRIPTION
Most windows do have an icon, but those that don't use this ugly black rectangle. A Puppy-style icon looks much better.

Before:
![before](https://user-images.githubusercontent.com/1471149/171123843-eee1eaf2-6e74-4493-ade8-eddbbee4d3e2.png)

After:
![after](https://user-images.githubusercontent.com/1471149/171123863-02cb738a-fe8a-48f5-b84c-1c86892a0081.png)

