### PR TITLE
Add /etc/windowmanager support to the Xwayland desktop

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -69,4 +69,8 @@ swayidle &
 # allow applications running as spot to talk to Xwayland
 xhost +local:
 
-[ "$GDK_BACKEND" = "x11" ] && jwm &
+if [ "$GDK_BACKEND" = "x11" ]; then
+	CURRENTWM="`cat /etc/windowmanager 2>/dev/null`"
+	[ -z "$CURRENTWM" -o -z "`command -v $CURRENTWM`" ] && CURRENTWM="jwm"
+	$CURRENTWM &
+fi


### PR DESCRIPTION
Xfce and KDE work just fine, and this will make .pet packages that set the window manager work under dwl, too.