### PR TITLE
Switch to X.Org, JWM, ROX-Filer and Aufs in jammy64

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -80,6 +80,7 @@ yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cmake|cmake,cmake-data,cmake-curses-gui,libuv1|exe>dev,dev,doc,nls||deps:yes
 no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
+yes|cpp|cpp|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
 no|ctorrent|ctorrent|exe,dev>null,doc,nls
 no|cryptsetup||exe # must use wce static binary
@@ -121,7 +122,6 @@ yes|dwarves|dwarves|exe>dev,dev,doc,nls||deps:yes
 yes|e2fsprogs|e2fsprogs,libblkid-dev,comerr-dev,ss-dev|exe,dev,doc,nls||deps:yes #note, strange ubuntu seems to have lost the dev component of libuuid.
 yes|efibootmgr|efibootmgr|exe,dev,doc,nls||deps:yes
 no|edid|read-edid|exe,dev>null,doc,nls
-yes|egl-wayland|libnvidia-egl-wayland1,libnvidia-egl-wayland-dev|exe,dev,doc,nls||deps:yes
 yes|eject|eject|exe,dev>null,doc,nls||deps:yes
 no|elfutils|elfutils,libasm1,libasm-dev,libdw1,libdw-dev,libelf1,libelf-dev|exe,dev,doc,nls #note, libelf is a different pkg.
 no|enchant|libenchant1c2a,libenchant-dev|exe,dev,doc,nls
@@ -201,7 +201,6 @@ no|gpptp||exe,dev>null,doc,nls
 no|gptfdisk||exe,doc,dev,nls
 yes|graphite2|libgraphite2-3,libgraphite2-dev|exe,dev,doc,nls||deps:yes #needed by harfbuzz.
 yes|grep|grep|exe,dev>null,doc,nls||deps:yes
-yes|grim|grim|exe,dev,doc,nls||deps:yes
 yes|groff|groff,groff-base|exe,dev,doc,nls||deps:yes
 no|grsync||exe,dev,doc,nls
 no|grub2_efi||exe
@@ -312,7 +311,6 @@ yes|libevent|libevent-2.1-7,libevent-dev|exe,dev,doc,nls||deps:yes #needed by tr
 no|libexif|libexif12,libexif-dev|exe,dev,doc,nls
 no|libexif-gtk|libexif-gtk5,libexif-gtk-dev|exe,dev,doc,nls
 no|libf2fs|libf2fs5,libf2fs-dev|exe,dev,doc,nls
-yes|libfcft|libfcft4,libfcft-dev|exe,dev,doc,nls||deps:yes
 yes|libffi|libffi8,libffi-dev|exe,dev,doc,nls||deps:yes
 no|libfftw3|libfftw3-3,libfftw3-bin,libfftw3-double3,libfftw3-long3,libfftw3-single3,libfftw3-quad3,libfftw3-dev|exe,dev,doc,nls
 no|libfs|libfs6,libfs-dev|exe,dev,doc,nls #120603 mavrothal reported need this for compiling xorg drivers.
@@ -332,7 +330,6 @@ no|libgphoto2|libgphoto2-6,libgphoto2-dev,libgphoto2-port12|exe,dev,doc,nls
 no|libgringotts|libgringotts2,libgringotts-dev|exe,dev,doc,nls
 no|libgsf|libgsf-1-114,libgsf-1-common,libgsf-1-dev|exe,dev,doc,nls
 no|libgtkhtml||exe,dev,doc,nls #needed by my osmo pet.
-yes|libgtk-layer-shell|libgtk-layer-shell0,libgtk-layer-shell-dev|exe,dev,doc,nls||deps:yes
 yes|libgudev|libgudev-1.0-0,libgudev-1.0-dev|exe,dev,doc,nls||deps:yes
 no|libical|libical2,libical-dev|exe,dev,doc,nls
 no|libid3tag|libid3tag0,libid3tag0-dev|exe,dev,doc,nls
@@ -440,7 +437,6 @@ yes|libxml2-utils|libxml2-utils|exe>dev,dev,doc,nls||deps:yes
 yes|libxshmfence|libxshmfence1,libxshmfence-dev|exe,dev,doc,nls||deps:yes #xorg needs this.
 yes|libxslt|libxslt1.1|exe>dev,dev,doc,nls||deps:yes
 no|libxvmc|libxvmc1,libxvmc-dev|exe,dev,doc,nls||deps:yes #this is actually part of xorg.
-yes|libyaml|libyaml-0-2,libyaml-dev|exe,dev,doc,nls||deps:yes
 yes|libxxhash|libxxhash0|exe,dev,doc,nls||deps:yes
 yes|libzstd|libzstd1,libzstd-dev|exe,dev,doc,nls||deps:yes
 no|linux_firmware_dvb||exe
@@ -597,8 +593,6 @@ no|rxvt-unicode||exe,dev>null,doc,nls
 no|sane-backends||exe,dev,doc,nls
 no|scale2x||exe
 no|sdl|libsdl1.2debian,libsdl-image1.2,libwebp6|exe,dev,doc,nls
-yes|seatd|seatd|exe,dev,doc,nls||deps:yes
-yes|scdoc|scdoc|exe>dev,dev,doc,nls||deps:yes
 yes|sed|sed|exe,dev>null,doc,nls||deps:yes
 yes|sensible-utils|sensible-utils|exe,dev,doc,nls||deps:yes
 yes|serf|libserf-1-1|exe>dev,dev,doc,nls||deps:yes #needed by svn.
@@ -607,7 +601,6 @@ yes|sgml-base|sgml-base|exe,dev,doc,nls||deps:yes
 yes|sgml-data|sgml-data|exe>dev,dev,doc,nls||deps:yes
 yes|shared-mime-info|shared-mime-info|exe,dev>exe,doc,nls||deps:yes
 no|simple-mtpfs||exe,dev,doc,nls #pupmtp
-yes|slurp|slurp|exe,dev,doc,nls||deps:yes
 yes|sqlite|libsqlite3-0|exe,dev,doc,nls||deps:yes
 yes|squashfs-tools|squashfs-tools|exe,dev,doc,nls||deps:yes
 no|ssh_gui||exe
@@ -616,9 +609,6 @@ yes|strace|strace|exe>dev,dev,doc,nls||deps:yes
 no|streamripper|streamripper|exe,dev
 yes|subversion|subversion,libsvn1,libaprutil1,libapr1|exe>dev,dev,doc,nls||deps:yes
 no|sudo||exe,dev
-no|swaybg|swaybg|exe,dev,doc,nls||deps:yes
-yes|swayidle|swayidle|exe,dev,doc,nls||deps:yes
-yes|swaylock|swaylock|exe>null,dev>null,doc>null,nls>null # using swaylock petbuild with root patch
 yes|sysfsutils|libsysfs2,sysfsutils|exe,dev,doc,nls||deps:yes
 yes|syslinux|syslinux,syslinux-common,syslinux-utils,syslinux-efi,extlinux,isolinux|exe,dev,doc,nls||deps:yes
 no|taglib|libtag1v5,libtag1-dev,libtag1v5-vanilla|exe,dev,doc,nls #needed by lots of media apps.
@@ -653,14 +643,12 @@ no|vobcopy|vobcopy|exe,dev,doc,nls
 no|vorbis-tools|vorbis-tools|exe,dev,doc,nls
 no|vboot-kernel-utils|vboot-kernel-utils|exe->dev,dev,doc,nls||deps:yes
 yes|vte|libvte-2.91-0,libvte-2.91-common,libvte-2.91-dev|exe,dev,doc,nls||deps:yes
-yes|wayland|libwayland-client0,libwayland-cursor0,libwayland-server0|exe,dev,doc,nls||deps:yes
+yes|wayland|libwayland-client0,libwayland-cursor0|exe,dev,doc,nls||deps:yes
 yes|wayland-dev|libwayland-dev,wayland-protocols,libwayland-bin|exe>dev,dev,doc,nls||deps:yes
 no|wcpufreq||exe,dev| #using this instead of cpu-scaling-ondemand.
 yes|wget|wget|exe,dev>null,doc,nls||deps:yes
 yes|wireless-tools|wireless-tools,libiw30,libiw-dev|exe,dev,doc,nls||deps:yes
 yes|wireplumber|wireplumber|exe,dev,doc,nls||deps:yes
-yes|wlroots|libwlroots10,libwlroots-dev|exe,dev,doc,nls||deps:yes
-yes|wlr-randr|wlr-randr|exe,dev,doc,nls||deps:yes
 no|wmctrl|wmctrl|exe,dev,doc,nls
 yes|wpa_supplicant|wpasupplicant|exe,dev>null,doc,nls||deps:yes
 no|wv|wv,libwv-1.2-4,libwv-dev|exe,dev,doc,nls
@@ -683,15 +671,13 @@ yes|xml-core|xml-core|exe>dev,dev,doc,nls||deps:yes
 yes|xorg_base_new|libglapi-mesa,libx11-xcb1,xfonts-utils,mesa-common-dev,libgl1,x11-xkb-utils,x11-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libglu1-mesa,libglu1-mesa-dev,libice6,libice-dev,libsm6,libsm-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,libx11-data,libxau6,libxau-dev,libxaw7,libxcomposite1,libxcomposite-dev,libxcursor1,libxcursor-dev,libxdamage1,libxdamage-dev,libxdmcp6,libxdmcp-dev,libxext6,libxext-dev,libxfixes3,libxfixes-dev,libxfont2,libxfont-dev,libxft2,libxft-dev,libxi6,libxi-dev,libxinerama1,libxkbfile1,libxkbfile-dev,libxmu6,libxmu-dev,libxmuu1,libxpm4,libxpm-dev,libxrandr2,libxrandr-dev,libxrender1,libxrender-dev,libxt6,libxt-dev,libxtst6,libxtst-dev,libxv1,libxxf86dga1,libxxf86vm1,xkb-data,xinput,xbitmaps,xauth,x11-common|exe,dev,doc,nls||deps:yes
 yes|xorg_dri|libgl1-mesa-dri,mesa-utils,libsensors5|exe,dev,doc,nls||deps:yes
 no|xserver-xorg-video-vmware|xserver-xorg-video-vmware|exe>null,dev>null,doc>null,nls>null # needs libxatracker2
-no|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xserver-xorg-input-wacom,xserver-xorg-video-intel,xserver-xorg-video-qxl,xinit|exe,dev,doc,nls||deps:yes
-no|xserver_xorg|xinit|exe,dev,doc,nls||deps:yes
+yes|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xserver-xorg-input-wacom,xserver-xorg-video-intel,xserver-xorg-video-qxl,xinit|exe,dev,doc,nls||deps:yes
 no|xsane||exe
 no|xserver_xorg|xserver-xorg,xserver-xorg-video-all,xserver-xorg-input-all,xinit|exe,dev,doc,nls||deps:yes
 yes|xsltproc|xsltproc|exe>dev,dev,doc,nls||deps:yes
 no|xsoldier|xsoldier|exe,dev>null,doc,nls
 yes|xtrans|xtrans-dev|exe>dev,dev,doc,nls||deps:yes
 no|xvidcore|libxvidcore4,libxvidcore-dev|exe,dev,doc,nls
-yes|xwayland|xwayland|exe,dev>exe,doc,nls||deps:yes
 yes|xz|xz-utils,liblzma5,liblzma-dev|exe,dev,doc,nls||deps:yes
 no|yad||exe
 no|yajl|libyajl2,libyajl-dev|exe,dev,doc,nls #needed by raptor2.

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -11,7 +11,7 @@
 STRIP_BINARIES=no
 
 ## UnionFS: aufs or overlay
-UNIONFS=overlay
+UNIONFS=aufs
 
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
@@ -41,7 +41,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat claws-mail"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad libicudata_stub lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
It's time to wind down Vanilla Upup 22.04. I prefer to invest my time in more real-world testing of Wayland support and "papercut bugs".

bookworm64 has reached feature parity with jammy64 and has all the goodies: PipeWire, JWM under Xwayland, a "pure Wayland" desktop with dwl and even a 32-bit flavor. Once Debian 12 is frozen (about 6 months from now?), I'll start to release Vanilla Dpup 10.x alpha releases without additional major features. Until then, bookworm64 needs to keep up with wlroots releases that land in Debian testing.

It will be much easier for somebody else to pick up jammy64 and continue where I left off if it's more like focal64.

#3026 can be closed and doesn't matter anymore if jammy64 switches to X.Org, because bookworm64 already has libxcvt 0.1.2 and this Wayland-specific bug is gone.