### PR TITLE
Use imv instead of gpicview, in the dwl variant of bookworm64

### DIFF
--- a/woof-code/packages-templates/imv_FIXUPHACK
+++ b/woof-code/packages-templates/imv_FIXUPHACK
@@ -1,0 +1,5 @@
+cat << EOF > pinstall.sh
+echo '#!/bin/sh
+exec /usr/libexec/imv/imv "\$@"' > usr/local/bin/defaultimageviewer
+chmod 755 usr/local/bin/defaultimageviewer
+EOF

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -700,6 +700,7 @@ if [ "$DISTRO_VARIANT" = "dwl" ]; then
 yes|xorg_base_new|libglapi-mesa,libx11-xcb1,mesa-common-dev,libgl1,x11-xkb-utils,x11-apps,fontconfig,fontconfig-config,libfontconfig-dev,libdrm2,libdrm-common,libdrm-dev,libdrm-radeon1,libdrm-amdgpu1,libdrm-nouveau2,libdrm-intel1,libepoxy0,libepoxy-dev,libfontconfig1,libfontconfig1-dev,libfontenc1,libfontenc-dev,libgl-dev,libunwind8,libunwind-dev,libx11-6,libx11-dev,xkb-data,xauth|exe,dev,doc,nls||deps:yes
 yes|foot|foot|exe,dev,doc,nls||deps:yes
 yes|gsimplecal|gsimplecal|exe,dev,doc,nls||deps:yes
+yes|imv|imv|exe,dev,doc,nls||deps:yes
 yes|slurp|slurp|exe,dev,doc,nls||deps:yes
 yes|swaybg|swaybg|exe,dev,doc,nls||deps:yes
 yes|tofi|tofi|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -41,11 +41,11 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask mtpaint osmo pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat claws-mail"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad libicudata_stub lxtask mtpaint osmo pcmanfm pup-volume-monitor transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-gtk fixmenusd spot-pkexec notification-daemon-stub dwl-kiosk swaylock wlopm weechat claws-mail"
 if [ "$DISTRO_VARIANT" = "dwl" ]; then
 	PETBUILDS="$PETBUILDS foot-puppy yambar-puppy"
 else
-	PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui"
+	PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui gpicview"
 fi
 
 ## GTK+ version to use when building packages that support GTK+ 2


### PR DESCRIPTION
gpicview is pretty much a dead project, so I don't think it's a good idea to invest time in #2621. A toolbar-less and keyboard controlled image viewer like imv is a better fit for a tiling window manager.