### PR TITLE
Skip pidof between init scripts

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.services
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.services
@@ -7,19 +7,11 @@
 #this sleep benefits all slow peripherals.
 [ "$DISTRO_TARGETARCH" = "x86" ] && sleep 6
 
-DBUS_PID=`pidof dbus-daemon`
-
 for service_script in /etc/init.d/*
 do
  if [ -x $service_script ]; then
   #Check if the script contains dbus-daemon
-  if [ -z "$(grep -F dbus-daemon $service_script)" ]; then
-   $service_script start
-  elif [ -z "$DBUS_PID" ]; then
-   #run dbus-daemon script if the dbus-daemon is not running
-   $service_script start
-   DBUS_PID=`pidof dbus-daemon`
-  fi
+  grep -qF dbus-daemon $service_script || $service_script start
  fi
 done
 


### PR DESCRIPTION
rc.sysinit already starts D-Bus and it's unreasonable to build a Puppy without D-Bus, so these `pidof` calls serve no purpose.