### PR TITLE
Add missing Bluetooth firmware for Intel cards (fixes #3195)

### DIFF
--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -86,6 +86,7 @@ echo "### If 'missing' is after a firmware entry it is missing or non-free and w
 # NOTE 1: some firmware files won't exist because they are proprietary
 # broadcom wireless is an example, and some dvb tuners and some bluetooth
 
+intelbt=0
 for m in `find "$module_dir" -type f -name "*.ko"`
 do
 	modinfo "$m" -F firmware | while read fw
@@ -125,6 +126,19 @@ do
 				;;
 			esac
 		else
+			case $fw in
+				intel/ibt-*.sfi|intel/ibt-*.ddc) # intel/ibt-%u-%u.sfi is formatted at runtime
+				[ $intelbt -eq 1 ] && continue
+				mkdir -p $FIRMWARE_RESULT_DIR/intel
+				for F in $SRC_FW_DIR/intel/ibt-*.{sfi,ddc} $SRC_FW_DIR/intel/ibt-hw-*.bseq;do
+					cp -L -n $F $FIRMWARE_RESULT_DIR/intel
+					fw_msg $F $fw_tmp_list # log to zdrv
+				done
+				intelbt=1
+				continue
+				;;
+			esac
+
 			if [ -e "$SRC_FW_DIR/$fw" ];then
 				mkdir -p $FIRMWARE_RESULT_DIR/$fw_dir
 				cp -L -n $SRC_FW_DIR/$fw $FIRMWARE_RESULT_DIR/$fw_dir


### PR DESCRIPTION
- [x] Finish the build
- [x] Make sure the missing files are included in fdrv
- [x] Make sure fdrv size hasn't increased too much

If this static approach doesn't work, maybe something more aggressive is needed:

```
	strings -a "$m" | grep -E -- '-%.*\.[a-zA-Z0-9]+$' | sed 's/%[0-9]*\.*[0-9]*[a-z]/\*/g' | grep -E '[a-zA-Z0-9-]*/.+\..+' | sort | uniq | while read pat
	do 
		find "$SRC_FW_DIR" -path "$SRC_FW_DIR/$pat" | while read F;do
			install -D -m 644 $SRC_FW_DIR/$pat $FIRMWARE_RESULT_DIR/$F
		done
	done
```