### PR TITLE
Drop trimming of sof-bin and use upstream tarballs

### DIFF
--- a/.github/workflows/dpup-kernel.yml
+++ b/.github/workflows/dpup-kernel.yml
@@ -39,7 +39,7 @@ jobs:
           [ ${{ matrix.release }} = sid ] || echo "deb http://deb.debian.org/debian-security ${{ matrix.release }}-security main contrib non-free" >> /etc/apt/sources.list
           [ ${{ matrix.arch }} != x86 ] || dpkg --add-architecture i386
           apt-get update -qq
-          apt-get install -y --no-install-recommends curl wget ca-certificates git file squashfs-tools xz-utils diffutils patch make flex bison python3 bc bzip2 kmod rsync libelf-dev libssl-dev dwarves gcc
+          apt-get install -y --no-install-recommends curl wget ca-certificates git file squashfs-tools xz-utils diffutils patch make flex bison python3 bc bzip2 kmod rsync libelf-dev libssl-dev dwarves gcc jq
           apt-get install -y linux-source
           [ ${{ matrix.arch }} != x86 ] || apt-get install -y --no-install-recommends gcc-multilib `dpkg --get-selections | grep -m1 ^linux-config- | awk '{print $1}' | sed s/amd64/i386/`
           curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o /usr/local/bin/vercmp -

--- a/.github/workflows/kernel-kit.yml
+++ b/.github/workflows/kernel-kit.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -qq
-          apt-get install -y --no-install-recommends curl wget ca-certificates git file squashfs-tools xz-utils diffutils patch make flex bison python3 bc bzip2 kmod rsync libelf-dev libssl-dev dwarves gcc gcc-multilib
+          apt-get install -y --no-install-recommends curl wget ca-certificates git file squashfs-tools xz-utils diffutils patch make flex bison python3 bc bzip2 kmod rsync libelf-dev libssl-dev dwarves gcc gcc-multilib jq
           curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o /usr/local/bin/vercmp -
           echo "dash dash/sh boolean false" | debconf-set-selections
           DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash
@@ -60,7 +60,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update -qq
-          apt-get install -y --no-install-recommends curl wget ca-certificates git file squashfs-tools xz-utils diffutils patch make flex bison python3 bc bzip2 kmod rsync libelf-dev libssl-dev dwarves gcc gcc-multilib
+          apt-get install -y --no-install-recommends curl wget ca-certificates git file squashfs-tools xz-utils diffutils patch make flex bison python3 bc bzip2 kmod rsync libelf-dev libssl-dev dwarves gcc gcc-multilib jq
           curl https://raw.githubusercontent.com/puppylinux-woof-CE/initrd_progs/master/pkg/w_apps_static/w_apps/vercmp.c | gcc -x c -o /usr/local/bin/vercmp -
           echo "dash dash/sh boolean false" | debconf-set-selections
           DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash

--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -169,7 +169,7 @@ do
 done
 # extra firmware from other sources
 if [ -n "`find $module_dir -name 'snd-sof*.ko' | head -n 1`" ];then
-	./get_sof.sh `pwd`/zfirmware_workdir "`pwd`/$module_dir" || exit 1
+	./get_sof.sh `pwd`/zfirmware_workdir || exit 1
 fi
 if [ "$EXTRA_FW" = 'yes' ];then
 	./firmware_extra.sh


### PR DESCRIPTION
The current output of `get_sof.sh` is broken and contains broken symlinks. The trimming operation is broken because it deletes unused files, while drivers use the symlink and not the link target when they ask the kernel to load firmware: the script considers most binaries to be unused.

It's not trivial to write a replacement, future-proof trimming script that works 100%, and the size difference between a properly trimmed fdrv and one with all SOF binaries is minimal.