### PR TITLE
Keep the spot session bus and PipeWire on X restart (fixes #3174)

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -53,29 +53,6 @@ if [ "$GDK_BACKEND" = "x11" ]; then
 	done
 fi
 
-(
-	read DBUS_SESSION_BUS_ADDRESS
-	read DBUS_SESSION_BUS_PID
-	echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID
-DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" > /tmp/.spot-session-bus
-) < <(run-as-spot dbus-daemon --fork --print-address 1 --print-pid 1 --session)
-
-if [ -e /usr/bin/wireplumber ]; then
-    rm -f /tmp/runtime-spot/pipewire-0
-    run-as-spot pipewire &
-    (
-        while [ ! -e /tmp/runtime-spot/pipewire-0 ]; do sleep 0.1; done
-        run-as-spot pipewire-pulse &
-        run-as-spot wireplumber &
-    ) &
-    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
-    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
-elif [ -e /usr/bin/pulseaudio ]; then
-    PULSE_SERVER= run-as-spot sh -c "pulseaudio --kill > /dev/null 2>&1; pulseaudio --start --log-target=syslog"
-    export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
-    export PULSE_COOKIE=/home/spot/.config/pulse/cookie
-fi
-
 . /etc/rc.d/wl_func
 apply_pthemerc
 

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -3,10 +3,34 @@
 export TEXTDOMAIN=xwin
 export OUTPUT_CHARSET=UTF-8
 
-export WLR_RENDERER_ALLOW_SOFTWARE=1
+cleanup() {
+	. /tmp/.spot-session-bus
+	kill $DBUS_SESSION_BUS_PID 2>/dev/null
+}
+trap cleanup EXIT
 
+(
+	read DBUS_SESSION_BUS_ADDRESS
+	read DBUS_SESSION_BUS_PID
+	echo "DBUS_SESSION_BUS_PID=$DBUS_SESSION_BUS_PID
+DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" > /tmp/.spot-session-bus
+) < <(run-as-spot dbus-daemon --fork --print-address 1 --print-pid 1 --session)
+
+if [ -e /usr/bin/wireplumber ]; then
+    rm -f /tmp/runtime-spot/pipewire-0
+    run-as-spot pipewire > /dev/null 2>&1 &
+    (
+        while [ ! -e /tmp/runtime-spot/pipewire-0 ]; do sleep 0.1; done
+        run-as-spot pipewire-pulse > /dev/null 2>&1 &
+        run-as-spot wireplumber > /dev/null 2>&1 &
+    ) &
+elif [ -e /usr/bin/pulseaudio ]; then
+    run-as-spot sh -c "pulseaudio --kill > /dev/null 2>&1; pulseaudio --start --log-target=syslog"
+fi
 export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
 export PULSE_COOKIE=/home/spot/.config/pulse/cookie
+
+export WLR_RENDERER_ALLOW_SOFTWARE=1
 
 while :
 do
@@ -61,9 +85,6 @@ do
 	else
 		dbus-run-session -- dwl-kiosk $DWL_ARGS > /tmp/xerrs.log 2>&1
 	fi
-
-	. /tmp/.spot-session-bus
-	kill $DBUS_SESSION_BUS_PID 2>/dev/null
 
 	echo '--------'
 	echo ''$(gettext 'Exited from dwl. Type "startdwl" to restart dwl.')''


### PR DESCRIPTION
PipeWire doesn't die when spot's session bus stops, so it fails to start and audio doesn't work after dwl is restarted.

labwc will need similar treatment and I want to wait with that until #2707 is fixed.