### PR TITLE
Apply the dwl theme to floating windows above Xwayland

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -75,21 +75,20 @@ do
 	[ -n "$LIBINPUT_DEFAULT_MIDDLE_EMULATION" ] && export LIBINPUT_DEFAULT_MIDDLE_EMULATION
 	[ -n "$LIBINPUT_DEFAULT_LEFT_HANDED" ] && export LIBINPUT_DEFAULT_LEFT_HANDED
 
+	BORDER_COLOR=""
+	FOCUS_COLOR=""
+	BORDER=""
+	. ~/.pthemerc
+	. "/usr/share/dwl/themes/$PTHEME_DWL"
+	export DWL_BORDER="$BORDER"
+	export DWL_BORDER_COLOR="$BORDER_COLOR"
+	export DWL_FOCUS_COLOR="$FOCUS_COLOR"
+
 	. ~/.dwlrc
 	DWL_ARGS="-s ~/.dwlinitrc"
 	if [ "$GDK_BACKEND" = "x11" ]; then
-		export DWL_BORDER="0"
 		DWL_ARGS="$DWL_ARGS -k"
 	else
-		BORDER_COLOR=""
-		FOCUS_COLOR=""
-		BORDER=""
-		. ~/.pthemerc
-		. "/usr/share/dwl/themes/$PTHEME_DWL"
-		export DWL_BORDER="$BORDER"
-		export DWL_BORDER_COLOR="$BORDER_COLOR"
-		export DWL_FOCUS_COLOR="$FOCUS_COLOR"
-
 		export MOZ_ENABLE_WAYLAND=1
 		DWL_ARGS="$DWL_ARGS -x"
 	fi


### PR DESCRIPTION
@01micko I think this makes sense, because these windows have no borders of their own and sometimes it's hard to distinguish between X and Wayland windows, or between Wayland windows and the focused Wayland window. Maybe it's ugly because it's visually inconsistent, but it's functional.

![floating](https://user-images.githubusercontent.com/1471149/180317476-2367b79f-9a66-4d02-a462-089ef234dab1.png)
