### PR TITLE
Replace the foot background and foreground colors with lxterminal defaults

### DIFF
--- a/woof-code/rootfs-petbuilds/foot-puppy/etc/xdg/foot/foot.ini
+++ b/woof-code/rootfs-petbuilds/foot-puppy/etc/xdg/foot/foot.ini
@@ -1,6 +1,8 @@
 term = xterm-256color
 initial-window-size-chars = 80x24
 [colors]
+background = 1a1a1a
+foreground = f8f8f8
 regular0 = 000000
 regular1 = aa0000
 regular2 = 00aa00


### PR DESCRIPTION
#3220 isn't enough because the default colors are not part of the color scheme. This explains bad contrast issues I couldn't put my finger on.