### PR TITLE
Prevent WeeChat from advertising its version number

### DIFF
--- a/woof-code/rootfs-petbuilds/weechat/petbuild
+++ b/woof-code/rootfs-petbuilds/weechat/petbuild
@@ -5,8 +5,9 @@ download() {
 build() {
     tar -xJf weechat-3.5.tar.xz
     cd weechat-3.5
+    patch -p1 < ../privacy.patch
     ./autogen.sh
-    ./configure --prefix=/usr --sysconfdir=/etc --enable-ncurses --enable-headless
+    ./configure --prefix=/usr --sysconfdir=/etc --enable-ncurses --enable-headless --disable-xfer
     make install
     rm -rf /usr/include /usr/lib/pkgconfig /usr/lib/weechat/plugins/*.a /usr/lib/weechat/plugins/*.la
     sed -e 's/^Categories=Network;Chat;/Categories=Chat;/' -i /usr/share/applications/weechat.desktop

--- a/woof-code/rootfs-petbuilds/weechat/privacy.patch
+++ b/woof-code/rootfs-petbuilds/weechat/privacy.patch
@@ -1,0 +1,36 @@
+diff -rupN weechat-3.5-orig/src/plugins/irc/irc-ctcp.c weechat-3.5/src/plugins/irc/irc-ctcp.c
+--- weechat-3.5-orig/src/plugins/irc/irc-ctcp.c	2022-07-06 08:12:57.938081298 +0300
++++ weechat-3.5/src/plugins/irc/irc-ctcp.c	2022-07-06 08:16:15.954853936 +0300
+@@ -40,12 +40,12 @@
+ 
+ 
+ struct t_irc_ctcp_reply irc_ctcp_default_reply[] =
+-{ { "clientinfo", "$clientinfo" },
+-  { "finger",     "WeeChat $versiongit" },
+-  { "source",     "$download" },
+-  { "time",       "$time" },
+-  { "userinfo",   "$username ($realname)" },
+-  { "version",    "WeeChat $versiongit ($compilation)" },
++{ { "clientinfo", "" },
++  { "finger",     "" },
++  { "source",     "" },
++  { "time",       "" },
++  { "userinfo",   "" },
++  { "version",    "" },
+   { NULL,         NULL },
+ };
+ 
+diff -rupN weechat-3.5-orig/src/plugins/irc/irc-server.c weechat-3.5/src/plugins/irc/irc-server.c
+--- weechat-3.5-orig/src/plugins/irc/irc-server.c	2022-07-06 08:12:57.938081298 +0300
++++ weechat-3.5/src/plugins/irc/irc-server.c	2022-07-06 08:15:50.331862125 +0300
+@@ -116,8 +116,8 @@ char *irc_server_options[IRC_SERVER_NUM_
+   { "away_check",           "0"                       },
+   { "away_check_max_nicks", "25"                      },
+   { "msg_kick",             ""                        },
+-  { "msg_part",             "WeeChat ${info:version}" },
+-  { "msg_quit",             "WeeChat ${info:version}" },
++  { "msg_part",             ""                        },
++  { "msg_quit",             ""                        },
+   { "notify",               ""                        },
+   { "split_msg_max_length", "512"                     },
+   { "charset_message",      "message"                 },


### PR DESCRIPTION
This is bad for privacy (makes users easier to fingerprint) and security (makes it easier to detect known vulnerabilities).

After this PR, WeeChat no longer gives away information like its version number and the client's local time (tested with two clients, one before and one after this PR):

![weechat](https://user-images.githubusercontent.com/1471149/177479810-e27d9dc5-3906-46a9-880d-a4fb321842ba.png)

