### PR TITLE
Kill the login shell to source /etc/profile again on locale change

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -1680,6 +1680,11 @@ if [ "`echo -n "$FLAG_CHANGED" | grep "restart"`" != "" ];then
  if [ "$EXIT" = "OK" ];then
   rm -rf /tmp/.X0-lock
   sync
+  SHELL=`pidof -- -sh`
+  if [ -n "$SHELL" ];then
+   rm -f /tmp/bootcnt.txt /root/.XLOADED
+   exec kill -HUP $SHELL
+  fi
   exec restartwm
  fi
 fi


### PR DESCRIPTION
"Restarting X" in the sense of running `restartwm` is not enough because it doesn't source /etc/profile. xwin exits and re-runs itself. To truly change the locale, the login shell needs to be killed to run a new login shell.