### PR TITLE
Add Claws Mail petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/claws-mail/pet.specs
+++ b/woof-code/rootfs-petbuilds/claws-mail/pet.specs
@@ -1,0 +1,1 @@
+claws-mail-4.1.0|claws-mail|4.1.0||Internet|2800K||claws-mail-4.1.0.pet||A GTK based fast email and news client|puppy|||

--- a/woof-code/rootfs-petbuilds/claws-mail/petbuild
+++ b/woof-code/rootfs-petbuilds/claws-mail/petbuild
@@ -1,0 +1,12 @@
+download() {
+    [ -f claws-mail-4.1.0.tar.xz ] || wget -t 3 -T 60 -O claws-mail-4.1.0.tar.xz https://www.claws-mail.org/download.php?file=releases/claws-mail-4.1.0.tar.xz
+}
+
+build() {
+    tar -xJf claws-mail-4.1.0.tar.xz
+    cd claws-mail-4.1.0
+    ./configure --prefix=/usr --disable-startup-notification --disable-libetpan --disable-notification-plugin
+    make install
+    sed 's/^Categories=.*/Categories=Email;/' -i /usr/share/applications/claws-mail.desktop
+    rm -rf /usr/lib/claws-mail/plugins/*.la /usr/lib/claws-mail/plugins/*.a /usr/include
+}

--- a/woof-code/rootfs-petbuilds/claws-mail/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/claws-mail/pinstall.sh
@@ -1,0 +1,3 @@
+echo '#!/bin/sh
+exec claws-mail "$@"' > usr/local/bin/defaultemail
+chmod 755 usr/local/bin/defaultemail

--- a/woof-code/rootfs-petbuilds/claws-mail/sha256.sum
+++ b/woof-code/rootfs-petbuilds/claws-mail/sha256.sum
@@ -1,0 +1,1 @@
+0e1a9ca0db8d2a9e058ae30cdc7fc919779214ec3c56ee0c8a7f88cc23817a8e  claws-mail-4.1.0.tar.xz

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer sylpheed transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -115,7 +115,7 @@ PROMPT='PS1="\w\$ "'
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot firefox-esr=true
-chroot . /usr/sbin/setup-spot sylpheed=true
+chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true
 mv -f root/.spot-status root/.spot-status.orig

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask lxterminal mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver labwc swaylock wlopm xdg-puppy-labwc pcmanfm pupmoon-font yambar connman-gtk fixmenusd spot-pkexec notification-daemon-stub pup-volume-monitor weechat claws-mail"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -115,6 +115,7 @@ PROMPT='PS1="\w\$ "'
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot firefox=true
+chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true
 mv -f root/.spot-status root/.spot-status.orig

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat claws-mail"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -116,6 +116,7 @@ PROMPT='PS1="\w\$ "'
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot netsurf-gtk=true
+chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true
 mv -f root/.spot-status root/.spot-status.orig


### PR DESCRIPTION
Claws Mail 4.x uses GTK+ 3, it's very similar to Sylpheed, and Sylpheed development has stalled (?) in 2020.