### PR TITLE
Persist file metadata changes in snapmergepuppy.overlay

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -184,7 +184,13 @@ do
 			read CTIME SIZE < <(stat -c "%Z %s" "$BASE/$N")
 			if [ ${NCTIME%%.*} -gt $CTIME ] ; then
 				if [ $SIZE -eq $NSIZE ] ; then
-					cmp -s "$N" "$BASE/$N" || cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
+					if cmp -s "$N" "$BASE/$N" ; then
+						chmod "$BASE/$N" --reference="$N" 2>>/tmp/snapmergepuppy-error
+						chown-FULL "$BASE/$N" --reference="$N" 2>>/tmp/snapmergepuppy-error
+						touch "$BASE/$N" --reference="$N" 2>>/tmp/snapmergepuppy-error
+					else
+						cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
+					fi
 				else
 					cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 				fi


### PR DESCRIPTION
For example, if woof-CE is checked out, git thinks that some files have changed after a `git checkout` followed by a reboot, because the timestamps and permissions are not changed in pup_ro1 when a file is identical to its copy in pup_rw.

In addition, this confuses file managers (and users) because file modification timestamps are wrong.