### PR TITLE
List tofi results vertically

### DIFF
--- a/woof-code/packages-templates/tofi_FIXUPHACK
+++ b/woof-code/packages-templates/tofi_FIXUPHACK
@@ -1,25 +1,24 @@
 mkdir -p root/.config/tofi
 cat << EOF > root/.config/tofi/config
 anchor = top
-width = 100%
-height = 26
-horizontal = true
+width = 25%
+height = 100%
 font-size = 10
 prompt-text = "\$ "
 font = monospace
 outline-width = 0
-border-width = 0
+border-width = 1
 background-color = #000000
+border-color = #00ff00
 text-color = #ffffff
 selection-color = #000000
 selection-background = #ffffff
-num-results = 10
-min-input-width = 64
-result-spacing = 10
-padding-top = 4
-padding-bottom = 4
-padding-left = 4
-padding-right = 4
+result-spacing = 2
+padding-top = 2
+padding-bottom = 2
+padding-left = 2
+padding-right = 2
+hint-font = false
 EOF
 
 cat << EOF > usr/bin/tofi-exec


### PR DESCRIPTION
All units in the tofi configuration file are specified in pixels or percents, except the font size, which is specified in points. This means the text is scaled while the background isn't, and that's bad with a scale factor > 1. A vertical layout with height of 100% scales nicely.

(The only problem is that dwl scales the 1px border to 2px if the scaling factor is 2, while tofi doesn't. But this outline width inconsistency it's not the end of the world.)

See https://github.com/philj56/tofi/issues/25.