### PR TITLE
Add a maximize button to floating Wayland windows

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -44,10 +44,12 @@ fi
 apply_pthemerc
 
 if [ "$GDK_BACKEND" = "x11" ]; then
+	gsettings set org.gnome.desktop.wm.preferences button-layout "appmenu:maximize,close"
 	fixPuppyPin ~/Choices/ROX-Filer/PuppyPin
 	roxfiler -p ~/Choices/ROX-Filer/PuppyPin
 	/sbin/pup_event_frontend_d &
 else
+	gsettings set org.gnome.desktop.wm.preferences button-layout "appmenu"
 	xdg_autostart.sh
 fi
 /usr/sbin/delayedrun &


### PR DESCRIPTION
Before:

![before](https://user-images.githubusercontent.com/1471149/183349100-3e9eeb9a-6433-4aa8-b3b8-eb6f6c3d9450.png)

After:

![after](https://user-images.githubusercontent.com/1471149/183349097-b369eb09-4142-4797-9c3b-33b48128f09b.png)

(Works for GTK+ 4 as well)