### PR TITLE
Start gsimplecal in the same monitor, not the selected one

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
@@ -1,10 +1,23 @@
-From 28b8f74da2c7366e109176e8754a5a6f28231347 Mon Sep 17 00:00:00 2001
+From f7067b43a315396af0df2bd6709ea051aac0c38a Mon Sep 17 00:00:00 2001
 From: Dima Krasner <dima@dimakrasner.com>
-Date: Sat, 6 Aug 2022 11:22:47 +0000
+Date: Tue, 9 Aug 2022 06:57:20 +0000
 Subject: [PATCH] Squashed commit of the following:
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
+
+commit 2d135a8d6aea4338506d85873b1319268cd15176
+Merge: 24a0a8a b30759f
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Tue Aug 9 06:56:38 2022 +0000
+
+    Merge branch 'center' into dwl-kiosk-v2
+
+commit b30759f8663db920e39c6645887a9361e8d2209f
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Tue Aug 9 06:56:00 2022 +0000
+
+    center floating windows
 
 commit 24a0a8a9b1d2848f09662140c1c2a17a9dcb0fc8
 Merge: 7e19f87 4ed9c32
@@ -403,10 +416,10 @@ Date:   Sun Mar 20 21:19:29 2022 +0100
 ---
  Makefile                                      |   9 +-
  config.def.h                                  |  45 +-
- dwl.c                                         | 415 +++++++++++++++++-
+ dwl.c                                         | 417 +++++++++++++++++-
  env.c                                         | 218 +++++++++
  ...lr-output-power-management-unstable-v1.xml | 128 ++++++
- 5 files changed, 777 insertions(+), 38 deletions(-)
+ 5 files changed, 779 insertions(+), 38 deletions(-)
  create mode 100644 env.c
  create mode 100644 protocols/wlr-output-power-management-unstable-v1.xml
 
@@ -535,7 +548,7 @@ index 29c6dbf8..408d8fec 100644
  	CHVT(7), CHVT(8), CHVT(9), CHVT(10), CHVT(11), CHVT(12),
  };
 diff --git a/dwl.c b/dwl.c
-index 039b8ff0..55b83fcd 100644
+index 039b8ff0..f78f92ae 100644
 --- a/dwl.c
 +++ b/dwl.c
 @@ -2,6 +2,7 @@
@@ -725,7 +738,7 @@ index 039b8ff0..55b83fcd 100644
  /* compile-time check if all tags fit into an unsigned int bit array. */
  struct NumTags { char limitexceeded[LENGTH(tags) > 31 ? -1 : 1]; };
  
-@@ -485,6 +535,15 @@ applyrules(Client *c)
+@@ -485,6 +535,17 @@ applyrules(Client *c)
  					mon = m;
  		}
  	}
@@ -736,12 +749,14 @@ index 039b8ff0..55b83fcd 100644
 +		} else
 +			c->isfloating = 1;
 +	}
-+	if (c->isfloating)
++	if (c->isfloating) {
++		mon = xytomon(cursor->x, cursor->y);
 +		center(c, &mon->w);
++	}
  	wlr_scene_node_reparent(c->scene, layers[c->isfloating ? LyrFloat : LyrTile]);
  	setmon(c, mon, newtags);
  }
-@@ -655,12 +714,11 @@ buttonpress(struct wl_listener *listener, void *data)
+@@ -655,12 +716,11 @@ buttonpress(struct wl_listener *listener, void *data)
  		/* Don't focus unmanaged clients */
  		if (c && !client_is_unmanaged(c))
  			focusclient(c, 1);
@@ -755,7 +770,7 @@ index 039b8ff0..55b83fcd 100644
  				b->func(&b->arg);
  				return;
  			}
-@@ -685,6 +743,24 @@ buttonpress(struct wl_listener *listener, void *data)
+@@ -685,6 +745,24 @@ buttonpress(struct wl_listener *listener, void *data)
  			event->time_msec, event->button, event->state);
  }
  
@@ -780,7 +795,7 @@ index 039b8ff0..55b83fcd 100644
  void
  chvt(const Arg *arg)
  {
-@@ -708,6 +784,9 @@ cleanup(void)
+@@ -708,6 +786,9 @@ cleanup(void)
  	wlr_output_layout_destroy(output_layout);
  	wlr_seat_destroy(seat);
  	wl_display_destroy(dpy);
@@ -790,7 +805,7 @@ index 039b8ff0..55b83fcd 100644
  }
  
  void
-@@ -894,8 +973,10 @@ createmon(struct wl_listener *listener, void *data)
+@@ -894,8 +975,10 @@ createmon(struct wl_listener *listener, void *data)
  	/* This event is raised by the backend when a new output (aka a display or
  	 * monitor) becomes available. */
  	struct wlr_output *wlr_output = data;
@@ -802,7 +817,7 @@ index 039b8ff0..55b83fcd 100644
  	m->wlr_output = wlr_output;
  
  	wlr_output_init_render(wlr_output, alloc, drw);
-@@ -920,7 +1001,17 @@ createmon(struct wl_listener *listener, void *data)
+@@ -920,7 +1003,17 @@ createmon(struct wl_listener *listener, void *data)
  	 * monitor supports only a specific set of modes. We just pick the
  	 * monitor's preferred mode; a more sophisticated compositor would let
  	 * the user configure it. */
@@ -821,7 +836,7 @@ index 039b8ff0..55b83fcd 100644
  	wlr_output_enable_adaptive_sync(wlr_output, 1);
  
  	/* Set up event listeners */
-@@ -931,6 +1022,14 @@ createmon(struct wl_listener *listener, void *data)
+@@ -931,6 +1024,14 @@ createmon(struct wl_listener *listener, void *data)
  	if (!wlr_output_commit(wlr_output))
  		return;
  
@@ -836,7 +851,7 @@ index 039b8ff0..55b83fcd 100644
  	wl_list_insert(&mons, &m->link);
  	printstatus();
  
-@@ -941,7 +1040,7 @@ createmon(struct wl_listener *listener, void *data)
+@@ -941,7 +1042,7 @@ createmon(struct wl_listener *listener, void *data)
  	 * output (such as DPI, scale factor, manufacturer, etc).
  	 */
  	m->scene_output = wlr_scene_output_create(scene, wlr_output);
@@ -845,7 +860,7 @@ index 039b8ff0..55b83fcd 100644
  
  	/* If length == 1 we need update selmon.
  	 * Maybe it will change in run(). */
-@@ -954,6 +1053,28 @@ createmon(struct wl_listener *listener, void *data)
+@@ -954,6 +1055,28 @@ createmon(struct wl_listener *listener, void *data)
  	}
  }
  
@@ -874,7 +889,7 @@ index 039b8ff0..55b83fcd 100644
  void
  createnotify(struct wl_listener *listener, void *data)
  {
-@@ -994,6 +1115,14 @@ createnotify(struct wl_listener *listener, void *data)
+@@ -994,6 +1117,14 @@ createnotify(struct wl_listener *listener, void *data)
  	LISTEN(&xdg_surface->toplevel->events.set_title, &c->set_title, updatetitle);
  	LISTEN(&xdg_surface->toplevel->events.request_fullscreen, &c->fullscreen,
  			fullscreennotify);
@@ -889,7 +904,7 @@ index 039b8ff0..55b83fcd 100644
  }
  
  void
-@@ -1034,11 +1163,32 @@ createpointer(struct wlr_input_device *device)
+@@ -1034,11 +1165,32 @@ createpointer(struct wlr_input_device *device)
  			libinput_device_config_accel_set_profile(libinput_device, accel_profile);
  			libinput_device_config_accel_set_speed(libinput_device, accel_speed);
  		}
@@ -922,7 +937,7 @@ index 039b8ff0..55b83fcd 100644
  void
  cursorframe(struct wl_listener *listener, void *data)
  {
-@@ -1087,6 +1237,10 @@ destroynotify(struct wl_listener *listener, void *data)
+@@ -1087,6 +1239,10 @@ destroynotify(struct wl_listener *listener, void *data)
  	wl_list_remove(&c->destroy.link);
  	wl_list_remove(&c->set_title.link);
  	wl_list_remove(&c->fullscreen.link);
@@ -933,7 +948,7 @@ index 039b8ff0..55b83fcd 100644
  #ifdef XWAYLAND
  	if (c->type != XDGShell) {
  		wl_list_remove(&c->configure.link);
-@@ -1132,7 +1286,7 @@ focusclient(Client *c, int lift)
+@@ -1132,7 +1288,7 @@ focusclient(Client *c, int lift)
  		return;
  
  	/* Raise client in stacking order if requested */
@@ -942,7 +957,7 @@ index 039b8ff0..55b83fcd 100644
  		wlr_scene_node_raise_to_top(c->scene);
  
  	if (c && client_surface(c) == old)
-@@ -1256,6 +1410,12 @@ fullscreennotify(struct wl_listener *listener, void *data)
+@@ -1256,6 +1412,12 @@ fullscreennotify(struct wl_listener *listener, void *data)
  	setfullscreen(c, fullscreen);
  }
  
@@ -955,7 +970,7 @@ index 039b8ff0..55b83fcd 100644
  void
  incnmaster(const Arg *arg)
  {
-@@ -1294,7 +1454,7 @@ inputdevice(struct wl_listener *listener, void *data)
+@@ -1294,7 +1456,7 @@ inputdevice(struct wl_listener *listener, void *data)
  }
  
  int
@@ -964,7 +979,7 @@ index 039b8ff0..55b83fcd 100644
  {
  	/*
  	 * Here we handle compositor keybindings. This is when the compositor is
-@@ -1305,7 +1465,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
+@@ -1305,7 +1467,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
  	const Key *k;
  	for (k = keys; k < END(keys); k++) {
  		if (CLEANMASK(mods) == CLEANMASK(k->mod) &&
@@ -973,7 +988,7 @@ index 039b8ff0..55b83fcd 100644
  			k->func(&k->arg);
  			handled = 1;
  		}
-@@ -1316,6 +1476,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
+@@ -1316,6 +1478,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
  void
  keypress(struct wl_listener *listener, void *data)
  {
@@ -981,7 +996,7 @@ index 039b8ff0..55b83fcd 100644
  	int i;
  	/* This event is raised when a key is pressed or released. */
  	Keyboard *kb = wl_container_of(listener, kb, key);
-@@ -1326,7 +1487,7 @@ keypress(struct wl_listener *listener, void *data)
+@@ -1326,7 +1489,7 @@ keypress(struct wl_listener *listener, void *data)
  	/* Get a list of keysyms based on the keymap for this keyboard */
  	const xkb_keysym_t *syms;
  	int nsyms = xkb_state_key_get_syms(
@@ -990,7 +1005,7 @@ index 039b8ff0..55b83fcd 100644
  
  	int handled = 0;
  	uint32_t mods = wlr_keyboard_get_modifiers(kb->device->keyboard);
-@@ -1338,7 +1499,7 @@ keypress(struct wl_listener *listener, void *data)
+@@ -1338,7 +1501,7 @@ keypress(struct wl_listener *listener, void *data)
  	if (!input_inhibit_mgr->active_inhibitor
  			&& event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
  		for (i = 0; i < nsyms; i++)
@@ -999,7 +1014,7 @@ index 039b8ff0..55b83fcd 100644
  
  	if (!handled) {
  		/* Pass unhandled keycodes along to the client. */
-@@ -1438,6 +1599,7 @@ mapnotify(struct wl_listener *listener, void *data)
+@@ -1438,6 +1601,7 @@ mapnotify(struct wl_listener *listener, void *data)
  		wlr_scene_node_reparent(c->scene, layers[LyrFloat]);
  		/* TODO recheck if !p->mon is possible with wlroots 0.16.0 */
  		setmon(c, p->mon ? p->mon : selmon, p->tags);
@@ -1007,7 +1022,7 @@ index 039b8ff0..55b83fcd 100644
  	} else {
  		applyrules(c);
  	}
-@@ -1531,7 +1693,15 @@ motionrelative(struct wl_listener *listener, void *data)
+@@ -1531,7 +1695,15 @@ motionrelative(struct wl_listener *listener, void *data)
  	 * special configuration applied for the specific input device which
  	 * generated the event. You can pass NULL for the device if you want to move
  	 * the cursor around without any input. */
@@ -1024,7 +1039,7 @@ index 039b8ff0..55b83fcd 100644
  	motionnotify(event->time_msec);
  }
  
-@@ -1546,6 +1716,8 @@ moveresize(const Arg *arg)
+@@ -1546,6 +1718,8 @@ moveresize(const Arg *arg)
  
  	/* Float the window and tell motionnotify to grab it */
  	setfloating(grabc, 1);
@@ -1033,7 +1048,7 @@ index 039b8ff0..55b83fcd 100644
  	switch (cursor_mode = arg->ui) {
  	case CurMove:
  		grabcx = cursor->x - grabc->geom.x;
-@@ -1689,6 +1861,16 @@ printstatus(void)
+@@ -1689,6 +1863,16 @@ printstatus(void)
  	}
  }
  
@@ -1050,7 +1065,7 @@ index 039b8ff0..55b83fcd 100644
  void
  quit(const Arg *arg)
  {
-@@ -1813,7 +1995,10 @@ run(char *startup_cmd)
+@@ -1813,7 +1997,10 @@ run(char *startup_cmd)
  	 * instead of (0, 0) and then jumping.  still may not be fully
  	 * initialized, as the image/coordinates are not transformed for the
  	 * monitor when displayed here */
@@ -1062,7 +1077,7 @@ index 039b8ff0..55b83fcd 100644
  	wlr_xcursor_manager_set_cursor_image(cursor_mgr, "left_ptr", cursor);
  
  	/* Run the Wayland event loop. This does not return until you exit the
-@@ -1856,6 +2041,8 @@ setfloating(Client *c, int floating)
+@@ -1856,6 +2043,8 @@ setfloating(Client *c, int floating)
  {
  	c->isfloating = floating;
  	wlr_scene_node_reparent(c->scene, layers[c->isfloating ? LyrFloat : LyrTile]);
@@ -1071,7 +1086,7 @@ index 039b8ff0..55b83fcd 100644
  	arrange(c->mon);
  	printstatus();
  }
-@@ -1863,13 +2050,17 @@ setfloating(Client *c, int floating)
+@@ -1863,13 +2052,17 @@ setfloating(Client *c, int floating)
  void
  setfullscreen(Client *c, int fullscreen)
  {
@@ -1090,7 +1105,7 @@ index 039b8ff0..55b83fcd 100644
  		/* The xdg-protocol specifies:
  		 *
  		 * If the fullscreened surface is not opaque, the compositor must make
-@@ -1909,6 +2100,25 @@ setlayout(const Arg *arg)
+@@ -1909,6 +2102,25 @@ setlayout(const Arg *arg)
  	printstatus();
  }
  
@@ -1116,7 +1131,7 @@ index 039b8ff0..55b83fcd 100644
  /* arg > 1.0 will set mfact absolutely */
  void
  setmfact(const Arg *arg)
-@@ -1998,6 +2208,7 @@ setup(void)
+@@ -1998,6 +2210,7 @@ setup(void)
  
  	/* Initialize the scene graph used to lay out windows */
  	scene = wlr_scene_create();
@@ -1124,7 +1139,7 @@ index 039b8ff0..55b83fcd 100644
  	layers[LyrBg] = &wlr_scene_tree_create(&scene->node)->node;
  	layers[LyrBottom] = &wlr_scene_tree_create(&scene->node)->node;
  	layers[LyrTile] = &wlr_scene_tree_create(&scene->node)->node;
-@@ -2034,6 +2245,9 @@ setup(void)
+@@ -2034,6 +2247,9 @@ setup(void)
  	activation = wlr_xdg_activation_v1_create(dpy);
  	wl_signal_add(&activation->events.request_activate, &request_activate);
  
@@ -1134,7 +1149,7 @@ index 039b8ff0..55b83fcd 100644
  	/* Creates an output layout, which a wlroots utility for working with an
  	 * arrangement of screens in a physical layout. */
  	output_layout = wlr_output_layout_create();
-@@ -2070,9 +2284,14 @@ setup(void)
+@@ -2070,9 +2286,14 @@ setup(void)
  	/* Use decoration protocols to negotiate server-side decorations */
  	wlr_server_decoration_manager_set_default_mode(
  			wlr_server_decoration_manager_create(dpy),
@@ -1150,7 +1165,7 @@ index 039b8ff0..55b83fcd 100644
  	/*
  	 * Creates a cursor, which is a wlroots utility for tracking the cursor
  	 * image shown on screen.
-@@ -2111,6 +2330,10 @@ setup(void)
+@@ -2111,6 +2332,10 @@ setup(void)
  	 * let us know when new input devices are available on the backend.
  	 */
  	wl_list_init(&keyboards);
@@ -1161,7 +1176,7 @@ index 039b8ff0..55b83fcd 100644
  	wl_signal_add(&backend->events.new_input, &new_input);
  	virtual_keyboard_mgr = wlr_virtual_keyboard_manager_v1_create(dpy);
  	wl_signal_add(&virtual_keyboard_mgr->events.new_virtual_keyboard,
-@@ -2129,6 +2352,9 @@ setup(void)
+@@ -2129,6 +2354,9 @@ setup(void)
  	wlr_scene_set_presentation(scene, wlr_presentation_create(dpy, backend));
  
  #ifdef XWAYLAND
@@ -1171,7 +1186,7 @@ index 039b8ff0..55b83fcd 100644
  	/*
  	 * Initialise the XWayland X server.
  	 * It will be started when the first X client is started.
-@@ -2161,6 +2387,99 @@ sigchld(int unused)
+@@ -2161,6 +2389,99 @@ sigchld(int unused)
  			child_pid = -1;
  }
  
@@ -1271,7 +1286,7 @@ index 039b8ff0..55b83fcd 100644
  void
  spawn(const Arg *arg)
  {
-@@ -2185,6 +2504,22 @@ startdrag(struct wl_listener *listener, void *data)
+@@ -2185,6 +2506,22 @@ startdrag(struct wl_listener *listener, void *data)
  	wl_signal_add(&drag->icon->events.destroy, &drag_icon_destroy);
  }
  
@@ -1294,7 +1309,7 @@ index 039b8ff0..55b83fcd 100644
  void
  tag(const Arg *arg)
  {
-@@ -2256,6 +2591,40 @@ togglefullscreen(const Arg *arg)
+@@ -2256,6 +2593,40 @@ togglefullscreen(const Arg *arg)
  		setfullscreen(sel, !sel->isfullscreen);
  }
  
@@ -1335,7 +1350,7 @@ index 039b8ff0..55b83fcd 100644
  void
  toggletag(const Arg *arg)
  {
-@@ -2340,6 +2709,7 @@ updatemons(struct wl_listener *listener, void *data)
+@@ -2340,6 +2711,7 @@ updatemons(struct wl_listener *listener, void *data)
  		wlr_output_configuration_v1_create();
  	Monitor *m;
  	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
@@ -1343,7 +1358,7 @@ index 039b8ff0..55b83fcd 100644
  	wl_list_for_each(m, &mons, link) {
  		struct wlr_output_configuration_head_v1 *config_head =
  			wlr_output_configuration_head_v1_create(config, m->wlr_output);
-@@ -2522,6 +2892,14 @@ createnotifyx11(struct wl_listener *listener, void *data)
+@@ -2522,6 +2894,14 @@ createnotifyx11(struct wl_listener *listener, void *data)
  	LISTEN(&xwayland_surface->events.destroy, &c->destroy, destroynotify);
  	LISTEN(&xwayland_surface->events.request_fullscreen, &c->fullscreen,
  			fullscreennotify);
@@ -1358,7 +1373,7 @@ index 039b8ff0..55b83fcd 100644
  }
  
  Atom
-@@ -2585,11 +2963,13 @@ main(int argc, char *argv[])
+@@ -2585,11 +2965,13 @@ main(int argc, char *argv[])
  	char *startup_cmd = NULL;
  	int c;
  
@@ -1373,7 +1388,7 @@ index 039b8ff0..55b83fcd 100644
  		else
  			goto usage;
  	}
-@@ -2599,11 +2979,12 @@ main(int argc, char *argv[])
+@@ -2599,11 +2981,12 @@ main(int argc, char *argv[])
  	/* Wayland requires XDG_RUNTIME_DIR for creating its communications socket */
  	if (!getenv("XDG_RUNTIME_DIR"))
  		die("XDG_RUNTIME_DIR must be set");


### PR DESCRIPTION
When the calendar emoji in yambar is clicked but the selected monitor is not the one where the cursor is, gsimplecal appears in the correct position but on the selected monitor and not the monitor where yambar is. 