### PR TITLE
Revive pre-ptheme tools and use them if PTHEME is unspecified

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,25 @@ The human-readable distro name (DISTRO_NAME), version (DISTRO_VERSION) and file 
 
 3builddistro takes the distro logo that appears in documentation and first-run dialogs from `woof-code/rootfs-skeleton/usr/share/doc/puplogos`. It looks for `${DISTRO_FILE_PREFIX}.svg` or `${DISTRO_BINARY_COMPAT}.svg`, then falls back to a generic Puppy logo.
 
-The artwork (window manager theme, GTK+ theme, icon theme, wallpaper and cursor theme) to use by default is specified in `_00build.conf`. Themes are not downloaded automatically by woof-CE and must be added to the build as binary packages or built from source during the build.
+There are two ways to specify the artwork (window manager theme, GTK+ theme, icon theme, wallpaper and cursor theme) to use by default, both via `_00build.conf`:
+
+1. Using pTheme: choose one of the global themes under `/usr/share/ptheme/globals`.
+
+       PTHEME="Original Pup"
+
+2. Using `support/choose_themes`: specify default themes individually.
+
+       THEME_WALLPAPER="Blue.svg"
+       THEME_GTK2="Flat-grey-rounded"
+       THEME_JWM="Flat-grey"
+       THEME_JWM_BUTTONS="Buntu"
+       THEME_GTK_ICONS="Puppy Standard"
+       THEME_DESK_ICONS="StandardSvg"
+       THEME_MOUSE="DMZ-Black"
+
+See `support/choose_themes` for a list of theme directories.
+
+Themes are not downloaded automatically by woof-CE and must be added to the build as binary packages or built from source during the build.
 
 # Adding Binary Packages
 

--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
@@ -102,8 +102,4 @@
 
 <DefaultIcon>/usr/share/pixmaps/puppy/execute.svg</DefaultIcon>
 
-<ButtonClose>/root/.jwm/window_buttons/close.png</ButtonClose>
-<ButtonMax>/root/.jwm/window_buttons/max.png</ButtonMax>
-<ButtonMaxActive>/root/.jwm/window_buttons/maxact.png</ButtonMaxActive>
-<ButtonMin>/root/.jwm/window_buttons/min.png</ButtonMin>
 </JWM>

--- a/woof-code/rootfs-packages/ptheme/pinstall.sh
+++ b/woof-code/rootfs-packages/ptheme/pinstall.sh
@@ -27,6 +27,7 @@ if [ "$PTHEME" != "" ] ; then
 	theme="$PTHEME"
 fi
 
+[ "$theme" = "" ] && rm -rf usr/sbin/ptheme usr/share/ptheme usr/share/applications/ptheme.desktop || (
 if [ ! -f usr/share/ptheme/globals/"${theme}" ];then
 	echo "Invalid theme: $theme - defaulting to Original Pup"
 	theme="Original Pup"
@@ -275,3 +276,4 @@ sync
 echo "done"
 echo
 echo
+)

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -6,7 +6,7 @@ export TEXTDOMAIN=ptheme
 export OUTPUT_CHARSET=UTF-8
 
 #check is X is runnning
-[ "`grep -F 'xwin' <<< $(ps -eo pid,command)`" ] && export X_IS_RUNNING=true || export X_IS_RUNNING=false
+pidof -s X Xorg dwl-kiosk labwc > /dev/null && export X_IS_RUNNING=true || export X_IS_RUNNING=false
 
 export WORKDIR=$HOME/.ptheme/tmp/ptheme
 [ ! -d $WORKDIR ] && mkdir -p $WORKDIR
@@ -26,12 +26,12 @@ set_gtk4_theme() {
 				! grep -q "$1" $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini &&  \
 					sed -i "s/^gtk-icon-theme-name.*/gtk-icon-theme-name = $1/" $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
 			else
-				echo "gtk-icon-theme-name = $ICON_THEME" >> $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
+				echo "gtk-icon-theme-name = $1" >> $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
 			fi
 		else
 			cat << _EOF > $REAL_XDG_CONFIG_HOME/gtk-4.0/settings.ini
 [Settings]
-gtk-icon-theme-name = $ICON_THEME
+gtk-icon-theme-name = $1
 _EOF
 		fi
 	else
@@ -65,12 +65,12 @@ set_gtk3_theme() {
 				! grep -q "$1" $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini &&  \
 					sed -i "s/^gtk-icon-theme-name.*/gtk-icon-theme-name = $1/" $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini
 			else
-				echo "gtk-icon-theme-name = $ICON_THEME" >> $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini
+				echo "gtk-icon-theme-name = $1" >> $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini
 			fi
 		else
 			cat << _EOF > $REAL_XDG_CONFIG_HOME/gtk-3.0/settings.ini
 [Settings]
-gtk-icon-theme-name = $ICON_THEME
+gtk-icon-theme-name = $1
 _EOF
 		fi
 	else
@@ -106,7 +106,7 @@ EOF
 
 set_theme_gtk (){
 	[ ! "$THEME" ] && export THEME="$ACTIVE_THEME"
-	if [ $X_IS_RUNNING = true -o "$WAYLAND_DISPLAY" ]; then
+	if [ $X_IS_RUNNING = true ]; then
 		if [ "$(which gtk-theme-switch2)" ] ; then
 			gtk-theme-switch2 -f "$FONT" "/usr/share/themes/$THEME"
 			set_gtk3_theme "$THEME"
@@ -151,8 +151,8 @@ _EOF
 	elif [ "$ACTIVE_ICON_THEME" ]; then
 		sed -i '/gtk-icon-theme-name/d' $HOME/.gtkrc-2.0
 		echo "gtk-icon-theme-name = \"$ACTIVE_ICON_THEME\"" >> $HOME/.gtkrc-2.0
-		set_gtk3_theme "ACTIVE_$ICON_THEME"
-		set_gtk4_theme "ACTIVE_$ICON_THEME"
+		set_gtk3_theme "$ACTIVE_ICON_THEME"
+		set_gtk4_theme "$ACTIVE_ICON_THEME"
 		# rox "Options"
 		sed -i "s/  <Option name=\"icon_theme\">.*$/  <Option name=\"icon_theme\">$ICON_THEME<\/Option>/" $HOME/.config/rox.sourceforge.net/ROX-Filer/Options
 	fi
@@ -222,6 +222,12 @@ while read I; do
 done <<<  "$(find /usr/share/icons -maxdepth 3 -type d -name "32*" | cut -d '/' -f 5 | sort -u)"
 [ ! "$ICON_THEME" ] && ICON_THEME="$ACTIVE_ICON_THEME"
 echo "$ICON_THEME" > $WORKDIR/ptheme-gtkicon
+PTHEME_BUTTON=""
+command -v ptheme > /dev/null && PTHEME_BUTTON='<button space-expand="false" space-fill="false">
+  '"`/usr/lib/gtkdialog/xml_button-icon puppy_theme.svg`"'
+  <label>" '$(gettext 'Global theming')' "</label>
+  <action>/usr/sbin/ptheme</action>
+</button>'
 
 export pThemeGTK='
 <window title="GTK '$(gettext 'theme switcher')'" icon-name="gtk-preferences">
@@ -309,11 +315,7 @@ export pThemeGTK='
       <label>'$(gettext 'More themes')'</label>
       <action>defaulthtmlviewer https://oldforum.puppylinux.com/viewtopic.php?t=30075 &</action>
     </button>
-    <button space-expand="false" space-fill="false">
-      '"`/usr/lib/gtkdialog/xml_button-icon puppy_theme.svg`"'
-      <label>" '$(gettext 'Global theming')' "</label>
-      <action>/usr/sbin/ptheme</action>
-    </button>
+'$PTHEME_BUTTON'
     <text space-expand="true" space-fill="true"><label>""</label></text>
     <button>
       '"`/usr/lib/gtkdialog/xml_button-icon cancel`"'
@@ -323,7 +325,7 @@ export pThemeGTK='
     <button>
       '"`/usr/lib/gtkdialog/xml_button-icon ok`"'
       <label>'$(gettext 'Ok')'</label>
-      <action>ptheme_gtk -t '$ACTIVE_THEME' &</action>
+      <action>ptheme_gtk -t '$THEME' &</action>
       <action>EXIT:exit</action>
     </button>
     '"`/usr/lib/gtkdialog/xml_scalegrip`"'

--- a/woof-code/support/choose_themes
+++ b/woof-code/support/choose_themes
@@ -7,11 +7,14 @@ if ! [ "$BUILDSYS" ] ; then
 fi
 
 # if not using ptheme, add these variables to _00build.conf:
-#	THEME_WALLPAPER='' # /usr/share/backgrounds
-#	THEME_GTK2=''      # /usr/share/themes/*/gtk-2.0 (* = theme)
-#	THEME_JWM=''       # /root/.jwm/themes/*-jwmrc (* = theme)
-#	THEME_DESK_ICONS=' # /usr/local/lib/X11/themes
-#	THEME_OPENBOX=''   # /usr/share/themes/*/openbox-3
+#	THEME_WALLPAPER=''   # /usr/share/backgrounds
+#	THEME_GTK2=''        # /usr/share/themes/*/gtk-2.0 (* = theme)
+#	THEME_JWM=''         # /usr/share/jwm/themes/*-jwmrc, /root/.jwm/themes/*-jwmrc (* = theme)
+#	THEME_JWM_BUTTONS='' # /usr/share/jwm/themes_window_buttons
+#	THEME_GTK_ICONS=''   # /usr/share/icons
+#	THEME_DESK_ICONS=''  # /usr/local/lib/X11/themes
+#	THEME_OPENBOX=''     # /usr/share/themes/*/openbox-3
+#	THEME_MOUSE=''       # /usr/share/icons
 
 echo "Running $0"
 echo
@@ -56,10 +59,10 @@ else
 fi
 
 if ! [ "$THEME_JWM" ];then
-	if [ -d rootfs-complete/root/.jwm/themes ] ; then
+	if [ -d rootfs-complete/usr/share/jwm/themes -o -d rootfs-complete/root/.jwm/themes ] ; then
 		echo "THEME_JWM='..' was not specified in _00build.conf"
 		echo "    ref: rootfs-complete/root/.jwm/themes/*-jwmrc (* = theme)"
-		JWMTHEME=`ls -1 rootfs-complete/root/.jwm/themes/*-jwmrc | rev | cut -f 1 -d '/' | cut -f 2-99 -d '-' | rev | head -n 1`
+		JWMTHEME=`ls -1 rootfs-complete/root/.jwm/themes/*-jwmrc rootfs-complete/usr/share/jwm/themes/*-jwmrc 2>/dev/null | rev | cut -f 1 -d '/' | cut -f 2-99 -d '-' | rev | head -n 1`
 		[ "$JWMTHEME" ] && echo "  * Autoselecting: $JWMTHEME"
 	fi
 else
@@ -88,18 +91,65 @@ if [ "$BACKGROUNDIMAGE" -a -f rootfs-complete/usr/share/backgrounds/$BACKGROUNDI
 	echo "Wallpaper: $BACKGROUNDIMAGE"
 	ext=${BACKGROUNDIMAGE##*.}
 	mv -f rootfs-complete/usr/share/backgrounds/$BACKGROUNDIMAGE rootfs-complete/usr/share/backgrounds/default.${ext}
-	sed -i -e "s%default\.jpg%default.${ext}%" rootfs-complete/root/Choices/ROX-Filer/PuppyPin
+	[ -f rootfs-complete/root/Choices/ROX-Filer/PuppyPin ] && sed -i -e "s%default\.jpg%default.${ext}%" rootfs-complete/root/Choices/ROX-Filer/PuppyPin
+	if [ -f rootfs-complete/usr/bin/jwm ]; then
+		echo "<?xml version=\"1.0\"?>
+
+<JWM>
+
+<Desktops>
+	<Background type=\"image\">/usr/share/backgrounds/default.${ext}</Background>
+</Desktops>
+</JWM>" > rootfs-complete/root/.jwm/jwmrc-wallpaper
+	fi
 fi
 
 if [ "${GTKTHEME}" -a -f rootfs-complete/usr/share/themes/${GTKTHEME}/gtk-2.0/gtkrc ] ; then
 	echo "Gtk theme: ${GTKTHEME}"
-	echo "# -- THEME AUTO-WRITTEN DO NOT EDIT
+	echo "# -- THEME AUTO-WRITTEN BY gtk-theme-switch2 DO NOT EDIT
 include \"/usr/share/themes/${GTKTHEME}/gtk-2.0/gtkrc\"
 
-include \"/root/.gtkrc.mine\"
+style \"user-font\"
+{
+  font_name=\"\"
+}
+widget_class \"*\" style \"user-font\"
 
-# -- THEME AUTO-WRITTEN DO NOT EDIT
-gtk-theme-name=\"${GTKTHEME}\"" > rootfs-complete/root/.gtkrc-2.0
+include \"/root/.gtkrc-2.0.mine\"
+
+# -- THEME AUTO-WRITTEN BY gtk-theme-switch2 DO NOT EDIT
+gtk-theme-name = \"${GTKTHEME}\"
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR" > rootfs-complete/root/.gtkrc-2.0
+fi
+
+if [ "${GTKTHEME}" -a -d rootfs-complete/usr/share/themes/${GTKTHEME}/gtk-3.0 ] ; then
+	echo "Gtk 3 theme: ${GTKTHEME}"
+	mkdir -p rootfs-complete/root/.config/gtk-3.0
+	echo "[Settings]
+gtk-theme-name = ${GTKTHEME}
+gtk-toolbar-style = GTK_TOOLBAR_BOTH
+gtk-toolbar-icon-size = GTK_ICON_SIZE_LARGE_TOOLBAR
+gtk-menu-images = 1
+gtk-button-images = 1
+gtk-enable-animations = 0" > rootfs-complete/root/.config/gtk-3.0/settings.ini
+fi
+
+if [ "$THEME_GTK_ICONS" ];then
+	echo "Gtk icon theme: ${THEME_GTK_ICONS}"
+	echo "gtk-icon-theme-name = \"${THEME_GTK_ICONS}\"" >> rootfs-complete/root/.gtkrc-2.0
+	[ -f rootfs-complete/root/.config/gtk-3.0/settings.ini ] && echo "gtk-icon-theme-name = ${THEME_GTK_ICONS}" >> rootfs-complete/root/.config/gtk-3.0/settings.ini
+fi
+
+[ -f rootfs-complete/root/.gtkrc-2.0 ] && install -D -m 644 rootfs-complete/root/.gtkrc-2.0 rootfs-complete/etc/gtk-2.0/gtkrc
+[ -f rootfs-complete/root/.config/gtk-3.0/settings.ini ] && install -D -m 644 rootfs-complete/root/.config/gtk-3.0/settings.ini rootfs-complete/etc/gtk-3.0/settings.ini
+
+if [ "$THEME_MOUSE" -a -d rootfs-complete/usr/share/icons/${THEME_MOUSE} ];then
+	echo "Cursor theme: ${THEME_MOUSE}"
+	mkdir -p rootfs-complete/root/.icons rootfs-complete/home/spot/.icons
+	ln -s /usr/share/icons/$THEME_MOUSE rootfs-complete/root/.icons/default
+	ln -s /usr/share/icons/$THEME_MOUSE rootfs-complete/home/spot/.icons/default
+	chroot rootfs-complete chown -R spot:spot /home/spot/.icons
 fi
 
 if [ "$DESKICONS" -a -d rootfs-complete/usr/local/lib/X11/themes/$DESKICONS ] ; then
@@ -107,10 +157,36 @@ if [ "$DESKICONS" -a -d rootfs-complete/usr/local/lib/X11/themes/$DESKICONS ] ; 
 	echo -n "$DESKICONS" > rootfs-complete/etc/desktop_icon_theme
 fi
 
-if [ "${JWMTHEME}" -a -d rootfs-complete/root/.jwm/themes ];then
+if [ "${JWMTHEME}" -a -f rootfs-complete/usr/bin/jwm -a -f rootfs-complete/usr/share/jwm/themes/${JWMTHEME}-jwmrc ];then
+	echo "Jwm theme: ${JWMTHEME}"
+	cp -f rootfs-complete/usr/share/jwm/themes/${JWMTHEME}-jwmrc rootfs-complete/root/.jwm/jwmrc-theme
+	echo ${JWMTHEME} > rootfs-complete/root/.jwm/theme
+elif [ "${JWMTHEME}" -a -f rootfs-complete/usr/bin/jwm -a -d rootfs-complete/root/.jwm/themes ];then
 	echo "Jwm theme: ${JWMTHEME}"
 	cp -f rootfs-complete/root/.jwm/themes/${JWMTHEME}-jwmrc rootfs-complete/root/.jwm/jwmrc-theme
 	cp -f rootfs-complete/root/.jwm/themes/${JWMTHEME}-colors rootfs-complete/root/.jwm/jwm_colors 2>/dev/null
+	echo ${JWMTHEME} > rootfs-complete/root/.jwm/theme
+fi
+
+if [ "${THEME_JWM_BUTTONS}" -a "${THEME_JWM_BUTTONS}" != "default" -a -f rootfs-complete/usr/bin/jwm -a -d rootfs-complete/usr/share/jwm/themes_window_buttons/${THEME_JWM_BUTTONS} ];then
+	sed -i '/^<\/JWM>/d' rootfs-complete/root/.jwm/jwmrc-personal
+	echo "<ButtonClose>/root/.jwm/window_buttons/close.png</ButtonClose>
+<ButtonMax>/root/.jwm/window_buttons/max.png</ButtonMax>
+<ButtonMaxActive>/root/.jwm/window_buttons/maxact.png</ButtonMaxActive>
+<ButtonMin>/root/.jwm/window_buttons/min.png</ButtonMin>
+</JWM>" >> rootfs-complete/root/.jwm/jwmrc-personal
+	mkdir -p rootfs-complete/root/.jwm/window_buttons
+	rm -f rootfs-complete/root/.jwm/window_buttons/*
+	CONVERT=`command -v rsvg-convert`
+	for ICON in rootfs-complete/usr/share/jwm/themes_window_buttons/${THEME_JWM_BUTTONS}/*.svg; do
+		BASE=${ICON##*/}
+		BASE=${BASE%.svg}
+		if [ -n "$CONVERT" ]; then
+			$CONVERT -w 48 -h 48 -o rootfs-complete/root/.jwm/window_buttons/${BASE}.png ${ICON}
+		else
+			ln -s ${ICON#rootfs-complete/} rootfs-complete/root/.jwm/window_buttons/${BASE}.png
+		fi
+	done
 fi
 
 if [ "${OBTHEME}" -a -f rootfs-complete/root/.config/openbox/rc.xml ];then #20100406

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -84,20 +84,15 @@ SFSCOMP='-comp zstd -Xcompression-level 19 -b 256K -no-exports -no-xattrs'
 ## This is usually not needed
 EXTRA_STRIPPING=no
 
-## -- pTheme -- applies only if ptheme pkg is being used
-##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-## You can choose a ptheme here if you wish
+## You can choose a theme here if you wish
 ## otherwise 3builddistro will ask you to choose one
-#PTHEME="Dark Touch"
-#PTHEME="Dark Mouse"
-#PTHEME="Bright Touch"
-#PTHEME="Bright Mouse"
-#PTHEME="Dark_Blue"
-if [ "$DISTRO_VARIANT" = "dwl" ]; then
-	PTHEME="Flat-grey"
-else
-	PTHEME="412"
-fi
+THEME_WALLPAPER="412.svg"
+THEME_GTK2="Gradient-grey"
+THEME_JWM="Gradient_grey"
+THEME_JWM_BUTTONS=""
+THEME_GTK_ICONS="Puppy Standard"
+THEME_DESK_ICONS="StandardSvg"
+THEME_MOUSE="DMZ-Black"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
@@ -155,8 +150,9 @@ chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop usr/share/applications/Puppy-package-manager-check-deps.desktop usr/share/applications/Remaster-Puppy-live-CD.desktop
 for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
-for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals/Flat-grey|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
-rm -vf usr/share/backgrounds/*.jpg
+for i in usr/share/jwm/themes/*; do case \"\$i\" in usr/share/jwm/themes/Buntoo-jwmrc|usr/share/jwm/themes/Gradient_grey-jwmrc|usr/share/jwm/themes/Gradient-blueish-jwmrc|usr/share/jwm/themes/Flat-grey-jwmrc|usr/share/jwm/themes/Stark_blueish-jwmrc) ;; *) rm -vf \"\$i\" ;; esac; done
+for i in usr/share/jwm/themes_window_buttons/*; do case \"\$i\" in usr/share/jwm/themes_window_buttons/Maccish|usr/share/jwm/themes_window_buttons/XPish|usr/share/jwm/themes_window_buttons/Buntu|usr/share/jwm/themes_window_buttons/Buntu_white) ;; *) rm -rvf \"\$i\" ;; esac; done
+rm -vf usr/share/backgrounds/*.jpg usr/share/backgrounds/Sky.svg \"usr/share/backgrounds/Stardust bright.svg\" \"usr/share/backgrounds/Stardust dark.svg\" usr/share/backgrounds/xfwallpaper.svg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
 rm -f var/packages/Packages-debian-*

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -71,19 +71,16 @@ SFSCOMP='-comp zstd -Xcompression-level 19 -b 256K -no-exports -no-xattrs'
 ## This is usually not needed
 EXTRA_STRIPPING=no
 
-## -- pTheme -- applies only if ptheme pkg is being used
-##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-## You can choose a ptheme here if you wish
+## You can choose a theme here if you wish
 ## otherwise 3builddistro will ask you to choose one
-#PTHEME="Dark Touch"
-#PTHEME="Dark Mouse"
-#PTHEME="Bright Touch"
-#PTHEME="Bright Mouse"
-#PTHEME="Dark_Blue"
-PTHEME="412"
+THEME_WALLPAPER="412.svg"
+THEME_GTK2="Gradient-grey"
+THEME_JWM="Gradient_grey"
+THEME_JWM_BUTTONS=""
+THEME_GTK_ICONS="Puppy Standard"
+THEME_DESK_ICONS="StandardSvg"
+THEME_MOUSE="DMZ-Black"
 
-## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
-## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
 ## For testing builds XERRS_FLG=yes is recommended. If the target device is low RAM suggest to leave this unset, especially for release
 #XERRS_FLG=yes
 
@@ -138,8 +135,9 @@ chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop usr/share/applications/Puppy-package-manager-check-deps.desktop usr/share/applications/Remaster-Puppy-live-CD.desktop
 for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
-for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals/Flat-grey|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
-rm -vf usr/share/backgrounds/*.jpg
+for i in usr/share/jwm/themes/*; do case \"\$i\" in usr/share/jwm/themes/Buntoo-jwmrc|usr/share/jwm/themes/Gradient_grey-jwmrc|usr/share/jwm/themes/Gradient-blueish-jwmrc|usr/share/jwm/themes/Flat-grey-jwmrc|usr/share/jwm/themes/Stark_blueish-jwmrc) ;; *) rm -vf \"\$i\" ;; esac; done
+for i in usr/share/jwm/themes_window_buttons/*; do case \"\$i\" in usr/share/jwm/themes_window_buttons/Maccish|usr/share/jwm/themes_window_buttons/XPish|usr/share/jwm/themes_window_buttons/Buntu|usr/share/jwm/themes_window_buttons/Buntu_white) ;; *) rm -rvf \"\$i\" ;; esac; done
+rm -vf usr/share/backgrounds/*.jpg usr/share/backgrounds/Sky.svg \"usr/share/backgrounds/Stardust bright.svg\" \"usr/share/backgrounds/Stardust dark.svg\" usr/share/backgrounds/xfwallpaper.svg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
 rm -f var/packages/Packages-debian-*

--- a/woof-distro/x86_64/debian/buster64/_00build.conf
+++ b/woof-distro/x86_64/debian/buster64/_00build.conf
@@ -51,7 +51,7 @@ EXTRA_STRIPPING=yes
 
 ## -- pTheme -- applies only if ptheme pkg is being used
 ##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-#THEME="Original Pup"
+PTHEME="Original Pup"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -70,16 +70,15 @@ SFSCOMP='-comp zstd -Xcompression-level 19 -b 256K -no-exports -no-xattrs'
 ## This is usually not needed
 EXTRA_STRIPPING=no
 
-## -- pTheme -- applies only if ptheme pkg is being used
-##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-## You can choose a ptheme here if you wish
+## You can choose a theme here if you wish
 ## otherwise 3builddistro will ask you to choose one
-#PTHEME="Dark Touch"
-#PTHEME="Dark Mouse"
-#PTHEME="Bright Touch"
-#PTHEME="Bright Mouse"
-#PTHEME="Dark_Blue"
-PTHEME="412"
+THEME_WALLPAPER="412.svg"
+THEME_GTK2="Gradient-grey"
+THEME_JWM="Gradient_grey"
+THEME_JWM_BUTTONS=""
+THEME_GTK_ICONS="Puppy Standard"
+THEME_DESK_ICONS="StandardSvg"
+THEME_MOUSE="DMZ-Black"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
@@ -137,8 +136,9 @@ chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop usr/share/applications/Puppy-package-manager-check-deps.desktop usr/share/applications/Remaster-Puppy-live-CD.desktop
 for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
-for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals/Flat-grey|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
-rm -vf usr/share/backgrounds/*.jpg
+for i in usr/share/jwm/themes/*; do case \"\$i\" in usr/share/jwm/themes/Buntoo-jwmrc|usr/share/jwm/themes/Gradient_grey-jwmrc|usr/share/jwm/themes/Gradient-blueish-jwmrc|usr/share/jwm/themes/Flat-grey-jwmrc|usr/share/jwm/themes/Stark_blueish-jwmrc) ;; *) rm -vf \"\$i\" ;; esac; done
+for i in usr/share/jwm/themes_window_buttons/*; do case \"\$i\" in usr/share/jwm/themes_window_buttons/Maccish|usr/share/jwm/themes_window_buttons/XPish|usr/share/jwm/themes_window_buttons/Buntu|usr/share/jwm/themes_window_buttons/Buntu_white) ;; *) rm -rvf \"\$i\" ;; esac; done
+rm -vf usr/share/backgrounds/*.jpg usr/share/backgrounds/Sky.svg \"usr/share/backgrounds/Stardust bright.svg\" \"usr/share/backgrounds/Stardust dark.svg\" usr/share/backgrounds/xfwallpaper.svg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s /usr/share/fontconfig/conf.avail/10-hinting-none.conf etc/fonts/conf.d/
 rm -f var/packages/Packages-debian-*

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -57,7 +57,7 @@ EXTRA_STRIPPING=yes
 
 ## -- pTheme -- applies only if ptheme pkg is being used
 ##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-#THEME="Original Pup"
+PTHEME="Original Pup"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'


### PR DESCRIPTION
This is something I've wanted to do for a very long time. I don't like ptheme, it tries to do way too many things in one tool, it's very buggy and it looks like users just want the old-style layout of one tray at the bottom, or one of the alternatives that conflict with ptheme.

If I understand correctly, choose_themes is in this half-broken, zombie state since the introduction of ptheme (2014?), so it's been a very long time since the days it was possible to build a Puppy without ptheme using woof-CE, without ugly hacks like replacing the .jwm directory. I had to make some adjustments like setting the GTK+ 3 theme, adding Xwayland support and changing paths to what Puppy uses nowadays.

ptheme_gtk is in very bad shape and even has some syntax errors, but we need some GTK+ theme switcher even when ptheme is disabled. I made ptheme_gtk work without refactoring and cleanup, ~~then moved it to rootfs-skeleton~~.

(This brings dpup even closer to what I consider to be the golden age of Puppy, the 4.1.x-4.3.x era)

![desktop](https://user-images.githubusercontent.com/1471149/199964254-2aa9bf2d-e8ce-403d-9cba-366fc6571892.png)

