### PR TITLE
Reapply X input device settings when a new device is connected

### DIFF
--- a/woof-code/rootfs-skeleton/etc/udev/rules.d/91-xinput-apply.rules
+++ b/woof-code/rootfs-skeleton/etc/udev/rules.d/91-xinput-apply.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="input", ACTION=="add", RUN+="/bin/sh -c 'sleep 1; xinput-apply'"

--- a/woof-code/rootfs-skeleton/etc/udev/rules.d/92-xkb-apply.rules
+++ b/woof-code/rootfs-skeleton/etc/udev/rules.d/92-xkb-apply.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="input", ACTION=="add", RUN+="/bin/sh -c 'sleep 1; xkb-apply'"

--- a/woof-code/rootfs-skeleton/usr/sbin/xinput-apply
+++ b/woof-code/rootfs-skeleton/usr/sbin/xinput-apply
@@ -1,9 +1,11 @@
 #!/bin/ash
 
-[ -z "$WAYLAND_DISPLAY" ] || exit 0
+[ -z "`pidof -s Xorg`" ] && exit 0
 grep -qm 1 "Using input driver 'libinput'" "/var/log/Xorg.${DISPLAY#:}.log" || exit 0
 
-. ~/.inputrc
+. /root/.inputrc
+
+export DISPLAY=:0
 
 xinput list --id-only | while read NAME; do
 	case "$LIBINPUT_DEFAULT_TAP" in

--- a/woof-code/rootfs-skeleton/usr/sbin/xkb-apply
+++ b/woof-code/rootfs-skeleton/usr/sbin/xkb-apply
@@ -1,7 +1,7 @@
 #!/bin/ash
 
-[ -n "$WAYLAND_DISPLAY" -a "$GDK_BACKEND" != "x11" ] && exit 0
+[ -z "`pidof -s Xorg`" ] && exit 0
 
-. ~/.xkbrc
+. /root/.xkbrc
 
-exec setxkbmap -model "$XKB_DEFAULT_MODEL" -layout "$XKB_DEFAULT_LAYOUT" -option "$XKB_DEFAULT_OPTIONS" -rules "$XKB_DEFAULT_RULES" -variant "$XKB_DEFAULT_VARIANT"
+DISPLAY=:0 exec setxkbmap -model "$XKB_DEFAULT_MODEL" -layout "$XKB_DEFAULT_LAYOUT" -option "$XKB_DEFAULT_OPTIONS" -rules "$XKB_DEFAULT_RULES" -variant "$XKB_DEFAULT_VARIANT"

--- a/woof-code/rootfs-skeleton/usr/sbin/xkbconfigmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/xkbconfigmanager
@@ -236,9 +236,7 @@ To add an additional layout, select it and press OK.')"
 		else
 			eval $ERRMSG
 		fi
-	fi
-
-	if [ -n "$WAYLAND_DISPLAY" ]; then
+	elif [ -n "$WAYLAND_DISPLAY" ]; then
 		XkbApplyLater
 	else
 		XkbApplyNow
@@ -315,9 +313,7 @@ To keep the current model, press cancel...')'" 30 80 0 \'
 		else
 			eval $ERRMSG
 		fi
-	fi
-
-	if [ -n "$WAYLAND_DISPLAY" ]; then
+	elif [ -n "$WAYLAND_DISPLAY" ]; then
 		XkbApplyLater
 	else
 		XkbApplyNow
@@ -391,9 +387,7 @@ To abort, press cancel.')"
 		else
 			eval $ERRMSG
 		fi
-	fi
-
-	if [ -n "$WAYLAND_DISPLAY" ]; then
+	elif [ -n "$WAYLAND_DISPLAY" ]; then
 		XkbApplyLater
 	else
 		XkbApplyNow
@@ -550,9 +544,7 @@ Xdialog --left --stdout --title "$gtxt1" --menubox "' >$TMPDIALOG
 			else
 				eval $ERRMSG
 			fi
-		fi
-
-		if [ -n "$WAYLAND_DISPLAY" ]; then
+		elif [ -n "$WAYLAND_DISPLAY" ]; then
 			XkbApplyLater
 		else
 			XkbApplyNow

--- a/woof-code/rootfs-skeleton/usr/sbin/xkbconfigmanager
+++ b/woof-code/rootfs-skeleton/usr/sbin/xkbconfigmanager
@@ -225,12 +225,8 @@ To add an additional layout, select it and press OK.')"
 
 	if [ -f "$XKBRC" ]; then
 		sed -i "s%^XKB_DEFAULT_LAYOUT=.*%XKB_DEFAULT_LAYOUT=$NEW%" $XKBRC
-		if [ -n "$WAYLAND_DISPLAY" ]; then
-			XkbApplyLater
-		else
-			XkbApplyNow
-		fi
-	elif [ -f $XORG_CONF ]; then
+	fi
+	if [ -f $XORG_CONF ]; then
 		# add new layout to line:
 		MODIFIED=`echo "$ORIGINAL" | sed "s%\"$CURRENT\"%\"$NEW\"%"`
 		# add to file
@@ -240,6 +236,12 @@ To add an additional layout, select it and press OK.')"
 		else
 			eval $ERRMSG
 		fi
+	fi
+
+	if [ -n "$WAYLAND_DISPLAY" ]; then
+		XkbApplyLater
+	else
+		XkbApplyNow
 	fi
 }
 
@@ -302,12 +304,8 @@ To keep the current model, press cancel...')'" 30 80 0 \'
 	[ -z "$CHOICE" ] && echo "cancelled" && exit
 	if [ -f "$XKBRC" ]; then
 		sed -i "s%^XKB_DEFAULT_MODEL=.*%XKB_DEFAULT_MODEL=$CHOICE%" $XKBRC
-		if [ -n "$WAYLAND_DISPLAY" ]; then
-			XkbApplyLater
-		else
-			XkbApplyNow
-		fi
-	elif [ -f $XORG_CONF ]; then
+	fi
+	if [ -f $XORG_CONF ]; then
 		# create the modified line to replace original:
 		MODIFIED=`echo "$ORIGINAL" | sed "s%\"$CURRENT\"%\"$NEW\"%"`
 		# add to file
@@ -317,6 +315,12 @@ To keep the current model, press cancel...')'" 30 80 0 \'
 		else
 			eval $ERRMSG
 		fi
+	fi
+
+	if [ -n "$WAYLAND_DISPLAY" ]; then
+		XkbApplyLater
+	else
+		XkbApplyNow
 	fi
 }
 
@@ -370,12 +374,8 @@ To abort, press cancel.')"
 
 	if [ -f "$XKBRC" ]; then
 		sed -i "s%^XKB_DEFAULT_OPTIONS=.*%XKB_DEFAULT_OPTIONS=$NEW%" $XKBRC
-		if [ -n "$WAYLAND_DISPLAY" ]; then
-			XkbApplyLater
-		else
-			XkbApplyNow
-		fi
-	elif [ -f $XORG_CONF ]; then
+	fi
+	if [ -f $XORG_CONF ]; then
 		# add new variant to line, or entire line, if it doesn't exist:
 		if [ "$ORIGINAL" = "" ] ;then
 			ORIGINAL=`fgrep '"XkbVariant"' $XORG_CONF | grep -v '#.*Option'`
@@ -391,6 +391,12 @@ To abort, press cancel.')"
 		else
 			eval $ERRMSG
 		fi
+	fi
+
+	if [ -n "$WAYLAND_DISPLAY" ]; then
+		XkbApplyLater
+	else
+		XkbApplyNow
 	fi
 }
 export -f XkbOption
@@ -528,12 +534,8 @@ Xdialog --left --stdout --title "$gtxt1" --menubox "' >$TMPDIALOG
 		[ "$NEW" = "$OLD" ] && NEW=`echo "$OLD" | tr ',' '\n' | sed "${ITSPOS}s/.*//" | tr '\n' ',' | sed 's/,$//'`
 		if [ -f $XKBRC ]; then
 			sed -i "s%^XKB_DEFAULT_VARIANT=.*%XKB_DEFAULT_VARIANT=$NEW%" $XKBRC
-			if [ -n "$WAYLAND_DISPLAY" ]; then
-				XkbApplyLater
-			else
-				XkbApplyNow
-			fi
-		elif [ -f $XORG_CONF ]; then
+		fi
+		if [ -f $XORG_CONF ]; then
 			# add new variant to line, or entire line, if it doesn't exist:
 			if [ "$ORIGINAL" = "" ] ;then
 				ORIGINAL="$LAYOUTSLINE"
@@ -548,6 +550,12 @@ Xdialog --left --stdout --title "$gtxt1" --menubox "' >$TMPDIALOG
 			else
 				eval $ERRMSG
 			fi
+		fi
+
+		if [ -n "$WAYLAND_DISPLAY" ]; then
+			XkbApplyLater
+		else
+			XkbApplyNow
 		fi
 	else
 		Xdialog --title "$(gettext 'layout'): $LAYOUTS" --msgbox "$(gettext 'No variants available for') $LAYOUTS" 0 0


### PR DESCRIPTION
xkbconfigmanager should modify xorg.conf **if present**, and xkb-apply must run when a keyboard is plugged in, in case xorg.conf is missing.