### PR TITLE
Fill LASTUNIONRECORD and PREVUNIONRECORD on first boot

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1398,8 +1398,8 @@ if [ "$PUPSAVE" ];then
  echo "$xBOOTCONFIG" > /pup_new/etc/rc.d/BOOTCONFIG
  echo "LASTUNIONRECORD='$(echo -n $NEWUNIONRECORD)'" >> /pup_new/etc/rc.d/BOOTCONFIG
 else
- echo "" > /pup_new/etc/rc.d/BOOTCONFIG
- echo "LASTUNIONRECORD=''" >> /pup_new/etc/rc.d/BOOTCONFIG
+ echo "PREVUNIONRECORD='$(echo -n $NEWUNIONRECORD)'" > /pup_new/etc/rc.d/BOOTCONFIG
+ echo "LASTUNIONRECORD='$(echo -n $NEWUNIONRECORD)'" >> /pup_new/etc/rc.d/BOOTCONFIG
 fi
 
 echo -n "$(printf "${L_SWITCH_ROOT}" "${UNIONFS}")" >/dev/console


### PR DESCRIPTION
Otherwise, applications can't tell if devx, docx and nlsx are auto-loaded on first boot (#3506).