### PR TITLE
Use defaultbrowser and defaultemail instead of relying on ROX-Filer

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/xdg-open
+++ b/woof-code/rootfs-skeleton/usr/local/bin/xdg-open
@@ -7,8 +7,8 @@ ROXFILER=`grep -E 'ROX-Filer|roxfiler' /usr/local/bin/defaultfilemanager | grep 
 if [ "$ROXFILER" ] ; then
 	case "$1" in
 		'') exit ;;
-		*://*) exec rox -U "$1" ;;
-		*@*.*) exec rox -U "mailto:${1}" ;;
+		*://*)    exec defaultbrowser "$1" ;;
+		*@*.*)    exec defaultemail "$1" ;;
 		magnet:*) exec defaulttorrent "$1" ;;
 		*) exec rox "$1" ;;
 	esac


### PR DESCRIPTION
VoidPup uses some old Slacko ROX-Filer package, and my builds use the petbuild. `rox -U  https://URL` doesn't work in any of these.

Unlike #3351, this solution will work in VoidPup without switching from the ancient ROX-Filer package to the petbuild.