### PR TITLE
Avoid recursive chown on /home/spot in setup-spot, if not needed

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/setup-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/setup-spot
@@ -113,7 +113,7 @@ do
  fi
  
  case ${ONEAPPvalue} in true|TRUE|yes|YES|on|ON)
-   chown -R spot:spot ${PREFIXDIR}${SPOT_HOME} ;;
+   [ -n "`find ${PREFIXDIR}${SPOT_HOME} ! -user spot -or ! -group spot | head -n 1`" ] && chown -R spot:spot ${PREFIXDIR}${SPOT_HOME} ;;
  esac
 
 done


### PR DESCRIPTION
Every time I `apt upgrade` my browser, fixmenusd triggers setup-spot to make it run as spot. The latter runs `chown -R spot:spot /home/spot` and that makes aufs/overlay copy the entire /home/spot to /initrd/pup_rw.

I don't think this chown is needed, and it's probably a hack, but if I remove it, this can break packages that place root-owned files in /home/spot. Therefore, as a compromise, I'm leaving that chown, but only if it's needed, and find is stopped after one match.