### PR TITLE
Let Xwayland handle keyboard layout switching (fixes #3169)

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xkb-apply
+++ b/woof-code/rootfs-skeleton/usr/sbin/xkb-apply
@@ -1,6 +1,6 @@
 #!/bin/ash
 
-[ -z "$WAYLAND_DISPLAY" ] || exit 0
+[ -n "$WAYLAND_DISPLAY" -a "$GDK_BACKEND" != "x11" ] && exit 0
 
 . ~/.xkbrc
 


### PR DESCRIPTION
At first, I thought layout switching is broken. But then I figured out the host catches the Alt+Shift key combination, so my VM doesn't receive it. Now, on a physical computer, I see that sometimes Alt+Shift works and sometimes it doesn't, **but only inside Xwayland**. In native Wayland windows that float on top of it, Alt+Shift works reliably. I still don't know why this happens and why I haven't seen this sooner, and this could be a race condition.