### PR TITLE
Skip the /usr symlinks safety check in sfs_load when using overlay

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -49,6 +49,10 @@
 
 . /etc/rc.d/PUPSTATE
 
+if [ "$PUNIONFS" = "overlay" ] ; then
+	exec sfs_load.overlay "$@"
+fi
+
 sym_list=""
 for fld2 in bin sbin lib lib64 lib32 libx32 usr/bin usr/sbin usr/lib usr/lib64 usr/lib32 usr/libx32
 do
@@ -87,10 +91,6 @@ if [ "$sym_list" != "" ]; then
  fi
  
 fi 
-
-if [ "$PUNIONFS" = "overlay" ] ; then
-	exec sfs_load.overlay "$@"
-fi
 
 for i in $@ ; do
 	if [ "$i" = "stop" ] ; then #simple thing to do, do it as fast as possible


### PR DESCRIPTION
Currently, dynamic SFS loading is unsupported with overlay. In the future (if #3398 is merged), the symlink-based SFS loading does not replace directories with symlinks or vice-versa, so this unneeded check only slows down SFS loading.