### PR TITLE
Fix breakage of the pupsave upgrade mechanism when using overlay

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -185,6 +185,10 @@ do
 	fi
 done
 
+# save DISTRO_SPECS, initrd uses it to determine whether or not to upgrade the save
+mkdir -p "$BASE/initrd"
+cmp -s /initrd/DISTRO_SPECS "$BASE/initrd/DISTRO_SPECS" || cp -af /initrd/DISTRO_SPECS "$BASE/initrd/DISTRO_SPECS"
+
 # =============================================================================
 
 sync


### PR DESCRIPTION
Unlike the aufs implementation of snapmergepuppy, the overlay one doesn't save /initrd, because there's a copy of these files in pup_rw anyway. It's a waste of space and writing cycles.

However, initrd relies on /initrd/pup_ro1/initrd/DISTRO_SPECS and uses it to determine whether or not an upgrade has occurred.