### PR TITLE
Allow spot to connect to Xwayland without using xhost

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -12,24 +12,19 @@ for F in $WAYLAND_DISPLAY $WAYLAND_DISPLAY.lock; do
 	mount --bind $XDG_RUNTIME_DIR/$F $SPOT_RUNTIME_DIR/$F
 done
 
+[ "$GDK_BACKEND" = "x11" ] && export DISPLAY=:0
+
+XAUTHORITY=~/.Xauthority
+echo "add $DISPLAY . `mcookie`" | xauth -q -f "$XAUTHORITY"
+cp -f $XAUTHORITY /home/spot/.Xauthority
+chown spot:spot /home/spot/.Xauthority
+
 if [ "$GDK_BACKEND" = "x11" ]; then
-	DISPLAY=:0
-	XAUTHORITY=~/.Xauthority
-
-	echo "add $DISPLAY . `mcookie`" | xauth -q -f "$XAUTHORITY"
-	if [ "`id -u`" -eq 0 ]; then
-		cp -f $XAUTHORITY /home/spot/.Xauthority
-		chown spot:spot /home/spot/.Xauthority
-	fi
-
 	args=
 	if [ -f ~/.Xresources ]; then
 		dpi=`grep ^Xft\.dpi: ~/.Xresources | awk '{print $2}'`
 		[ -n "$dpi" ] && args="$args -dpi $dpi"
 	fi
-
-	export DISPLAY
-	export XAUTHORITY
 
 	Xwayland $DISPLAY -auth $XAUTHORITY $args &
 
@@ -57,9 +52,6 @@ fi
 
 # desktop settings
 [ -e "$XDG_CONFIG_HOME/wmonitors/wmon_cmd" ] && . $XDG_CONFIG_HOME/wmonitors/wmon_cmd
-
-# allow applications running as spot to talk to Xwayland
-xhost +local:
 
 if [ "$GDK_BACKEND" = "x11" ]; then
 	CURRENTWM="`cat /etc/windowmanager 2>/dev/null`"

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/Xwayland-spot
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/Xwayland-spot
@@ -1,0 +1,3 @@
+#!/bin/ash
+
+exec Xwayland "$@" -auth ~/.Xauthority

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -34,6 +34,7 @@ fi
 export PULSE_SERVER=unix:/tmp/runtime-spot/pulse/native
 export PULSE_COOKIE=/home/spot/.config/pulse/cookie
 
+export WLR_XWAYLAND=/usr/bin/Xwayland-spot
 [ $PUPMODE -eq 5 ] && export WLR_RENDERER_ALLOW_SOFTWARE=1
 
 while :

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -79,7 +79,6 @@ yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc,nls||deps:yes
 no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
-yes|cpp|cpp|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
 no|ctorrent|ctorrent|exe,dev>null,doc,nls
 no|cryptsetup||exe # must use wce static binary
@@ -699,7 +698,7 @@ no|zzznet||exe
 
 if [ "$DISTRO_VARIANT" = "dwl" ]; then
 	PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
-yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-xserver-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
 yes|foot|foot|exe,dev,doc,nls||deps:yes
 yes|gsimplecal|gsimplecal|exe,dev,doc,nls||deps:yes
 yes|swaybg|swaybg|exe,dev,doc,nls||deps:yes
@@ -708,7 +707,7 @@ yes|yambar|yambar|exe,dev,doc,nls||deps:yes
 "
 else
 	PKGS_SPECS_TABLE="$PKGS_SPECS_TABLE
-yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-xserver-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libxmu6,libxmu-dev,libxpm4,libxpm-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libxmu6,libxmu-dev,libxpm4,libxpm-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
 yes|xdotool|xdotool,libxdo3|exe,dev,doc,nls||deps:yes
 "
 fi

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -80,7 +80,6 @@ yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc,nls||deps:yes
 no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
-yes|cpp|cpp|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
 no|ctorrent|ctorrent|exe,dev>null,doc,nls
 no|cryptsetup||exe # must use wce static binary
@@ -681,7 +680,7 @@ no|xfdiff-cut||exe
 no|xlock_gui||exe
 no|xlockmore||exe
 yes|xml-core|xml-core|exe>dev,dev,doc,nls||deps:yes
-yes|xorg_base_new|libglapi-mesa,libx11-xcb1,xfonts-utils,mesa-common-dev,libgl1,x11-xkb-utils,x11-xserver-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libglu1-mesa,libglu1-mesa-dev,libice6,libice-dev,libsm6,libsm-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libx11-data,libxau6,libxau-dev,libxaw7,libxcomposite1,libxcomposite-dev,libxcursor1,libxcursor-dev,libxdamage1,libxdamage-dev,libxdmcp6,libxdmcp-dev,libxext6,libxext-dev,libxfixes3,libxfixes-dev,libxfont2,libxfont-dev,libxft2,libxft-dev,libxi6,libxi-dev,libxinerama1,libxkbfile1,libxkbfile-dev,libxmu6,libxmu-dev,libxmuu1,libxpm4,libxpm-dev,libxrandr2,libxrandr-dev,libxrender1,libxrender-dev,libxt6,libxt-dev,libxtst6,libxtst-dev,libxv1,libxxf86dga1,libxxf86vm1,xkb-data,xinput,xbitmaps,xauth,x11-common|exe,dev,doc,nls||deps:yes
+yes|xorg_base_new|libglapi-mesa,libx11-xcb1,xfonts-utils,mesa-common-dev,libgl1,x11-xkb-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libglu1-mesa,libglu1-mesa-dev,libice6,libice-dev,libsm6,libsm-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libx11-data,libxau6,libxau-dev,libxaw7,libxcomposite1,libxcomposite-dev,libxcursor1,libxcursor-dev,libxdamage1,libxdamage-dev,libxdmcp6,libxdmcp-dev,libxext6,libxext-dev,libxfixes3,libxfixes-dev,libxfont2,libxfont-dev,libxft2,libxft-dev,libxi6,libxi-dev,libxinerama1,libxkbfile1,libxkbfile-dev,libxmu6,libxmu-dev,libxmuu1,libxpm4,libxpm-dev,libxrandr2,libxrandr-dev,libxrender1,libxrender-dev,libxt6,libxt-dev,libxtst6,libxtst-dev,libxv1,libxxf86dga1,libxxf86vm1,xkb-data,xinput,xbitmaps,xauth,x11-common|exe,dev,doc,nls||deps:yes
 yes|xorg_dri|libgl1-mesa-dri,mesa-utils,libsensors5|exe,dev,doc,nls||deps:yes
 no|xserver-xorg-video-vmware|xserver-xorg-video-vmware|exe>null,dev>null,doc>null,nls>null # needs libxatracker2
 no|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xserver-xorg-input-wacom,xserver-xorg-video-intel,xserver-xorg-video-qxl,xinit|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
That xhost call in ~/.dwlinitrc is problematic because:
1) It causes Xwayland to run in every dwl desktop session, even if no X11 application is used, and that's a huge waste of memory
2) If Xwayland crashes or gets killed, nothing runs xhost again and spot can't run X applications until dwl is restarted and ~/.dwlinitrc runs xhost against a new Xwayland instance
3) xhost comes from x11-xserver-utils, which depends on a big package: cpp

This PR creates ~/.Xauthority even when using the "pure Wayland" session, configures Xwayland to accept connections if they present the correct cookie, and makes run-as-spot copy root's .Xauthority although XAUTHORITY is unset.