### PR TITLE
Auto-scale the fullscreen Xwayland window (re-introduces #3333)

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
@@ -1,10 +1,16 @@
-From c9ca8c4a74e1f65d50c0624ffe1fcccade905121 Mon Sep 17 00:00:00 2001
+From a822eb06bcc40f3275e25ee0ef7258522ba4c6a2 Mon Sep 17 00:00:00 2001
 From: Dima Krasner <dima@dimakrasner.com>
-Date: Thu, 22 Sep 2022 05:48:11 +0000
+Date: Fri, 23 Sep 2022 06:53:37 +0000
 Subject: [PATCH] Squashed commit of the following:
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
+
+commit 07a883913455611c5c7898d42c4a5e8cb640f15c
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Fri Sep 23 06:53:21 2022 +0000
+
+    restore auto-scaling in kiosk mode
 
 commit a83f9c64a469c378f47e58d395a064cc3ac74e13
 Merge: 27f9ce2 d1936f1
@@ -448,7 +454,7 @@ index ec1f0528..dcf1843a 100644
  	CHVT(7), CHVT(8), CHVT(9), CHVT(10), CHVT(11), CHVT(12),
  };
 diff --git a/dwl.c b/dwl.c
-index 6fbc7717..e9585652 100644
+index 6fbc7717..54cd4fbb 100644
 --- a/dwl.c
 +++ b/dwl.c
 @@ -1,6 +1,7 @@
@@ -726,7 +732,7 @@ index 6fbc7717..e9585652 100644
 +				wlr_output_set_scale(wlr_output, r->scale);
 +			else {
 +				struct wlr_output_mode *native = wlr_output_preferred_mode(wlr_output);
-+				float ppi = (native && native->height >= 1080 && wlr_output->phys_width > 0 && !kiosk) ? native->width / (wlr_output->phys_width / 25.4) : 96;
++				float ppi = (native && native->height >= 1080 && wlr_output->phys_width > 0) ? native->width / (wlr_output->phys_width / 25.4) : 96;
 +				if (ppi >= 96 * 2)
 +					wlr_output_set_scale(wlr_output, 2);
 +				else if (ppi >= 96 * 1.5)


### PR DESCRIPTION
I have a solution for #3334, but I think I changed my mind.

If GTK+ respects Xft.dpi, the real-world dimensions of text and icons are different across different monitors. For example, if you have an old laptop that works best with scale factor 1, connected to a modern monitor that works best with scale factor 2, `Xft.dpi: 192` will make text on the external monitor readable (and not half the size of readable text) but will also double the size of text in the internal monitor, making it unusable.

Another downside of Xft.dpi is that you have to constantly change it and restart X when you switch monitors. For example, I have a more dense monitor at home, and one (unusable) 1080p monitor at work. #3349 automatically chooses the correct scaling factor for each monitor, making the experience seamless.

The only way to make all monitors usable with a big Xwayland window that covers the entire output layout is to stretch each monitor's portion of this window according to the scale factor.

That's how scaling of X11 applications is handled under Wayland, even without this fullscreen Xwayland setup, and we should probably align with that and mention this known limitation in the release notes.

IMO, #3333 as a known limitation > fix for #3334. HiDPI works great under Wayland if the GTK+ theme scales nicely (#3335), and the attempt to make HiDPI work under Xwayland is futile.