### PR TITLE
Increase the dwl scale factor only in >= 1080p displays

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
@@ -1,10 +1,23 @@
-From 70c98b6c3750542006e71e06680f2c36e465edea Mon Sep 17 00:00:00 2001
+From a99b4c433ea566da45e36faf3aad5ffe9a74d959 Mon Sep 17 00:00:00 2001
 From: Dima Krasner <dima@dimakrasner.com>
-Date: Sun, 28 Aug 2022 09:52:14 +0000
+Date: Wed, 31 Aug 2022 05:23:02 +0000
 Subject: [PATCH] Squashed commit of the following:
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
+
+commit 3645855359e650a570e45811258174da1f70a90c
+Merge: db69ed3 c2b606b
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Wed Aug 31 05:22:30 2022 +0000
+
+    Merge branch 'auto-dpi' into dwl-kiosk-v2
+
+commit c2b606bd5d4a667a5de4f121c9e5eb0010bb17df
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Wed Aug 31 05:20:54 2022 +0000
+
+    automatically choose the scale factor if <= 0
 
 commit db69ed3aadfe7532efc2377b7da833d2c4f86328
 Merge: 9c9e77e a6607a1
@@ -639,7 +652,7 @@ index 29c6dbf8..28d4965f 100644
  	CHVT(7), CHVT(8), CHVT(9), CHVT(10), CHVT(11), CHVT(12),
  };
 diff --git a/dwl.c b/dwl.c
-index f76e30f0..384ebd9b 100644
+index f76e30f0..a5b3dc52 100644
 --- a/dwl.c
 +++ b/dwl.c
 @@ -2,6 +2,7 @@
@@ -918,12 +931,12 @@ index f76e30f0..384ebd9b 100644
 +				wlr_output_set_scale(wlr_output, r->scale);
 +			else {
 +				struct wlr_output_mode *mode = wlr_output_preferred_mode(wlr_output);
-+				float ppi = mode ? mode->width / (wlr_output->phys_width / 25.4) : 96;
++				float ppi = (mode && mode->height >= 1080 && wlr_output->phys_width > 0) ? mode->width / (wlr_output->phys_width / 25.4) : 96;
 +				if (ppi >= 96 * 2)
 +					wlr_output_set_scale(wlr_output, 2);
 +				else if (ppi >= 96 * 1.5)
 +					wlr_output_set_scale(wlr_output, 1.5);
-+				else if (ppi >= 96 * 1.25 && mode && mode->width >= 1920)
++				else if (ppi >= 96 * 1.25)
 +					wlr_output_set_scale(wlr_output, 1.25);
 +				else
 +					wlr_output_set_scale(wlr_output, 1);


### PR DESCRIPTION
Tiny virtual machine windows satisfy the condition of >= 96 DPI, not because they are dense, but because they are tiny.