### PR TITLE
Make box_splash work under Wayland, when invoked from the tty

### DIFF
--- a/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
+++ b/woof-code/rootfs-skeleton/usr/lib/gtkdialog/box_splash
@@ -10,6 +10,12 @@ export OUTPUT_CHARSET=UTF-8   # even if not gettext.
 
 [ ! -f /tmp/yaf-splash ] && ln -s "`which gtkdialog`" /tmp/yaf-splash
 
+# when invoked from the tty (for example, by pm13), XDG_SESSION_TYPE is unset
+if [ -z "$XDG_SESSION_TYPE" ]; then
+	XDG_SESSION_TYPE='x11'
+	pidof -s dwl-kiosk labwc && XDG_SESSION_TYPE='wayland'
+fi
+
 if [ "$XDG_SESSION_TYPE" != 'wayland' ]; then
 	geometry=$(xwininfo -root | grep ' \-geometry ')
 	geometry=${geometry%%\+*}


### PR DESCRIPTION
The alternative is setting `XDG_SESSION_TYPE=wayland` everywhere (as in #3354), but as far as I see (correct me if I'm wrong) it's only box_splash that's involved outside of the GUI session.