### PR TITLE
If the lid is closed but xlock is already running, suspend without locking

### DIFF
--- a/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
+++ b/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
@@ -49,7 +49,7 @@ y*|Y*|true|True|TRUE|1) echo -n mem > /sys/power/state ;;
   if [ -n "$WAYLAND_DISPLAY" ]; then
     puplock
     echo mem > /sys/power/state
-  elif [ -n "$DISPLAY" ]; then
+  elif [ -n "$DISPLAY" -a -z "`pidof -s xlock`" ]; then
     xlock -startCmd "echo mem > /sys/power/state"
   else
     echo -n mem > /sys/power/state


### PR DESCRIPTION
If the laptop lid is closed while the screen is locked by xlock, the laptop doesn't suspend. suspend.sh relies on xlock to suspend, but this second xlock fails because the screen is already locked, so it doesn't run `-startCmd`.