### PR TITLE
When using overlay, display {dev,doc,nls}x as auto-loaded SFSs

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -88,7 +88,7 @@ BUTTONS=""
 KBUILDSFS="kbuild-`uname -r`.sfs"
 for SFS in `find $SFS_DIRS -maxdepth 1 -name '*.sfs' -printf '%f\n' | sort | uniq`; do
 	case "$SFS" in
-	$DISTRO_BDRVSFS|$DISTRO_PUPPYSFS|$DISTRO_ZDRVSFS|$DISTRO_FDRVSFS|$DISTRO_ADRVSFS|$DISTRO_YDRVSFS|$KBUILDSFS)
+	$DISTRO_BDRVSFS|$DISTRO_PUPPYSFS|$DISTRO_ZDRVSFS|$DISTRO_FDRVSFS|$DISTRO_ADRVSFS|$DISTRO_YDRVSFS|$KBUILDSFS|devx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs|docx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs|nlsx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs)
 		BUTTONS="<togglebutton><label>$SFS</label><default>true</default><sensitive>false</sensitive></togglebutton>$BUTTONS"
 		continue
 		;;


### PR DESCRIPTION
Regression since #3506.