### PR TITLE
If settings.ini does not exist, add leading [Settings]

### DIFF
--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -28,6 +28,11 @@ set_gtk4_theme() {
 			else
 				echo "gtk-icon-theme-name = $ICON_THEME" >> $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
 			fi
+		else
+			cat << _EOF > $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
+[Settings]
+gtk-icon-theme-name = $ICON_THEME
+_EOF
 		fi
 	else
 		PTHEME_GTK4="$1"
@@ -36,6 +41,10 @@ set_gtk4_theme() {
 			cat > $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini << _EOF
 [Settings]
 gtk-theme-name = ${PTHEME_GTK4}
+_EOF
+		else
+			cat > $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini << _EOF
+[Settings]
 _EOF
 		fi
 	fi
@@ -57,6 +66,11 @@ set_gtk3_theme() {
 			else
 				echo "gtk-icon-theme-name = $ICON_THEME" >> $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini
 			fi
+		else
+			cat << _EOF > $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini
+[Settings]
+gtk-icon-theme-name = $ICON_THEME
+_EOF
 		fi
 	else
 		PTHEME_GTK3="$1"
@@ -65,6 +79,12 @@ set_gtk3_theme() {
 			cat > $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini << _EOF
 [Settings]
 gtk-theme-name = ${PTHEME_GTK3}
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
+_EOF
+		else
+			cat > $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini << _EOF
+[Settings]
 gtk-toolbar-style = GTK_TOOLBAR_BOTH
 gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
 _EOF


### PR DESCRIPTION
In a system with GTK+ 4, with an icon theme and without a GTK+ theme, the file starts with `gtk-icon-theme-name` and it's faulty.