### PR TITLE
Remove glib-memory-alloc

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile.d/glib-memory-alloc
+++ b/woof-code/rootfs-skeleton/etc/profile.d/glib-memory-alloc
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-export G_SLICE="always_malloc"


### PR DESCRIPTION
`G_SLICE=always-malloc` is a debugging feature and shouldn't be enabled normally.

@rizalmart Why is it needed? What applications depend on this debugging feature?