### PR TITLE
Avoid killing Xwayland to prevent SIGHUP in wmexit

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/wmexit
+++ b/woof-code/rootfs-skeleton/usr/bin/wmexit
@@ -71,7 +71,7 @@ sleep 0.2
 sync
 
          #xfce       #lxde     #LXQt        #window managers
-for i in xfce4-panel lxsession lxqt-session `cat /etc/windowmanager` jwm icewm openbox X Xorg Xwayland labwc
+for i in xfce4-panel lxsession lxqt-session `cat /etc/windowmanager` jwm icewm openbox X Xorg labwc
 do
 	for pid in `pidof $i` ; do
 		kill $pid || kill -9 $pid


### PR DESCRIPTION
wmexit kills Xwayland, which creates a race condition. wmexit receives a SIGHUP, and sometimes, this signal is received before wmexit kills dwl, leaving the user with a black screen with a cursor (because Xwayland, JWM, etc' are killed, while dwl is still running, with zero windows).