### PR TITLE
Skip the /usr symlinks safety check in sfs_load when --cli is specified

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # sfs_load 28 Jan 2011 by shinobar
 # always assume squashfs 4.0
 # some code from the otf_sfs_loader by goingnuts, the sfs_installation.sh by 01micko and scrips by Barry
@@ -57,7 +57,7 @@ done
 
 if [ "$sym_list" != "" ]; then
 
- if [ "$1" ]; then
+ if [ -n "$1" -a "${1:0:1}" != "-" ]; then
  
    SFSFILE="$(basename "$1")"
    MNTFLD="$(echo "${SFSFILE}-module" | sed -e 's#\ #_#g')"


### PR DESCRIPTION
The assumption that `$1` is a SFS path is false. I won't bother fixing this bug because I think 6d5393e0c5 is a bad idea in first place. For now, I want to silence these errors and avoid the slowdown of rc.sysinit.

![sfs](https://user-images.githubusercontent.com/1471149/190862099-3c8e3b9f-85ec-4bfa-9164-5d12a1db7e27.png)
