### PR TITLE
Auto-accept pupsave upgrade when updating from x.y.z to x.y.z+n

### DIFF
--- a/initrd-progs/0initrd/sbin/validate_pupsave_upgrade
+++ b/initrd-progs/0initrd/sbin/validate_pupsave_upgrade
@@ -32,23 +32,37 @@ OLD_DISTRO_VERSION="$(grep '^DISTRO_VERSION' $OLD_DISTRO_SPECS | cut -f 2 -d '='
 
 MSG=
 
-if [ "$WOOF_VERSION" != "$OLD_WOOF_VERSION" ]; then
-  MSG="
--     WOOF_VERSION=\\033[1;36m${WOOF_VERSION}\\033[0;39m
-- OLD_WOOF_VERSION=\\033[1;36m${OLD_WOOF_VERSION}\\033[0;39m  [pupsave]
-"
-
-elif [ "$DISTRO_NAME" != "$OLD_DISTRO_NAME" ]; then
+if [ "$DISTRO_NAME" != "$OLD_DISTRO_NAME" ]; then
   MSG="
 -     DISTRO_NAME=\\033[1;36m${DISTRO_NAME}\\033[0;39m
 - OLD_DISTRO_NAME=\\033[1;36m${OLD_DISTRO_NAME}\\033[0;39m  [pupsave]
 "
 
 elif [ "$DISTRO_VERSION" != "$OLD_DISTRO_VERSION" ]; then
+  # if both version numbers adhere to MAJOR.MINOR.PATCH, auto-accept upgrade from PATCH to PATCH+n
+  case "$DISTRO_VERSION" in [0-9]*.[0-9]*.[0-9]*)
+    case "$OLD_DISTRO_VERSION" in [0-9]*.[0-9]*.[0-9]*)
+      case "$DISTRO_VERSION" in "${OLD_DISTRO_VERSION%.*}".*)
+        NEW_PATCH="${DISTRO_VERSION##*.}"
+        OLD_PATCH="${OLD_DISTRO_VERSION##*.}"
+        [ "$NEW_PATCH" -gt "$OLD_PATCH" ] && exit 0
+      esac
+      ;;
+    esac
+    ;;
+  esac
+
   MSG="
 -     DISTRO_VERSION=\\033[1;36m${DISTRO_VERSION}\\033[0;39m
 - OLD_DISTRO_VERSION=\\033[1;36m${OLD_DISTRO_VERSION}\\033[0;39m  [pupsave]
 "
+
+elif [ "$WOOF_VERSION" != "$OLD_WOOF_VERSION" ]; then
+  MSG="
+-     WOOF_VERSION=\\033[1;36m${WOOF_VERSION}\\033[0;39m
+- OLD_WOOF_VERSION=\\033[1;36m${OLD_WOOF_VERSION}\\033[0;39m  [pupsave]
+"
+
 fi
 
 if [ "$MSG" ] ; then


### PR DESCRIPTION
The warning against save file upgrades is misleading when it's a safe bugfix release, and all Puppy releases I looked at use a x.y versioning scheme, so they won't be affected.

In addition, I reordered the checks, so we check the distro name first, then the version, then the woof-CE version: in most upgrades, the user should see the changed distro name or version, not the (meaningless) woof-CE version.