### PR TITLE
Make pupsave-backup work without rsync

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/pupsave-backup
+++ b/woof-code/rootfs-skeleton/usr/sbin/pupsave-backup
@@ -210,10 +210,10 @@ Backup file name: ${destfile}"
 				rsync -aX ${1}/ ${destfile}/
 				RETVAL=$?
 			else
-				find "${1}" -mindepth 1 -maxdepth 1 | while read i ; do
+				while read i ; do
 					cp -a --remove-destination ${i} ${destfile}/
 					RETVAL=$?
-				done
+				done < <(find "${1}" -mindepth 1 -maxdepth 1)
 			fi
 			sync
 			kill $pidx

--- a/woof-code/rootfs-skeleton/usr/sbin/pupsave-backup
+++ b/woof-code/rootfs-skeleton/usr/sbin/pupsave-backup
@@ -213,7 +213,6 @@ Backup file name: ${destfile}"
 				find "${1}" -mindepth 1 -maxdepth 1 | while read i ; do
 					cp -a --remove-destination ${i} ${destfile}/
 					RETVAL=$?
-					sync
 				done
 			fi
 			sync


### PR DESCRIPTION
The "no rsync, no compression" code path is inefficient and broken because RETVAL is set in a subshell.