### PR TITLE
Disable Firefox autoplay by default

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -38,6 +38,9 @@ defaultPref("browser.uitour.enabled", false);
 defaultPref("identity.fxaccounts.enabled", false);
 defaultPref("identity.fxaccounts.toolbar.enabled", false);
 
+// disable autoplay
+defaultPref("media.autoplay.default", 5);
+
 // privacy
 defaultPref("privacy.trackingprotection.enabled", true);
 defaultPref("privacy.resistFingerprinting", true);


### PR DESCRIPTION
This reduces the browser's RAM and CPU footprint.