### PR TITLE
Remove spurious \ in mount-pup

### DIFF
--- a/woof-code/rootfs-skeleton/bin/mount-pup
+++ b/woof-code/rootfs-skeleton/bin/mount-pup
@@ -39,7 +39,7 @@ MYPID=${$}
 
 #extract all the '-' options, on separate lines... do NOT use $@!!!!...
 #v3.93 eliminate ' -- ' and all past it...
-DASHOPTS="`echo "$*" | tr '\t' ' '  | sed -e 's/ -- .*//' | tr ' ' '\n' | grep '^\-'`"
+DASHOPTS="`echo "$*" | tr '\t' ' '  | sed -e 's/ -- .*//' | tr ' ' '\n' | grep '^-'`"
 
 case "$*" in
 	*' vfat '*) VFAT_FLAG=yes ;;


### PR DESCRIPTION
Causes warning in new grep