### PR TITLE
Add syslinux support to bootflash

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/bootflash
+++ b/woof-code/rootfs-skeleton/usr/sbin/bootflash
@@ -198,7 +198,7 @@ write_wee_mbr() {
 # $1 = drv
 # $2 = XFSTYPE (vfat, ntfs, ext3, ext4)
 # $3 = XFSTYPE2 (f2fs)  (optional - $2 becomes vfat)
-create_grub4dos_bootable_drv() {
+create_bios_bootable_drv() {
 	local XDEV=${1##*/}
 	local XFSTYPE=$2
 	local XFSTYPE2=$3
@@ -256,8 +256,38 @@ create_grub4dos_bootable_drv() {
 	echo 'Wait 4 seconds for block device nodes to populate...'
 	sleep 4
 	sync
+}
 
-	write_wee_mbr /dev/${XDEV} #install wee.mbr
+# syslinux - make bootable
+# $1: targetdir 
+# $2: pdrv
+# $3: pmedia
+# $4: fstype2
+create_syslinux_conf() {
+	local HOMEDIR="$1"
+	local PDRV="$2"
+	local PMEDIA="$3"
+	local XFSTYPE2="$4"
+
+	INITRD="initrd.gz"
+	[ -f ${SRCPATH}/ucode.cpio ] && INITRD="ucode.cpio,${INITRD}"
+
+	APPEND="pfix=fsck pmedia=${PMEDIA}"
+	if [ ! "${XFSTYPE2}" ] ; then
+		UUID=$(blkid -o export ${PDRV} | grep ^UUID= | cut -f 2 -d =)
+		[ "$UUID" ] && APPEND="${APPEND} pupsfs=${UUID} psave=${UUID}"
+	fi
+
+	cat << EOF > ${HOMEDIR}/syslinux.cfg
+DEFAULT puppy
+
+LABEL puppy
+	LINUX vmlinuz
+	INITRD ${INITRD}
+	APPEND ${APPEND}
+EOF
+
+	sync
 }
 
 #--
@@ -391,6 +421,14 @@ if [ "$(ls /usr/share/grub2-efi/grub*.efi* 2>/dev/null)" ] ; then
 	)
 fi
 
+if command -v syslinux > /dev/null && [ -f /usr/lib/SYSLINUX/mbr.bin ] ; then
+	SYSLINUX_USB_INSTALLER=$(
+		create_dlg_item "$(gettext '<b>Create syslinux USB (MBR - BIOS)</b>')" \
+			"$(gettext 'Does not support UEFI. Installs the running system. For computers booting with BIOS.')" \
+			install_options.svg 6
+	)
+fi
+
 export ASKDIALOG='
 <window title="'"Bootflash $USBDRV"'" icon-name="gtk-preferences">
 <vbox>
@@ -403,6 +441,8 @@ export ASKDIALOG='
 		"$(gettext 'Does not support UEFI. Installs the running system. For computers booting with BIOS.')" \
 		install_options.svg 2
 		)'
+
+    '${SYSLINUX_USB_INSTALLER}'
 
     '$(create_dlg_item "$(gettext '<b>Write .img[.gz|.xz] file to USB drive</b>')" \
 		"$(gettext "IMG files meant to be written to usb sticks/SD cards...")" \
@@ -549,6 +589,49 @@ case $EXIT in
 		esac
 		;;
 
+	6)
+		#========================
+		#    SYSLINUX
+		#========================
+		BOOTLOADER=syslinux
+		export SYSLINUX_DIALOG='<window title="'"BootFlash: $USBDRV"'" icon-name="gtk-preferences">
+<vbox>
+    '$(/usr/lib/gtkdialog/xml_info fixed execute_yes.svg 30 "$(gettext 'The intention of BootFlash is to make a USB memory stick (Flash drive) bootable.. then to install Puppy on it')")'
+
+	'${F2FS_DLG}'
+
+	'$(create_dlg_item "$(gettext '<b>FAT32 partition + syslinux</b>')" \
+		"$(gettext 'Create FAT32 partition and install syslinux')" \
+		install_options.svg 11
+		)'
+
+    <hbox homogeneous="true" space-expand="true" space-fill="true">
+       <text use-markup="true" space-expand="true" space-fill="true">
+         <label>"<span fgcolor='"'#821811'"'><b>'$(gettext "THIS WILL DESTROY ALL DATA ON ${USBDRV}")'</b></span>"</label>
+       </text>
+    </hbox>
+    <hseparator></hseparator>
+
+    <hbox space-expand="false" space-fill="false">
+     <button>
+       '"`/usr/lib/gtkdialog/xml_button-icon quit`"'
+       <label>'$(gettext 'Quit')'</label>
+       <action type="exit">EXIT</action>
+     </button>
+    </hbox>
+
+  </vbox>
+</window>'
+		. /usr/lib/gtkdialog/xml_info gtk
+		RETPARAMS="`gtkdialog --center --program=SYSLINUX_DIALOG`"
+		eval "$RETPARAMS"
+		case $EXIT in
+			15) FSTYPE='vfat' ; FSTYPE2='f2fs' ;;
+			11) FSTYPE='vfat' ;;
+			*) exit ;;
+		esac
+		;;
+
 	3)
 		#========================
 		#   DD IMG TO USB DRV
@@ -648,7 +731,11 @@ done
 X1PID=$!
 
 if [ "$BOOTLOADER" = "grub4dos" ] ; then
-	create_grub4dos_bootable_drv ${USBDRV} ${FSTYPE} ${FSTYPE2}
+	create_bios_bootable_drv ${USBDRV} ${FSTYPE} ${FSTYPE2}
+	write_wee_mbr /dev/${USBDRV##*/} #install wee.mbr
+elif [ "$BOOTLOADER" = "syslinux" ] ; then
+	create_bios_bootable_drv ${USBDRV} ${FSTYPE} ${FSTYPE2}
+	dd if=/usr/lib/SYSLINUX/mbr.bin of=/dev/${USBDRV##*/}
 elif [ "$BOOTLOADER" = "grub2" ] ; then
 	create_gpt_drv ${USBDRV} ${FSTYPE2}
 else
@@ -687,17 +774,26 @@ fi
 
 if [ "$BOOTLOADER" = "grub4dos" ] ; then
 	copy_g4dos_cd /mnt/${PBOOTPART} auto ${PMEDIA}
+elif [ "$BOOTLOADER" = "syslinux" ] ; then
+	syslinux /dev/${USBDRV}1
+	create_syslinux_conf /mnt/${PBOOTPART} /dev/${PBOOTPART} ${PMEDIA} ${FSTYPE2}
 elif [ "$BOOTLOADER" = "grub2" ] ; then
 	copy_grub2_uefi_boot /mnt/${PBOOTPART} ${PMEDIA}
 fi
 
 FILES2COPY="vmlinuz
 initrd.gz
+ucode.cpio
 ${DISTRO_PUPPYSFS}
 ${DISTRO_ZDRVSFS}
 ${DISTRO_FDRVSFS}
 ${DISTRO_ADRVSFS}
-${DISTRO_YDRVSFS}"
+${DISTRO_YDRVSFS}
+${DISTRO_BDRVSFS}
+kbuild-`uname -r`.sfs
+devx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs
+docx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs
+nlsx_${DISTRO_FILE_PREFIX}_${DISTRO_VERSION}.sfs"
 
 #-------------------------
 if [ "${FSTYPE2}" ] ; then # fat32 + f2fs
@@ -711,6 +807,7 @@ if [ "${FSTYPE2}" ] ; then # fat32 + f2fs
 	#-
 	cp -fv ${SRCPATH}/vmlinuz /mnt/${USBDRV}1/
 	cp -fv ${SRCPATH}/initrd.gz /mnt/${USBDRV}1/
+	[ -f ${SRCPATH}/ucode.cpio ] && cp -fv ${SRCPATH}/ucode.cpio /mnt/${USBDRV}1/
 	#- get partition UUID
 	UUID=$(busybox blkid /dev/${USBDRV}2 | grep -o ' UUID=".*' | cut -f2 -d '"')
 	if [ "$UUID" ] ; then
@@ -720,6 +817,9 @@ if [ "${FSTYPE2}" ] ; then # fat32 + f2fs
 		fi
 		if [ -f /mnt/${USBDRV}1/grub.cfg ] ; then
 			SEDFILES="$SEDFILES /mnt/${USBDRV}1/grub.cfg"
+		fi
+		if [ -f /mnt/${USBDRV}1/syslinux.cfg ] ; then
+			SEDFILES="$SEDFILES /mnt/${USBDRV}1/syslinux.cfg"
 		fi
 		PUPSFS="pupsfs=$UUID psave=$UUID"
 		sed -i \


### PR DESCRIPTION
Unlike extlinux support implemented in #3602, syslinux support in bootflash has the following advantages:
1. The partition layout is identical to that with UEFI (FAT32 partition or FAT32+F2FS), simplifying the code and making the BIOS/UEFI distinction irrelevant in most cases; this PR is the BIOS equivalent of #3599
2. The boot loader, the kernel and the initramfs are on a FAT32 partition, making it easy to makes changes to things like `pfix=`, when all you have is a Windows or Mac machine that can't mount an ext4 partition