### PR TITLE
Add group input;x;31;

### DIFF
--- a/woof-code/rootfs-skeleton/etc/group
+++ b/woof-code/rootfs-skeleton/etc/group
@@ -28,3 +28,4 @@ tape::108:root
 tty::109:root,spot
 plugdev::110:root,spot
 bluetooth::111:root,spot
+input:x:31:

--- a/woof-code/rootfs-skeleton/etc/group
+++ b/woof-code/rootfs-skeleton/etc/group
@@ -28,4 +28,4 @@ tape::108:root
 tty::109:root,spot
 plugdev::110:root,spot
 bluetooth::111:root,spot
-input:x:31:
+input:x:31:root,spot


### PR DESCRIPTION
Required by Slackware eudev - /lib/udev/rules.d/50-udev-default.rules  i.e lines 29-30
SUBSYSTEM=="input", GROUP="input"
SUBSYSTEM=="input", KERNEL=="js[0-9]*", MODE="0664"

value from:
https://patchwork.ozlabs.org/comment/883148/