### PR TITLE
Skip sockets and FIFOs in snapmergepuppy.overlay

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -148,6 +148,8 @@ find . -mount \
 	   -not -path . \
 	   -not -type d \
 	   -not -type c \
+	   -not -type s \
+	   -not -type p \
 	   -regextype posix-extended \
 	   -not \( -regex '^./initrd.*|^./mnt.*|^./media.*|^./proc.*|^./sys.*|^./tmp.*|^./pup_.*|^./zdrv_.*|^./root/tmp.*|.*_zdrv_.*|^./dev.*|^./var/run.*|^./root/ftpd.*|^./var/tmp.*|^./var/lock.*|.*\.XLOADED$' \) \
 	   -not \( -regex '.*\.thumbnails.*|.*\.part$|.*\.crdownload$' \) \


### PR DESCRIPTION
There's no need to save these because they're useless after the system is rebooted, anyway.