### PR TITLE
Disable Debian package support in PPM if bdrv is loaded

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -45,6 +45,10 @@ else
   . /root/.packages/DISTRO_PET_REPOS
   cd /root/.packages
   RUNNINGPUP='yes'
+  if [ -e /var/local/bdrv_loaded ]; then
+    PKG_DOCS_DISTRO_COMPAT=""
+    REPOS_DISTRO_COMPAT=""
+  fi
 fi
 
 #======================================================================
@@ -159,7 +163,7 @@ case $DISTRO_BINARY_COMPAT in ubuntu|trisquel|debian|devuan) #130319 removed |ra
    esac
 esac
 
-if [ "$DISTRO_BINARY_COMPAT" = "debian" ]; then
+if [ "$DISTRO_BINARY_COMPAT" = "debian" -a -n "$PKG_DOCS_DISTRO_COMPAT" ]; then
   wget --spider --tries 1 -T 3 -F --max-redirect 0 http://deb.debian.org/debian-security/dists/${DISTRO_COMPAT_VERSION}-security/
   if [ $? -eq 0 ]; then
    PKGLISTS_COMPAT_S="z|http://deb.debian.org/debian-security/dists/${DISTRO_COMPAT_VERSION}-security/main/binary-${DBIN_ARCH}/Packages.xz|Packages-debian-${DISTRO_COMPAT_VERSION}-security-main

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -211,3 +211,6 @@ if [ -d bdrv/usr/share/gnome/help ]; then
 	mv bdrv/usr/share/gnome/help bdrv_DOC/usr/share/gnome/
 	rmdir bdrv/usr/share/gnome 2>/dev/null
 fi
+
+mkdir -p bdrv/var/local
+touch bdrv/var/local/bdrv_loaded

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -141,6 +141,7 @@ for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
+rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -134,6 +134,7 @@ for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
+rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -134,6 +134,7 @@ for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
+rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -135,6 +135,7 @@ for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s ../conf.avail/10-hinting-none.conf etc/fonts/conf.d/
+rm -f var/packages/Packages-ubuntu-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless


### PR DESCRIPTION
This will prevent users from breaking their system, wasting extra space and running into conflicts between PPM and apt. Users shouldn't use PPM for Debian packages (unless they don't have apt), period.