### PR TITLE
Add a watermark to development builds with Wayland (V2)

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/etc/xdg/autostart/dwl-watermark.desktop
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/etc/xdg/autostart/dwl-watermark.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=dwl-watermark
+Comment=Development build watermark
+Exec=dwl-watermark
+Terminal=false
+Type=Application

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/dwl-watermark
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/dwl-watermark
@@ -1,0 +1,30 @@
+#!/bin/ash
+
+. /etc/DISTRO_SPECS
+
+cat > /tmp/${0##*\/}.css <<_S
+window {
+	background-color: rgba(0, 0, 0, 0);
+}
+
+label {
+	color: black;
+	font-size: 12px;
+}
+_S
+
+export P='<window edge="bottomright" width-request="600" layer="overlay">
+ <hbox>
+  <vbox>
+   <hbox>
+    <text id="title"><label>'"$DISTRO_NAME $DISTRO_VERSION"'</label></text>
+   </hbox>
+   <hbox>
+    <text><label>This is an unstable development build</label></text>
+   </hbox>
+  </vbox>
+  <button relief="2"><input file stock="gtk-close"></input><action>exit:EXIT</action></button>
+ </hbox>
+</window>'
+
+exec gtkdialog -p P --styles=/tmp/${0##*\/}.css


### PR DESCRIPTION
gtkdialog based and can be closed:

![watermark](https://user-images.githubusercontent.com/1471149/187018008-f23a9913-ee8b-4b32-a6d3-c9d0a237928c.png)
