### PR TITLE
Kill PipeWire before starting it

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -19,6 +19,8 @@ DBUS_SESSION_BUS_ADDRESS=$DBUS_SESSION_BUS_ADDRESS" > /tmp/.spot-session-bus
 ) < <(run-as-spot dbus-daemon --fork --print-address 1 --print-pid 1 --session)
 
 if [ -e /usr/bin/wireplumber ]; then
+    # TODO: check why they don't terminate after the session bus is terminated
+    killall pipewire pipewire-pulse wireplumber 2>/dev/null
     rm -f /tmp/runtime-spot/pipewire-0
     run-as-spot pipewire > /dev/null 2>&1 &
     (


### PR DESCRIPTION
This is weird, pipewire and pipewire-pulse keep running after the spot session bus is killed, and after tty1 is dead. As a result, audio is broken until they're killed and restarted.