### PR TITLE
Add support for including docx and nlsx in the ISO

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -396,15 +396,6 @@ do
 				cp -a --remove-destination ${ONEDIR}/* ${DOC_DIR}/${ONEDIR}/
 				rm -rf ${ONEDIR}
 			fi
-			if [ "$INCLUDE_MAN_PAGES" = "yes" -a -z "$EXE" ]; then
-				case "$ONEDIR" in
-				*"/man")
-					mkdir -p ${ONEDIR}
-					cp -av --remove-destination ${DOC_DIR}/${ONEDIR}/man[1-9]* ${ONEDIR}
-					rm -rf ${DOC_DIR}/${ONEDIR}/man[1-9]*
-					;;
-				esac
-			fi
 			continue
 			;;
 		#-- DEV -- development

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1124,11 +1124,17 @@ if [ "$SDFLAG" = "" ] ; then #120506
 			mv -f ${DEVXSFS} ../${WOOF_OUTPUT}/
 			( cd ../${WOOF_OUTPUT} ; md5sum ${DEVXSFS} > ${DEVXSFS}.md5.txt )
 		fi
-		if [ -f ${DOCXSFS} ] ; then
+		if [ -f ${DOCXSFS} -a "$DOCX_IN_ISO" = "yes" ] ; then #_00build.conf
+			XTRA_FLG="${XTRA_FLG}-docx"
+			mv -f ${DOCXSFS} ./build/
+		elif [ -f ${DOCXSFS} ] ; then
 			mv -f ${DOCXSFS} ../${WOOF_OUTPUT}/
 			( cd ../${WOOF_OUTPUT} ; md5sum ${DOCXSFS} > ${DOCXSFS}.md5.txt )
 		fi
-		if [ -f ${NLSXSFS} ] ; then
+		if [ -f ${NLSXSFS} -a "$NLSX_IN_ISO" = "yes" ] ; then #_00build.conf
+			XTRA_FLG="${XTRA_FLG}-nlsx"
+			mv -f ${NLSXSFS} ./build/
+		elif [ -f ${NLSXSFS} ] ; then
 			mv -f ${NLSXSFS} ../${WOOF_OUTPUT}/
 			( cd ../${WOOF_OUTPUT} ; md5sum ${NLSXSFS} > ${NLSXSFS}.md5.txt )
 		fi

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -202,10 +202,6 @@ fi
 mkdir -p bdrv_NLS/usr/share bdrv_DOC/usr/share
 mv bdrv/usr/share/locale bdrv_NLS/usr/share/
 mv bdrv/usr/share/doc bdrv/usr/share/info bdrv/usr/share/man bdrv_DOC/usr/share/
-if [ "$INCLUDE_MAN_PAGES" = "yes" ]; then
-	mkdir -p bdrv/usr/share/man
-	mv -v bdrv_DOC/usr/share/man/man[1-9]* bdrv/usr/share/man/
-fi
 if [ -d bdrv/usr/share/gnome/help ]; then
 	mkdir -p bdrv_DOC/usr/share/gnome
 	mv bdrv/usr/share/gnome/help bdrv_DOC/usr/share/gnome/

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -319,11 +319,6 @@ for NAME in $PKGS; do
         mv ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/${DOCDIR} ../packages-${DISTRO_FILE_PREFIX}/${NAME}_DOC/usr/share/
     done
 
-    if [ "$INCLUDE_MAN_PAGES" = "yes" -a -d ../packages-${DISTRO_FILE_PREFIX}/${NAME}_DOC/usr/share/man ]; then
-        mkdir ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/man
-        mv -v ../packages-${DISTRO_FILE_PREFIX}/${NAME}_DOC/usr/share/man/man[1-9]* ../packages-${DISTRO_FILE_PREFIX}/${NAME}/usr/share/man/
-    fi
-
     for SUFFIX in _DOC _NLS; do
         [ ! -d ../packages-${DISTRO_FILE_PREFIX}/${NAME}${SUFFIX} ] && continue
         sed -e "s/^${NAME}/${NAME}${SUFFIX}/" -e "s/|${NAME}/|${NAME}${SUFFIX}/g" ../packages-${DISTRO_FILE_PREFIX}/${NAME}/pet.specs > ../packages-${DISTRO_FILE_PREFIX}/${NAME}${SUFFIX}/pet.specs

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -34,6 +34,12 @@ BUILD_DEVX=yes
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no
 
+## include docx SFS in ISO?
+DOCX_IN_ISO=yes
+
+## include nlsx SFS in ISO?
+NLSX_IN_ISO=yes
+
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -98,9 +98,6 @@ fi
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
-## include man pages in main SFS?
-INCLUDE_MAN_PAGES=yes
-
 ## ucode.cpio initial ram disk with CPU bugfixes
 ## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown
 ## You can specify 'amd' or 'intel' as args to latest_microcode.sh

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -34,6 +34,12 @@ BUILD_DEVX=yes
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no
 
+## include docx SFS in ISO?
+DOCX_IN_ISO=yes
+
+## include nlsx SFS in ISO?
+NLSX_IN_ISO=yes
+
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -84,9 +84,6 @@ PTHEME="412"
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
-## include man pages in main SFS?
-INCLUDE_MAN_PAGES=yes
-
 ## ucode.cpio initial ram disk with CPU bugfixes
 ## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown
 ## You can specify 'amd' or 'intel' as args to latest_microcode.sh

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -34,6 +34,12 @@ BUILD_DEVX=yes
 ## include devx SFS in ISO?
 DEVX_IN_ISO=no
 
+## include docx SFS in ISO?
+DOCX_IN_ISO=yes
+
+## include nlsx SFS in ISO?
+NLSX_IN_ISO=yes
+
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -83,9 +83,6 @@ PTHEME="412"
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
-## include man pages in main SFS?
-INCLUDE_MAN_PAGES=yes
-
 ## ucode.cpio initial ram disk with CPU bugfixes
 ## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown
 ## You can specify 'amd' or 'intel' as args to latest_microcode.sh

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -77,9 +77,6 @@ PTHEME="Tahrpup"
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
-## include man pages in main SFS?
-INCLUDE_MAN_PAGES=yes
-
 ## ucode.cpio initial ram disk with CPU bugfixes
 ## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown
 ## You can specify 'amd' or 'intel' as args to latest_microcode.sh


### PR DESCRIPTION
Some users and even reviewers complain about lack of support for non-English languages and the misleading message that asks the user to find non-existing "language packs". Many Puppy users will be happy with nlsx in the ISO, and those who speak English or don't want it can delete this small SFS.

In addition, this PR replaces the `INCLUDE_MAN_PAGES=yes` mechanism with something less fine-grained that's easier to maintain and less likely to break. Users who want man pages won't mind the other kinds of documentation, and those who don't want documentation can delete this SFS, too.