### PR TITLE
Add mpv to dpup and jammy64

### DIFF
--- a/woof-code/packages-templates/mpv_FIXUPHACK
+++ b/woof-code/packages-templates/mpv_FIXUPHACK
@@ -1,0 +1,6 @@
+cat << EOF > pinstall.sh
+echo '#!/bin/ash
+[ \$# -eq 0 ] && exec mpv --player-operation-mode=pseudo-gui
+exec mpv "\$@"' > usr/local/bin/defaultmediaplayer
+chmod 755 usr/local/bin/defaultmediaplayer
+EOF

--- a/woof-code/support/rootfs-hacks.sh_desktop
+++ b/woof-code/support/rootfs-hacks.sh_desktop
@@ -61,7 +61,7 @@ fi
 if [ -e ${SR}/usr/share/applications/mpv.desktop ] ; then
 	sed -i \
 		-e 's%Name=.*%Name=mpv%' \
-		-e 's%Comment=.*%Media Player%' \
+		-e 's%Comment=.*%Comment=Media Player%' \
 		-e 's%Exec=.*%Exec=mpv --player-operation-mode=pseudo-gui%' \
 		-e '/TryExec=/d' \
 		-e 's%Categories=.*%Categories=Player%' \

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -268,9 +268,8 @@ no|lcms2|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc,nls
 yes|less|less|exe,dev>null,doc,nls||deps:yes
 no|libaacs|libaacs0,libaacs-dev|exe,dev,doc,nls #mplayer needs this.
 no|libao|libao4,libao-common,libao-dev|exe,dev,doc,nls||deps:yes
-yes|libavcodec|libavcodec59|exe,dev,doc,nls||deps:yes
 no|libappindicator|libappindicator3-1,libappindicator3-dev,libindicator3-7,libindicator3-dev|exe,dev,doc,nls #needs gtk3, needed by transmission. no, using my pet.
-yes|libarchive|libarchive13|exe>dev,dev,doc,nls||deps:yes #needed by cmake.
+yes|libarchive|libarchive13|exe,dev,doc,nls||deps:yes #needed by mpv.
 no|libart|libart-2.0-2,libart-2.0-dev|exe,dev,doc,nls
 yes|libasyncns|libasyncns0|exe,dev,doc,nls||deps:yes #needed by mplayer.
 no|libayatana|libayatana-appindicator3-1,libayatana-indicator3-7,libayatana-indicator7,libayatana-appindicator3-dev,libayatana-ido3-0.4-0,libayatana-ido3-dev|exe,dev,doc,nls
@@ -470,7 +469,7 @@ no|mirdir||exe
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
 no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
-no|mpv|mpv,libguess1,libguess-dev,libuchardet0,libuchardet-dev|exe,dev,doc,nls
+yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 no|mplayer_samba|libsmbclient,libldb1,liblmdb0,libtalloc2,libtevent0,libwbclient0,python-talloc,samba-libs|exe,dev,doc,nls
 no|ms-sys||exe
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls||deps:yes #needed by synaptics_drv.so in xorg.

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -267,9 +267,8 @@ no|lcms2|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc,nls
 yes|less|less|exe,dev>null,doc,nls||deps:yes
 no|libaacs|libaacs0,libaacs-dev|exe,dev,doc,nls #mplayer needs this.
 no|libao|libao4,libao-common,libao-dev|exe,dev,doc,nls||deps:yes
-yes|libavcodec|libavcodec58|exe,dev,doc,nls||deps:yes
 no|libappindicator|libappindicator3-1,libappindicator3-dev,libindicator3-7,libindicator3-dev|exe,dev,doc,nls #needs gtk3, needed by transmission. no, using my pet.
-yes|libarchive|libarchive13|exe>dev,dev,doc,nls||deps:yes #needed by cmake.
+yes|libarchive|libarchive13|exe,dev,doc,nls||deps:yes #needed by mpv.
 no|libart|libart-2.0-2,libart-2.0-dev|exe,dev,doc,nls
 yes|libasyncns|libasyncns0|exe,dev,doc,nls||deps:yes #needed by mplayer.
 no|libayatana|libayatana-appindicator3-1,libayatana-indicator3-7,libayatana-indicator7,libayatana-appindicator3-dev,libayatana-ido3-0.4-0,libayatana-ido3-dev|exe,dev,doc,nls
@@ -467,7 +466,7 @@ no|mirdir||exe
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
 no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
-no|mpv|mpv,libguess1,libguess-dev,libuchardet0,libuchardet-dev|exe,dev,doc,nls
+yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 no|mplayer_samba|libsmbclient,libldb1,liblmdb0,libtalloc2,libtevent0,libwbclient0,python-talloc,samba-libs|exe,dev,doc,nls
 no|ms-sys||exe
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls||deps:yes #needed by synaptics_drv.so in xorg.

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -271,9 +271,8 @@ no|lcms2|liblcms2-2,liblcms2-dev,liblcms2-utils|exe,dev,doc,nls
 yes|less|less|exe,dev>null,doc,nls||deps:yes
 no|libaacs|libaacs0,libaacs-dev|exe,dev,doc,nls #mplayer needs this.
 no|libao|libao4,libao-common,libao-dev|exe,dev,doc,nls||deps:yes
-yes|libavcodec|libavcodec59|exe,dev,doc,nls||deps:yes
 no|libappindicator|libappindicator3-1,libappindicator3-dev,libindicator3-7,libindicator3-dev|exe,dev,doc,nls #needs gtk3, needed by transmission. no, using my pet.
-yes|libarchive|libarchive13|exe>dev,dev,doc,nls||deps:yes #needed by cmake.
+yes|libarchive|libarchive13|exe,dev,doc,nls||deps:yes #needed by mpv.
 no|libart|libart-2.0-2,libart-2.0-dev|exe,dev,doc,nls
 yes|libasyncns|libasyncns0|exe,dev,doc,nls||deps:yes #needed by mplayer.
 no|libayatana|libayatana-appindicator3-1,libayatana-indicator3-7,libayatana-indicator7,libayatana-appindicator3-dev,libayatana-ido3-0.4-0,libayatana-ido3-dev|exe,dev,doc,nls
@@ -474,7 +473,7 @@ no|mirdir||exe
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
 no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
-no|mpv|mpv,libguess1,libguess-dev,libuchardet0,libuchardet-dev|exe,dev,doc,nls
+yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 no|mplayer_samba|libsmbclient,libldb1,liblmdb0,libtalloc2,libtevent0,libwbclient0,python-talloc,samba-libs|exe,dev,doc,nls
 no|ms-sys||exe
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls||deps:yes #needed by synaptics_drv.so in xorg.

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -269,7 +269,7 @@ no|libaacs|libaacs0,libaacs-dev|exe,dev,doc,nls #mplayer needs this.
 no|libao|libao4,libao-common,libao-dev|exe,dev,doc,nls||deps:yes
 no|libavcodec|libavcodec58|exe,dev,doc,nls||deps:yes
 no|libappindicator|libappindicator3-1,libappindicator3-dev,libindicator3-7,libindicator3-dev|exe,dev,doc,nls #needs gtk3, needed by transmission. no, using my pet.
-yes|libarchive|libarchive13|exe>dev,dev,doc,nls||deps:yes #needed by cmake.
+yes|libarchive|libarchive13|exe,dev,doc,nls||deps:yes #needed by mpv.
 no|libart|libart-2.0-2,libart-2.0-dev|exe,dev,doc,nls
 yes|libasyncns|libasyncns0|exe,dev,doc,nls||deps:yes #needed by mplayer.
 no|libayatana|libayatana-appindicator3-1,libayatana-indicator3-7,libayatana-indicator7,libayatana-appindicator3-dev,libayatana-ido3-0.4-0,libayatana-ido3-dev|exe,dev,doc,nls
@@ -468,7 +468,7 @@ no|mirdir||exe
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 no|mpeg2dec|libmpeg2-4,libmpeg2-4-dev|exe,dev,doc,nls #needed by mplayer.
 no|mplayer|mplayer,libdv4,liblirc-client0,libvorbisidec1|exe,dev,doc,nls
-no|mpv|mpv,libguess1,libguess-dev,libuchardet0,libuchardet-dev|exe,dev,doc,nls
+yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 no|mplayer_samba|libsmbclient,libldb1,liblmdb0,libtalloc2,libtevent0,libwbclient0,python-talloc,samba-libs|exe,dev,doc,nls
 no|ms-sys||exe
 yes|mtdev|libmtdev1,libmtdev-dev|exe,dev,doc,nls||deps:yes #needed by synaptics_drv.so in xorg.


### PR DESCRIPTION
This also pulls the `libavcodec%d` dependency, so Firefox is able to decode online videos.