### PR TITLE
Revert "default to UTC for the system clock"

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -160,7 +160,6 @@ rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 [ \"\$DISTRO_VARIANT\" = \"dwl\" ] && rm -f etc/xdg/autostart/blueman.desktop

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -143,7 +143,6 @@ rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 "

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -142,7 +142,6 @@ rm -f var/packages/Packages-debian-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 rm -f etc/xdg/autostart/blueman.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/pcmanfm.desktop etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -133,7 +133,6 @@ rm -f var/packages/Packages-ubuntu-*
 truncate -s 0 var/packages/Packages-*
 chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/6697 -autoconnect -ssl;/set irc.server.libera.autojoin #puppylinux;/quit\"
 rm -f usr/bin/weechat-headless
-echo HWCLOCKTIME=utc > etc/clock
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 "


### PR DESCRIPTION
Many users just click "OK" without bothering to read first, and don't see that the default is UTC and not localtime. Then, they complain that their clock is messed up.