### PR TITLE
Disable jwm_config if JWM is not part of the build

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -113,11 +113,18 @@ and edit it to include your customised package list.
 			state=false
 			grep -q 'yes|rox.*filer|' $PKGSSPECS && state=true
 			;;
-		jwm_config|ptheme|pt_*)
+		jwm_config)
 			if grep -q 'yes|jwmconfig' $PKGSSPECS ; then
 				state=false #cant choose them if jwmconfig is in specs. 
 			elif grep -q 'yes|jwm|' $PKGSSPECS ; then
 				state=true
+			else
+				state=false
+				for PETBUILD in $PETBUILDS; do
+					[ "$PETBUILD" = "jwm" ] || continue
+					state=true
+					break
+				done
 			fi
 			;;
 		pmusic*)


### PR DESCRIPTION
The code, the way it is today, has a bug: the jwm_config block doesn't have an `else` block that sets `state=true`. jwm_config is included in the build because it comes after imageview, which is always enabled.

This PR keeps ptheme enabled, always (as today, thanks to this bug), but disables jwm_config if JWM is not included in the build.