### PR TITLE
Call extended_update if docx is auto-loaded on first boot (fixes #3536)

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -19,6 +19,9 @@ status_func() {
 #set -x
 
 . /etc/DISTRO_SPECS
+. /etc/rc.d/PUPSTATE
+. /etc/rc.d/BOOTCONFIG
+
 if [ "$DISTRO_ARCHDIR" ] ; then
 	ARCHDIR="/$DISTRO_ARCHDIR"
 fi
@@ -184,7 +187,17 @@ case $PUPMODE in
   #PUPMODE=5 is first boot, ignore.
   /usr/sbin/savesession-dvd 5 # creates /archive if booting from cd..
   basic_update
-  if [ -f /etc/rc.d/WOOFMERGEVARS ];then # inserted by 3builddistro.
+  EXTENDED=0
+  for SFS in $LASTUNIONRECORD;do
+   case "$SFS" in
+   devx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs|docx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs|nlsx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs)
+    extended_update
+    EXTENDED=1
+    break
+    ;;
+   esac
+  done
+  if [ $EXTENDED -eq 0 -a -f /etc/rc.d/WOOFMERGEVARS ];then # inserted by 3builddistro.
    . /etc/rc.d/WOOFMERGEVARS
    if [ "$WOOF_HOSTARCH" != "$WOOF_TARGETARCH" -a -z "$WOOF_QEMU" ];then #woof did a cross-build
     if [ "$WOOF_HOSTARCH" != "x86_64" -o "$WOOF_TARGETARCH" != "x86" ]; then
@@ -329,9 +342,7 @@ cp -af ${NEWFILESMNTPT}/etc/DISTRO_SPECS /etc/
 touch /etc/DISTRO_SPECS #important, as snapmergepuppy uses '-u' cp option. ...huh, why?
 
 # if aufs layers have changed, may need to fix menu (etc)...
-. /etc/rc.d/PUPSTATE
 if [ "$PUNIONFS" = "aufs" -o "$PUNIONFS" = "overlay" ];then
-	. /etc/rc.d/BOOTCONFIG
 	# multisession-cd, different folder at each startup, so screen out...
 	xLASTUNIONRECORD="`echo -n "$LASTUNIONRECORD" | sed -e 's/^20[0-9][0-9][-0123456789]* //'`"
 	xPREVUNIONRECORD="`echo -n "$PREVUNIONRECORD" | sed -e 's/^20[0-9][0-9][-0123456789]* //'`"

--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -1318,7 +1318,15 @@ if [ "$SET_LOCALE" ];then
   fi
   [ "$MYBASE" = "chooselocale" ] && [ "$PARAM1" = "cli" ] && exit #refer rc.country.
 
-  if [ "$OLDLANGLINE" != "$NEWLANGLINE" -a ! -e /var/local/nlsx_loaded ];then
+  NLSX_LOADED=0
+  for SFS in $LASTUNIONRECORD;do
+   if [ "$SFS" = "nlsx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs" ];then
+    NLSX_LOADED=1
+    break
+   fi
+  done
+
+  if [ "$OLDLANGLINE" != "$NEWLANGLINE" -a $NLSX_LOADED -eq 0 ];then
    #120213 need language-pack...
    LANG1=${LANGCHOICE%_*}  #"`echo -n $LANGCHOICE | cut -f 1 -d '_'`"  #ex: de
    LANG12=${LANGCHOICE%.*} #"`echo -n $LANGCHOICE | cut -f 1 -d '.'`" #ex: de_DE

--- a/woof-code/support/docx_nlsx.sh
+++ b/woof-code/support/docx_nlsx.sh
@@ -61,8 +61,6 @@ if [ "$BUILD_NLSX" = "yes" ] ; then
 	fi
 	echo
 	rm -f nlsx/pet.specs
-	mkdir -p nlsx/var/local
-	touch nlsx/var/local/nlsx_loaded
 	[ "$USR_SYMLINKS" = "yes" ] && usrmerge nlsx 0
 	echo "Creating $NLSXSFS..."
 	[ -d nlsx/root ] && busybox chmod 700 nlsx/root


### PR DESCRIPTION
That `chroot rootfs-complete /etc/rc.d/rc.update w` in 3builddistro runs against rootfs-complete without the files in devx, docx and nlsx. Some caches are not what they should be: for example, `man -k` doesn't work because the cache generated during 3builddistro doesn't list the man pages in docx.

#3521 takes care of updating these caches if docx is no longer queued for loading. However, it doesn't deal with the corner case PUPMODE 5 and an auto-loaded docx.

Therefore, the smallest and safest fix I see is calling extended_update if PUPMODE 5 and any of these SFSs is loaded.

(Needs #3547)