### PR TITLE
Work around corruption of quicksetup by forcing Xwayland (fixes #3322)

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -1161,7 +1161,7 @@ export QUICKSETUP_DIALOG='
 wPID=0
 if [ -n "$DISPLAY" -o -n "$WAYLAND_DISPLAY" ];then
  . /usr/lib/gtkdialog/xml_info gtk #build bg_pixmap for gtk-theme
- RETVALS="`gtkdialog -p QUICKSETUP_DIALOG --styles=/tmp/gtkrc_xml_info.css --geometry="${WVAL}x${HVAL}" 2>/dev/null`"
+ RETVALS="`GDK_BACKEND=x11 gtkdialog -p QUICKSETUP_DIALOG --styles=/tmp/gtkrc_xml_info.css --geometry="${WVAL}x${HVAL}" 2>/dev/null`"
  eval "$RETVALS"
  [ "$EXIT" != "OK" -a "$EXIT" != "NVIDIA" ] && exit
 


### PR DESCRIPTION
This can be reverted when wlroots 0.16.0 is out and all build configurations with dwl and labwc are migrated to it, assuming wlroots 0.16.0 fixes this issue.