### PR TITLE
Avoid >100 dirname calls during the init script

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -422,7 +422,7 @@ echo 5000 > /sys/module/block/parameters/events_dfl_poll_msecs
 #replay uevents from /sys...
 for ONEMODALIAS in $MODALIASES
 do
- ONEPATH="`dirname $ONEMODALIAS`"
+ ONEPATH="${ONEMODALIAS%/*}"
  if [ -e ${ONEPATH}/uevent ];then
   echo add > ${ONEPATH}/uevent #generates an 'add' uevent.
   [ "$DISTRO_TARGETARCH" = "x86" ] && sleep 0.02


### PR DESCRIPTION
Before:

```
~$ time sh -c '(for x in `ls /sys/bus/*/devices/*/modalias`; do [ -e `dirname $x`/uevent ] && echo $x; done) > /dev/null'

real	0m0.357s
user	0m0.189s
sys	0m0.180s
```

After:

```
~$ time sh -c '(for x in `ls /sys/bus/*/devices/*/modalias`; do [ -e {x%/*}/uevent ] && echo $x; done) > /dev/null'

real	0m0.025s
user	0m0.010s
sys	0m0.016s
```