### PR TITLE
If not using ROX-Filer, let the file manager define mimeapps.list

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -934,20 +934,55 @@ exec $value \"\$@\"" > ${DRV_TGT}/usr/local/bin/$field
 	chmod 755 ${DRV_TGT}/usr/local/bin/$field
 done
 
-echo "Checking for missing default apps ..."
-for default in rootfs-complete/usr/local/bin/default* ; do
-    app=${default##*/}
-    app=${app/default/}
-    dexec=`grep '^exec' $default | cut -f 2 -d " "`
-    chroot rootfs-complete sh -c "command -v $dexec >/dev/null 2>&1" && continue
+if [ -e rootfs-complete/usr/local/apps/ROX-Filer/AppRun ]; then
+	echo "Checking for missing default apps ..."
+	for default in rootfs-complete/usr/local/bin/default* ; do
+		app=${default##*/}
+		app=${app/default/}
+		dexec=`grep '^exec' $default | cut -f 2 -d " "`
+		chroot rootfs-complete sh -c "command -v $dexec >/dev/null 2>&1" && continue
 
-    echo -n "$dexec "
-    cat << EOF > $default
+		echo -n "$dexec "
+		cat << EOF > $default
 #!/bin/sh
 exec missingdefaultapp $app
 EOF
-done
-echo
+	done
+	echo
+else
+	echo "Setting up default apps via xdgdefaultapp ..."
+
+	rm -f rootfs-complete/usr/share/applications/mimeapps.list \
+	      rootfs-complete/usr/share/applications/mimeinfo.cache \
+	      rootfs-complete/usr/share/applications/default*.desktop \
+	      rootfs-complete/usr/share/applications/puppyapps.desktop
+
+	for PAIR in defaultarchiver=application/x-tar \
+	            defaultaudioeditor=audio/x-wav \
+	            defaultaudioplayer=audio/x-mp3 \
+	            defaultbrowser=x-scheme-handler/https \
+	            defaultcdplayer=audio/x-mp3 \
+	            defaultchat=x-scheme-handler/ircs \
+	            defaultdraw=image/svg+xml \
+	            defaultemail=x-scheme-handler/mailto \
+	            defaulthtmleditor=text/plain \
+	            defaulthtmlviewer=text/html \
+	            defaultimageeditor=image/bmp \
+	            defaultimageviewer=image/bmp \
+	            defaultmediaplayer=video/mp4 \
+	            defaultpaint=image/bmp \
+	            defaultpdfviewer=application/pdf \
+	            defaultspreadsheet=application/vnd.oasis.opendocument.spreadsheet \
+	            defaulttexteditor=text/plain \
+	            defaulttextviewer=text/plain \
+	            defaulttorrent=application/x-bittorrent \
+	            defaultwordprocessor=application/vnd.oasis.opendocument.text; do
+		cat << EOF > rootfs-complete/usr/local/bin/${PAIR%=*}
+#!/bin/ash
+exec xdgdefaultapp "${PAIR#*=}" "\$@"
+EOF
+	done
+fi
 
 [ -n "$QEMU" ] && rm -f rootfs-complete/${QEMU}
 

--- a/woof-code/rootfs-skeleton/usr/local/bin/xdgdefaultapp
+++ b/woof-code/rootfs-skeleton/usr/local/bin/xdgdefaultapp
@@ -1,0 +1,18 @@
+#!/bin/ash
+
+# this script detects the default MIME type handler for argv[1], then invokes it with argv[2:]
+
+DEFAULT=`xdg-mime query default "$1" 2>/dev/null`
+if [ -n "$DEFAULT" ]; then
+	IFS=:
+	for DIR in $XDG_DATA_DIRS; do
+		[ ! -e "$DIR/applications/$DEFAULT" ] && continue
+		EXEC=`grep -m1 ^Exec= "$DIR/applications/$DEFAULT" | sed -e s/^Exec=// -e s/\ %.$// -e s/\ @@.*//`
+		[ -z "$EXEC" ] && continue
+		shift
+		grep -qm1 ^Terminal=true "$DIR/applications/$DEFAULT" && exec defaultterminal -e $EXEC "$@"
+		exec $EXEC "$@"
+	done
+fi
+
+exec missingdefaultapp "$1"


### PR DESCRIPTION
The way xdg-utils works in Puppy is a hack:
1. There are hidden menu entries for `default%s` applications
2. These hidden pseudo-applications are configured as the default for various MIME types and URL schemes in woof-code/rootfs-skeleton/usr/share/applications/mimeapps.list
3. ROX-Filer has its own list of handlers (in /etc/xdg/rox.sourceforge.net/MIME-types): it uses `default%s` as well
4. Applications other than ROX-Filer respect mimeapps.list and not the ROX-Filer scripts, so they use the same handlers
5. A Puppy-specific application configures default MIME type handlers **by modifying `default%s`, rather than modifying ~/.config/mimeapps.list** like GNOME, Xfce, etc' do
6. xdg-open is replaced with a stub that runs ROX-Filer, because mimeapps.list defines only a subset of the handlers in ROX-Filer's internal list of handlers

This pile of hacks replaces the source of truth, which should be mimeapps.list, with the `default%s` applications, and only because ROX-Filer doesn't respect mimeapps.list.

This PR removes this hack **if ROX-Filer is missing**:
1. Puppy's special xdg-open is still there, and still uses the file manager to open files
2. The file manager shows a dialog that lets the user choose the MIME type handler and adds it to mimeapps.list, if no handler is configured, otherwise it invokes the handler
3. The `default%s` applications invoke configured MIME type handlers by querying them via `xdg-mime`

This logic should work equally well with pcmanfm and spacefm, making Puppy more compatible with DEs and applications that obey the XDG standards, while retaining backward compatibility with old Puppy tools that  invoke `default%s`.