### PR TITLE
Add a Xwayland variant of bookworm

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -146,7 +146,6 @@ no|foomatic-db-engine|foomatic-db-engine|exe,dev,doc,nls
 no|foomatic-filters|foomatic-filters|exe,dev,doc,nls
 yes|fonts-liberation2|fonts-liberation2|exe,dev,doc,nls||deps:yes
 yes|fonts-noto-color-emoji|fonts-noto-color-emoji|exe,dev,doc,nls||deps:yes
-yes|foot|foot|exe,dev,doc,nls||deps:yes
 no|fpm2||exe,dev
 no|freeglut|freeglut3,freeglut3-dev|exe,dev,doc,nls
 no|freememapplet||exe
@@ -615,7 +614,6 @@ yes|strace|strace|exe>dev,dev,doc,nls||deps:yes
 no|streamripper|streamripper|exe,dev
 no|subversion|subversion,libsvn1,libaprutil1,libapr1|exe>dev,dev,doc,nls||deps:yes
 no|sudo||exe,dev
-yes|swaybg|swaybg|exe,dev,doc,nls||deps:yes
 yes|swayidle|swayidle|exe,dev,doc,nls||deps:yes
 yes|swaylock|swaylock|exe>null,dev>null,doc>null,nls>null # using swaylock petbuild with root patch
 yes|sysfsutils|libsysfs2,sysfsutils|exe,dev,doc,nls||deps:yes
@@ -630,7 +628,6 @@ no|telepathy-glib|libtelepathy-glib0|exe,dev,doc,nls #needed by abiword. left ou
 yes|texinfo|texinfo|exe>dev,dev,doc,nls||deps:yes
 no|tidy|libtidy5deb1,libtidy-dev|exe,dev,doc,nls #needed by abiword.
 yes|time|time|exe,dev>null,doc,nls||deps:yes
-yes|tofi|tofi|exe,dev,doc,nls||deps:yes
 no|transmission|transmission-gtk,transmission-common|exe,dev,doc,nls
 no|tree|tree|exe,dev,doc,nls
 yes|udev|udev|exe,dev,doc,nls||deps:yes
@@ -673,13 +670,11 @@ no|xcur2png||exe #pcur needs this
 no|xdelta||exe
 no|xdg-puppy-jwm||exe
 yes|xdg-utils|xdg-utils|exe,dev,doc,nls||deps:yes
-yes|xdotool|xdotool,libxdo3|exe,dev,doc,nls||deps:yes
 no|Xdialog||exe
 no|xfdiff-cut||exe
 no|xlock_gui||exe
 no|xlockmore||exe
 yes|xml-core|xml-core|exe>dev,dev,doc,nls||deps:yes
-yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-xserver-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
 yes|xorg_dri|libgl1-mesa-dri,mesa-utils,libsensors5|exe,dev,doc,nls||deps:yes
 no|xserver-xorg-video-vmware|xserver-xorg-video-vmware|exe>null,dev>null,doc>null,nls>null # needs libxatracker2
 no|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xserver-xorg-input-wacom,xserver-xorg-video-intel,xserver-xorg-video-qxl,xinit|exe,dev,doc,nls||deps:yes
@@ -694,7 +689,6 @@ yes|xwayland|xwayland|exe,dev>exe,doc,nls||deps:yes
 yes|xz|xz-utils,liblzma5,liblzma-dev|exe,dev,doc,nls||deps:yes
 no|yad||exe
 no|yajl|libyajl2,libyajl-dev|exe,dev,doc,nls #needed by raptor2.
-yes|yambar|yambar|exe,dev,doc,nls||deps:yes
 no|yasm|yasm|exe>dev,dev>null,doc,nls
 no|YASSM||exe,dev>null,doc,nls
 yes|zip|zip|exe,dev>null,doc,nls||deps:yes
@@ -702,3 +696,18 @@ yes|zlib|zlib1g,zlib1g-dev|exe,dev,doc,nls||deps:yes
 yes|zstd|zstd|exe,dev,doc,nls||deps:yes
 no|zzznet||exe
 '
+
+if [ "$DISTRO_VARIANT" = "dwl" ]; then
+	PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-xserver-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
+yes|foot|foot|exe,dev,doc,nls||deps:yes
+yes|swaybg|swaybg|exe,dev,doc,nls||deps:yes
+yes|tofi|tofi|exe,dev,doc,nls||deps:yes
+yes|yambar|yambar|exe,dev,doc,nls||deps:yes
+"
+else
+	PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-xserver-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libxmu6,libxmu-dev,libxpm4,libxpm-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
+yes|xdotool|xdotool,libxdo3|exe,dev,doc,nls||deps:yes
+"
+fi

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -41,7 +41,12 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask foot-puppy mtpaint osmo pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat claws-mail yambar-puppy"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask mtpaint osmo pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat claws-mail"
+if [ "$DISTRO_VARIANT" = "dwl" ]; then
+	PETBUILDS="$PETBUILDS foot-puppy yambar-puppy"
+else
+	PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui"
+fi
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -140,6 +145,7 @@ ln -s /bin/busybox usr/bin/man
 echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
-sed -i s/^GDK_BACKEND=x11/GDK_BACKEND=wayland/ root/.dwlrc
-rm -f etc/xdg/autostart/blueman.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop
+[ \"\$DISTRO_VARIANT\" = \"dwl\" ] && sed -i s/^GDK_BACKEND=x11/GDK_BACKEND=wayland/ root/.dwlrc
+[ \"\$DISTRO_VARIANT\" = \"dwl\" ] && rm -f etc/xdg/autostart/blueman.desktop etc/xdg/autostart/pcmanfm.desktop
+rm -f etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop
 "


### PR DESCRIPTION
`DISTRO_VARIANT=dwl ./0setup`, etc' activates the smaller and lighter "pure Wayland" mode, while the default is JWM under Xwayland.

The difference is very minimal, unlike separate X.Org and Wayland variants, so I don't think it's a huge maintenance burden to have these two variants.

![dwl](https://user-images.githubusercontent.com/1471149/180731035-6d1eabc6-3c7f-4e7b-94cf-170a1dab406b.png)
![xwayland](https://user-images.githubusercontent.com/1471149/180731043-f4a0fcb8-e96b-46be-a7b9-4f00aa8406bd.png)


