### PR TITLE
Avoid excessive use of FTP

### DIFF
--- a/kernel-kit/4.19.x-x86-build.conf
+++ b/kernel-kit/4.19.x-x86-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/4.19.x-x86_64-build.conf
+++ b/kernel-kit/4.19.x-x86_64-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.10.x-x86-build.conf
+++ b/kernel-kit/5.10.x-x86-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.10.x-x86_64-build.conf
+++ b/kernel-kit/5.10.x-x86_64-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.13.x-x86_64-build.conf
+++ b/kernel-kit/5.13.x-x86_64-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.15.x-x86-build.conf
+++ b/kernel-kit/5.15.x-x86-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.15.x-x86_64-build.conf
+++ b/kernel-kit/5.15.x-x86_64-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.4.x-x86-build.conf
+++ b/kernel-kit/5.4.x-x86-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/5.4.x-x86_64-build.conf
+++ b/kernel-kit/5.4.x-x86_64-build.conf
@@ -91,13 +91,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/build.conf
+++ b/kernel-kit/build.conf
@@ -89,13 +89,7 @@ STRIP_KMODULES=no
 
 ## Kernel download mirrors
 kernel_mirrors='https://www.kernel.org/pub/linux/kernel
-ftp://ftp.ntu.edu.tw/linux/kernel
-ftp://ftp.heanet.ie/pub/kernel.org/pub/linux/kernel
-ftp://ftp.yandex.ru/pub/linux/kernel/
-https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel
-ftp://ftp.jaist.ac.jp/pub/Linux/kernel.org/linux/kernel
-ftp://www.mirrorservice.org/pub/linux/kernel
-ftp://ftp.be.debian.org/pub/linux/kernel'
+https://mirror.aarnet.edu.au/pub/ftp.kernel.org/linux/kernel'
 
 ## This kit now gets firmware from kernel.org
 ## The default is to produce a firmware package that is based on the running

--- a/kernel-kit/funcs.sh
+++ b/kernel-kit/funcs.sh
@@ -13,8 +13,8 @@ function git_aufs_util_branch() {
 
 # sets $aufsv
 function git_aufs_branch() {
- #  aufs_git_4="git://github.com/sfjro/aufs4-standalone.git"
- #  aufs_git_5="git://github.com/sfjro/aufs5-standalone.git"
+ #  aufs_git_4="https://github.com/sfjro/aufs4-standalone.git"
+ #  aufs_git_5="https://github.com/sfjro/aufs5-standalone.git"
  #---
  # $kernel_version       is set by build.sh
  # $kernel_major_version is set by build.sh

--- a/woof-code/README.pkgs_specs
+++ b/woof-code/README.pkgs_specs
@@ -18,11 +18,9 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/testing/woof-dist
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/testing/woof-distro/x86/Packages-puppy-common32-official|z
 "
 PET_REPOS="
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://01micko.com/wdlkmpx/puppylinux|Packages-puppy-stretch-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 "
 PACKAGELISTS_PET_ORDER="
 Packages-puppy-${DISTRO_DB_SUBNAME}-official
@@ -87,7 +85,7 @@ PET OR COMPAT?
       0     1          2            3           4!
      yes|isomaster|isomaster|exe,dev,doc,nls|pet:tahr
 
-     ( |pet:tahr = http://distro.ibiblio.org/puppylinux/pet_packages-tahr/ )
+     ( |pet:tahr = https://distro.ibiblio.org/puppylinux/pet_packages-tahr/ )
      
    This is not encouraged, as its adds unnecesary complexity.
    Please don't use it so I can simplify findpkgs...

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load
@@ -2160,7 +2160,7 @@ fi
 
 if [ "$FILEISAT" = "" ];then
 	case "$DIRNAME" in
-		http://*|ftp://*) FILEISAT="url" ;;
+		https://*|http://*|ftp://*) FILEISAT="url" ;;
 		/mnt/cdrom*|/mnt/dvd*|/mnt/sr*) FILEISAT="cd";;
 		$MNTHOME/$PSUBDIR) FILEISAT="home";; #20151004
 		$MNTHOME) FILEISAT="home";;

--- a/woof-distro/x86/debian/buster/DISTRO_PET_REPOS
+++ b/woof-distro/x86/debian/buster/DISTRO_PET_REPOS
@@ -29,17 +29,12 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS="
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://01micko.com/wdlkmpx/puppylinux|Packages-puppy-stretch-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 "
 

--- a/woof-distro/x86/debian/buster/DISTRO_PET_REPOS
+++ b/woof-distro/x86/debian/buster/DISTRO_PET_REPOS
@@ -32,8 +32,6 @@ PET_REPOS="
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 "

--- a/woof-distro/x86/debian/stretch/DISTRO_PET_REPOS
+++ b/woof-distro/x86/debian/stretch/DISTRO_PET_REPOS
@@ -29,17 +29,12 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS="
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://01micko.com/wdlkmpx/puppylinux|Packages-puppy-stretch-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 "
 

--- a/woof-distro/x86/debian/stretch/DISTRO_PET_REPOS
+++ b/woof-distro/x86/debian/stretch/DISTRO_PET_REPOS
@@ -32,8 +32,6 @@ PET_REPOS="
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 "

--- a/woof-distro/x86/slackware/14.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PET_REPOS
@@ -34,9 +34,6 @@ z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://01micko.com/wdlkmpx/puppylinux|Packages-puppy-${DISTRO_DB_SUBNAME}-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86/slackware/14.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/14.0/DISTRO_PET_REPOS
@@ -30,17 +30,14 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://01micko.com/wdlkmpx/puppylinux|Packages-puppy-${DISTRO_DB_SUBNAME}-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://01micko.com/wdlkmpx/puppylinux|Packages-puppy-${DISTRO_DB_SUBNAME}-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86/slackware/14.1/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/14.1/DISTRO_PET_REPOS
@@ -30,16 +30,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86/slackware/14.1/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/14.1/DISTRO_PET_REPOS
@@ -33,9 +33,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86/slackware/14.2/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/14.2/DISTRO_PET_REPOS
@@ -30,16 +30,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86/slackware/14.2/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/14.2/DISTRO_PET_REPOS
@@ -33,9 +33,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86/slackware/15.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/15.0/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86/slackware/15.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86/slackware/15.0/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86/slackware/DISTRO_COMPAT_REPOS
+++ b/woof-distro/x86/slackware/DISTRO_COMPAT_REPOS
@@ -17,8 +17,8 @@ esac
 case "$DISTRO_COMPAT_VERSION" in
 	14.0|14.1) SALIX_EXTRA="" ;;
 	*) #14.2+ this will change when 15 goes stable
-		SALIX_EXTRA="z|http://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/extra/PACKAGES.TXT|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-extra"
-		SALIX_EXTRA_MIRRORS="z|http://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/extra|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-extra
+		SALIX_EXTRA="z|https://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/extra/PACKAGES.TXT|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-extra"
+		SALIX_EXTRA_MIRRORS="z|https://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/extra|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-extra
 z|http://slackware.uk/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/extra|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-extra
 z|http://www.gtlib.gatech.edu/pub/salixos/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/extra|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-extra"
 		;;
@@ -33,8 +33,8 @@ esac
 #   3 - name of db file when local and after being processed into standard format
 
 PKG_DOCS_DISTRO_COMPAT="
-z|http://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/PACKAGES.TXT|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}/PACKAGES.TXT|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
+z|https://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}/PACKAGES.TXT|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
+z|https://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}/PACKAGES.TXT|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
 $SALIX_EXTRA
 "
 
@@ -47,16 +47,11 @@ $SALIX_EXTRA
 #   3 - name of db-file(s) associated with that repo. it may have glob wildcards.
 
 REPOS_DISTRO_COMPAT="
-z|http://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
-z|http://slackware.uk/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://slackware.uk/salix/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
-z|http://www.gtlib.gatech.edu/pub/salixos/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://www.gtlib.gatech.edu/pub/salixos/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
-z|http://mirror.aarnet.edu.au/pub/slackware/slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://slackware.cs.utah.edu/pub/slackware/slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://slackware.mirrors.tds.net/pub/slackware/slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
-z|http://ftp.gwdg.de/pub/linux/slackware/slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
+z|https://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
+z|https://ftp.nluug.nl/pub/os/Linux/distr/salix/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
+z|https://slackware.uk/salix/${SALIX_ARCH}/slackware-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
+z|https://slackware.uk/salix/${SALIX_ARCH}/${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-salix
+z|https://mirror.aarnet.edu.au/pub/slackware/slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}|Packages-slackware${DSUFFIX}-${DISTRO_COMPAT_VERSION}-official
 $SALIX_EXTRA_MIRRORS
 "
 

--- a/woof-distro/x86/ubuntu/trusty/DISTRO_PET_REPOS
+++ b/woof-distro/x86/ubuntu/trusty/DISTRO_PET_REPOS
@@ -30,16 +30,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/testing/woof-dist
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86/ubuntu/trusty/DISTRO_PET_REPOS
+++ b/woof-distro/x86/ubuntu/trusty/DISTRO_PET_REPOS
@@ -33,9 +33,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86/ubuntu/upupbb/DISTRO_PET_REPOS
+++ b/woof-distro/x86/ubuntu/upupbb/DISTRO_PET_REPOS
@@ -31,18 +31,15 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://smokey01.com/peebee/upupbb/extras|Packages-puppy-upupbb-extra
+z|https://smokey01.com/peebee/upupbb/extras|Packages-puppy-upupbb-extra
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 '
 
 #----------------------

--- a/woof-distro/x86/ubuntu/upupbb/DISTRO_PET_REPOS
+++ b/woof-distro/x86/ubuntu/upupbb/DISTRO_PET_REPOS
@@ -36,9 +36,6 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Pac
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 '
 

--- a/woof-distro/x86/ubuntu/xenial/DISTRO_PET_REPOS
+++ b/woof-distro/x86/ubuntu/xenial/DISTRO_PET_REPOS
@@ -30,16 +30,12 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/testing/woof-dist
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86/ubuntu/xenial/DISTRO_PET_REPOS
+++ b/woof-distro/x86/ubuntu/xenial/DISTRO_PET_REPOS
@@ -33,8 +33,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/debian/buster64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/debian/buster64/DISTRO_PET_REPOS
@@ -29,17 +29,14 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux/test|Packages-puppy-buster-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux/test|Packages-puppy-buster-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/debian/buster64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/debian/buster64/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://distro.ibiblio.org/puppylinux/test|Packages-puppy-buster-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official

--- a/woof-distro/x86_64/slackware64/14.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/14.0/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/slackware64/14.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/14.0/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/slackware64/14.1/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/14.1/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/slackware64/14.1/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/14.1/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/slackware64/14.2/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/14.2/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/slackware64/15.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/15.0/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/slackware64/15.0/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/slackware64/15.0/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PET_REPOS
@@ -34,9 +34,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PET_REPOS
@@ -31,16 +31,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PET_REPOS
@@ -35,9 +35,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PET_REPOS
@@ -32,16 +32,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://distro.ibiblio.org/puppylinux/Packages-puppy-fossa64-official|z
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PET_REPOS
@@ -29,16 +29,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/trusty64/DISTRO_PET_REPOS
@@ -32,9 +32,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '

--- a/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PET_REPOS
@@ -30,16 +30,13 @@ z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE/${WCE_BRANCH}/woo
 #   ex: Packages-puppy-4-official (note, url paths are in the database)
 
 PET_REPOS='
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|ftp://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|http://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|ftp://ftp.vcu.edu/pub/gnu+linux/puppylinux|Packages-puppy-*-official
-z|http://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|http://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
-z|http://mirror.internode.on.net/pub/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
+z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
+z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
+z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '
 

--- a/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PET_REPOS
+++ b/woof-distro/x86_64/ubuntu/xenial64/DISTRO_PET_REPOS
@@ -33,9 +33,6 @@ PET_REPOS='
 z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
 z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
 z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
-z|https://distro.ibiblio.org/puppylinux|Packages-puppy-*-official
-z|https://ftp.nluug.nl/ftp/pub/os/Linux/distr/puppylinux|Packages-puppy-*-official
-z|https://ftp.cc.uoc.gr/mirrors/linux/puppylinux|Packages-puppy-*-official
 z|https://mirror.aarnet.edu.au/pub/puppylinux|Packages-puppy-*-official
 z|https://raw.githubusercontent.com/puppylinux-woof-CE/woof-CE-noarch/master|Packages-puppy-noarch-official
 '


### PR DESCRIPTION
Hello everyone! Today, I've looked at the woof-CE source code, and found that it excessively uses insecure protocols that don't verify the integrity of received data and therefore vulnerable to malicious injections from untrusted networks. I would like to avoid that, because woof-CE deals with very sensitive software code (such as the kernel).