### PR TITLE
snapmergepuppy: Avoid active opened files

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -204,12 +204,18 @@ do
 		if [ -L "$N" ] && [ -d "$BASE/$N" ] ; then
 			rm -rf "$BASE/$N"	# SFR: in case if folder has been replaced with a symlink (cp won't overwrite a dir with a symlink)
 		fi
-		cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
-		rm "$N"
+		#Move if the file was not opened by a process
+		if [ "$(lsof | awk '{ print $3 }' | grep "/" | grep -vE "\/dev|\/proc|\/sys|\/tmp|\/run|\/mnt|\/media" | sort | uniq | grep "$N")" == "" ]; then
+		 cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
+		 rm "$N"
+		fi
 	else
 		if [ ! -e "$BASE/$N" ] || [ ${NCTIME%%.*} -gt `stat -c %Z "$BASE/$N"` ] ; then
+		    #Move if the file was not opened by a process
+		    if [ "$(lsof | awk '{ print $3 }' | grep "/" | grep -vE "\/dev|\/proc|\/sys|\/tmp|\/run|\/mnt|\/media" | sort | uniq | grep "$N")" == "" ]; then
 			cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 			rm "$N"
+		    fi
 		fi
 	fi
 


### PR DESCRIPTION
Don't move the file to save file/folder if the file was currently opened by a process