### PR TITLE
Make releases workflow set prefix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
       unionfs: ${{ github.event.inputs.unionfs }}
       artifact: ${{ github.workflow }}-${{ github.event.inputs.arch }}-${{ github.event.inputs.compat-distro }}-${{ github.event.inputs.compat-distro-version }}-${{ github.run_number }}
       retention: 1
+      prefix: ${{ github.event.inputs.prefix }}
   upload:
     needs: build
     runs-on: ubuntu-20.04


### PR DESCRIPTION
Latest commits to the github workflow system disabled a user to set prefix by running directly the releases workflow in github.

Resolved the issue by making `releases` workflow file call `build` workflow file while setting `prefix` variable as well.