### PR TITLE
Use the foot default of TERM=foot

### DIFF
--- a/woof-code/rootfs-petbuilds/foot-puppy/etc/xdg/foot/foot.ini
+++ b/woof-code/rootfs-petbuilds/foot-puppy/etc/xdg/foot/foot.ini
@@ -1,4 +1,3 @@
-term = xterm-256color
 initial-window-size-chars = 80x24
 [colors]
 background = 1a1a1a


### PR DESCRIPTION
foot supports many useful features, and tools like chafa support them if TERM=foot. Compatibility with rxvt-unicode is nice, but comes at the cost of incompatibility or degraded functionality in some modern console applications.