### PR TITLE
slacko64: add wayland libraries and programs

### DIFF
--- a/woof-distro/x86_64/slackware64/15.0/Packages-puppy-slacko6415.0-official
+++ b/woof-distro/x86_64/slackware64/15.0/Packages-puppy-slacko6415.0-official
@@ -105,6 +105,8 @@ gphoto2_DOC-2.5.10-x86_64_s700|gphoto2_DOC|2.5.10-x86_64_s700||BuildingBlock|60|
 gphoto2_NLS-2.5.10-x86_64_s700|gphoto2_NLS|2.5.10-x86_64_s700||BuildingBlock|1020||gphoto2_NLS-2.5.10-x86_64_s700.pet|+gphoto2|gphoto2 locales||||
 gphotofs-0.5-x86_64_s700|gphotofs|0.5-x86_64_s700||BuildingBlock|32||gphotofs-0.5-x86_64_s700.pet|+fuse|gphotofs is a FUSE filesystem module to mount your camera as a filesystem on Linux|slackware64|14.2||
 gphotofs_DEV-0.5-x86_64_s700|gphotofs_DEV|0.5-x86_64_s700||BuildingBlock|20||gphotofs_DEV-0.5-x86_64_s700.pet|+gphotofs|gphotofs development|slackware64|14.2||
+gtk-layer-shell-617744ccb51c6a30c5e63547182e75991b5c1d43-x86_64_s88|gtk-layer-shell|617744ccb51c6a30c5e63547182e75991b5c1d43-x86_64_s88||BuildingBlock|240||gtk-layer-shell-617744ccb51c6a30c5e63547182e75991b5c1d43-x86_64_s88.pet|+gtk+-3.0,+libwayland|wlroots layer-shell gtk3 bindings|slackware64|15.0||
+gtk-layer-shell_DEV-617744ccb51c6a30c5e63547182e75991b5c1d43-x86_64_s88|gtk-layer-shell_DEV|617744ccb51c6a30c5e63547182e75991b5c1d43-x86_64_s88||BuildingBlock|56||gtk-layer-shell_DEV-617744ccb51c6a30c5e63547182e75991b5c1d43-x86_64_s88.pet|+gtk-layer-shell|gtk-layer-shell development|slackware64|15.0||
 gtk2dialog-0.8.4d-x86_64_s82gtk2|gtk2dialog|0.8.4d-x86_64_s82gtk2||BuildingBlock|316||gtk2dialog-0.8.4d-x86_64_s82gtk2.pet|+gtk+2|gtkialog is a small utility for fast and easy GUI building|slackware64|15.0||
 gtk2dialog_DOC-0.8.4d-x86_64_s82gtk2|gtk2dialog_DOC|0.8.4d-x86_64_s82gtk2||BuildingBlock|1884||gtk2dialog_DOC-0.8.4d-x86_64_s82gtk2.pet|+gtk2dialog|gtk2dialog documentation||||
 gtksourceview-2.10.5-x86_64_s700|gtksourceview|2.10.5-x86_64_s700||BuildingBlock|1420||gtksourceview-2.10.5-x86_64_s700.pet|+gtk+2|gtk source viewing libraries|slackware64|14.2||
@@ -319,6 +321,11 @@ sane-backends_NLS-1.0.32-x86_64_s81|sane-backends_NLS|1.0.32-x86_64_s81||Buildin
 sbsigntools-0.9.1-x86_64_s81|sbsigntools|0.9.1-x86_64_s81||BuildingBlock|364||sbsigntools-0.9.1-x86_64_s81.pet|+keyutils,+help2man|tool for signing efi trusted binaries|slackware64|15.0||
 sbsigntools_DEV-0.9.1-x86_64_s81|sbsigntools_DEV|0.9.1-x86_64_s81||BuildingBlock|20||sbsigntools_DEV-0.9.1-x86_64_s81.pet|+sbsigntools|sbsigntools development|slackware64|15.0||
 sbsigntools_DOC-0.9.1-x86_64_s81|sbsigntools_DOC|0.9.1-x86_64_s81||BuildingBlock|40||sbsigntools_DOC-0.9.1-x86_64_s81.pet|+sbsigntools|sbsigntools documentation||||
+scdoc-4af1e1e-x86_64_s88|scdoc|4af1e1e-x86_64_s88||BuildingBlock|912||scdoc-4af1e1e-x86_64_s88.pet|+libc6|markdown to man converter|slackware64|15.0||
+scdoc_DEV-4af1e1e-x86_64_s88|scdoc_DEV|4af1e1e-x86_64_s88||BuildingBlock|32||scdoc_DEV-4af1e1e-x86_64_s88.pet|+scdoc|scdoc development|slackware64|15.0||
+scdoc_DOC-4af1e1e-x86_64_s88|scdoc_DOC|4af1e1e-x86_64_s88||BuildingBlock|36||scdoc_DOC-4af1e1e-x86_64_s88.pet|+scdoc|scdoc documentation||||
+seatd-0.5.0-x86_64_s88|seatd|0.5.0-x86_64_s88||BuildingBlock|72||seatd-0.5.0-x86_64_s88.pet|+libc6|wlroots seat|slackware64|15.0||
+seatd_DEV-0.5.0-x86_64_s88|seatd_DEV|0.5.0-x86_64_s88||BuildingBlock|44||seatd_DEV-0.5.0-x86_64_s88.pet|+seatd|seatd development|slackware64|15.0||
 sfml-2.4.2-x86_64_s700|sfml|2.4.2-x86_64_s700||BuildingBlock|808||sfml-2.4.2-x86_64_s700.pet||games library|slackware64|14.2||
 sfml_DEV-2.4.2-x86_64_s700|sfml_DEV|2.4.2-x86_64_s700||BuildingBlock|1164||sfml_DEV-2.4.2-x86_64_s700.pet|+sfml|sfml development||||
 simple-mtpfs-0.3.0-x86_64_s81|simple-mtpfs|0.3.0-x86_64_s81||BuildingBlock|136||simple-mtpfs-0.3.0-x86_64_s81.pet|+libmtp|mount mobile devices with mtp protocol|slackware64|15.0||
@@ -353,6 +360,8 @@ vobcopy_DOC-1.2.0-x86_64_s81|vobcopy_DOC|1.2.0-x86_64_s81||Multimedia|200||vobco
 wireless_tools-30.0-x86_64_s700|wireless_tools|30.0-x86_64_s700||BuildingBlock|316||wireless_tools-30.0-x86_64_s700.pet||BuildingBlock|slackware64|14.2||
 wireless_tools_DEV-30.0-x86_64_s700|wireless_tools_DEV|30.0-x86_64_s700||BuildingBlock|84||wireless_tools_DEV-30.0-x86_64_s700.pet|+wireless_tools|wireless_tools development||||
 wireless_tools_DOC-30.0-x86_64_s700|wireless_tools_DOC|30.0-x86_64_s700||BuildingBlock|328||wireless_tools_DOC-30.0-x86_64_s700.pet|+wireless_tools|wireless_tools documentation||||
+wlroots-0.15.1-x86_64_s88|wlroots|0.15.1-x86_64_s88||BuildingBlock|868||wlroots-0.15.1-x86_64_s88.pet|+libc6|wlroots wayland library|slackware64|15.0||
+wlroots_DEV-0.15.1-x86_64_s88|wlroots_DEV|0.15.1-x86_64_s88||BuildingBlock|556||wlroots_DEV-0.15.1-x86_64_s88.pet|+wlroots|wlroots development|slackware64|15.0||
 wv-1.2.4-x86_64_s80|wv|1.2.4-x86_64_s80||BuildingBlock|2400||wv-1.2.4-x86_64_s80.pet|+glib2,+libgsf,+libpng,+libxml2|a library for reading Microsoft Word files|slackware64|15.0||
 wv_DEV-1.2.4-x86_64_s80|wv_DEV|1.2.4-x86_64_s80||BuildingBlock|168||wv_DEV-1.2.4-x86_64_s80.pet|+wv|wv development|slackware64|15.0||
 wv_DOC-1.2.4-x86_64_s80|wv_DOC|1.2.4-x86_64_s80||BuildingBlock|96||wv_DOC-1.2.4-x86_64_s80.pet|+wv|wv documentation||||


### PR DESCRIPTION
Slackware doesn't ship wlroots and some friends.
I have uploaded to ibiblio the packages in this commit to make it easier
and less complicated for labwc and friends in woof-code/rootfs-petbuilds