### PR TITLE
Work around breakage of the JWM menu tool by using gtk2dialog

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/usr/local/jwm_config/menu
+++ b/woof-code/rootfs-packages/jwm_config/usr/local/jwm_config/menu
@@ -290,4 +290,4 @@ export JWM_menu='
 </window>
 '
 . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
-gtkdialog -p JWM_menu --styles=/tmp/gtkrc_xml_info.css 2>/dev/null
+gtk2dialog -p JWM_menu --styles=/tmp/gtkrc_xml_info.css 2>/dev/null


### PR DESCRIPTION
The spinbutton is broken with GTK+ 3. It has no use under Wayland and this is not the first time something in jwm_config is broken, so I prefer not to waste my time on fixing this.