### PR TITLE
Speed up rc.country by trying busybox hwclock first

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.country
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.country
@@ -83,7 +83,8 @@ fi
 #======================================
 
 #120629 raspberry pi does not have a hw clock, set date to reasonable value...
-HWDATE="`hwclock --show 2>/dev/null`" #ex: "Fri 29 Jun 2012 07:45:28 AM WST  -0.725833 seconds"
+HWDATE="`busybox hwclock --show 2>/dev/null`"
+[ "$HWDATE" = "" ] && HWDATE="`hwclock --show 2>/dev/null`" #ex: "Fri 29 Jun 2012 07:45:28 AM WST  -0.725833 seconds"
 if [ "$HWDATE" = "" ];then
 	if [ -f /var/local/shutdown_date_saved ];then #see /etc/rc.d/rc.shutdown
 		date -s "`cat /var/local/shutdown_date_saved`"


### PR DESCRIPTION
`strace -T hwclock --show` shows that `hwclock` wastes time in this select() call, almost a second on my laptop:

```
openat(AT_FDCWD, "/dev/rtc0", O_RDONLY) = 4 <0.000021>
...
ioctl(4, RTC_UIE_ON)                    = 0 <0.000202>
pselect6(5, [4], NULL, NULL, {tv_sec=10, tv_nsec=0}, NULL) = 1 (in [4], left {tv_sec=9, tv_nsec=296592327}) <0.703507>
ioctl(4, PHN_NOT_OH or RTC_UIE_OFF)     = 0 <0.000133>
ioctl(4, RTC_RD_TIME, {tm_sec=26, tm_min=17, tm_hour=14, tm_mday=22, tm_mon=9, tm_year=122, ...}) = 0 <0.000163>
```

... while `busybox hwclock --show` doesn't do that:

```
openat(AT_FDCWD, "/dev/rtc", O_RDONLY)  = 3 <0.000023>
ioctl(3, RTC_RD_TIME, {tm_sec=35, tm_min=18, tm_hour=14, tm_mday=22, tm_mon=9, tm_year=122, ...}) = 0 <0.000047>
```

99% of computers running Puppy are x86 computers, so `hwclock --show` should work, and we waste 1s of boot time only because a minority of users runs Puppy on a Pi.

If #3461 looks like a scary change, maybe this PR won't. It changes rc.country so it tries the faster busybox hwclock first: if the output is not empty, "real" hwclock is skipped.

Inspired by https://bkhome.org/news/202210/set-hwclock-type-gui-improved.html.