### PR TITLE
Default to UTC for the system clock, but only in dpup and jammy64

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -136,4 +136,7 @@ chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/66
 rm -f usr/bin/weechat-headless
 rm -f usr/bin/man
 ln -s /bin/busybox usr/bin/man
+echo HWCLOCKTIME=utc > etc/clock
+rm -f etc/localtime
+ln -s /usr/share/zoneinfo/Etc/UTC etc/localtime
 "

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -135,4 +135,7 @@ chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/66
 rm -f usr/bin/weechat-headless
 rm -f usr/bin/man
 ln -s /bin/busybox usr/bin/man
+echo HWCLOCKTIME=utc > etc/clock
+rm -f etc/localtime
+ln -s /usr/share/zoneinfo/Etc/UTC etc/localtime
 "

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -136,4 +136,7 @@ chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/66
 rm -f usr/bin/weechat-headless
 rm -f usr/bin/man
 ln -s /bin/busybox usr/bin/man
+echo HWCLOCKTIME=utc > etc/clock
+rm -f etc/localtime
+ln -s /usr/share/zoneinfo/Etc/UTC etc/localtime
 "


### PR DESCRIPTION
https://github.com/puppylinux-woof-CE/woof-CE/pull/3139#issuecomment-1146772403

This is an experiment: early testers of Vanilla Dpup 9.2.0 testing builds seem to prefer UTC. I want to keep this in the 9.2.0 release, and revert the change if feedback is negative. If this change is well-received even in the final release, this PR can be reverted and #3139 can be merged.

