### PR TITLE
Remove the old and broken continuous TRIM implementation in favor of /etc/init.d/trim

### DIFF
--- a/initrd-progs/0initrd/README.txt
+++ b/initrd-progs/0initrd/README.txt
@@ -226,11 +226,10 @@ pimod=<, separated list of kernel module names>
    But sometimes init needs to request input from the user via the keyboard.
    Specifying kernel modules in this parameter will cause init to load them before any possible keyboard interaction.
 
-pfix=<ram, nox, trim, nocopy, fsck, fsckp, rdsh, <number>>
+pfix=<ram, nox, nocopy, fsck, fsckp, rdsh, <number>>
    The pfix parameter is a ',' separated list of 1 or more of the above sub-parameters.
    ram:      run in ram only (do not load ${DISTRO_FILE_PREFIX}save).
    nox:      do not start X.
-   trim:     add "discard" to mount options if SSD.
    copy:     copy .sfs files into ram
    nocopy:   do not copy .sfs files into ram (default is copy if ram <= 1024 MB).
    fsck:     do fsck of ${DISTRO_FILE_PREFIX}save.?fs file.

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -866,7 +866,6 @@ if [ "$pfix" ];then
    xorgwizard) PXORGWIZARD="yes";;#force xorgwizard for this session
    nox)     PNOX="yes";;          #do not start X.
    clean)   PCLEAN="yes";;        #force version upgrade and cleanup.
-   trim)    PTRIM="yes";;         #add "discard" to mount options if SSD
    copy)    PCOPY="yes";;         #copy .sfs files into ram.
    nocopy)  PNOCOPY="yes";;        #do not copy .sfs files into ram (default is copy if enough ram).
    fsck)    PFSCK="yes";;         #do a fsck of ${DISTRO_FILE_PREFIX}save file.

--- a/initrd-progs/0initrd/sbin/mountpartition
+++ b/initrd-progs/0initrd/sbin/mountpartition
@@ -29,14 +29,7 @@ mkdir -p ${MNT_DIR}
 
 #-----------------------------------------------------
 
-. /etc/rc.d/functions_x
 MNT_O='noatime'
-MNT_DSK=$(fx_get_drvname $MNT_DEV)
-if [ "$MNT_FS" = "ext4" -o "$MNT_FS" = "f2fs" ] ; then
-  if [ "$(cat /sys/block/${MNT_DSK}/queue/rotational 2>/dev/null)" = "0" ] ; then
-    MNT_O="-o discard,noatime" # enable SSD TRIM
-  fi
-fi
 
 case $MNT_FS in
   ntfs)

--- a/woof-code/rootfs-skeleton/sbin/init
+++ b/woof-code/rootfs-skeleton/sbin/init
@@ -138,15 +138,6 @@ PDEV1=${PDEV1##*/} #basename - only want drv name
 
 #exec /bin/ash <dev/console >dev/console 2>&1
 
-if [ "$BOOT_ATIME" = "noatime" -a "$DEV1FS" = "ext4" ] ; then
-	if [ -e /sys/block/${PDEV1}/queue/rotational ] ; then
-		if [ "$(cat /sys/block/${PDEV1}/queue/rotational)" = "0" ] ; then
-			# enable SSD TRIM
-			BOOT_ATIME="discard,noatime"
-		fi
-	fi
-fi
-
 #===================================================================
 #create a ram disk to change /dev/root to /dev/drv and/or check f.s.
 #===================================================================


### PR DESCRIPTION
According to various sources, periodic TRIM is better for SSD health, and that's why we have /etc/init.d/trim. I have an old SSD that becomes unreliable and forces me to reboot every once in a while if a partition is mounted with `discard`.

(And it looks like `pfix=trim` doesn't do anything, because PTRIM is ignored.)

EDIT: and this old support for continuous TRIM is broken since 2019 anyway!