### PR TITLE
Update cache files if the SFS stack has changed

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -328,7 +328,8 @@ cp -af ${NEWFILESMNTPT}/etc/DISTRO_SPECS /etc/
 touch /etc/DISTRO_SPECS #important, as snapmergepuppy uses '-u' cp option. ...huh, why?
 
 # if aufs layers have changed, may need to fix menu (etc)...
-if [ "$PUNIONFS" = "aufs" ];then
+. /etc/rc.d/PUPSTATE
+if [ "$PUNIONFS" = "aufs" -o "$PUNIONFS" = "overlay" ];then
 	. /etc/rc.d/BOOTCONFIG
 	# multisession-cd, different folder at each startup, so screen out...
 	xLASTUNIONRECORD="`echo -n "$LASTUNIONRECORD" | sed -e 's/^20[0-9][0-9][-0123456789]* //'`"
@@ -336,7 +337,7 @@ if [ "$PUNIONFS" = "aufs" ];then
 	#-
 	if [ "$xLASTUNIONRECORD" != "$xPREVUNIONRECORD" ];then
 		echo -en " layered-filesystem \\033[1;35mnext boot will be faster!\\033[0;39m" > /dev/console
-		echo "Aufs layers have changed since previous boot, updating menus..."
+		echo "$PUNIONFS layers have changed since previous boot, updating menus..."
 		update_cache_files
 	fi
 fi


### PR DESCRIPTION
Is this block broken since it was introduced in 7f4f1841ad? `PUNIONFS` is undefined because rc.update doesn't source PUPSTATE.