### PR TITLE
Add support for UEFI boot using Ubuntu's signed shim

### DIFF
--- a/woof-code/support/mk_iso.sh
+++ b/woof-code/support/mk_iso.sh
@@ -373,37 +373,15 @@ OUT=${WOOF_OUTPUT}/${ISO_BASENAME}.iso
 ISOLINUX=`find $PX/usr -maxdepth 3 -type f -name 'isolinux.bin'`
 CHAIN32=`find $PX/usr -maxdepth 5 -type f -name 'chain.c32' | grep -v efi`
 #FIXUSB=`find $PX/usr -maxdepth 2 -type f -name 'fix-usb.sh'`
-if [ -e "${PX}/usr/local/frugalpup" ] ; then
-	UEFI_ISO=yes
-	FPGRUB2XZ=`find $PX/usr/local/frugalpup -maxdepth 1 -name 'grub2-efi.tar.xz'`
-	FPBOOT=/tmp/grub2/EFI/boot
-	CER=/tmp/grub2/puppy.cer
-	FONT=$PX/usr/share/boot-dialog/font.pf2
-elif [ -d "devx/usr/share/cd-boot-images-amd64" ]; then
-	(
-		cd "devx/usr/share/cd-boot-images-amd64/tree"
-		mkdir -p /tmp/grub2/EFI/boot
-		cp EFI/boot/*.efi /tmp/grub2/EFI/boot/
-		cat << EOF > /tmp/grub2/EFI/boot/grub.cfg
-# The real config file for grub is /grub.cfg
-configfile /grub.cfg
-EOF
-		install -D /tmp/grub2/EFI/boot/grub.cfg /tmp/grub2/boot/grub/grub.cfg
-		cd /tmp/grub2
-		tar -c * | xz -1 > /tmp/grub2-efi.tar.xz
-		cd ..
-		rm -rf grub2
-	)
-	UEFI_ISO=yes
-	FPGRUB2XZ=/tmp/grub2-efi.tar.xz
-	FPBOOT=/tmp/grub2/EFI/boot
-	CER=
-	FONT=devx/usr/share/cd-boot-images-amd64/tree/boot/grub/fonts/unicode.pf2
-elif [ -f "devx/usr/lib/shim/shimx64.efi.signed" -a -f "devx/usr/lib/shim/mmx64.efi.signed" -a -f "devx/usr/lib/grub/x86_64-efi-signed/gcdx64.efi.signed" -a -f "devx/usr/share/grub/unicode.pf2" ]; then
+if [ -f "devx/usr/lib/shim/shimx64.efi.signed" -a -f "devx/usr/lib/grub/x86_64-efi-signed/gcdx64.efi.signed" -a -f "devx/usr/share/grub/unicode.pf2" ] && [ -f "devx/usr/lib/shim/mmx64.efi.signed" -o -f "devx/usr/lib/shim/mmx64.efi" ] ; then
 	(
 		mkdir -p /tmp/grub2/EFI/boot
 		cp -f devx/usr/lib/shim/shimx64.efi.signed /tmp/grub2/EFI/boot/bootx64.efi
-		cp -f devx/usr/lib/shim/mmx64.efi.signed /tmp/grub2/EFI/boot/mmx64.efi
+		if [ -f devx/usr/lib/shim/mmx64.efi.signed ]; then
+			cp -f devx/usr/lib/shim/mmx64.efi.signed /tmp/grub2/EFI/boot/mmx64.efi
+		else
+			cp -f devx/usr/lib/shim/mmx64.efi /tmp/grub2/EFI/boot/mmx64.efi
+		fi
 		cp -f devx/usr/lib/grub/x86_64-efi-signed/gcdx64.efi.signed /tmp/grub2/EFI/boot/grubx64.efi
 		cat << EOF > /tmp/grub2/EFI/boot/grub.cfg
 # The real config file for grub is /grub.cfg
@@ -420,6 +398,12 @@ EOF
 	FPBOOT=/tmp/grub2/EFI/boot
 	CER=
 	FONT=devx/usr/share/grub/unicode.pf2
+elif [ -e "${PX}/usr/local/frugalpup" ] ; then
+	UEFI_ISO=yes
+	FPGRUB2XZ=`find $PX/usr/local/frugalpup -maxdepth 1 -name 'grub2-efi.tar.xz'`
+	FPBOOT=/tmp/grub2/EFI/boot
+	CER=/tmp/grub2/puppy.cer
+	FONT=$PX/usr/share/boot-dialog/font.pf2
 else
 	UEFI_ISO=
 	rm -f ${BUILD}/boot/efi.img

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -683,6 +683,7 @@ yes|setvol||exe
 yes|sgml-base|sgml-base|exe>dev,dev,doc,nls
 yes|sgml-data|sgml-data|exe>dev,dev,doc,nls
 yes|shared-mime-info||exe,dev,doc,nls
+yes|shim-signed|shim-signed,grub-efi-amd64-signed|exe>dev,dev,doc,nls||deps:yes
 yes|simple-mtpfs||exe,dev,doc,nls #pupmtp
 yes|simplegtkradio||exe,dev,doc,nls
 yes|simplescreenrecorder||exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
@@ -731,6 +731,7 @@ yes|setvol||exe
 yes|sgml-base|sgml-base|exe>dev,dev,doc,nls
 yes|sgml-data|sgml-data|exe>dev,dev,doc,nls
 yes|shared-mime-info||exe,dev,doc,nls|
+yes|shim-signed|shim-signed,grub-efi-amd64-signed|exe>dev,dev,doc,nls||deps:yes
 yes|simple-mtpfs||exe,dev,doc,nls
 yes|simplegtkradio||exe,dev,doc,nls
 yes|simplescreenrecorder||exe,dev,doc,nls

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -71,7 +71,6 @@ yes|ca-certificates|ca-certificates|exe,dev,doc,nls||deps:yes
 yes|cairo|libcairo2,libcairo2-dev,libcairo-gobject2,libcairo-script-interpreter2|exe,dev,doc,nls||deps:yes
 yes|ccache|ccache|exe>dev,dev,doc,nls||deps:yes
 no|cdparanoia|cdparanoia,libcdparanoia0,libcdparanoia-dev|exe,dev,doc,nls
-yes|cd-boot-images-amd64|cd-boot-images-amd64|exe>dev,dev,doc,nls||deps:yes
 no|cgpt|cgpt|exe>dev,dev,doc,nls||deps:yes
 no|cifs-utils|cifs-utils|exe,dev,doc,nls
 yes|connman|connman|exe,dev,doc,nls||deps:yes
@@ -600,6 +599,7 @@ no|setserial|setserial|exe,dev>null,doc,nls
 yes|sgml-base|sgml-base|exe,dev,doc,nls||deps:yes
 yes|sgml-data|sgml-data|exe>dev,dev,doc,nls||deps:yes
 yes|shared-mime-info|shared-mime-info|exe,dev>exe,doc,nls||deps:yes
+yes|shim-signed|shim-signed,grub-efi-amd64-signed|exe>dev,dev,doc,nls||deps:yes
 no|simple-mtpfs||exe,dev,doc,nls #pupmtp
 yes|sqlite|libsqlite3-0|exe,dev,doc,nls||deps:yes
 yes|squashfs-tools|squashfs-tools|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
This makes #3321 work for Ubuntu as well and replaces #2912 with a more generic solution, that  works for older Ubuntu releases too.

Frugalpup's old binaries are used only if Ubuntu's newer, signed binaries don't.