### PR TITLE
Try x-www-browser before Firefox

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -83,9 +83,18 @@ EOF
 
 (
 echo "echo '"'#!/bin/sh'"' > usr/local/bin/defaultbrowser"
+echo "echo '"'#!/bin/sh'"' > usr/local/bin/defaulthtmlviewer"
+
+case ${DISTRO_BINARY_COMPAT} in ubuntu|trisquel|debian|devuan|raspbian)
+	echo "echo 'ALT=\`command -v x-www-browser\`' >> usr/local/bin/defaultbrowser"
+	echo "echo '[ -n \"\$ALT\" ] && exec \"\$ALT\" \"\$@\"' >> usr/local/bin/defaultbrowser"
+	echo "echo 'ALT=\`command -v x-www-browser\`' >> usr/local/bin/defaulthtmlviewer"
+	echo "echo '[ -n \"\$ALT\" ] && exec \"\$ALT\" \"\$@\"' >> usr/local/bin/defaulthtmlviewer"
+	;;
+esac
+
 echo "echo 'exec firefox \"\$@\"' >> usr/local/bin/defaultbrowser"
 echo "chmod 755 usr/local/bin/defaultbrowser"
-echo "echo '"'#!/bin/sh'"' > usr/local/bin/defaulthtmlviewer"
 echo "echo 'exec firefox \"\$@\"' >> usr/local/bin/defaulthtmlviewer"
 echo "chmod 755 usr/local/bin/defaulthtmlviewer"
 echo 'echo "setting up Firefox"'


### PR DESCRIPTION
Users who don't like the preinstalled Firefox don't have to change defaultbrowser once they install their browser of choice, if defaultbrowser tries x-www-browser first.