### PR TITLE
Make spot-pkexec work under Wayland

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -61,13 +61,11 @@ EOF
 		fi
 	done
 
-	if [ "${XDG_RUNTIME_DIR}" ] ; then
-		export XDG_RUNTIME_DIR=/tmp/runtime-${XUSER}
-		if [ ! -d ${XDG_RUNTIME_DIR} ] ; then
-			mkdir -p ${XDG_RUNTIME_DIR}
-			chmod 0700 ${XDG_RUNTIME_DIR}
-			chown ${XUSER} ${XDG_RUNTIME_DIR}
-		fi
+	export XDG_RUNTIME_DIR=/tmp/runtime-${XUSER}
+	if [ ! -d ${XDG_RUNTIME_DIR} ] ; then
+		mkdir -p ${XDG_RUNTIME_DIR}
+		chmod 0700 ${XDG_RUNTIME_DIR}
+		chown ${XUSER} ${XDG_RUNTIME_DIR}
 	fi
 
 	if [ -s /tmp/.spot-session-bus ]; then


### PR DESCRIPTION
It fails for two reasons:
1) ~~Unsafe use of environment variables - they must be copied aside before clearenv()~~ probably not an issue and probably not true
2) XDG_RUNTIME_DIR is not set so GTK+ cannot build the Wayland socket path