### PR TITLE
Run fixmenus on locale change if nlsx is loaded

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/quicksetup
+++ b/woof-code/rootfs-skeleton/usr/sbin/quicksetup
@@ -1412,14 +1412,15 @@ Note: Before downloading the langpack, you will have to make an Internet connect
      fi
     fi
    fi
+  fi
 
    #120209 scripts fixdesk and fixmenus translate files to new language (as specified in /usr/share/sss/menu_strings and desk_strings).
    #so need to call them here...
    #note, these are also called in /etc/rc.d/rc.update ...
+  if [ "$OLDLANGLINE" != "$NEWLANGLINE" ];then
    LANG=${LANGCHOICE}${UTF8} fixdesk
    LANG=${LANGCHOICE}${UTF8} fixmenus
    #...no need to refresh screen, as changing locale requires restart of X.
-
   fi
  fi
 fi #end SET_LOCALE


### PR DESCRIPTION
`fixdesk` and `fixdesk` run only if the locale has changed and nlsx is not loaded. Instead, they should run on locale change even if nlsx is loaded: only the misleading message about language packs should be skipped if nlsx loaded.