### PR TITLE
Run Xwayland with the default DPI until #3334 is fixed

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -20,13 +20,7 @@ cp -f $XAUTHORITY /home/spot/.Xauthority
 chown spot:spot /home/spot/.Xauthority
 
 if [ "$GDK_BACKEND" = "x11" ]; then
-	args=
-	if [ -f ~/.Xresources ]; then
-		dpi=`grep ^Xft\.dpi: ~/.Xresources | awk '{print $2}'`
-		[ -n "$dpi" ] && args="$args -dpi $dpi"
-	fi
-
-	Xwayland $DISPLAY -auth $XAUTHORITY $args &
+	Xwayland $DISPLAY -auth $XAUTHORITY &
 
 	MAX=20
 	CT=0


### PR DESCRIPTION
Some applications, including JWM, respect the `-dpi` value, while others rely on `Xft.dpi`. Until #3334 is fixed and GTK+ 3/4 applications use a larger font size, let's use the same font size everwhere.

(The "pure Wayland" setup is unaffected, and scaling mostly works under Wayland, with the notable exceptions of #3331 and #3332.)