### PR TITLE
Update man cache if missing

### DIFF
--- a/woof-code/packages-templates/man-db_FIXUPHACK
+++ b/woof-code/packages-templates/man-db_FIXUPHACK
@@ -1,0 +1,6 @@
+mkdir -p etc/init.d
+cat << EOF > etc/init.d/man-db
+#!/bin/ash
+[ "\$1" = start ] && [ -z "\`ls /var/cache/man/index.* 2>/dev/null\`" ] && mandb > /dev/null 2>&1 &
+EOF
+chmod 755 etc/init.d/man-db

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -117,7 +117,7 @@ yes|libzstd|libzstd1,libzstd-dev|exe,dev,doc,nls||deps:yes
 yes|login|login|exe>null,dev>null,doc>null,nls>null
 yes|lsb-base|lsb-base|exe,dev,doc,nls||deps:yes
 yes|lzma|lzma|exe,dev,doc,nls||deps:yes
-yes|man|man-db|exe,dev,doc,nls||deps:yes
+yes|man-db|man-db|exe,dev,doc,nls||deps:yes
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -119,7 +119,7 @@ yes|libzstd|libzstd1,libzstd-dev|exe,dev,doc,nls||deps:yes
 yes|login|login|exe>null,dev>null,doc>null,nls>null
 yes|lsb-base|lsb-base|exe,dev,doc,nls||deps:yes
 yes|lzma|lzma|exe,dev,doc,nls||deps:yes
-yes|man|man-db|exe,dev,doc,nls||deps:yes
+yes|man-db|man-db|exe,dev,doc,nls||deps:yes
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -119,7 +119,7 @@ yes|libzstd|libzstd1,libzstd-dev|exe,dev,doc,nls||deps:yes
 yes|login|login|exe>null,dev>null,doc>null,nls>null
 yes|lsb-base|lsb-base|exe,dev,doc,nls||deps:yes
 yes|lzma|lzma|exe,dev,doc,nls||deps:yes
-yes|man|man-db|exe,dev,doc,nls||deps:yes
+yes|man-db|man-db|exe,dev,doc,nls||deps:yes
 yes|mpclib3|libmpc3|exe,dev,doc,nls||deps:yes #needed by gcc.
 yes|mpv|mpv|exe,dev,doc,nls||deps:yes
 yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,libncursesw6,libtinfo6|exe,dev,doc,nls||deps:yes


### PR DESCRIPTION
Minimal fix, alternative to #3545 and #3547.

(Only works if using overlay and docx and nlsx are auto-loaded by init, and that's the case in dpup. AFAIK, dpup is the only Puppy configured like this.)