### PR TITLE
Escape dots when replacing the kernel version in .config (fixes #3511)

### DIFF
--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -96,6 +96,7 @@ if [ -n "$DOTconfig_file" -a -n "$LatestK" ] ; then
 		DOTconfig_new_ver=${DOTconfig_new_ver_pre% *}
 		DOTconfig_type=${DOTconfig_new_ver_pre#* }
 		log_msg "Latest Linux $DOTconfig_new_ver $DOTconfig_type"
+		b=`echo "$b" | sed 's/\\./\\\\./g'`
 		NEW_DOTconfig_file=`echo $DOTconfig_file | sed "s%$b%$DOTconfig_new_ver%"`
 		log_msg "New DOTconfig_file is $NEW_DOTconfig_file"
 		mv $DOTconfig_file $NEW_DOTconfig_file


### PR DESCRIPTION
```
~$ b=6.0
~$ DOTconfig_new_ver=6.0.2
~$ (echo CONFIG_ISO9660_FS=y; echo "This is Linux 6.0") | sed "s%$b%$DOTconfig_new_ver%"
CONFIG_ISO96.0.2_FS=y      <- bug
This is Linux 6.0.2
~$ b=`echo "$b" | sed 's/\\./\\\\./g'` <- fix
~$ (echo CONFIG_ISO9660_FS=y; echo "This is Linux 6.0") | sed "s%$b%$DOTconfig_new_ver%"
CONFIG_ISO9660_FS=y    <- no bug
This is Linux 6.0.2
```