### PR TITLE
Ask the user to provide the ISO image if vmlinuz and initrd.gz are not found

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/bootflash
+++ b/woof-code/rootfs-skeleton/usr/sbin/bootflash
@@ -297,14 +297,14 @@ locate_puppy_src_files() { # set $SRCPATH $CDDRIVE
 			# not mounted
 			mkdir -p /mnt/$PDEV1
 			mount -t $PDEV1_FS /dev/$PDEV1 /mnt/$PDEV1
-			if [ $? -eq 0 -a -f /mnt/${PDEV1}${PSUBDIR}/${DISTRO_PUPPYSFS} ] ; then
+			if [ $? -eq 0 -a -f /mnt/${PDEV1}${PSUBDIR}/${DISTRO_PUPPYSFS} -a -f /mnt/${PDEV1}${PSUBDIR}/vmlinuz -a -f /mnt/${PDEV1}${PSUBDIR}/initrd.gz ] ; then
 				SRCPATH=/mnt/${PDEV1}${PSUBDIR}
 			else
 				umount /mnt/$PDEV1 2>/dev/null
 			fi
 		else
 			# already mounted
-			if [ -f ${PDEV1_MP}${PSUBDIR}/${DISTRO_PUPPYSFS} ] ; then
+			if [ -f ${PDEV1_MP}${PSUBDIR}/${DISTRO_PUPPYSFS} -a -f ${PDEV1_MP}${PSUBDIR}/vmlinuz -a -f ${PDEV1_MP}${PSUBDIR}/initrd.gz ] ; then
 				SRCPATH=${PDEV1_MP}${PSUBDIR}
 			fi
 		fi


### PR DESCRIPTION
It's possible to have a UEFI-bootable flash drive with vmlinuz and initrd.gz in the ESP and not the partition where the SFSs are. This PR forces the user to supply the ISO in this case, instead of letting bootflash fail.