### PR TITLE
Pass WAYLAND_DISPLAY to Flatpak applications

### DIFF
--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/3055.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/3055.patch
@@ -20,7 +20,7 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 -    cmd = exec;
 +    if (g_str_has_prefix(exec, "/usr/bin/flatpak run"))
 +    {
-+      cmd = g_strdup_printf("WAYLAND_DISPLAY= run-as-spot %s", exec);
++      cmd = g_strdup_printf("run-as-spot %s", exec);
 +    }
 +    else
 +    {


### PR DESCRIPTION
Not needed since 0a5057b and 4bd6f3a.