### PR TITLE
Add SOF binaries to fdrv

### DIFF
--- a/kernel-kit/.gitignore
+++ b/kernel-kit/.gitignore
@@ -5,3 +5,4 @@ linux-*
 aufs_sources
 aufs-util
 DOTconfig
+sof-bin

--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -168,6 +168,9 @@ do
 	esac
 done
 # extra firmware from other sources
+if [ -n "`find $module_dir -name 'snd-sof*.ko' | head -n 1`" ];then
+	./get_sof.sh `pwd`/zfirmware_workdir "`pwd`/$module_dir" || exit 1
+fi
 if [ "$EXTRA_FW" = 'yes' ];then
 	./firmware_extra.sh
 	sed -i -e '/^b43/d' -e '/^ipw/d' $fw_tmp_list

--- a/kernel-kit/get_sof.sh
+++ b/kernel-kit/get_sof.sh
@@ -1,0 +1,18 @@
+#!/bin/sh -xe
+
+[ -d sof-bin ] || git clone https://github.com/thesofproject/sof-bin
+cd sof-bin
+ver=`git describe --abbrev=0 --tags`
+mkdir -p "$1/lib/firmware/intel"
+cp -r $ver*/sof-$ver "$1/lib/firmware/intel/"
+ln -s sof-$ver "$1/lib/firmware/intel/sof"
+cp -r $ver*/sof-tplg-$ver "$1/lib/firmware/intel/"
+ln -s sof-tplg-$ver "$1/lib/firmware/intel/sof-tplg"
+mkdir -p "$1/usr/share/doc/sof-bin"
+cp -f LICENCE.* Notice.* "$1/usr/share/doc/sof-bin/"
+
+strings -a `find "$2" -type f -name 'snd-*.ko'` | grep ^sof- | sort | uniq > /tmp/sofstrings
+find "$1/lib/firmware/intel/sof-$ver" "$1/lib/firmware/intel/sof-tplg-$ver" -type f -name 'sof-*.*' | while read F; do
+	fgrep -qlm1 ${F##*/} /tmp/sofstrings || rm -f $F
+done
+rm -f /tmp/sofstrings


### PR DESCRIPTION
Some users complain about missing firmware. This affects some recent (>= 2020) Intel laptops as far as I see.