### PR TITLE
Update jammy64

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -296,6 +296,7 @@ yes|libcurl3-gnutls|libcurl3-gnutls|exe,dev,doc,nls||deps:yes #this is needed by
 no|libdaemon|libdaemon0,libdaemon-dev|exe,dev,doc,nls||deps:yes
 yes|libdatrie|libdatrie1,libdatrie-dev|exe,dev,doc,nls||deps:yes
 yes|libdb|libdb5.3,libdb5.3-dev|exe,dev,doc,nls||deps:yes
+yes|libdbus-glib|libdbus-glib-1-2|exe,dev,doc,nls||deps:yes #needed by palemoon
 no|libdbusmenu|libdbusmenu-gtk3-4,libdbusmenu-glib4|exe,dev,doc,nls #needed by libappindicator. left off dev debs.
 no|libdc1394|libdc1394-22,libdc1394-22-dev|exe,dev,doc,nls #ffmpeg3 compiled in luci needs this
 no|libdca|libdca0,libdca-dev|exe,dev,doc,nls #mplayer needs this.

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -488,7 +488,7 @@ yes|ncurses|ncurses-base,ncurses-term,ncurses-bin,libncurses6,libncurses-dev,lib
 no|nenscript||exe
 yes|netbase|netbase|exe>null,dev>null,doc>null,nls>null
 yes|net-tools|net-tools|exe,dev,doc,nls||deps:yes
-yes|netsurf|netsurf-gtk|exe,dev,doc,nls||deps:yes
+no|netsurf|netsurf-gtk|exe,dev,doc,nls||deps:yes #use palemoon 'petbuild' instead
 yes|nettle|libnettle8,nettle-dev,libhogweed6|exe,dev,doc,nls||deps:yes #needed by libarchive.
 no|netmon_wce||exe,dev
 no|network_roxapp_samba||exe

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -76,7 +76,7 @@ PTHEME="Flat-grey"
 #XERRS_FLG=yes
 
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
-INCLUDE_PKG=n
+INCLUDE_PKG=y
 
 ## ucode.cpio initial ram disk with CPU bugfixes
 ## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -38,7 +38,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3
@@ -103,7 +103,7 @@ defaultarchiver=
 defaultaudioeditor=
 defaultaudiomixer=
 defaultaudioplayer=
-defaultbrowser=
+defaultbrowser=palemoon
 defaultcalendar=Xdialog --calendar '' 350x270
 defaultcdplayer=deadbeef
 defaultcdrecorder=

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -76,7 +76,7 @@ PTHEME="Flat-grey"
 #XERRS_FLG=yes
 
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
-INCLUDE_PKG=y
+INCLUDE_PKG=n
 
 ## ucode.cpio initial ram disk with CPU bugfixes
 ## build the microcode initrd to mitigate aganst cpu bugs like spectre/meltdown

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -67,7 +67,8 @@ EXTRA_STRIPPING=no
 #PTHEME="Bright Touch"
 #PTHEME="Bright Mouse"
 #PTHEME="Dark_Blue"
-PTHEME="Tahrpup"
+#PTHEME="Tahrpup"
+PTHEME="Flat-grey"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -38,7 +38,7 @@ DEVX_IN_ISO=no
 USR_SYMLINKS=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint osmo pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -98,7 +98,40 @@ UCODE_EXEC=../support/latest_microcode.sh
 ## If you specify a value it will override anything that previously
 ##   set that value in the corresponding script...
 ## These are the current default*apps (scripts) in /usr/local/bin
-DEFAULTAPPS=""
+DEFAULTAPPS="
+defaultarchiver=
+defaultaudioeditor=
+defaultaudiomixer=
+defaultaudioplayer=
+defaultbrowser=
+defaultcalendar=Xdialog --calendar '' 350x270
+defaultcdplayer=deadbeef
+defaultcdrecorder=
+defaultchat=
+defaultchmviewer=
+defaultconnect=
+defaultcontact=
+defaultdraw=
+defaultemail=claws-mail
+defaultfilemanager=
+defaulthandler=
+defaulthtmleditor=
+defaulthtmlviewer=defaultbrowser
+defaultimageeditor=
+defaultimageviewer=
+defaultmediaplayer=
+defaultpaint=
+defaultpdfviewer=
+defaultprocessmanager=
+defaultrun=
+defaultscreenshot=mtpaint -s
+defaultspreadsheet=
+defaultterminal=lxterminal
+defaulttexteditor=geany
+defaulttextviewer=geany
+defaulttorrent=
+defaultwordprocessor=
+"
 
 ## PROMPT - change the CLI prompt to whatever you like. Default is unset
 PROMPT='PS1="\e[1;32m\u@\H\e[0m:\e[1;34m\w\e[0m\$ "'

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -101,7 +101,7 @@ UCODE_EXEC=../support/latest_microcode.sh
 DEFAULTAPPS=""
 
 ## PROMPT - change the CLI prompt to whatever you like. Default is unset
-PROMPT='PS1="\w\$ "'
+PROMPT='PS1="\e[1;32m\u@\H\e[0m:\e[1;34m\w\e[0m\$ "'
 
 ## -- EXTRA FLAG --
 ## This allows some customisation for the iso name


### PR DESCRIPTION
This PR updates `jammy64` with few configurations. **Palemoon** is also added (petbuild version). **Osmo** is also removed. **Xdialog** calendar is used instead.