### PR TITLE
Update dpkg status on Puppy update

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -311,6 +311,7 @@ if [ -f /initrd/tmp/version_update_flag ]; then
  find -L / \( -mount -path '*/lib/*' -type l -name *.so -o -path '*/lib/*' -type l -name *.so.* \) -delete
 
  basic_update
+ bdrv-update
  #*** sometimes these go back to 755...
  chmod 1777 /tmp
  chmod 777 /var

--- a/woof-code/rootfs-skeleton/sbin/bdrv-update
+++ b/woof-code/rootfs-skeleton/sbin/bdrv-update
@@ -1,0 +1,44 @@
+#!/bin/ash
+
+cmp -s /initrd/pup_b/var/lib/dpkg/status /var/lib/dpkg/status
+[ $? -ne 1 ] && exit 0
+
+# get package information for all packages in the new bdrv
+F=`mktemp`
+while IFS="" read -r LINE; do
+	echo "$LINE" >> $F
+	if [ -z "$LINE" ]; then
+		NAME=`grep ^Package: $F | awk -F ": " '{print $2}'`
+		[ -z "$NAME" ] && exit 1
+		mv -f $F "/tmp/.dpkgstatus-$NAME.new"
+	fi
+done < /initrd/pup_b/var/lib/dpkg/status
+
+(
+	while IFS="" read -r LINE; do
+		echo "$LINE" >> $F
+		if [ -z "$LINE" ]; then
+			NAME=`grep ^Package: $F | awk -F ": " '{print $2}'`
+			VERSION=`grep ^Version: $F | awk -F ": " '{print $2}'`
+
+			NF=/tmp/.dpkgstatus-${NAME}.new
+			if [ -f "$NF" ]; then
+				NEWVERSION=`grep ^Version: "$NF" | awk -F ": " '{print $2}'`
+				# take the package information from bdrv if it's a newer version
+				if [ -n "$NEWVERSION" ]; then
+					vercmp "$NEWVERSION" gt "$VERSION" && cat "$NF" || cat $F
+				else
+					cat "$NF"
+				fi
+				rm -f "$NF"
+			else
+				cat $F
+			fi
+
+			truncate -s 0 $F
+		fi
+	done < /var/lib/dpkg/status
+	rm -f $F
+) > /tmp/.dpkgstatus
+
+mv -f /tmp/.dpkgstatus /var/lib/dpkg/status


### PR DESCRIPTION
A library in Vanilla Dpup version x has version 3.7.1-5, and 3.7.1-5+deb11u1 in version y. If the user installs version x and runs `apt install`, the list of packages installed at build time gets copied to the save file and the newly installed package is added.

When the user updates from version x to version y, the library files in the main SFS correspond to version 3.7.1-5+deb11u1, although the package list in the save file says it's still 3.7.1-5. The package manager thinks the package version is 3.7.1-5, because the Puppy update swapped the library under its feet, while keeping the same package list.

This is a problem because sometimes, the -dev package of a library must be the same version of the non-dev package, so the user has to force reinstallation of the package to update the package list, while creating copies of the library files in the save file.

This PR fixes the package list by fixing the version number and other metadata during update. The updated package list is identical to the one in the save file and even has the same order of packages, except changes like this:

```
-Version: 3.7.1-5
+Version: 3.7.1-5+deb11u1
```