### PR TITLE
Limit the yambar window title width

### DIFF
--- a/woof-code/rootfs-petbuilds/yambar-puppy/usr/share/yambar/config-labwc.yml.in
+++ b/woof-code/rootfs-petbuilds/yambar-puppy/usr/share/yambar/config-labwc.yml.in
@@ -91,7 +91,7 @@ bar:
             values:
               false: {empty: {}}
               true:
-                - string: {text: "{title}"}
+                - string: {text: "{title}", max: 90}
 
   right:
     - removables:

--- a/woof-code/rootfs-petbuilds/yambar-puppy/usr/share/yambar/config.yml.in
+++ b/woof-code/rootfs-petbuilds/yambar-puppy/usr/share/yambar/config.yml.in
@@ -162,7 +162,7 @@ bar:
                          true: {string: {text: " 9 ", <<: *sel}}
                          false: {string: {text: " 9 ", <<: *default}}
              - string: {text: " {layout} ", <<: *sel}
-             - string: {text: " {title}"}
+             - string: {text: " {title}", max: 90}
   right:
     - alsa:
         card: default


### PR DESCRIPTION
Without this, the title is written over the "tray" on the right.