### PR TITLE
Move libpopt to the main SFS

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -556,7 +556,7 @@ no|pmirrorget||exe
 no|pnethood||exe| #using network_roxapp and YASSM instead. leave it in, some users want it.
 no|pnscan||exe,dev,doc,nls #peasyport
 no|poppler|libpoppler102,libpoppler-dev,poppler-utils,libpoppler-glib8,libpoppler-glib-dev|exe,dev
-yes|popt|libpopt0|exe>dev,dev||deps:yes
+yes|popt|libpopt0|exe,dev,doc,nls||deps:yes
 no|powerapplet_tray||exe
 no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -550,7 +550,7 @@ no|pmirrorget||exe
 no|pnethood||exe| #using network_roxapp and YASSM instead. leave it in, some users want it.
 no|pnscan||exe,dev,doc,nls #peasyport
 no|poppler|libpoppler102,libpoppler-dev,poppler-utils,libpoppler-glib8,libpoppler-glib-dev|exe,dev
-yes|popt|libpopt0|exe>dev,dev||deps:yes
+yes|popt|libpopt0|exe,dev,doc,nls||deps:yes
 no|powerapplet_tray||exe
 no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -559,7 +559,7 @@ no|pmirrorget||exe
 no|pnethood||exe| #using network_roxapp and YASSM instead. leave it in, some users want it.
 no|pnscan||exe,dev,doc,nls #peasyport
 no|poppler|libpoppler102,libpoppler-dev,poppler-utils,libpoppler-glib8,libpoppler-glib-dev|exe,dev
-yes|popt|libpopt0|exe>dev,dev||deps:yes
+yes|popt|libpopt0|exe,dev,doc,nls||deps:yes
 no|powerapplet_tray||exe
 no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -558,7 +558,7 @@ no|pmirrorget||exe
 no|pnethood||exe| #using network_roxapp and YASSM instead. leave it in, some users want it.
 no|pnscan||exe,dev,doc,nls #peasyport
 no|poppler|libpoppler102,libpoppler-dev,poppler-utils,libpoppler-glib8,libpoppler-glib-dev|exe,dev
-yes|popt|libpopt0|exe>dev,dev||deps:yes
+yes|popt|libpopt0|exe,dev,doc,nls||deps:yes
 no|powerapplet_tray||exe
 no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls


### PR DESCRIPTION
It's a dependency of gdisk, among others.