### PR TITLE
Prefer compat distro terminfo files

### DIFF
--- a/woof-code/support/rootfs-hacks.sh
+++ b/woof-code/support/rootfs-hacks.sh
@@ -228,6 +228,7 @@ done
 
 # need to enforce pterminfo: xterm -- see /etc/profile
 if [ -d ${SR}/usr/share/terminfox ] ; then
+	[ -e ${SR}/usr/share/terminfo ] && cp -r ${SR}/usr/share/terminfo/* ${SR}/usr/share/terminfox/
 	rm -rf ${SR}/usr/share/terminfo
 	mv -f ${SR}/usr/share/terminfox ${SR}/usr/share/terminfo
 fi

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -482,7 +482,7 @@ no|nano|nano|exe,dev,doc,nls
 no|nas|libaudio2,libaudio-dev|exe,dev,doc,nls #needed by mplayer, qupzilla
 yes|nasm|nasm|exe>dev,dev,doc,nls||deps:yes
 no|nbtscan|nbtscan|exe,dev
-yes|ncurses|ncurses-base,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
+yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
 no|nenscript||exe
 yes|netbase|netbase|exe>null,dev>null,doc>null,nls>null
 yes|net-tools|net-tools|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -478,7 +478,7 @@ no|nano|nano|exe,dev,doc,nls
 no|nas|libaudio2,libaudio-dev|exe,dev,doc,nls #needed by mplayer, qupzilla
 yes|nasm|nasm|exe>dev,dev,doc,nls||deps:yes
 no|nbtscan|nbtscan|exe,dev
-yes|ncurses|ncurses-base,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
+yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
 no|nenscript||exe
 yes|netbase|netbase|exe>null,dev>null,doc>null,nls>null
 yes|net-tools|net-tools|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -486,7 +486,7 @@ no|nano|nano|exe,dev,doc,nls
 no|nas|libaudio2,libaudio-dev|exe,dev,doc,nls #needed by mplayer, qupzilla
 yes|nasm|nasm|exe>dev,dev,doc,nls||deps:yes
 no|nbtscan|nbtscan|exe,dev
-yes|ncurses|ncurses-base,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
+yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
 no|nenscript||exe
 yes|netbase|netbase|exe>null,dev>null,doc>null,nls>null
 yes|net-tools|net-tools|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -479,7 +479,7 @@ no|nano|nano|exe,dev,doc,nls
 no|nas|libaudio2,libaudio-dev|exe,dev,doc,nls #needed by mplayer, qupzilla
 yes|nasm|nasm|exe>dev,dev,doc,nls||deps:yes
 no|nbtscan|nbtscan|exe,dev
-yes|ncurses|ncurses-base,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
+yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes
 no|nenscript||exe
 yes|netbase|netbase|exe>null,dev>null,doc>null,nls>null
 yes|net-tools|net-tools|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
I don't understand why we need terminfox, because all of these terminfo files are part of ncurses, and the old binary files in terminfox are old and different.

I prefer to use the more current compat distro versions of these files, in case using old versions can introduce issues and incompatibility.

To reduce the risk of breaking builds with a broken ncurses package that rely on terminfox, I'm keeping terminfox.