### PR TITLE
Add xdg-desktop-portal-wlr to dpup

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -38,8 +38,8 @@ fi
 apply_pthemerc
 
 # pass environment variables to D-Bus activated applications like Blueman
-dbus-update-activation-environment WAYLAND_DISPLAY DISPLAY GDK_BACKEND
-run-as-spot dbus-update-activation-environment WAYLAND_DISPLAY DISPLAY GDK_BACKEND
+dbus-update-activation-environment WAYLAND_DISPLAY DISPLAY GDK_BACKEND XDG_CURRENT_DESKTOP
+run-as-spot dbus-update-activation-environment WAYLAND_DISPLAY DISPLAY GDK_BACKEND XDG_CURRENT_DESKTOP
 
 if [ "$GDK_BACKEND" = "x11" ]; then
 	export QT_QPA_PLATFORM=xcb

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/startdwl
@@ -36,6 +36,9 @@ export PULSE_COOKIE=/home/spot/.config/pulse/cookie
 
 export WLR_XWAYLAND=/usr/bin/Xwayland-spot
 
+# same value as labwc
+export XDG_CURRENT_DESKTOP=wlroots
+
 # hack for virtual machines (see https://github.com/swaywm/sway/issues/5834, https://github.com/swaywm/sway/issues/3814, etc') and hardware that needs third-party drivers
 systemd-detect-virt -qv 2>/dev/null
 if [ $? -eq 0 -o $PUPMODE -eq 5 ]; then

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -315,7 +315,7 @@ yes|libfcft|libfcft4,libfcft-dev|exe,dev,doc,nls||deps:yes
 yes|libffi|libffi8,libffi-dev|exe,dev,doc,nls||deps:yes
 no|libfftw3|libfftw3-3,libfftw3-bin,libfftw3-double3,libfftw3-long3,libfftw3-single3,libfftw3-quad3,libfftw3-dev|exe,dev,doc,nls
 no|libfs|libfs6,libfs-dev|exe,dev,doc,nls #120603 mavrothal reported need this for compiling xorg drivers.
-yes|libfuse2|libfuse2|exe,dev,doc,nls||deps:yes # used by AppImages
+no|libfuse2|libfuse2|exe,dev,doc,nls||deps:yes # used by AppImages
 yes|libgcrypt|libgcrypt20,libgcrypt20-dev|exe,dev,doc,nls||deps:yes
 no|libgd2|libgd3,libgd-dev|exe,dev,doc,nls #needed by libgphoto2.
 no|libgee|libgee-0.8-2,libgee-0.8-dev|exe,dev,doc,nls
@@ -496,7 +496,7 @@ no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 no|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
 no|nss|libnss3|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
-yes|ntfs-3g|ntfs-3g|exe,dev,doc,nls||deps:yes
+no|ntfs-3g|ntfs-3g|exe,dev,doc,nls||deps:yes
 yes|ntpdate|ntpdate|exe,dev,doc,nls||deps:yes #used by psync to sync local time and date from the internet.
 no|numlockx||exe| #needed by shinobars firstrun.
 no|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc,nls #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
@@ -665,6 +665,7 @@ yes|xclip|xclip|exe,dev,doc,nls||deps:yes
 no|xcur2png||exe #pcur needs this
 no|xdelta||exe
 no|xdg-puppy-jwm||exe
+yes|xdg-desktop-portal-wlr|xdg-desktop-portal-wlr|exe,dev,doc,nls||deps:yes
 yes|xdg-utils|xdg-utils|exe,dev,doc,nls||deps:yes
 no|Xdialog||exe
 no|xfdiff-cut||exe

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -315,7 +315,7 @@ yes|libfcft|libfcft4,libfcft-dev|exe,dev,doc,nls||deps:yes
 yes|libffi|libffi8,libffi-dev|exe,dev,doc,nls||deps:yes
 no|libfftw3|libfftw3-3,libfftw3-bin,libfftw3-double3,libfftw3-long3,libfftw3-single3,libfftw3-quad3,libfftw3-dev|exe,dev,doc,nls
 no|libfs|libfs6,libfs-dev|exe,dev,doc,nls #120603 mavrothal reported need this for compiling xorg drivers.
-no|libfuse2|libfuse2|exe,dev,doc,nls||deps:yes # used by AppImages
+yes|libfuse2|libfuse2|exe,dev,doc,nls||deps:yes # used by AppImages
 yes|libgcrypt|libgcrypt20,libgcrypt20-dev|exe,dev,doc,nls||deps:yes
 no|libgd2|libgd3,libgd-dev|exe,dev,doc,nls #needed by libgphoto2.
 no|libgee|libgee-0.8-2,libgee-0.8-dev|exe,dev,doc,nls

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -500,7 +500,7 @@ no|nrg2iso|nrg2iso|exe,dev,doc,nls #used by pburn.
 yes|nscd|unscd|exe||deps:yes
 yes|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
 yes|nss|libnss3|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
-yes|ntfs-3g|ntfs-3g|exe,dev,doc,nls||deps:yes
+no|ntfs-3g|ntfs-3g|exe,dev,doc,nls||deps:yes
 yes|ntpdate|ntpdate|exe,dev,doc,nls||deps:yes #used by psync to sync local time and date from the internet.
 no|numlockx||exe| #needed by shinobars firstrun.
 no|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc,nls #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
@@ -672,6 +672,7 @@ no|xcur2png||exe #pcur needs this
 no|xdelta||exe
 no|xdg-puppy-jwm||exe
 yes|xdg-utils|xdg-utils|exe,dev,doc,nls||deps:yes
+yes|xdg-desktop-portal-wlr|xdg-desktop-portal-wlr|exe,dev,doc,nls||deps:yes
 yes|xdotool|xdotool,libxdo3|exe,dev,doc,nls||deps:yes
 no|Xdialog||exe
 no|xfdiff-cut||exe


### PR DESCRIPTION
labwc sets XDG_CURRENT_DESKTOP and takes care of running dbus-update-activation-environment *for root*.

~~Among other things, this should prevent Blueman from starting as a native Wayland window when running JWM under Xwayland.~~ Moved to 0a5057b

EDIT: super cool stuff, now OBS (from Flatpak!) works. It's a X11 window thanks to 4bd6f3a. Now that xdg-desktop-portal-wlr is installed, screen capture via PipeWire works, in addition to screen capture via X!

![obs](https://user-images.githubusercontent.com/1471149/193824049-7af31e16-7376-4af6-b90d-01a9041cbb42.png)
