### PR TITLE
Drop the libcanberra-pulseonly package templates

### DIFF
--- a/woof-code/packages-templates/libcanberra-pulseonly_FIXUPHACK
+++ b/woof-code/packages-templates/libcanberra-pulseonly_FIXUPHACK
@@ -1,1 +1,0 @@
-find -name libcanberra-alsa.so -delete

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -280,7 +280,7 @@ no|libbonobo|libbonobo2-0,libbonobo2-dev,libbonoboui2-0,libbonoboui2-dev|exe,dev
 no|libboost-filesystem|libboost-filesystem1.67.0,libboost-filesystem1.67-dev|exe,dev,doc,nls
 no|libboost-system|libboost-system1.67.0,libboost-system1.67-dev|exe,dev,doc,nls
 yes|libbsd|libbsd0|exe,dev,doc,nls||deps:yes #needed by libedit.
-yes|libcanberra-pulseonly|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev,libcanberra-pulse|exe,dev,doc,nls||deps:yes #libbonobui needs this.
+yes|libcanberra|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev|exe,dev,doc,nls||deps:yes #libbonobui needs this.
 yes|libcap|libcap2|exe,dev,doc,nls||deps:yes
 yes|libcap-ng|libcap-ng0|exe,dev,doc,nls||deps:yes
 no|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls #debian/ubuntu pkg missing cddb_query, also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.
@@ -561,7 +561,6 @@ no|pptp|pptp-linux|exe,dev,doc,nls
 yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
 yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
 yes|pulseaudio-compat|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
-yes|pulseaudio-null|pulseaudio|exe>null,dev>null,doc>null,nls>null
 no|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
 no|psynclient||exe
 no|pupmixer||exe

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -279,7 +279,7 @@ no|libbonobo|libbonobo2-0,libbonobo2-dev,libbonoboui2-0,libbonoboui2-dev|exe,dev
 no|libboost-filesystem|libboost-filesystem1.67.0,libboost-filesystem1.67-dev|exe,dev,doc,nls
 no|libboost-system|libboost-system1.67.0,libboost-system1.67-dev|exe,dev,doc,nls
 yes|libbsd|libbsd0|exe,dev,doc,nls||deps:yes #needed by libedit.
-yes|libcanberra-pulseonly|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev,libcanberra-pulse|exe,dev,doc,nls||deps:yes #libbonobui needs this.
+yes|libcanberra|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev|exe,dev,doc,nls||deps:yes #libbonobui needs this.
 yes|libcap|libcap2|exe,dev,doc,nls||deps:yes
 yes|libcap-ng|libcap-ng0|exe,dev,doc,nls||deps:yes
 no|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls #debian/ubuntu pkg missing cddb_query, also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -283,7 +283,7 @@ no|libbonobo|libbonobo2-0,libbonobo2-dev,libbonoboui2-0,libbonoboui2-dev|exe,dev
 no|libboost-filesystem|libboost-filesystem1.67.0,libboost-filesystem1.67-dev|exe,dev,doc,nls
 no|libboost-system|libboost-system1.67.0,libboost-system1.67-dev|exe,dev,doc,nls
 yes|libbsd|libbsd0|exe,dev,doc,nls||deps:yes #needed by libedit.
-yes|libcanberra-pulseonly|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev,libcanberra-pulse|exe,dev,doc,nls||deps:yes #libbonobui needs this.
+yes|libcanberra|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev|exe,dev,doc,nls||deps:yes #libbonobui needs this.
 yes|libcap|libcap2|exe,dev,doc,nls||deps:yes
 yes|libcap-ng|libcap-ng0|exe,dev,doc,nls||deps:yes
 no|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls #debian/ubuntu pkg missing cddb_query, also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -279,7 +279,7 @@ no|libbonobo|libbonobo2-0,libbonobo2-dev,libbonoboui2-0,libbonoboui2-dev|exe,dev
 no|libboost-filesystem|libboost-filesystem1.67.0,libboost-filesystem1.67-dev|exe,dev,doc,nls
 no|libboost-system|libboost-system1.67.0,libboost-system1.67-dev|exe,dev,doc,nls
 yes|libbsd|libbsd0|exe,dev,doc,nls||deps:yes #needed by libedit.
-yes|libcanberra-pulseonly|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev,libcanberra-pulse|exe,dev,doc,nls||deps:yes #libbonobui needs this.
+yes|libcanberra|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev|exe,dev,doc,nls||deps:yes #libbonobui needs this.
 yes|libcap|libcap2|exe,dev,doc,nls||deps:yes
 yes|libcap-ng|libcap-ng0|exe,dev,doc,nls||deps:yes
 no|libcddb|libcddb2,libcddb2-dev|exe,dev,doc,nls #debian/ubuntu pkg missing cddb_query, also very old version (warning: .deb cddb package has nothing to do with libcddb pkg). 120907 yes.
@@ -560,7 +560,6 @@ no|pptp|pptp-linux|exe,dev,doc,nls
 yes|procps|procps,libprocps8|exe,dev,doc,nls||deps:yes
 yes|psmisc|psmisc|exe,dev>null,doc,nls||deps:yes
 yes|pulseaudio-compat|libpulse0,libpulse-dev,pulseaudio-utils|exe,dev,doc,nls||deps:yes
-yes|pulseaudio-null|pulseaudio|exe>null,dev>null,doc>null,nls>null
 no|pulseaudio|pulseaudio,libpulse-mainloop-glib0,libpulse0,libpulse-dev,libwebrtc-audio-processing1,pulseaudio-utils,pulseaudio-module-bluetooth|exe,dev,doc,nls||deps:yes #needed by mplayer, gnome-mplayer and gmtk
 no|psynclient||exe
 no|pupmixer||exe


### PR DESCRIPTION
debdb2pupdb doesn't understand the concept of a dependency on `pulseaudio|pipewire-pulse, and takes the first option (which happens to be pulseaudio) even in builds that include pipewire-pulse. This breaks builds, because this makes resolvedeps.sh add pulseaudio to builds with pipewire-pulse, although they're marked as conflicting in bookworm.