### PR TITLE
Add PipeWire support to 0fcb3c6ab1

### DIFF
--- a/woof-code/packages-templates/pavucontrol_FIXUPHACK
+++ b/woof-code/packages-templates/pavucontrol_FIXUPHACK
@@ -3,3 +3,5 @@ echo '#!/bin/sh
 exec pavucontrol "\$@"' > usr/local/bin/defaultaudiomixer
 chmod 755 usr/local/bin/defaultaudiomixer
 EOF
+
+echo "rm -f usr/share/applications/defaultaudiomixer.desktop usr/share/applications/ALSA-sound-Wizard.desktop usr/sbin/alsawizard" > pinstall.sh

--- a/woof-code/packages-templates/pulseaudio_FIXUPHACK
+++ b/woof-code/packages-templates/pulseaudio_FIXUPHACK
@@ -1,6 +1,5 @@
 echo '
 echo "Configuring Pulseaudio"
-rm -f usr/share/applications/defaultaudiomixer.desktop usr/share/applications/ALSA-sound-Wizard.desktop usr/sbin/alsawizard
 chroot . busybox addgroup pulse
 chroot . busybox addgroup pulse-access
 chroot . busybox adduser -D -s /bin/false -g 'PulseAudio' -G audio -h /var/run/pulse pulse 2>/dev/null

--- a/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
@@ -53,7 +53,7 @@ export WizardWizard='
       <button image-position="2">
         <label>'$(gettext 'Sound')'</label>
         '"`/usr/lib/gtkdialog/xml_button-icon sound.svg huge`"'
-        <action>command -v pulseaudio > /dev/null 2>&1 && pavucontrol || /usr/sbin/alsawizard &</action>
+        <action>command -v pulseaudio pipewire-pulse > /dev/null 2>&1 && pavucontrol || /usr/sbin/alsawizard &</action>
       </button>
       '$BUTTON_22'
       <button image-position="2">


### PR DESCRIPTION
The ALSA-related menu entries and "wizards" need to be removed if using PipeWire, too. Both PulseAudio and PipeWire use pavucontrol, so that's the best place to do that.