### PR TITLE
Add missing Atheros firmware that does not appear in modinfo

### DIFF
--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -148,6 +148,24 @@ do
 			fi
 		fi		
 	done
+
+	case $m in
+	*/ath*k*.ko) # some firmware doesn't appear in modinfo
+	fw_top_dir=${m##*/}
+	fw_top_dir=${fw_top_dir%%_*}
+	fw_top_dir=${fw_top_dir%.ko}
+	strings -a $m > /tmp/modstrings
+	for F in $SRC_FW_DIR/$fw_top_dir/*/hw*;do
+		fw_subdir=${F#$SRC_FW_DIR/}
+		[ -e $FIRMWARE_RESULT_DIR/$fw_subdir ] && continue
+		fgrep -qlm1 ${fw_subdir#$fw_top_dir/} /tmp/modstrings || continue
+		mkdir -p $FIRMWARE_RESULT_DIR/${fw_subdir%/*}
+		cp -r -L -n $F $FIRMWARE_RESULT_DIR/${fw_subdir%/*}
+		fw_msg $fw_subdir $fw_tmp_list # log to zdrv
+	done
+	rm -f /tmp/modstrings
+	;;
+	esac
 done
 # extra firmware from other sources
 if [ "$EXTRA_FW" = 'yes' ];then


### PR DESCRIPTION
- [x] Finish the build
- [x] Check size
- [x] Make sure all required firmware is picked up

This PR adds:

```
ath10k/QCA4019/hw1.0
ath10k/QCA9888/hw2.0
ath10k/QCA9984/hw1.0
ath10k/QCA99X0/hw2.0
ath10k/WCN3990/hw1.0
ath11k/IPQ6018/hw1.0
ath11k/IPQ8074/hw2.0
ath11k/QCA6390/hw2.0
```