### PR TITLE
Ensure ktls is available for applications running as spot

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -702,6 +702,9 @@ if which dbus-daemon >/dev/null 2>&1 ; then
  fi
 fi
 
+# enable ktls, in case all internet-facing processes run as spot and cannot load tls
+modprobe tls 2>/dev/null
+
 #----------------------
 (
  sleep 5 # in some cases network modules take some time to load


### PR DESCRIPTION
ktls can speed up applications like browsers. If `CONFIG_TLS=m`, `tls` is loaded automatically when processes with CAP_NET_ADMIN try to use ktls, but browsers running as spot don't qualify.