### PR TITLE
Make PPM safer to use when using overlay (fixes #3188)

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
+++ b/woof-code/rootfs-skeleton/usr/local/petget/installpkg.sh
@@ -73,7 +73,7 @@ DL_SAVE_FLAG=$(cat /var/local/petget/nd_category 2>/dev/null)
 
 clean_and_die () {
   rm -f /var/packages/${DLPKG_NAME}.files
-  [ "$PUPMODE" != "2" ] && busybox mount -t aufs -o remount,udba=reval unionfs / #remount with faster evaluation mode.
+  [ "$PUPMODE" != "2" -a "$PUNIONFS" != "overlay" ] && busybox mount -t aufs -o remount,udba=reval unionfs / #remount with faster evaluation mode.
   exit 1
 }
 
@@ -194,7 +194,7 @@ if [ "$PUPMODE" = "2" ]; then # from BK's quirky6.1
 	fi
 
 #boot from flash: bypass tmpfs top layer, install direct to pup_save file... #170623 reverse this!
-elif [ $PUPMODE -eq 13 ];then
+elif [ $PUPMODE -eq 13 -a "$PUNIONFS" != "overlay" ];then
 	# SFR: let user chose...
 	if [ -f /var/local/petget/install_mode ] ; then
 	 IM="`cat /var/local/petget/install_mode`"


### PR DESCRIPTION
Modification of lower layers leads to undefined behavior under overlay, so applications must be installed to / and removed from /. This ensures whiteout files in pup_rw are created correctly, and snapmergepuppy.overlay synchronizes the installed/removed package to pup_ro1.

In addition to the extra safety, it's nice to be able to install or remove a package and reboot without saving the changes if you regret what you did.