### PR TITLE
Skip hwclock --show on x86 to speed up rc.country

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.country
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.country
@@ -83,15 +83,21 @@ fi
 #======================================
 
 #120629 raspberry pi does not have a hw clock, set date to reasonable value...
-HWDATE="`hwclock --show 2>/dev/null`" #ex: "Fri 29 Jun 2012 07:45:28 AM WST  -0.725833 seconds"
-if [ "$HWDATE" = "" ];then
-	if [ -f /var/local/shutdown_date_saved ];then #see /etc/rc.d/rc.shutdown
-		date -s "`cat /var/local/shutdown_date_saved`"
-	else
-		#either of these formats can set the date: "29 JUN 2012 10:00:00" "2012-06-28 16:20:08"
-		date -s "`stat -c %z /etc/DISTRO_SPECS | cut -f 1 -d '.' | cut -f 1,2 -d ' '`" #creation date of build. ex: "2012-06-28 16:20:08"
-	fi
+if [ -f /var/local/shutdown_date_saved ];then #see /etc/rc.d/rc.shutdown
+	date -s "`cat /var/local/shutdown_date_saved`"
 else
+	#either of these formats can set the date: "29 JUN 2012 10:00:00" "2012-06-28 16:20:08"
+	date -s "`stat -c %z /etc/DISTRO_SPECS | cut -f 1 -d '.' | cut -f 1,2 -d ' '`" #creation date of build. ex: "2012-06-28 16:20:08"
+fi
+HWCLOCK=1
+case $(uname -m) in arm*|aarch*)
+	HWDATE="`hwclock --show 2>/dev/null`" #ex: "Fri 29 Jun 2012 07:45:28 AM WST  -0.725833 seconds"
+	if [ "$HWDATE" = "" ];then
+		HWCLOCK=0
+	fi
+	;;
+esac
+if [ $HWCLOCK -eq 1 ];then
 	if [ "$ASKCLOCK" = "yes" ];then
 		/usr/sbin/timezone-set cli > /dev/console
 		/usr/sbin/set_hwclock_type cli --hctosys > /dev/console #hw to sys


### PR DESCRIPTION
On my Thinkpad, the `hwclock --show` check takes somewhere between 400ms and 1s.

Instead of running `hwclock --show` on any computer that runs Puppy just in case it's a Pi, the logic should be:
1. Set the time using /var/local/shutdown_date_saved or DISTRO_SPECS, as fallback in case set_hwclock_type fails or it's a Pi
2. If it's ARM, run `hwclock --show`
3. Skip set_hwclock_type if this is ARM and `hwclock --show`'s output is empty