### PR TITLE
Drop X-only autostart processes if using Wayland

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -563,7 +563,7 @@ no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls
 yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
 yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
-yes|pulseaudio|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
+yes|pulseaudio-compat|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
 yes|pulseaudio-null|pulseaudio|exe>null,dev>null,doc>null,nls>null
 no|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
 no|psynclient||exe

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -141,4 +141,5 @@ echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 sed -i s/^GDK_BACKEND=x11/GDK_BACKEND=wayland/ root/.dwlrc
+rm -f etc/xdg/autostart/blueman.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop
 "

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -565,7 +565,7 @@ no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls
 yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
 yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
-yes|pulseaudio|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
+yes|pulseaudio-compat|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
 no|psynclient||exe
 no|pupmixer||exe
 no|Pup-Kview||exe

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -142,4 +142,5 @@ ln -s /bin/busybox usr/bin/man
 echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
+rm -f etc/xdg/autostart/blueman.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop
 "

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -565,7 +565,7 @@ no|ppp|ppp|exe,dev>null
 no|pptp|pptp-linux|exe,dev,doc,nls
 yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
 yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
-yes|pulseaudio|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
+yes|pulseaudio-compat|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
 yes|pulseaudio-null|pulseaudio|exe>null,dev>null,doc>null,nls>null
 no|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
 no|psynclient||exe


### PR DESCRIPTION
ppavol and Blueman keep running although there's no tray icon. It's a waste of RAM.