### PR TITLE
Fix breakage of latest_microcode.sh

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/latest_microcode.sh
+++ b/woof-code/rootfs-skeleton/usr/sbin/latest_microcode.sh
@@ -66,8 +66,8 @@ intel_func() {
 	INTEL_TIMESTAMP=$(curl -s $SRC_URL_INTEL | grep -om1 '202[0-9][01][0-9][0-3][0-9]' | sort -u)
 	echo $INTEL_TIMESTAMP > /tmp/ucode_intel.log
 	[ -n "$Q" ] && return
-	PKG_INTEL=${PRE_URL_INTEL##*\/}
-	URL_INTEL="https://github.com/${PRE_URL_INTEL}"
+	PKG_INTEL=microcode-${INTEL_TIMESTAMP}.tar.gz
+	URL_INTEL="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/archive/refs/tags/${PKG_INTEL}"
 	wget -q $URL_INTEL || return 1
 	tar axf $PKG_INTEL || return 1
 }

--- a/woof-code/rootfs-skeleton/usr/sbin/latest_microcode.sh
+++ b/woof-code/rootfs-skeleton/usr/sbin/latest_microcode.sh
@@ -64,6 +64,7 @@ intel_func() {
 	SRC_URL_INTEL="https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases"
 	PRE_URL_INTEL=$(curl -s $SRC_URL_INTEL | grep -om1 '\/intel.*tar\.gz')
 	INTEL_TIMESTAMP=$(curl -s $SRC_URL_INTEL | grep -om1 '202[0-9][01][0-9][0-3][0-9]' | sort -u)
+	[ -n "$INTEL_TIMESTAMP" ] || return 1
 	echo $INTEL_TIMESTAMP > /tmp/ucode_intel.log
 	[ -n "$Q" ] && return
 	PKG_INTEL=microcode-${INTEL_TIMESTAMP}.tar.gz


### PR DESCRIPTION
```
2022-09-13T15:15:13.4414714Z + LANG=C
2022-09-13T15:15:13.4415100Z + set -e
2022-09-13T15:15:13.4415594Z + case $(uname -m) in
2022-09-13T15:15:13.4419289Z ++ uname -m
2022-09-13T15:15:13.4426456Z + '[' -e /etc/rc.d/PUPSTATE ']'
2022-09-13T15:15:13.4426960Z + ver=0.2
2022-09-13T15:15:13.4427293Z + PROG=latest_microcode.sh
2022-09-13T15:15:13.4475860Z + TMPDIR=/tmp/microcode
2022-09-13T15:15:13.4476180Z + rm -rf /tmp/microcode
2022-09-13T15:15:13.4476489Z + rm -f '/tmp/ucode*.log' '/tmp/ucode*.tmp'
2022-09-13T15:15:13.4476722Z + PKG_INTEL=
2022-09-13T15:15:13.4476897Z + PKG_AMD=
2022-09-13T15:15:13.4477066Z + PUPMNT=
2022-09-13T15:15:13.4477309Z + grep -q '' /proc/mounts
2022-09-13T15:15:13.4477496Z + MTD=0
2022-09-13T15:15:13.4477710Z + '[' 0 -ne 0 ']'
2022-09-13T15:15:13.4477896Z + read x y MTPT z
2022-09-13T15:15:13.4478064Z ++ grep
2022-09-13T15:15:13.4478277Z Usage: grep [OPTION]... PATTERNS [FILE]...
2022-09-13T15:15:13.4478588Z Try 'grep --help' for more information.
2022-09-13T15:15:13.4478794Z ++ mount
2022-09-13T15:15:13.4490338Z + PUPDIR=/
2022-09-13T15:15:13.4490549Z + PUPINSTALL=
2022-09-13T15:15:13.4490728Z + AMDM=1
2022-09-13T15:15:13.4490881Z + INTM=1
2022-09-13T15:15:13.4491045Z + LABEL=
2022-09-13T15:15:13.4491323Z + grep -q '' /proc/mounts
2022-09-13T15:15:13.4502721Z + MTD=0
2022-09-13T15:15:13.4503063Z + '[' 0 -ne 0 ']'
2022-09-13T15:15:13.4503252Z + INSTALL=0
2022-09-13T15:15:13.4503440Z + case $1 in
2022-09-13T15:15:13.4503622Z + AMDM=0
2022-09-13T15:15:13.4503782Z + INTM=0
2022-09-13T15:15:13.4503960Z + LABEL=combined
2022-09-13T15:15:13.4504194Z + '[' '' = install ']'
2022-09-13T15:15:13.4504530Z + echo 'Please wait while microcode is downloaded and built'
2022-09-13T15:15:13.4504846Z + mkdir -p /tmp/microcode
2022-09-13T15:15:13.4505109Z Please wait while microcode is downloaded and built
2022-09-13T15:15:13.4519105Z + cd /tmp/microcode
2022-09-13T15:15:13.4519363Z + TGTDIR=kernel/x86/microcode
2022-09-13T15:15:13.4519726Z + mkdir -p kernel/x86/microcode
2022-09-13T15:15:13.4531363Z + '[' 0 -eq 0 ']'
2022-09-13T15:15:13.4531561Z + intel_func
2022-09-13T15:15:13.4531735Z + Q=
2022-09-13T15:15:13.4532186Z + SRC_URL_INTEL=https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases
2022-09-13T15:15:13.4534864Z ++ grep -om1 '\/intel.*tar\.gz'
2022-09-13T15:15:13.4538070Z ++ curl -s https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases
2022-09-13T15:15:14.1419704Z + PRE_URL_INTEL=
2022-09-13T15:15:14.1425100Z ++ curl -s https://github.com/intel/Intel-Linux-Processor-Microcode-Data-Files/releases
2022-09-13T15:15:14.1426565Z ++ sort -u
2022-09-13T15:15:14.1436321Z ++ grep -om1 '202[0-9][01][0-9][0-3][0-9]'
2022-09-13T15:15:14.8763590Z + INTEL_TIMESTAMP=20220809
2022-09-13T15:15:14.8764147Z + echo 20220809
2022-09-13T15:15:14.8764769Z + '[' -n '' ']'
2022-09-13T15:15:14.8765077Z + PKG_INTEL=
2022-09-13T15:15:14.8766007Z + URL_INTEL=https://github.com/
2022-09-13T15:15:14.8766530Z + wget -q https://github.com/
2022-09-13T15:15:15.1793836Z + tar axf
2022-09-13T15:15:15.1804906Z tar: Old option 'f' requires an argument.
2022-09-13T15:15:15.1805496Z Try 'tar --help' or 'tar --usage' for more information.
2022-09-13T15:15:15.1806174Z + return 1
2022-09-13T15:15:15.1806526Z + exit 1
2022-09-13T15:15:15.1832837Z ##[error]Process completed with exit code 1.
```

There are more issues to fix here, like like grep without quotes thing, but that can wait for later. Let's fix broken builds first.