### PR TITLE
Fix failure to apply mouse settings when two mice have the same name

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xinput-apply
+++ b/woof-code/rootfs-skeleton/usr/sbin/xinput-apply
@@ -5,7 +5,7 @@ grep -qm 1 "Using input driver 'libinput'" "/var/log/Xorg.${DISPLAY#:}.log" || e
 
 . ~/.inputrc
 
-xinput list --name-only | while read NAME; do
+xinput list --id-only | while read NAME; do
 	case "$LIBINPUT_DEFAULT_TAP" in
 	0) xinput set-prop "$NAME" "libinput Tapping Enabled" 0 ;;
 	1) xinput set-prop "$NAME" "libinput Tapping Enabled" 1 ;;


### PR DESCRIPTION
`xinput` doesn't do anything if the device is specified by name and two devices have the same name. When properties are set using the unique device ID, it works fine.