### PR TITLE
Optionally restrict file system access for applications running as spot

### DIFF
--- a/woof-code/rootfs-petbuilds/spot-pkexec/etc/xdg/autostart/pkexecd.desktop
+++ b/woof-code/rootfs-petbuilds/spot-pkexec/etc/xdg/autostart/pkexecd.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=pkexecd
+Comment=pkexec daemon
+Exec=pkexecd
+Terminal=false
+Type=Application

--- a/woof-code/rootfs-petbuilds/spot-pkexec/petbuild
+++ b/woof-code/rootfs-petbuilds/spot-pkexec/petbuild
@@ -4,4 +4,10 @@ download() {
 
 build() {
     $CC $CFLAGS -D_GNU_SOURCE pkexec.c $LDFLAGS -o /usr/bin/pkexec
+    $CC $CFLAGS -D_GNU_SOURCE pkexecd.c $LDFLAGS -o /usr/bin/pkexecd
+    if [ -e /usr/include/linux/landlock.h ]; then
+        $CC $CFLAGS -D_GNU_SOURCE -DHAVE_LANDLOCK sandbox.c $LDFLAGS -o /usr/bin/spot-sandbox
+    else
+        $CC $CFLAGS -D_GNU_SOURCE sandbox.c $LDFLAGS -o /usr/bin/spot-sandbox
+    fi
 }

--- a/woof-code/rootfs-petbuilds/spot-pkexec/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/spot-pkexec/pinstall.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-
-chown root:root usr/bin/pkexec
-chmod 4755 usr/bin/pkexec

--- a/woof-code/rootfs-petbuilds/spot-pkexec/pkexecd.c
+++ b/woof-code/rootfs-petbuilds/spot-pkexec/pkexecd.c
@@ -1,0 +1,150 @@
+#include <syscall.h>
+#include <sys/types.h>
+#include <signal.h>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <sys/wait.h>
+
+static inline
+int pidfd_open(pid_t pid, unsigned int flags)
+{
+	return syscall(__NR_pidfd_open, pid, flags);
+}
+
+static inline
+int pidfd_getfd(int pidfd, int targetfd, unsigned int flags)
+{
+	return syscall(__NR_pidfd_getfd, pidfd, targetfd, flags);
+}
+
+static
+void exec_child(const pid_t pid, char *argv[])
+{
+	int fd, i, pid_fd;
+
+	if ((pid_fd = pidfd_open(pid, 0)) < 0) return;
+
+	for (i = STDIN_FILENO; i <= STDERR_FILENO; ++i) {
+		if ((fd = pidfd_getfd(pid_fd, i, 0)) < 0) {
+			if (errno != ESRCH) return;
+			continue;
+		}
+		if (dup2(fd, i) != i) return;
+		close(fd);
+	}
+
+	close(pid_fd);
+
+	execvp(argv[0], argv);
+}
+
+void run_cmd(const pid_t pid, char *buf, const size_t len)
+{
+	static char *argv[32] = {"/usr/sbin/pkexec-ask"};
+	pid_t ask, reaped;
+	int argc, status;
+
+	for (argc = 2, argv[1] = buf; argc < 31; ++argc) {
+		if (!(argv[argc] = memchr(argv[argc - 1], '\0', len - (argv[argc] - buf)))) break;
+		else if (argv[argc] < &buf[len - 2]) ++(argv[argc]);
+		else {
+			argv[argc] = NULL;
+			if ((ask = fork()) == 0) {
+				execv(argv[0], argv);
+				exit(EXIT_FAILURE);
+			} else if (ask > 0) {
+				while ((reaped = waitpid(ask, &status, 0)) != ask) {
+					if (reaped < 0) {
+						if (errno == EINTR) continue;
+						return;
+					}
+				}
+				if (!WIFEXITED(status) || (WEXITSTATUS(status) != EXIT_SUCCESS))
+					return;
+
+				exec_child(pid, &argv[1]);
+			}
+			break;
+		}
+	}
+}
+
+static
+void handle(const pid_t pid, const int fd)
+{
+	static char buf[1024];
+	ssize_t chunk, total;
+
+	for (total = 0; total < sizeof(buf);) {
+		if ((chunk = recv(fd, &buf[total], sizeof(buf) - total, 0)) < 0) {
+			if (errno == EINTR) continue;
+			break;
+		}
+		else if (chunk == 0) break;
+		total += (size_t)chunk;
+		if (total > 2 && buf[total - 2] == '\0' && buf[total - 1] == '\0') {
+			run_cmd(pid, buf, total);
+			break;
+		}
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	struct sockaddr_un sun = {.sun_family = AF_UNIX, .sun_path = "/tmp/pkexecd.socket"};
+	struct ucred cred;
+	pid_t pid, reaped;
+	int s, c;
+	socklen_t len = sizeof(cred);
+
+	if ((s = socket(AF_UNIX, SOCK_STREAM | SOCK_CLOEXEC, 0)) < 0) return EXIT_FAILURE;
+	if (bind(s, (const struct sockaddr *)&sun, sizeof(sun)) < 0) {
+		if (errno != EADDRINUSE || (unlink(sun.sun_path) < 0 && errno != ENOENT) || bind(s, (const struct sockaddr *)&sun, sizeof(sun)) < 0) {
+			close(s);
+			return EXIT_FAILURE;
+		}
+	}
+	if (chmod(sun.sun_path, 0766) < 0 || listen(s, 5) < 0) {
+		close(s);
+		unlink(sun.sun_path);
+		return EXIT_FAILURE;
+	}
+
+	while (1) {
+		if ((c = accept4(s, NULL, NULL, SOCK_CLOEXEC)) < 0) continue;
+		if ((pid = fork()) == 0) {
+			close(s);
+
+			if (setsid() < 0) goto done;
+			if ((pid = fork()) > 0) {
+				close(c);
+				return EXIT_SUCCESS;
+			}
+			else if (pid < 0) goto done;
+
+			if (getsockopt(c, SOL_SOCKET, SO_PEERCRED, &cred, &len) < 0 || len != sizeof(cred)) goto done;
+
+			handle(cred.pid, c);
+
+done:
+			close(c);
+			return EXIT_FAILURE;
+		} else if (pid > 0) {
+			while ((reaped = waitpid(pid, NULL, 0)) != pid) {
+				if (reaped < 0) {
+					if (errno == EINTR) continue;
+					break;
+				}
+			}
+			close(c);
+		}
+	}
+
+	close(s);
+	unlink(sun.sun_path);
+	return EXIT_FAILURE;
+}

--- a/woof-code/rootfs-petbuilds/spot-pkexec/sandbox.c
+++ b/woof-code/rootfs-petbuilds/spot-pkexec/sandbox.c
@@ -1,0 +1,153 @@
+#ifdef HAVE_LANDLOCK
+#	include <linux/landlock.h>
+#	include <syscall.h>
+#endif
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/prctl.h>
+#include <dirent.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#ifdef HAVE_LANDLOCK
+
+static inline
+long landlock_create_ruleset(const struct landlock_ruleset_attr *const attr, const size_t size, const __u32 flags)
+{
+	return syscall(__NR_landlock_create_ruleset, attr, size, flags);
+}
+
+static inline
+long landlock_add_rule(const int ruleset_fd, const enum landlock_rule_type rule_type, const void *const rule_attr, const __u32 flags)
+{
+	return syscall(__NR_landlock_add_rule, ruleset_fd, rule_type, rule_attr, flags);
+}
+
+static inline
+long landlock_restrict_self(const int ruleset_fd, const __u32 flags)
+{
+	return syscall(__NR_landlock_restrict_self, ruleset_fd, flags);
+}
+
+static
+int add_rule(const int ruleset_fd, const int rootfd, const char *path, struct landlock_path_beneath_attr *attr)
+{
+	int err;
+	attr->parent_fd = openat(rootfd, path, O_PATH);
+	if (attr->parent_fd < 0) return -1;
+	err = landlock_add_rule(ruleset_fd, LANDLOCK_RULE_PATH_BENEATH, attr, 0);
+	close(attr->parent_fd);
+	return err;
+}
+
+#endif
+
+int main(int argc, char *argv[])
+{
+#ifdef HAVE_LANDLOCK
+	static const char *rw_dirs[] = {
+		"home/spot",
+		"dev",
+		"proc",
+		"tmp",
+	};
+	static const char *skip_dirs[] = {
+		"..",
+		"root",
+		"home",
+		"dev",
+		"proc",
+		"tmp",
+	};
+	struct landlock_ruleset_attr ruleset_attr = {
+		.handled_access_fs =
+			LANDLOCK_ACCESS_FS_EXECUTE |
+			LANDLOCK_ACCESS_FS_WRITE_FILE |
+			LANDLOCK_ACCESS_FS_READ_FILE |
+			LANDLOCK_ACCESS_FS_READ_DIR |
+			LANDLOCK_ACCESS_FS_REMOVE_DIR |
+			LANDLOCK_ACCESS_FS_REMOVE_FILE |
+			LANDLOCK_ACCESS_FS_MAKE_CHAR |
+			LANDLOCK_ACCESS_FS_MAKE_DIR |
+			LANDLOCK_ACCESS_FS_MAKE_REG |
+			LANDLOCK_ACCESS_FS_MAKE_SOCK |
+			LANDLOCK_ACCESS_FS_MAKE_FIFO |
+			LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+			LANDLOCK_ACCESS_FS_MAKE_SYM |
+			LANDLOCK_ACCESS_FS_REFER
+	};
+	struct landlock_path_beneath_attr ro_attr = {
+		.allowed_access =
+			LANDLOCK_ACCESS_FS_EXECUTE |
+			LANDLOCK_ACCESS_FS_READ_FILE |
+			LANDLOCK_ACCESS_FS_READ_DIR
+	};
+	struct landlock_path_beneath_attr rw_attr = {
+		.allowed_access =
+			LANDLOCK_ACCESS_FS_EXECUTE |
+			LANDLOCK_ACCESS_FS_WRITE_FILE |
+			LANDLOCK_ACCESS_FS_READ_FILE |
+			LANDLOCK_ACCESS_FS_READ_DIR |
+			LANDLOCK_ACCESS_FS_REMOVE_DIR |
+			LANDLOCK_ACCESS_FS_REMOVE_FILE |
+			LANDLOCK_ACCESS_FS_MAKE_CHAR |
+			LANDLOCK_ACCESS_FS_MAKE_DIR |
+			LANDLOCK_ACCESS_FS_MAKE_REG |
+			LANDLOCK_ACCESS_FS_MAKE_SOCK |
+			LANDLOCK_ACCESS_FS_MAKE_FIFO |
+			LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+			LANDLOCK_ACCESS_FS_MAKE_SYM |
+			LANDLOCK_ACCESS_FS_REFER
+	};
+	DIR *dir = NULL;
+	struct dirent *ent;
+	int i, root_fd = -1, ruleset_fd = -1;
+#endif
+
+	if (prctl(PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0) < 0) goto exec;
+
+#ifdef HAVE_LANDLOCK
+	if (landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION) < 2) {
+		ruleset_attr.handled_access_fs &= ~LANDLOCK_ACCESS_FS_REFER;
+		rw_attr.allowed_access &= ~LANDLOCK_ACCESS_FS_REFER;
+	}
+
+	if ((ruleset_fd = landlock_create_ruleset(&ruleset_attr, sizeof(ruleset_attr), 0)) < 0) goto exec;
+	if ((root_fd = open("/", O_DIRECTORY)) < 0) goto exec;
+	if (!(dir = fdopendir(root_fd))) goto exec;
+
+	while (1) {
+next:
+		errno = 0;
+		if (!(ent = readdir(dir))) {
+			if (errno) goto exec;
+			break;
+		}
+
+		if (ent->d_type != DT_DIR) continue;
+
+		for (i = 0; i < sizeof(skip_dirs) / sizeof(skip_dirs[0]); ++i) {
+			if (strcmp(ent->d_name, skip_dirs[i]) == 0) goto next;
+		}
+
+		if (add_rule(ruleset_fd, root_fd, ent->d_name, &ro_attr) < 0) goto exec;
+	}
+
+	for (i = 0; i < sizeof(rw_dirs) / sizeof(rw_dirs[0]); ++i) {
+		if (add_rule(ruleset_fd, root_fd, rw_dirs[i], &rw_attr) < 0) goto exec;
+	}
+
+	landlock_restrict_self(ruleset_fd, 0);
+#endif
+
+exec:
+#ifdef HAVE_LANDLOCK
+	if (dir) closedir(dir);
+	else if (root_fd != -1) close(root_fd);
+	if (ruleset_fd != -1) close(ruleset_fd);
+#endif
+
+	execvp(argv[1], &argv[1]);
+	return EXIT_FAILURE;
+}

--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -17,6 +17,14 @@ case $0 in *run-as|*run-as-user)
 	shift
 esac
 
+# if spot-sandbox is present, run the shell inside a sandbox
+SANDBOX=
+case "$1" in
+*.AppImage|flatpak|*/flatpak) ;;
+dbus-daemon) ;; # Landlock breaks xdg-desktop-portal, which fails to open /proc/%u/root
+*) SANDBOX=`command -v spot-sandbox` ;;
+esac
+
 CWD=$PWD
 CMD=''
 while [ "$1" ]; do
@@ -82,13 +90,16 @@ EOF
 	done
 
 	exec su ${XUSER} -s /bin/ash -c '
-# try to switch to original directory, unless it is /root
-if [ "'"$CURDIR"'" = /root ]; then
+# try to switch to original directory, unless it is under /root
+case "'"$CURDIR"'" in
+/root|/root/*)
 	cd "'"$USER_HOME"'"
-else
+	;;
+*)
 	cd "'"$CURDIR"'"
-fi
-exec '"$CMD"'
+	;;
+esac
+exec '"${SANDBOX}"' '"$CMD"'
 '
 else
 	exec ash -c "exec $CMD"


### PR DESCRIPTION
Landlock is a new kernel API that allows a process to restrict its file system access: for example, it allows a process to disallow all access to /root, allow reading from /tmp and allow writing to /tmp/runtime-spot, then exec() an application.

This is a nice security feature that can be used as a second layer of defense for applications running as spot. Some Puppy packages mess up directory permissions and ownership, and nobody notices that because everything works just fine for applications running as root, and extra permissions for spot don't break anything. In some Puppy releases, spot can read files under /root, maybe even write to them! Landlock is a great, fine-grained security solution that can be used to prevent spot from doing things it shouldn't do, even if file system permissions say otherwise.

Before this PR, pkexec is a root SUID executable that shows a yes/no prompt (using a restricted yad process that runs as spot), then runs a process as root if the user agrees. However, Landlock requires the PR_SET_NO_NEW_PRIVS bit to be set, which means a process that uses Landlock cannot run SUID executables: a process running as spot which uses Landlock will run pkexec as spot despite the SUID bit.

Therefore, this PR moves most functionality from pkexec to a daemon that runs as root, pkexecd. pkexec talks to this daemon over a Unix socket, doesn't do anything on its own and doesn't need to be a SUID executable.

To enable:
1. Switch to kernel >= 5.15.x
2. Build the kernel with
```
CONFIG_SECURITY_LANDLOCK=y
CONFIG_LSM="landlock"
```
(CONFIG_LSM should contain `landlock`, doesn't have to be exactly `landlock` - currently, Puppy doesn't use any LSM AFAIK)
3. Enable the `spot-pkexec` petbuild

If the kernel is too old, Landlock is missing or Landlock is disabled, `spot-sandbox` continues with PR_SET_NO_NEW_PRIVS and without Landlock.

If `spot-sandbox` is not available, run-as-spot doesn't use it.

When `spot-sandbox` is available, processes running as spot can:
- Read from /, minus /root and /home
- Read from and write to /home/spot, /dev, /proc and /tmp

If /tmp loses its 1777 permissions, spot can't write to it. In other words, Landlock is a second layer of security on top of file permissions: if file permissions disallow a certain action, these rules don't apply.

After `chmod 777 /root`, with and without this Landlock-based sandboxing:

![image](https://user-images.githubusercontent.com/1471149/192103981-2106b395-3731-4a38-8771-4791bf3cd2e0.png)
![image](https://user-images.githubusercontent.com/1471149/192104043-c1abd661-9fbe-480e-873a-1af8a0e86ee9.png)

Chrome installation through gdebi+pkexec+sandboxed Firefox running as spot:

![image](https://user-images.githubusercontent.com/1471149/192104293-26333adf-434d-41be-beff-e427f5b5fe80.png)
![image](https://user-images.githubusercontent.com/1471149/192104332-a80c10f8-fdc3-4069-84f2-f867d2049e2d.png)
![image](https://user-images.githubusercontent.com/1471149/192104352-95f0f6fc-35d1-4dc7-960c-fe1b38cc5864.png)
![image](https://user-images.githubusercontent.com/1471149/192104377-b1e52ec3-dde1-4645-b29d-d1eb9f9f2e80.png)

EDIT: had to add write permissions for /tmp, because Chrome creates temporary files directly under /tmp.
EDIT 2: now pkexecd handles multiple requests in parallel

## TODO

- [x] Test Firefox with WebGL
- [x] Test Chrome with WebGL
- [x] Test .deb package installation through gdebi, when gdebi is started by downloading a package through the browser