### PR TITLE
Add 5.4.x patch

### DIFF
--- a/kernel-kit/patches/aufs_sources/apply
+++ b/kernel-kit/patches/aufs_sources/apply
@@ -35,4 +35,11 @@ if [ "$kseries" = "3.2" ] ; then
 	fi
 fi
 
+if [ "$kseries" = "5.4" ] ; then
+	if vercmp $kver ge 5.4.210 ; then
+		# remove the file_table.c patch from aufs-5.4.3 as kernel sources now include the EXPORT
+		patch aufs5-standalone.patch ../patches/aufs_sources/k5.4.x.patch
+	fi
+fi
+
 ### END ###

--- a/kernel-kit/patches/aufs_sources/k5.4.x.patch
+++ b/kernel-kit/patches/aufs_sources/k5.4.x.patch
@@ -1,0 +1,29 @@
+--- aufs5-standalone.patch	2022-09-04 07:15:50.109114000 +0100
++++ aufs5-standalone.patch	2022-09-02 16:58:23.992059643 +0100
+@@ -45,26 +45,6 @@
+  
+  static void f_modown(struct file *filp, struct pid *pid, enum pid_type type,
+                       int force)
+-diff --git a/fs/file_table.c b/fs/file_table.c
+-index 30d55c9a1744a..34b9bbf4c5566 100644
+---- a/fs/file_table.c
+-+++ b/fs/file_table.c
+-@@ -162,6 +162,7 @@ struct file *alloc_empty_file(int flags, const struct cred *cred)
+- 	}
+- 	return ERR_PTR(-ENFILE);
+- }
+-+EXPORT_SYMBOL_GPL(alloc_empty_file);
+- 
+- /*
+-  * Variant of alloc_empty_file() that doesn't check and modify nr_files.
+-@@ -375,6 +376,7 @@ void __fput_sync(struct file *file)
+- }
+- 
+- EXPORT_SYMBOL(fput);
+-+EXPORT_SYMBOL_GPL(__fput_sync);
+- 
+- void __init files_init(void)
+- {
+ diff --git a/fs/inode.c b/fs/inode.c
+ index aaeacde398eec..5be87f2d3828a 100644
+ --- a/fs/inode.c


### PR DESCRIPTION
remove the file_table.c patch from aufs-5.4.3 as kernel sources now include the EXPORT