### PR TITLE
Produce a useful bootinit.log on loglevel=7

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -55,6 +55,7 @@ L_SFFS_ERROR="ERROR: savefile filesystem is not ext2/3/4"
 
 /sbin/usablefs # mount: /proc /sys /dev / (proc sysfs devtmpfs rootfs)
 
+read LOGLEVEL ETC < /proc/sys/kernel/printk
 for i in $(cat /proc/cmdline) ; do
   case $i in
     fullinstall) exec ash /sbin/init_full_install ;;
@@ -94,6 +95,7 @@ KBUILD_DEF_FN="kbuild-$KERNELVER.sfs"
 
 if [ ! "$LOGLEVEL" ] ; then
   echo '3' > /proc/sys/kernel/printk # '3' is the standard loglevel.
+  LOGLEVEL=3
 fi
 
 #List the builtin filesystem support
@@ -824,7 +826,8 @@ echo -en "\\033[0;34m -\\033[0;37m Linux ${KERNELVER} "
 echo -en "\\033[0;31m[\\033[0;37m`uname -m`\\033[0;31m]"
 echo -e "\\033[0;34m ***\\033[0;39m"
 
-[ ! "$LOGLEVEL" ] && exec 1>/tmp/bootinit.log 2>&1 #remove o/p from console. v2.22 loglevel added.
+[ "$LOGLEVEL" -eq 7 ] && set -x
+[ "$LOGLEVEL" -le 3 -o "$LOGLEVEL" -eq 7 ] && exec 1>/tmp/bootinit.log 2>&1 #remove o/p from console. v2.22 loglevel added.
 
 [ ! -f /bin/resize2fs ] && touch /tmp/no_resize2fs
 


### PR DESCRIPTION
If `loglevel=7` (`KERN_DEBUG`), bootinit.log is not produced, so `loglevel=7` is hardly useful. In addition, it's hard to tell why something failed (things like #3489) without `-x`.