### PR TITLE
Make PipeWire the ALSA default

### DIFF
--- a/woof-code/rootfs-skeleton/etc/init.d/10alsa
+++ b/woof-code/rootfs-skeleton/etc/init.d/10alsa
@@ -141,7 +141,7 @@ case "$1" in
 	fi
 	
 	
-	if [ "$(which pulseaudio)" != "" ]; then
+	if [ "$(which pulseaudio)" != "" -o "$(which pipewire-pulse)" != "" ]; then
 	 if [ -e /etc/asound.conf ] && [ "$(cat /etc/asound.conf | grep "ctl.pulse")" == "" ]; then
 	  echo "pcm.pulse {
 			type pulse


### PR DESCRIPTION
This will make more ALSA-only tools work under PipeWire and ensure the Master mixer exists in the default sound card (yambar relies on this).