### PR TITLE
Switch to system-provided gtk-layer-shell

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -329,6 +329,7 @@ no|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc,nls
 no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
 no|libgsf|libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc,nls
 no|libgtkhtml||exe,dev,doc,nls #needed by my osmo pet.
+yes|libgtk-layer-shell|libgtk-layer-shell0,libgtk-layer-shell-dev|exe,dev,doc,nls||deps:yes
 yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc,nls||deps:yes
 no|libical|libical2,libical-dev|exe,dev,doc,nls
 no|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -333,6 +333,7 @@ no|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc,nls
 no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
 no|libgsf|libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc,nls
 no|libgtkhtml||exe,dev,doc,nls #needed by my osmo pet.
+yes|libgtk-layer-shell|libgtk-layer-shell0,libgtk-layer-shell-dev|exe,dev,doc,nls||deps:yes
 yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc,nls||deps:yes
 no|libical|libical2,libical-dev|exe,dev,doc,nls
 no|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -331,6 +331,7 @@ no|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc,nls
 no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
 no|libgsf|libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc,nls
 no|libgtkhtml||exe,dev,doc,nls #needed by my osmo pet.
+yes|libgtk-layer-shell|libgtk-layer-shell0,libgtk-layer-shell-dev|exe,dev,doc,nls||deps:yes
 yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc,nls||deps:yes
 no|libical|libical2,libical-dev|exe,dev,doc,nls
 no|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls


### PR DESCRIPTION
See puppylinux-woof-CE/gtkdialog#148.

This library will be used once gtkdialog is updated.