### PR TITLE
Redirect the output of applications started using Super+p to /dev/null

### DIFF
--- a/woof-code/packages-templates/tofi_FIXUPHACK
+++ b/woof-code/packages-templates/tofi_FIXUPHACK
@@ -25,6 +25,6 @@ EOF
 cat << EOF > usr/bin/tofi-exec
 #!/bin/ash
 cmd="\`tofi-run\`"
-[ -n "\$cmd" ] && exec "\$cmd"
+[ -n "\$cmd" ] && "\$cmd" > /dev/null 2>&1 &
 EOF
 chmod 755 usr/bin/tofi-exec


### PR DESCRIPTION
dwl-status has nothing to do with this output.