### PR TITLE
Move /usr/share/aclocal/{gettext,iconv}.m4 to the main SFS

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -166,7 +166,7 @@ no|gdmap|gdmap|exe,dev>null,doc,nls
 no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
 no|getflash||exe
 no|get_libreoffice||exe
-yes|gettext-full|gettext,gettext-base|exe,dev,doc,nls||deps:yes
+yes|gettext-full|gettext,gettext-base|exe,dev>exe,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
 no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -166,7 +166,7 @@ no|getflash||exe
 no|get_libreoffice||exe
 no|gettext_devxonly|gettext-base,gettext|exe>dev,dev,doc,nls||deps:yes
 no|gettext|gettext-base,gettext|exe,dev>null,doc,nls||deps:yes
-yes|gettext-full|gettext-base,gettext|exe,dev,doc,nls||deps:yes
+yes|gettext-full|gettext-base,gettext|exe,dev>exe,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
 no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -167,7 +167,7 @@ no|gdmap|gdmap|exe,dev>null,doc,nls
 no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
 no|getflash||exe
 no|get_libreoffice||exe
-yes|gettext-full|gettext-base,gettext|exe,dev,doc,nls||deps:yes
+yes|gettext-full|gettext-base,gettext|exe,dev>exe,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
 no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -167,7 +167,7 @@ no|gdmap|gdmap|exe,dev>null,doc,nls
 no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
 no|getflash||exe
 no|get_libreoffice||exe
-yes|gettext-full|gettext,gettext-base|exe,dev,doc,nls||deps:yes
+yes|gettext-full|gettext,gettext-base|exe,dev>exe,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls
 no|ghostscript|ghostscript,ghostscript-x,libgs9,libgs9-common,libgs-dev|exe,dev,doc,nls


### PR DESCRIPTION
The gettext package is broken. It's impossible to build JWM after `apt install gcc`, etc', because some m4 macros are undefined.