### PR TITLE
Apply sysctl.d rules on boot

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -254,6 +254,8 @@ busybox mount -a #Load fstab entries
 
 [ -d /var/run ] && find /var/run -name '*.pid' -delete
 
+sysctl --system
+
 ## process some specific kernel params here
 for i in $(cat /proc/cmdline) ; do
 	case $i in


### PR DESCRIPTION
xdg-desktop-portal-wlr depends on bubblewrap, which adds /usr/lib/sysctl.d/50-bubblewrap.conf, but nothing applies it. This probably affects other packages too.