### PR TITLE
Automatically fall back to overlay if aufs is unsupported

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
   build:
     if: (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-20.04
-    continue-on-error: true
+    continue-on-error: ${{ matrix.unionfs == 'aufs' }}
     strategy:
       matrix:
         include:
@@ -22,54 +22,67 @@ jobs:
             compat-distro: slackware
             compat-distro-version: 14.2
             kernel: 4.19.x-x86
+            unionfs: aufs
           - arch: x86
             compat-distro: debian
             compat-distro-version: bullseye
             kernel: 5.10.x-x86
+            unionfs: overlay
           - arch: x86
             compat-distro: debian
             compat-distro-version: bookworm
             kernel: 5.10.x-x86
+            unionfs: overlay
           - arch: x86_64
             compat-distro: slackware64
             compat-distro-version: 14.2
             kernel: 4.19.x-x86_64
+            unionfs: aufs
           - arch: x86_64
             compat-distro: debian
             compat-distro-version: bullseye64
             kernel: 5.10.x-x86_64
+            unionfs: overlay
           - arch: x86_64
             compat-distro: debian
             compat-distro-version: bookworm64
             kernel: 5.10.x-x86_64
+            unionfs: overlay
           - arch: x86_64
             compat-distro: ubuntu
             compat-distro-version: jammy64
             kernel: 5.15.x-x86_64
+            unionfs: aufs
           - arch: x86_64
             compat-distro: ubuntu
             compat-distro-version: focal64
             kernel: 5.4.x-x86_64
+            unionfs: aufs
           - arch: x86_64
             compat-distro: slackware64
             compat-distro-version: "15.0"
             kernel: 5.15.x-x86_64
+            unionfs: aufs
           - arch: x86
             compat-distro: slackware
             compat-distro-version: "15.0"
             kernel: 5.15.x-x86
+            unionfs: aufs
           - arch: x86_64
             compat-distro: ubuntu
             compat-distro-version: bionic64
             kernel: 4.19.x-x86_64
+            unionfs: aufs
           - arch: x86_64
             compat-distro: debian
             compat-distro-version: sid64
             kernel: 5.15.x-x86_64
+            unionfs: overlay
           - arch: arm
             compat-distro: debian
             compat-distro-version: bullseye-veyron-speedy
             kernel: 5.4.x-veyron-speedy
+            unionfs: overlay
     steps:
     - name: Checkout code
       uses: actions/checkout@v2
@@ -121,11 +134,10 @@ jobs:
       id: choose_kernel_variant
       run: |
         cd ../woof-out_*
-        UNIONFS="aufs"
         . _00build.conf
         [ ! -e _00build_2.conf ] || . _00build_2.conf
-        name="kernel-kit-output-usrmerge-$UNIONFS-${{ matrix.kernel }}"
-        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-$UNIONFS-${{ matrix.kernel }}"
+        name="kernel-kit-output-usrmerge-${{ matrix.unionfs }}-${{ matrix.kernel }}"
+        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-${{ matrix.unionfs }}-${{ matrix.kernel }}"
         echo "::set-output name=artifact_name::$name"
       shell: bash
     - name: Get cached kernel-kit output

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,6 @@ jobs:
       run: sudo sed -i s/^DISTRO_VERSION=.*/DISTRO_VERSION=${{ github.event.inputs.version }}/ ../woof-out_*/DISTRO_SPECS
     - name: Set file name prefix
       run: sudo sed -i s/^DISTRO_FILE_PREFIX=.*/DISTRO_FILE_PREFIX=${{ github.event.inputs.prefix }}/ ../woof-out_*/DISTRO_SPECS
-    - name: Set layered file system
-      run: echo "UNIONFS=${{ github.event.inputs.unionfs }}" | sudo tee -a ../woof-out_*/_00build_2.conf
     - name: 0setup
       run: |
         cd ../woof-out_*

--- a/initrd-progs/0initrd/README.txt
+++ b/initrd-progs/0initrd/README.txt
@@ -137,7 +137,8 @@ psubdir=</path/to/install/directory>
    This is the default path for locating any puppy file and any partition.
 
 punionfs=<aufs|overlay>
-   Overrides the union file system choice made at build time.
+   Overrides the union file system choice.
+   The default is aufs, if the kernel is built with aufs support.
    Use with care, as aufs and overlay are incompatible with each other.
    To switch from aufs to overlay or vice versa, start with a fresh save layer (pfix=ram).
 

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -433,9 +433,8 @@ setup_onepupdrv() {
  fi
  if [ -n "$punionfs" ]; then
   UNIONFS="$punionfs"
- elif [ -f $SFS_MP/etc/rc.d/PUPSTATE ]; then
-  . $SFS_MP/etc/rc.d/PUPSTATE
-  [ -n "$PUNIONFS" ] && UNIONFS="$PUNIONFS"
+ elif [ "$UNIONFS" = 'aufs' ]; then
+  grep -qm1 aufs /proc/filesystems || UNIONFS="overlay"
  fi
  if [ "$UNIONFS" = 'overlay' ]; then
   remount_overlay -e "s~lowerdir=([^,]+)~lowerdir=${SFS_MP}:\1~" -e "s~lowerdir=,~lowerdir=${SFS_MP},~"

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -900,8 +900,6 @@ if [ "$SDFLAG" != "" -o "$CROSFLAG" != "" ];then
 	echo "BOOT_BOARD='${BOOT_BOARD}'" >> rootfs-complete/etc/rc.d/BOOTCONSTRAINED #120714 read by quicksetup.
 fi
 
-echo "PUNIONFS='$UNIONFS'" >> rootfs-complete/etc/rc.d/PUPSTATE
-
 # users shouldn't be able to read files under another home directory - i.e. leak .netrc
 busybox chmod 700 rootfs-complete/root rootfs-complete/home/spot
 

--- a/woof-code/_00build.conf
+++ b/woof-code/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 #XAUTOCONF=yes
 

--- a/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
+++ b/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
@@ -8,7 +8,6 @@
 #YDRV_SFS_URL=
 #FDRV_SFS_URL=
 
-UNIONFS=overlay
 USR_SYMLINKS=no
 BUILD_CROS_IMAGE=yes
 BOOT_BOARD='veyron-speedy'

--- a/woof-distro/arm/raspbian/buster/_00build.conf
+++ b/woof-distro/arm/raspbian/buster/_00build.conf
@@ -15,9 +15,6 @@ STRIP_BINARIES=yes
 
 BOOT_BOARD='raspi'
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=yes
 

--- a/woof-distro/x86/debian/buster/_00build.conf
+++ b/woof-distro/x86/debian/buster/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86/debian/stretch/_00build.conf
+++ b/woof-distro/x86/debian/stretch/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86/slackware/14.0/_00build.conf
+++ b/woof-distro/x86/slackware/14.0/_00build.conf
@@ -14,9 +14,6 @@ STRIP_BINARIES=no
 # 3builddistro
 #-------------
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86/slackware/14.2/_00build.conf
+++ b/woof-distro/x86/slackware/14.2/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=yes
 

--- a/woof-distro/x86/slackware/15.0/_00build.conf
+++ b/woof-distro/x86/slackware/15.0/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=
 

--- a/woof-distro/x86/ubuntu/trusty/_00build.conf
+++ b/woof-distro/x86/ubuntu/trusty/_00build.conf
@@ -14,9 +14,6 @@ STRIP_BINARIES=yes
 # 3builddistro
 #-------------
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86/ubuntu/upupbb/_00build.conf
+++ b/woof-distro/x86/ubuntu/upupbb/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=yes
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86/ubuntu/xenial/_00build.conf
+++ b/woof-distro/x86/ubuntu/xenial/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=yes
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=overlay
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=overlay
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/debian/buster64/_00build.conf
+++ b/woof-distro/x86_64/debian/buster64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=yes
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=overlay
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/slackware64/14.2/_00build.conf
+++ b/woof-distro/x86_64/slackware64/14.2/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=yes
 

--- a/woof-distro/x86_64/slackware64/15.0/_00build.conf
+++ b/woof-distro/x86_64/slackware64/15.0/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=
 

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=yes
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages. binaries are usually already stripped. set to 'no' to speed up process
 STRIP_BINARIES=yes
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 #xorg-autoconf from rizalmart - changes perms on /usr/sbin/xorg-autoconf to enable; default is unset
 XAUTOCONF=yes
 

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=no
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/ubuntu/trusty64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/trusty64/_00build.conf
@@ -14,9 +14,6 @@ STRIP_BINARIES=yes
 # 3builddistro
 #-------------
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 

--- a/woof-distro/x86_64/ubuntu/xenial64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/xenial64/_00build.conf
@@ -10,9 +10,6 @@
 # 2createpackages
 STRIP_BINARIES=yes
 
-## UnionFS: aufs or overlay
-UNIONFS=aufs
-
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 


### PR DESCRIPTION
This doesn't break anything for anyone, and doesn't change the current default of aufs.

If (and only if) aufs is unavailable, the init script falls back to overlay and allows Puppy to boot instead of failing; currently, our kernels are built with aufs, and this PR makes it possible to swap the kernel with one without aufs.

This means UNIONFS is redundant: the init script can just default to aufs if supported. As before, the user can force of use of overlay when using a kernel that supports aufs, by adding `punionfs=overlay` to the kernel command-line.

See https://github.com/puppylinux-woof-CE/woof-CE/discussions/3362.