### PR TITLE
Reduce swappiness before swap is enabled

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -273,13 +273,12 @@ for i in $(cat /proc/cmdline) ; do
 done
 
 ######################LOAD SWAP#####################
+# we prefer not to use swap unless we have to; this should improve responsiveness if we don't have much RAM
+echo 5 > /proc/sys/vm/swappiness
 [ "$BOOT_DISABLESWAP" ] && SWAPON="$BOOT_DISABLESWAP" #120704 now ask in 3builddistro if want use swap file/partition. anything not "yes" means no.
 EXTRAALLOCK=0
 [ "$SWAPON" != "yes" ] && loadswap_func
 if [ "$SWAPON" = "yes" ];then
-  # we prefer not to use swap unless we have to; this should improve responsiveness if we don't have much RAM
- echo 5 > /proc/sys/vm/swappiness
-
  # resize tmpfs
  # this code is meant to increase the size of the tmpfs
  # taking into account swap space and sfs_ram_sizek[might be removed]


### PR DESCRIPTION
If swappiness is reduced after swap is activated, the kernel is wasting CPU cycles by moving stuff to swap. Setting swappiness before swap is activated can shorten boot times.