### PR TITLE
Disable the Blueman tray icon on x86_64

### DIFF
--- a/woof-code/packages-templates/blueman_FIXUPHACK
+++ b/woof-code/packages-templates/blueman_FIXUPHACK
@@ -8,4 +8,4 @@ chroot . /usr/sbin/setup-spot blueman-manager=true
 EOF
 
 # the tray applet is written in Python and eats up precious RAM
-[ "$DISTRO_TARGETARCH" = "x86" ] && rm -vf etc/xdg/autostart/blueman.desktop
+rm -vf etc/xdg/autostart/blueman.desktop


### PR DESCRIPTION
It eats way too much RAM in bookworm64, and Blueman is responsible for a significant portion of the total RAM consumption of the empty bookworm64 desktop. Tray icons are gone in the post-X11 world, so let's just disable it!