### PR TITLE
Revert "keep using aufs in bullseye"

### DIFF
--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -11,7 +11,7 @@
 STRIP_BINARIES=no
 
 ## UnionFS: aufs or overlay
-UNIONFS=aufs
+UNIONFS=overlay
 
 ## Kernel tarballs repo URL for choosing/downloading kernel
 KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels


### PR DESCRIPTION
This reverts commit 2609dfedc454a698159d11b9a38dbd975e9a2d8d.