### PR TITLE
When using overlay, simulate dynamic SFS loading using symlinks

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -290,7 +290,16 @@ case $PUPMODE in
    fi
    cp -a $ONEDIR/ /tmp/save1stpup${PFIX}/
   done
-  [ "$PUNIONFS" = 'overlay' ] && find /tmp/save1stpup${PFIX} -type c -delete
+  if [ "$PUNIONFS" = 'overlay' ];then
+    find /tmp/save1stpup${PFIX} -type c -delete
+    while read ONELINK; do
+      ONEDST="`readlink "$ONELINK" 2>/dev/null`"
+      case "$ONEDST" in
+      /initrd/pup_ro1|/initrd/pup_ro1/*|/initrd/pup_ro2|/initrd/pup_ro2/*) ;;
+      /initrd/pup_ro[0-9]*) rm -f "$ONELINK" ;; # do not keep symlinks to files from dynamically loaded SFSs
+      esac
+     done < <(find /tmp/save1stpup${PFIX} -type L)
+  fi
   #copy initmodules config file from /tmp if it exists
   [ -f /tmp/${DISTRO_FILE_PREFIX}initmodules.txt ] && cp -f /tmp/${DISTRO_FILE_PREFIX}initmodules.txt ${SMNTPT}${SAVEPATH}/${DISTRO_FILE_PREFIX}initmodules.txt
   sync

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -57,6 +57,9 @@ if [ $# -ne 0 ]; then
 				fi
 				ASKMOUNT=0
 
+				yaf-splash -bg orange -placement top -close never -text "$(gettext Loading) ${SFS##*/}" &
+				PID=$!
+
 				# mirror the SFS directory tree in /, then create
 				# symlinks for everything else
 				while read ABSPATH; do
@@ -75,12 +78,16 @@ if [ $# -ne 0 ]; then
 					fixmenus
 					pidof -s jwm && jwm -reload
 				fi
+
+				kill $PID
 			fi
 		elif [ -n "$LOOPDEV" ]; then
 			yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to unload") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
 			if [ $? -eq 0 ]; then
 				MNT="`grep "^$LOOPDEV " /proc/mounts 2>/dev/null | head -n 1 | cut -f 2 -d ' '`"
 				if [ -n "$MNT" ]; then
+					yaf-splash -bg orange -placement top -close never -text "$(gettext Unloading) ${SFS##*/}" &
+					PID=$!
 					while read ABSPATH; do
 						RELPATH=${ABSPATH#$MNT}
 						[ -z "$RELPATH" -o ! -L "$RELPATH" ] && continue
@@ -93,6 +100,7 @@ if [ $# -ne 0 ]; then
 						fixmenus
 						pidof -s jwm && jwm -reload
 					fi
+					kill $PID
 				else
 					losetup -d "$LOOPDEV"
 				fi

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -31,6 +31,76 @@ EOF
 
 if [ $# -ne 0 ]; then
 	for SFS in "$@"; do
+		ASKMOUNT=1
+		# assumption: if we have a loop device associated with this SFS, it's mounted or loaded
+		LOOPDEV="`losetup -n -j "$SFS" | head -n 1 | cut -f 1 -d :`"
+
+		# TODO: add PUPMODE 12 support, without leaving broken symlinks behind after reboot
+		if [ $PUPMODE -eq 5 -o $PUPMODE -eq 13 ] && [ -z "$LOOPDEV" ]; then
+			yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to load") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+			if [ $? -eq 0 ]; then
+				FOUND=0
+				for i in `seq 3 99`
+				do
+					MNT="/initrd/pup_ro$i"
+					mountpoint -q "$MNT" && continue
+					FOUND=1
+					break
+				done
+				[ $FOUND -eq 0 ] && exit 1
+
+				mkdir -p "$MNT" || continue
+				mount -r -t squashfs -o loop,noatime "$SFS" "$MNT"
+				if [ $? -ne 0 ]; then
+					rmdir "$MNT"
+					continue
+				fi
+				ASKMOUNT=0
+
+				# mirror the SFS directory tree in /, then create
+				# symlinks for everything else
+				while read ABSPATH; do
+					RELPATH=${ABSPATH#$MNT}
+					[ -z "$RELPATH" -o -e "$RELPATH" ] && continue
+					if [ -d "$ABSPATH" -a ! -L "$ABSPATH" ]; then
+						mkdir "$RELPATH"
+					else
+						ln -s "$ABSPATH" "$RELPATH"
+					fi
+					chown-FULL -h --reference "$ABSPATH" "$RELPATH"
+					touch -h --reference "$ABSPATH" "$RELPATH"
+				done < <(find "$MNT" | sort)
+
+				if [ -e "$MNT/usr/share/applications" -o -e "$MNT/usr/local/share/applications" ]; then
+					fixmenus
+					pidof -s jwm && jwm -reload
+				fi
+			fi
+		elif [ -n "$LOOPDEV" ]; then
+			yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to unload") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+			if [ $? -eq 0 ]; then
+				MNT="`grep "^$LOOPDEV " /proc/mounts 2>/dev/null | head -n 1 | cut -f 2 -d ' '`"
+				if [ -n "$MNT" ]; then
+					while read ABSPATH; do
+						RELPATH=${ABSPATH#$MNT}
+						[ -z "$RELPATH" -o ! -L "$RELPATH" ] && continue
+						[ "`readlink "$RELPATH" 2>/dev/null`" = "$ABSPATH" ] && rm -f "$RELPATH"
+					done < <(find "$MNT")
+					NEEDFIXMENUS=0
+					[ -e "$MNT/usr/share/applications" -o -e "$MNT/usr/local/share/applications" ] && NEEDFIXMENUS=1
+					umount -l "$LOOPDEV"
+					if [ $NEEDFIXMENUS -eq 1 ]; then
+						fixmenus
+						pidof -s jwm && jwm -reload
+					fi
+				else
+					losetup -d "$LOOPDEV"
+				fi
+			fi
+
+			ASKMOUNT=0
+		fi
+
 		BASE="${SFS##*/}"
 
 		SKIP=0
@@ -62,6 +132,9 @@ if [ $# -ne 0 ]; then
 			fi
 		fi
 
+		[ $ASKMOUNT -eq 0 ] && continue
+		yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to mount") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+		[ $? -ne 0 ] && continue
 		MNT="/mnt/`echo "$BASE" | tr '/ ' '+_'`"
 		mkdir -p "$MNT"
 		mountpoint -q "$MNT"

--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -174,7 +174,12 @@ do
 	fi
  
 	if [ -L "$N" ];then
-		[ "`readlink "$BASE/$N" 2>/dev/null`" = "`readlink "$N"`" ] && continue
+		DST="`readlink "$N"`"
+		[ "`readlink "$BASE/$N" 2>/dev/null`" = "$DST" ] && continue
+		case "$DST" in
+		/initrd/pup_ro1|/initrd/pup_ro1/*|/initrd/pup_ro2|/initrd/pup_ro2/*) ;;
+		/initrd/pup_ro[0-9]*) continue ;; # do not copy symlinks to files from dynamically loaded SFSs
+		esac
 		rm -rf "$BASE/$N"	# SFR: in case if folder has been replaced with a symlink (cp won't overwrite a dir with a symlink)
 		cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 	else


### PR DESCRIPTION
The SFS directory structure is replicated under / (and the save layer). Then, all other files under SFS are symlinked to the matching directories under /, and these symlinks don't get copied. If /usr/share/applications or /usr/local/share/applications exist in the SFS, fixmenus is triggered.

(Relies on #3401; before sfs_load runs sfs_load.overlay, it leaks a loop device and that makes sfs_load.overlay think the SFS is already mounted or loaded)