### PR TITLE
Switch to overlay in jammy64

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -11,7 +11,7 @@
 STRIP_BINARIES=no
 
 ## UnionFS: aufs or overlay
-UNIONFS=aufs
+UNIONFS=overlay
 
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels


### PR DESCRIPTION
This is what Vanilla Upup 22.04.55 does, and now the jammy64 configuration is exactly the same thing minus the kernel.