### PR TITLE
Default to UTC for the system clock

### DIFF
--- a/woof-code/rootfs-skeleton/etc/clock
+++ b/woof-code/rootfs-skeleton/etc/clock
@@ -1,5 +1,5 @@
 #Set this to either 'utc' or 'localtime' based on which one your computer's
 #hardware clock uses.
-HWCLOCKTIME=localtime
-#HWCLOCKTIME=utc
+HWCLOCKTIME=utc
+#HWCLOCKTIME=localtime
 

--- a/woof-code/rootfs-skeleton/etc/localtime
+++ b/woof-code/rootfs-skeleton/etc/localtime
@@ -1,1 +1,1 @@
-/usr/share/zoneinfo/Etc/GMT-8
+/usr/share/zoneinfo/Etc/UTC

--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -187,7 +187,7 @@ After making a choice, /etc/localtime will point to the appropriate timezone fil
 UTC is Coordinated Universal Time, which is basically the same as GMT, Greenwich Mean Time. The latter is the time at the Royal Observatory in Greenwich, London -- this is a time that does not have daylight saving or summer time as does the rest of the UK. It is said to simplify things if the computer hardware clock is set to UTC.
 
 <b>Local time</b>
-By default, Puppy Linux assumes that the hardware clock is set to local time, as this is what MS DOS and Windows systems normally use. If you were to change the hardware clock to UTC, you would also have to ensure that all operating systems recognise that, else they will show the wrong time/date.'`" > /tmp/box_help
+The hardware clock is set to local time, as this is what MS DOS and Windows systems normally use. If you were to change the hardware clock to UTC, you would also have to ensure that all operating systems recognise that, else they will show the wrong time/date.'`" > /tmp/box_help
    ;;
   locale)
    HEADING="`gettext 'Locale'`"
@@ -857,8 +857,8 @@ if [ "$SET_COUNTRY" ];then
   [ "$DEFAULT" ] && DEFAULTXML="<item>${DEFAULT}</item>" #111107 combobox does not support default tag.
   ITEMS=`sed -e 's% on$%%' -e 's% off$%%' -e 's%"%%g' -e "s% %${TABCHAR}%" -e 's%^%<item>%' -e 's%$%</item>%' /var/local/quicksetup-timezone-table-x`
 
-  DEFAULT_UTC="false"
-  [ "$HWCLOCKTIME" = "utc" ] && DEFAULT_UTC="true" #see /etc/clock
+  DEFAULT_UTC="true"
+  [ "$HWCLOCKTIME" = "localtime" ] && DEFAULT_UTC="false" #see /etc/clock
   CHECKUTCXML='
   <hbox tooltip-text="'$(gettext 'Tick checkbox if hardware clock is set to UTC, untick if hardware clock set to local time')'" space-expand="true" space-fill="true">
     <checkbox space-expand="false" space-fill="false">

--- a/woof-code/rootfs-skeleton/usr/sbin/set_hwclock_type
+++ b/woof-code/rootfs-skeleton/usr/sbin/set_hwclock_type
@@ -43,7 +43,7 @@ if [ -z $HWCLOCKTIME ] ; then
 	[ -f /etc/clock ] && . /etc/clock
 	case $HWCLOCKTIME in
 		localtime|utc) ok=1 ;;
-		*) HWCLOCKTIME=localtime ;;
+		*) HWCLOCKTIME=utc ;;
 	esac
 fi
 


### PR DESCRIPTION
If I'm not mistaken, distros with systemd (= all popular distros) do that, and this should make life easier for those who dual-boot.