### PR TITLE
is_mbp is always empty

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -633,7 +633,7 @@ fi
 ##############platform adjustments################## see fd64's #rc.platform
 ###  - do it before we configure network and services
 # detect if it's MacBookPro (mavrothal)
-is_mbp="`dmesg | grep -q -i -m 1 macbookpro`"
+is_mbp="`dmesg | grep -i -m 1 macbookpro`"
 if [ "$is_mbp" ] ; then
 	# enable gpe suppression and mbpfan
 	chmod 755 /etc/init.d/z-disable-spurious-gpe


### PR DESCRIPTION
~~@rizalmart Maybe that's not the only bug introduced?~~

Whoa, it's been this way since 66b42e6 @wdlkmpx 

If this entire thing is broken since at least 2018 (= never worked) and nobody complains, maybe it's a better idea to just remove it? Fixing something broken for years can introduce new issues with today's kernels, and maybe it's not needed anymore. EDIT: see #3447.