### PR TITLE
Hide the yambar battery "applet" if no battery is present

### DIFF
--- a/woof-code/rootfs-petbuilds/yambar-puppy/usr/share/yambar/config.yml.in
+++ b/woof-code/rootfs-petbuilds/yambar-puppy/usr/share/yambar/config.yml.in
@@ -188,22 +188,33 @@ bar:
     - script:
         path: /usr/bin/batmon
         content:
-          ramp:
+          map:
             tag: capacity
             on-click: batinfo
-            items:
-              - string: {text: "🪫{capacity}%"}
-              - string: {text: "🪫{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-              - string: {text: "🔋{capacity}%"}
-            max: 100
-            min: 1
+            values:
+              -1: {string: {text: ""}}
+              0: {string: {text: "🪫0%"}}
+              1: {string: {text: "🪫1%"}}
+              2: {string: {text: "🪫2%"}}
+              3: {string: {text: "🪫3%"}}
+              4: {string: {text: "🪫4%"}}
+              5: {string: {text: "🪫5%"}}
+              6: {string: {text: "🪫6%"}}
+              7: {string: {text: "🪫7%"}}
+              8: {string: {text: "🪫8%"}}
+              9: {string: {text: "🪫9%"}}
+              10: {string: {text: "🪫10%"}}
+              11: {string: {text: "🪫11%"}}
+              12: {string: {text: "🪫12%"}}
+              13: {string: {text: "🪫13%"}}
+              14: {string: {text: "🪫14%"}}
+              15: {string: {text: "🪫15%"}}
+              16: {string: {text: "🪫16%"}}
+              17: {string: {text: "🪫17%"}}
+              18: {string: {text: "🪫18%"}}
+              19: {string: {text: "🪫19%"}}
+              20: {string: {text: "🪫20%"}}
+            default: {string: {text: "🔋{capacity}%"}}
     - script:
         path: /usr/bin/netmon
         content:


### PR DESCRIPTION
This is a regression. The `ramp.min` value normalizes -1 to 0% and that makes the battery "applet" appear in virtual machines.

Maybe there's a cleaner way to have one emoji for low battery, another for not-low battery, and nothing for -1 🤔 