### PR TITLE
Fix failure of find_onepupdrv after the /mnt/{pdrv,dev_save} renaming

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -366,12 +366,8 @@ setup_onepupdrv() {
   ONE_MP="" #actually it's '/'.
   COPY2RAM='yes' #actually it is already in ram, but load_sfs_file code puts it in a tmpfs.
  else
-  if [ "$ONE_PART" = "$P_PART" ];then
-   ONE_MP="$P_MP"
-  else
-   ONE_MP="$(mount | grep -m1 "/dev/$ONE_PART " | cut -f 3 -d ' ')"
-   [ "$ONE_MP" ] || return 2
-  fi
+  ONE_MP="$(mount | grep -m1 "/dev/$ONE_PART " | cut -f 3 -d ' ')"
+  [ "$ONE_MP" ] || return 2
  fi
  ONE_FN="${ONE_MP}${ONE_REL_FN}"
  ONE_BASENAME="$(basename $ONE_REL_FN)"


### PR DESCRIPTION
`$ONE_PART` is no longer mounted at `P_PART` (=`/mnt/pdrv`) after it's moved to `/mnt/dev_save`, and that explains #3489.