### PR TITLE
Generate SHA512 checksums

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,6 +165,10 @@ jobs:
       run: |
         for i in `ls ../woof-out_*/woof-output-*/*.{sfs,iso} 2>/dev/null`; do sudo mv -f $i .; done
         sudo mv -f ../woof-out_*/kernel-kit/output/kernel_sources-*.sfs .
+    - name: Generate SHA1 checksums
+      run: |
+        find . -type f -name '*.sfs' -exec sha1sum {} \; > SHA1checksums.sha1
+        find . -type f -name '*.iso' -exec sha1sum {} \; >> SHA1checksums.sha1
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -172,4 +176,5 @@ jobs:
         path: |
           *.iso
           *.sfs
+          SHA1checksums.sha1
         retention-days: ${{ inputs.retention }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -165,10 +165,6 @@ jobs:
       run: |
         for i in `ls ../woof-out_*/woof-output-*/*.{sfs,iso} 2>/dev/null`; do sudo mv -f $i .; done
         sudo mv -f ../woof-out_*/kernel-kit/output/kernel_sources-*.sfs .
-    - name: Generate SHA1 checksums
-      run: |
-        find . -type f -name '*.sfs' -exec sha1sum {} \; > SHA1checksums.sha1
-        find . -type f -name '*.iso' -exec sha1sum {} \; >> SHA1checksums.sha1
     - name: Upload build artifacts
       uses: actions/upload-artifact@v3
       with:
@@ -176,5 +172,4 @@ jobs:
         path: |
           *.iso
           *.sfs
-          SHA1checksums.sha1
         retention-days: ${{ inputs.retention }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,6 +67,10 @@ jobs:
         with:
           name: ${{ github.workflow }}-${{ github.event.inputs.arch }}-${{ github.event.inputs.compat-distro }}-${{ github.event.inputs.compat-distro-version }}-${{ github.run_number }}
           path: .
+      - name: Generate SHA512 checksums
+        run: |
+          find . -type f -name '*.sfs' -exec sha512sum {} \; > SHA512checksums.txt
+          find . -type f -name '*.iso' -exec sha512sum {} \; >> SHA512checksums.txt
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -76,5 +80,6 @@ jobs:
           files: |
             *.iso
             *.sfs
+            SHA512checksums.txt
           draft: true
           prerelease: false


### PR DESCRIPTION
This PR allows Github Actions to generate and upload `SHA512` checksums for `.iso` and `.sfs` files.