### PR TITLE
Make tofi visually consistent with dwl

### DIFF
--- a/woof-code/packages-templates/tofi_FIXUPHACK
+++ b/woof-code/packages-templates/tofi_FIXUPHACK
@@ -27,7 +27,7 @@ EOF
 
 cat << EOF > usr/bin/tofi-exec
 #!/bin/ash
-cmd="\`tofi-run\`"
+cmd="\`tofi-run 2>/dev/null\`"
 [ -n "\$cmd" ] && exec "\$cmd"
 EOF
 chmod 755 usr/bin/tofi-exec

--- a/woof-code/packages-templates/tofi_FIXUPHACK
+++ b/woof-code/packages-templates/tofi_FIXUPHACK
@@ -8,8 +8,9 @@ font-size = 10
 prompt-text = "\$ "
 font = monospace
 outline-width = 0
-border-width = 0
+border-width = 1
 background-color = #000000
+border-color = #00ff00
 text-color = #ffffff
 selection-color = #000000
 selection-background = #ffffff
@@ -20,6 +21,8 @@ padding-top = 4
 padding-bottom = 4
 padding-left = 4
 padding-right = 4
+hint-font = false
+scale = true
 EOF
 
 cat << EOF > usr/bin/tofi-exec


### PR DESCRIPTION
This PR adds a 1px bright green border around tofi. dwl doesn't draw the green border around this window and it steals the focus until closed.

bookworm has tofi 0.4.0 and will probably receive philj56/tofi@ea64fc43a6a321fcc7417f35d5ce50a2c7ee9d7e shortly after the next tofi release. This commit makes tofi visually consistent with dwl: without it, tofi doesn't scale the 1px border to 2px when the scale factor is 2.