### PR TITLE
Add ROX-Filer URI handlers to make xdg-open work for URLs

### DIFF
--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/cdda
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/cdda
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultmediaplayer

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/dvb
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/dvb
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultmediaplayer

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/dvd
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/dvd
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultmediaplayer

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/file
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/file
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultbrowser

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/http
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/http
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultbrowser

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/https
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/https
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultbrowser

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/mailto
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/mailto
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultemail

--- a/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/rtsp
+++ b/woof-code/rootfs-petbuilds/rox-filer/etc/xdg/rox.sourceforge.net/URI/rtsp
@@ -1,0 +1,1 @@
+/usr/local/bin/defaultmediaplayer


### PR DESCRIPTION
Stolen from FossaPup64. Alternative to #3350, probably a better solution.

![open](https://user-images.githubusercontent.com/1471149/187142645-c5f273e3-c268-407d-a2a0-e8d35e950d89.png)
.