### PR TITLE
Avoid swaybg if using JWM, to reduce flickering

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -1,13 +1,15 @@
 #!/bin/ash
 
-mode=stretch
-case "`cat ~/.config/wallpaper/backgroundmode 2>/dev/null`" in
-Centre) mode=center ;;
-Tile) mode=tile ;;
-Scale) mode=fit ;;
-esac
+if [ "$GDK_BACKEND" != "x11" ]; then
+	mode=stretch
+	case "`cat ~/.config/wallpaper/backgroundmode 2>/dev/null`" in
+	Centre) mode=center ;;
+	Tile) mode=tile ;;
+	Scale) mode=fit ;;
+	esac
 
-swaybg -i `cat ~/.config/wallpaper/bg_img` -m $mode &
+	swaybg -i `cat ~/.config/wallpaper/bg_img` -m $mode &
+fi
 
 # allow applications running as spot to talk to dwl
 SPOT_RUNTIME_DIR=`run-as-spot sh -c 'mkdir -p $XDG_RUNTIME_DIR && echo $XDG_RUNTIME_DIR'`


### PR DESCRIPTION
When dwl starts, the background is black, then swaybg changes it, then we start Xwayland (a fullscreen black window), then JWM sets the wallpaper again.