### PR TITLE
Replace busybox man with man-db

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -132,6 +132,7 @@ extended_update() {
 	  fi
 	done
 
+	[ -x /usr/bin/mandb ] && mandb # this makes man -k work
 }
 
 update_cache_files() {

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -461,7 +461,7 @@ no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls||deps:yes
-yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
+yes|man|man-db|exe,dev,doc,nls||deps:yes
 yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
 yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -142,8 +142,6 @@ rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-rm -f usr/bin/man
-ln -s /bin/busybox usr/bin/man
 echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -457,7 +457,7 @@ no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls||deps:yes
-yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
+yes|man|man-db|exe,dev,doc,nls||deps:yes
 yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
 yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -135,8 +135,6 @@ rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-rm -f usr/bin/man
-ln -s /bin/busybox usr/bin/man
 echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -465,7 +465,7 @@ no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls||deps:yes
-yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
+yes|man|man-db|exe,dev,doc,nls||deps:yes
 yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
 yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -135,8 +135,6 @@ rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-rm -f usr/bin/man
-ln -s /bin/busybox usr/bin/man
 echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -459,7 +459,7 @@ no|lua|lua5.2,liblua5.2-0,liblua5.2-dev|exe,dev,doc,nls
 yes|m4|m4|exe>dev,dev,doc,nls||deps:yes
 no|madplay|madplay|exe,dev,doc,nls
 yes|make|make|exe>dev,dev,doc,nls||deps:yes
-yes|man|man-db|exe>dev,dev,doc,nls||deps:yes
+yes|man|man-db|exe,dev,doc,nls||deps:yes
 yes|mesa|libgbm1,libgbm-dev,libegl1,libegl-mesa0,libwayland-egl1,libegl1-mesa-dev,libgles1,libgles2,libgles-dev,libglvnd0,libglvnd-dev,libegl-dev,libglx0,libglx-dev,libglx-mesa0,libopengl-dev,libegl-amber0,libgl1-amber-dri,libglx-amber0|exe,dev,doc,nls||deps:yes #have most in xorg_base. these extra needed by gstreamer. GSTREAMER1.0
 yes|meson|meson|exe>dev,dev,doc,nls||deps:yes
 no|mhash|libmhash2,libmhash-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -136,8 +136,6 @@ rm -f var/packages/Packages-ubuntu-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-rm -f usr/bin/man
-ln -s /bin/busybox usr/bin/man
 echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime


### PR DESCRIPTION
busybox man lacks some basic features, like man -k. All dependencies are already present, so it's a very small addition to the main SFS.

![mank](https://user-images.githubusercontent.com/1471149/189361111-4c73d244-9a0b-44b4-b231-8c269fb52445.png)
