### PR TITLE
Remove broken handling of pfix={nox,xorgwizard} from rc.sysinit

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -262,15 +262,6 @@ for i in $(cat /proc/cmdline) ; do
 		inteluxa|intel_uxa|uxa) xorg_intel_uxa.sh ;;
 		xerrs)   rm -f /var/local/xwin_disable_xerrs_log_flag ;; # see xwin / bootmanager
 		noxerrs) touch /var/local/xwin_disable_xerrs_log_flag ;; # see xwin / bootmanager
-		pfix=*)
-			pfix=${i#pfix=} #remove pfix=
-			for ONEFIX in ${pfix//,/ } ; do
-				case $ONEFIX in
-					xorgwizard) /tmp/xwin_xorgwizard_cli ;; 
-					nox)        /tmp/bootcnt.txt ;;
-				esac
-			done
-			;;
 	esac
 done
 


### PR DESCRIPTION
Yet another years-old bug! This one was introduced in e0d75cc299.

This block never worked: it should have been `touch /tmp/xwin_xorgwizard_cli` and `touch /tmp/bootcnt.txt`. Without `touch`, it tries to run a non-existing file.