### PR TITLE
Avoid a second rfkill call in rc.sysinit

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -789,7 +789,7 @@ if [ "$BOOT_SCHEDULER" ];then #120704 see /etc/rc.d/BOOTCONSTRAINED, variable se
 fi
 
 # peebee work around for rfkill in some HP laptops
-rfkill list | grep -q "yes" && rfkill unblock wlan
+rfkill unblock wlan
 
 # SFR hack for IO bug http://murga-linux.com/puppy/viewtopic.php?p=681383#681383
 KERNVER=${KERNVER%%-*} # just for appending "-4g","-PAE" or whatever


### PR DESCRIPTION
`rfkill unblock wlan` doesn't do anything if the interface is not blocked, so there's no reason to run `rfkill` to check if `rfkill unblock wlan` is needed.