### PR TITLE
Disable "save tabs" by default to make spacefm work better with pmount

### DIFF
--- a/woof-code/rootfs-petbuilds/spacefm/puppy-defaults.patch
+++ b/woof-code/rootfs-petbuilds/spacefm/puppy-defaults.patch
@@ -1,6 +1,6 @@
-diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.am spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.am
---- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.am	2022-10-10 07:43:22.252722720 +0000
-+++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.am	2022-10-10 08:25:42.577315662 +0000
+diff -rupN spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.am spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.am
+--- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.am	2022-11-19 19:48:55.826543892 +0200
++++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.am	2022-11-19 19:49:00.426542756 +0200
 @@ -13,7 +13,6 @@ if NO_PIXMAPS
  icon48dir = $(datadir)/icons/hicolor/48x48/apps
  icon48_DATA = \
@@ -23,9 +23,9 @@ diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.am
  			spacefm-find.png \
  			spacefm-128-cube-blue.png \
  			spacefm-128-cube-green.png \
-diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.in spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.in
---- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.in	2022-10-10 07:43:22.252722720 +0000
-+++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.in	2022-10-10 08:25:42.577315662 +0000
+diff -rupN spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.in spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.in
+--- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.in	2022-11-19 19:48:55.826543892 +0200
++++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/data/Makefile.in	2022-11-19 19:49:00.426542756 +0200
 @@ -318,7 +318,6 @@ DISTCLEANFILES = spacefm.desktop \
  @NO_PIXMAPS_TRUE@icon48dir = $(datadir)/icons/hicolor/48x48/apps
  @NO_PIXMAPS_TRUE@icon48_DATA = \
@@ -48,9 +48,9 @@ diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/data/Makefile.in
  @NO_PIXMAPS_FALSE@			spacefm-find.png \
  @NO_PIXMAPS_FALSE@			spacefm-128-cube-blue.png \
  @NO_PIXMAPS_FALSE@			spacefm-128-cube-green.png \
-diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/main-window.c spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/main-window.c
---- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/main-window.c	2022-10-10 07:43:22.264722709 +0000
-+++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/main-window.c	2022-10-10 08:25:42.581315664 +0000
+diff -rupN spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/main-window.c spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/main-window.c
+--- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/main-window.c	2022-11-19 19:48:55.842543889 +0200
++++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/main-window.c	2022-11-19 19:49:00.426542756 +0200
 @@ -1011,8 +1011,6 @@ void update_window_icon( GtkWindow* wind
      XSet* set = xset_get( "main_icon" );
      if ( set->icon )
@@ -105,9 +105,9 @@ diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/main-window.
          else
              name = "spacefm";
          gtk_about_dialog_set_logo_icon_name( GTK_ABOUT_DIALOG ( about_dlg ), name );
-diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/ptk/ptk-file-browser.c spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/ptk/ptk-file-browser.c
---- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/ptk/ptk-file-browser.c	2022-10-10 07:43:22.264722709 +0000
-+++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/ptk/ptk-file-browser.c	2022-10-10 08:25:42.581315664 +0000
+diff -rupN spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/ptk/ptk-file-browser.c spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/ptk/ptk-file-browser.c
+--- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/ptk/ptk-file-browser.c	2022-11-19 19:48:55.842543889 +0200
++++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/ptk/ptk-file-browser.c	2022-11-19 19:49:00.430542755 +0200
 @@ -4510,9 +4510,6 @@ void init_list_view( PtkFileBrowser* fil
                      xset_get_b_panel_mode( p, column_names[j], mode ) );
          }
@@ -118,9 +118,9 @@ diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/ptk/ptk-file
          gtk_tree_view_column_pack_start( col, renderer, TRUE );       
          gtk_tree_view_column_set_attributes( col, renderer, "text", cols[ j ],
                                                                          NULL );
-diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.c spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.c
---- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.c	2022-10-10 07:43:22.264722709 +0000
-+++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.c	2022-10-10 08:26:38.137341618 +0000
+diff -rupN spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.c spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.c
+--- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.c	2022-11-19 19:48:55.842543889 +0200
++++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.c	2022-11-19 19:51:21.234499476 +0200
 @@ -84,14 +84,14 @@ const gboolean show_wm_menu_default = FA
  const gboolean desk_single_click_default = FALSE;
  const gboolean desk_no_single_hover_default = FALSE;
@@ -148,6 +148,15 @@ diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.c s
      else
          name = "spacefm";
      GtkIconTheme* theme = gtk_icon_theme_get_default();
+@@ -11331,7 +11329,7 @@ void xset_defaults()
+ 
+     set = xset_set( "main_save_tabs", "lbl", _("Save Ta_bs") );
+     set->menu_style = XSET_MENU_CHECK;
+-    set->b = XSET_B_TRUE;
++    set->b = XSET_B_FALSE;
+ 
+     set = xset_set( "main_exit", "lbl", _("E_xit") );
+     xset_set_set( set, "icn", "gtk-quit" );
 @@ -11559,7 +11557,7 @@ void xset_defaults()
      set->menu_style = XSET_MENU_SUBMENU;
  
@@ -191,9 +200,9 @@ diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.c s
          if ( p != 1 )
              xset_set_set( set, "shared_key", "panel1_detcol_date" );
  
-diff -rup spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.h spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.h
---- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.h	2022-10-10 07:43:22.264722709 +0000
-+++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.h	2022-10-10 08:25:42.585315665 +0000
+diff -rupN spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.h spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.h
+--- spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8-orig/src/settings.h	2022-11-19 19:48:55.842543889 +0200
++++ spacefm-e6f291858067e73db44fb57c90e4efb97b088ac8/src/settings.h	2022-11-19 19:49:00.430542755 +0200
 @@ -330,6 +330,7 @@ GList* xset_cmd_history;
  
  static const char* terminal_programs[] =  //for pref-dialog.c


### PR DESCRIPTION
Otherwise, every time a partition is mounted, a new tab is added and these tabs persist to the next spacefm session unless closed by the user.