### PR TITLE
Show available options when merge2out is given a non-existing directory

### DIFF
--- a/merge2out
+++ b/merge2out
@@ -35,6 +35,17 @@ if [ "$1" != "" ]; then
 		ALTERNATE_BUILD=$COMPATVERSION_DIR
 	else
 		echo "Missing configuration directory: $1"
+		DIR="$1"
+		while [ -n "$DIR" ]; do
+			if [ -d "$DIR" ]; then
+				echo -e "\nAvailable under $DIR:"
+				ls -1 "$DIR" | grep -v -e ^Packages- -e ^DISTRO_
+				break
+			fi
+			PREV="$DIR"
+			DIR="${DIR%/*}"
+			[ "$DIR" = "$PREV" ] && break
+		done
 		exit 1
 	fi
 fi


### PR DESCRIPTION
```
~/woof-CE$ ./merge2out woof-distro/x86_6/debia/sid6
Missing configuration directory: woof-distro/x86_6/debia/sid6

Available under woof-distro:
arm
x86
x86_64
~/woof-CE$ ./merge2out woof-distro/x86_64/debia/sid6
Missing configuration directory: woof-distro/x86_64/debia/sid6

Available under woof-distro/x86_64:
debian
slackware64
ubuntu
~/woof-CE$ ./merge2out woof-distro/x86_64/debian/sid6
Missing configuration directory: woof-distro/x86_64/debian/sid6

Available under woof-distro/x86_64/debian:
bookworm64
bullseye64
buster64
sid64
~/woof-CE$ ./merge2out woof-distro/x86_64/debian/sid64

This script merges woof-arch, woof-code
woof-distro, kernel-kit and initrd-progs to ../woof-out_*.
See README.md
...
```