### PR TITLE
Copy a recently modified file to pup_ro1 only if it differs

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -180,7 +180,7 @@ do
 		if [ ! -e "$BASE/$N" ] ; then
 			cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 		elif [ ${NCTIME%%.*} -gt `stat -c %Z "$BASE/$N"` ] ; then
-			cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
+			cmp -s "$N" "$BASE/$N" || cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 		fi
 	fi
 done


### PR DESCRIPTION
A `touch` or a temporary modification of a file increases the number of writes to flash media.