### PR TITLE
Add 5.10.x and 5.15.x kernels without aufs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ jobs:
   build:
     if: (github.event_name != 'schedule') || (github.event_name == 'schedule' && github.repository == 'puppylinux-woof-CE/woof-CE' && github.ref == 'refs/heads/testing') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
     runs-on: ubuntu-20.04
+    continue-on-error: true
     strategy:
       matrix:
         include:
@@ -120,10 +121,11 @@ jobs:
       id: choose_kernel_variant
       run: |
         cd ../woof-out_*
+        UNIONFS="aufs"
         . _00build.conf
         [ ! -e _00build_2.conf ] || . _00build_2.conf
-        name="kernel-kit-output-usrmerge-${{ matrix.kernel }}"
-        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-${{ matrix.kernel }}"
+        name="kernel-kit-output-usrmerge-$UNIONFS-${{ matrix.kernel }}"
+        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-$UNIONFS-${{ matrix.kernel }}"
         echo "::set-output name=artifact_name::$name"
       shell: bash
     - name: Get cached kernel-kit output

--- a/.github/workflows/kernel-kit.yml
+++ b/.github/workflows/kernel-kit.yml
@@ -19,34 +19,60 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ${{ matrix.image }}
+    continue-on-error: ${{ matrix.unionfs == 'aufs' }}
     strategy:
       matrix:
         include:
           - kernel-kit-config: 4.19.x-x86
+            unionfs: aufs
             deps: gcc gcc-multilib
             image: ubuntu:bionic
           - kernel-kit-config: 4.19.x-x86_64
+            unionfs: aufs
             deps: gcc
             image: ubuntu:bionic
           - kernel-kit-config: 5.4.x-x86
+            unionfs: aufs
             deps: gcc gcc-multilib
             image: ubuntu:focal
           - kernel-kit-config: 5.4.x-x86_64
+            unionfs: aufs
             deps: gcc
             image: ubuntu:focal
           - kernel-kit-config: 5.10.x-x86
+            unionfs: aufs
+            deps: gcc gcc-multilib
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.10.x-x86
+            unionfs: overlay
             deps: gcc gcc-multilib
             image: debian:bullseye-slim
           - kernel-kit-config: 5.10.x-x86_64
+            unionfs: aufs
+            deps: gcc
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.10.x-x86_64
+            unionfs: overlay
             deps: gcc
             image: debian:bullseye-slim
           - kernel-kit-config: 5.15.x-x86
+            unionfs: aufs
+            deps: gcc gcc-multilib
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.15.x-x86
+            unionfs: overlay
             deps: gcc gcc-multilib
             image: debian:bullseye-slim
           - kernel-kit-config: 5.15.x-x86_64
+            unionfs: aufs
+            deps: gcc
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.15.x-x86_64
+            unionfs: overlay
             deps: gcc
             image: debian:bullseye-slim
           - kernel-kit-config: 5.4.x-veyron-speedy
+            unionfs: overlay
             deps: gcc-arm-linux-gnueabihf
             image: ubuntu:focal
     steps:
@@ -62,13 +88,14 @@ jobs:
         run: |
           cd kernel-kit
           cp -f ${{ matrix.kernel-kit-config }}-build.conf build.conf
+          [ ${{ matrix.unionfs }} != aufs ] && echo "AUFS=no" >> build.conf
           CREATE_KBUILD_SFS=yes ./build.sh
           mkdir small-output
           mv `ls output/kernel_sources-*.sfs* output/kbuild-*.sfs* output/*.tar* 2>/dev/null` small-output
       - name: Upload kernel
         uses: actions/upload-artifact@v2
         with:
-          name: kernel-kit-output-${{ matrix.kernel-kit-config }}
+          name: kernel-kit-output-${{ matrix.unionfs }}-${{ matrix.kernel-kit-config }}
           path: kernel-kit/small-output
           retention-days: 14
   usrmerge:
@@ -77,16 +104,33 @@ jobs:
     runs-on: ubuntu-20.04
     container:
       image: ${{ matrix.image }}
+    continue-on-error: ${{ matrix.unionfs == 'aufs' }}
     strategy:
       matrix:
         include:
           - kernel-kit-config: 5.10.x-x86
+            unionfs: aufs
             image: debian:bullseye-slim
           - kernel-kit-config: 5.10.x-x86_64
+            unionfs: aufs
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.10.x-x86
+            unionfs: overlay
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.10.x-x86_64
+            unionfs: overlay
             image: debian:bullseye-slim
           - kernel-kit-config: 5.15.x-x86
+            unionfs: aufs
             image: debian:bullseye-slim
           - kernel-kit-config: 5.15.x-x86_64
+            unionfs: aufs
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.15.x-x86
+            unionfs: overlay
+            image: debian:bullseye-slim
+          - kernel-kit-config: 5.15.x-x86_64
+            unionfs: overlay
             image: debian:bullseye-slim
     steps:
       - uses: actions/checkout@v2
@@ -97,7 +141,7 @@ jobs:
       - name: Get build output
         uses: actions/download-artifact@v2
         with:
-          name: kernel-kit-output-${{ matrix.kernel-kit-config }}
+          name: kernel-kit-output-${{ matrix.unionfs }}-${{ matrix.kernel-kit-config }}
           path: kernel-kit/output
       - name: Repackage kernel
         run: |
@@ -106,6 +150,6 @@ jobs:
       - name: Upload kernel
         uses: actions/upload-artifact@v2
         with:
-          name: kernel-kit-output-usrmerge-${{ matrix.kernel-kit-config }}
+          name: kernel-kit-output-usrmerge-${{ matrix.unionfs }}-${{ matrix.kernel-kit-config }}
           path: kernel-kit/output
           retention-days: 14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,8 +97,8 @@ jobs:
         cd ../woof-out_*
         . _00build.conf
         [ ! -e _00build_2.conf ] || . _00build_2.conf
-        name="kernel-kit-output-usrmerge-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}"
-        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}"
+        name="kernel-kit-output-usrmerge-${{ github.event.inputs.unionfs }}-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}"
+        [ "$USR_SYMLINKS" = yes ] || name="kernel-kit-output-${{ github.event.inputs.unionfs }}-${{ github.event.inputs.kernel }}.x-${{ github.event.inputs.arch }}"
         echo "::set-output name=artifact_name::$name"
       shell: bash
     - name: Get cached kernel-kit output

--- a/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
+++ b/woof-distro/arm/debian/bullseye-veyron-speedy/_00build_2.conf
@@ -8,7 +8,7 @@
 #YDRV_SFS_URL=
 #FDRV_SFS_URL=
 
-ADRV_INC=
+UNIONFS=overlay
 USR_SYMLINKS=no
 BUILD_CROS_IMAGE=yes
 BOOT_BOARD='veyron-speedy'


### PR DESCRIPTION
Right now, CI builds that use overlay use a kernel with aufs (although it's unused), and all builds are aborted if one build fails.

This PR doesn't change the default of aufs, but stops punishing builds with overlay if aufs is broken.

It:
1. Adds 5.10.x and 5.15.x kernels without aufs, so they don't fail to build when aufs breaks
2. Allows other builds to continue if one job has failed (i.e. so the 5.10.x kernel without aufs doesn't get aborted if the build with aufs fails)
3. Switches from the kernel with aufs to the one without it, in development builds that use overlay and don't need aufs (currently, bookworm{,64} and sid64)