### PR TITLE
Mark newly-added packages as installed when updating bdrv

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/bdrv-update
+++ b/woof-code/rootfs-skeleton/sbin/bdrv-update
@@ -3,6 +3,8 @@
 cmp -s /initrd/pup_b/var/lib/dpkg/status /var/lib/dpkg/status
 [ $? -ne 1 ] && exit 0
 
+rm -f /tmp/.dpkgstatus-*.new
+
 # get package information for all packages in the new bdrv
 F=`mktemp`
 while IFS="" read -r LINE; do
@@ -39,6 +41,10 @@ done < /initrd/pup_b/var/lib/dpkg/status
 		fi
 	done < /var/lib/dpkg/status
 	rm -f $F
+
+	# if a package was added, add its entry
+	cat /tmp/.dpkgstatus-*.new
+	rm -f /tmp/.dpkgstatus-*.new
 ) > /tmp/.dpkgstatus
 
 mv -f /tmp/.dpkgstatus /var/lib/dpkg/status


### PR DESCRIPTION
Now, init-system-helpers in bookworm depends on usrmerge. This breaks apt, because when bdrv-update synchronizes the dpkg status file, it only update entries for updated packages and doesn't add entries for newly-added packages, so init-system-helpers installed but with a missing dependency.