### PR TITLE
Explicitly add gsettings-desktop-schemas to the main SFS (fixes #3172)

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -205,7 +205,7 @@ yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
 no|grub4dos||exe,dev>null,doc,nls
-no|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev #needs d-conf.
+yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls||deps:yes #needs d-conf.
 no|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
 no|gstreamer1|libgstreamer1.0-0,libgstreamer-plugins-base1.0-0|exe,dev,doc,nls
 yes|gtk+|libgtk2.0-0,libgtk2.0-dev|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -203,7 +203,7 @@ yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
 no|grub4dos||exe,dev>null,doc,nls
-no|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev #needs d-conf.
+yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls||deps:yes #needs d-conf.
 no|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
 no|gstreamer1|libgstreamer1.0-0,libgstreamer-plugins-base1.0-0|exe,dev,doc,nls
 yes|gtk+|libgtk2.0-0,libgtk2.0-dev|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -207,7 +207,7 @@ yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
 no|grub4dos||exe,dev>null,doc,nls
-no|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev #needs d-conf.
+yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls||deps:yes #needs d-conf.
 no|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
 no|gstreamer1|libgstreamer1.0-0,libgstreamer-plugins-base1.0-0|exe,dev,doc,nls
 yes|gtk+|libgtk2.0-0|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -206,7 +206,7 @@ yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
 no|grub4dos||exe,dev>null,doc,nls
-no|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev #needs d-conf.
+yes|gsettings-desktop-schemas|gsettings-desktop-schemas|exe,dev,doc,nls||deps:yes #needs d-conf.
 no|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
 no|gstreamer1|libgstreamer1.0-0,libgstreamer-plugins-base1.0-0|exe,dev,doc,nls
 yes|gtk+|libgtk2.0-0,libgtk2.0-dev|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
bullseye64 has gsettings-desktop-schemas in the main SFS thanks to this dependency chain:

`libgtk-3-0 -> librest-0.7-0 -> libsoup2.4-1 -> glib-networking -> gsettings-desktop-schemas`

In bookworm64, sid64 and jammy64, libgtk-3-0 doesn't depend on librest-0.7-0, hence gsettings-desktop-schemas is missing (or present only in bdrv), and GTK+ 3 cannot read settings (like the default cursor size).