### PR TITLE
timebar: improvements for gtk3/wayland

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/pinstall.sh
+++ b/woof-code/rootfs-packages/jwm_config/pinstall.sh
@@ -4,6 +4,8 @@
 
 rm -f root/.jwm/jwmrc-personal_old
 
+( cd usr/local/jwm_config; ln -sf ../bin/timebar time )
+
 # windows are slow to move or resize if drawing is slow
 if [ ! -f usr/bin/startdwl ]; then
     case "${DISTRO_TARGETARCH}" in

--- a/woof-code/rootfs-skeleton/usr/local/bin/timebar
+++ b/woof-code/rootfs-skeleton/usr/local/bin/timebar
@@ -29,12 +29,20 @@ fi
 
 #set extended gtk-theme
 if [ "$GTKDIALOG_BUILD" = 'GTK3' ] ; then #gtk3
-	echo 'textview#JWM_Calendar {
+	echo '*textview#JWM_Calendar {
+	
 	font-family: monospace;
 	font-size: 11pt;
 	font-weight: bold;
-	background-color: #111111;
+}
+textview#JWM_Calendar text {
+	background-color: rgba(15,15,15,0.95);
 	color: #B4CAB6;
+}
+window {
+	color: rgba(15,15,15,0.95);
+	background-color: rgba(125,125,125,0.85);
+	border-radius: 12px;
 }' > $WORKDIR/gtkrc_mono.css
 else
 	echo 'style "mono" {
@@ -46,15 +54,23 @@ widget "*JWM_Calendar" style "mono"' > $WORKDIR/gtkrc_mono
 fi
 
 #Y placement
-TMP=`xwininfo -root | grep -m 1 '\geometry' | cut -f4 -d ' ' | cut -f2 -d 'x' | cut -f1 -d '+'`
-HEIGHT=$((TMP-27)) #minus main-tray
-[ ! "$HEIGHT" ] && HEIGHT=571 #in case
-#X placement
-TMP=`xwininfo -root | grep -m 1 '\geometry' | cut -f4 -d ' ' | cut -f1 -d 'x'`
-X=$((TMP-250)) #minus main-tray
-[ ! "$X" ] && X=1 #in case
-#Y placement
-[ "`cut -d' ' -f2 <<< $(getcurpos)`" -lt 100 ] && Y=27 || Y=1
+if [ "$XDG_SESSION_TYPE" = 'wayland' ]; then
+	read TMP OTHER <<<$(wlr-randr | grep -m1 'current')
+	HEIGHT=${TMP#*x}
+	HEIGHT=$((HEIGHT-67))
+	OPTION=' edge="right"'
+else
+	TMP=`xwininfo -root | grep -m 1 '\geometry' | cut -f4 -d ' ' | cut -f2 -d 'x' | cut -f1 -d '+'`
+	HEIGHT=$((TMP-27)) #minus main-tray
+	#X placement
+	TMP=`xwininfo -root | grep -m 1 '\geometry' | cut -f4 -d ' ' | cut -f1 -d 'x'`
+	X=$((TMP-250)) #minus width of bar
+	[ -z "$X" ] && X=1 #in case
+	#Y placement
+	[ "`cut -d' ' -f2 <<< $(getcurpos)`" -lt 100 ] && Y=27 || Y=1
+fi
+[ -z "$HEIGHT" ] && HEIGHT=571 #in case
+
 #GMT
 export MYGMT="`readlink /etc/localtime | cut -d/ -f6 | sed -e 's,^GMT-,GMTx,' -e 's,^GMT+,GMT-,' -e 's,^GMTx,GMT+,'`"
 
@@ -101,7 +117,7 @@ get_cal $TMP_MONTH $TMP_YEAR
 
 #run app
 S='
-<window title="JWM_time" width-request="250" height-request="'$HEIGHT'" decorated="false">
+<window title="JWM_time" width-request="250" height-request="'$HEIGHT'" decorated="false"'$OPTION'>
 <vbox spacing="0" space-expand="true" space-fill="true">
   <vbox space-expand="false" space-fill="false">
     <hbox space-expand="true" space-fill="true">
@@ -164,15 +180,17 @@ S='
         '"`/usr/lib/gtkdialog/xml_button-icon date_time.svg`"'
         <action>set-time-for-puppy &</action>
       </button>
-    </hbox>
+    </hbox>'
+    pidof jwm >/dev/null 2>&1 && S=$S'
     <hbox space-expand="true" space-fill="true">
       <text xalign="0.98" space-expand="true" space-fill="true"><label>'$(gettext 'Clock format (tray)')'</label></text>
       <button space-expand="false" space-fill="false">
         '"`/usr/lib/gtkdialog/xml_button-icon clock_digital.svg`"'
         <action>/usr/local/jwm_config/tray -clock &</action>
       </button>
-    </hbox>
-      <vbox>
+    </hbox>'
+
+    S=$S'  <vbox>
         <hbox space-expand="true" space-fill="true">
           <text xalign="0.98" space-expand="true" space-fill="true"><label>'$(gettext 'Set timezone')' ('$MYGMT')</label></text>
           <button space-expand="false" space-fill="false">
@@ -210,7 +228,6 @@ S='
   </vbox>
   <text space-expand="false" space-fill="false"><label>""</label></text>
 </vbox>
-<action signal="button-release-event">EXIT:exit</action>
 </window>'
 
 export JWM_time="$S"


### PR DESCRIPTION
- move to woof-code/rootfs-skeleton
- made mostly independant of jwm
- add symlink back to usr/local/bin/jwm_config/time for
backward compatibility
- bugfix window close on any button click
- tested on jwm/gtk2 and wayland/gtk3