### PR TITLE
Disable software rendering on second boot

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+. /etc/rc.d/PUPSTATE
+
 export TEXTDOMAIN=xwin
 export OUTPUT_CHARSET=UTF-8
 
@@ -30,7 +32,7 @@ fi
 export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
 export PULSE_COOKIE=/home/spot/.config/pulse/cookie
 
-export WLR_RENDERER_ALLOW_SOFTWARE=1
+[ $PUPMODE -eq 5 ] && export WLR_RENDERER_ALLOW_SOFTWARE=1
 
 while :
 do


### PR DESCRIPTION
Software rendering seems to increase dwl's memory usage, even if unused.