### PR TITLE
Look for exact matches when filtering out packages in {A,Y,F}DRV_INC

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -262,12 +262,18 @@ for PKG in ${ADRV_INC} ${YDRV_INC} ${FDRV_INC}; do
 		EXTRAS_LIST="${PKG}"
 	fi
 done
-if [ -n "${EXTRAS_LIST}" ];then
-	PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | sed s/#.*//g | grep -vE "${EXTRAS_LIST}" | cut -f 2 -d '|' | tr '\n' ' '`"
-else
-	PKGLIST="`echo "$PKGS_SPECS_TABLE" | grep '^yes' | sed s/#.*//g | cut -f 2 -d '|' | tr '\n' ' '`"
-fi
-PKGLIST="${PKGLIST}"
+PKGLIST=
+while IFS='|' read YESNO NAME ETC; do
+	[ "$YESNO" != "yes" ] && continue
+	case "$EXTRAS_LIST" in
+	"$NAME"|"$NAME|"*|*"|$NAME|"*|*"|$NAME") continue ;;
+	esac
+	if [ -n "$PKGLIST" ]; then
+		PKGLIST="$PKGLIST $NAME"
+	else
+		PKGLIST="$NAME"
+	fi
+done <<< "$PKGS_SPECS_TABLE"
 copy_pkgs_to_build "${PKGLIST}" rootfs-complete
 echo
 


### PR DESCRIPTION
If ADRV_INC contains `mp`, `gcc_lib` is not copied to rootfs-complete, because it contains `libgomp`.