### PR TITLE
Allow apt support even if using .pet packages and enable in jammy64

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -25,7 +25,6 @@ for i in $@ ; do
 			BUILD_DEVX=yes
 			BUILD_DOCX=yes
 			BUILD_NLSX=yes
-			BUILD_BDRV=yes
 			;;
 	esac
 done

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -4,12 +4,6 @@
 . ../_00build.conf
 [ ! -e ../_00build_2.conf ] || . ../_00build_2.conf
 
-PETS=`cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 2,5 -d \| | grep -v ^compat\| | cut -f 2 -d \| | tr '\n' ' '`
-if [ -n "$PETS" ]; then
-	echo "Cannot build bdrv, using pet packages: $PETS"
-	exit 0
-fi
-
 debootstrap=`command -v debootstrap || :`
 if [ -z "$debootstrap" ]; then
 	echo "WARNING: debootstrap is missing"
@@ -94,8 +88,10 @@ chroot bdrv apt-mark hold busybox-static
 chroot bdrv apt-mark hold snapd
 
 # install all packages that didn't get fully redirected to devx
-PKGS=`cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 1,5 -d \| |
-while IFS=\| read GENERICNAME NAME; do
+PKGS=`cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 1,2,5 -d \| |
+while IFS=\| read GENERICNAME TYPE NAME; do
+	[ "$TYPE" = "compat" ] || continue
+
 	case "$NAME" in
 	*-dev|*-dev-bin|*-devtools|*-headers) continue ;;
 	esac
@@ -144,7 +140,9 @@ find bdrv | tac | while read FILE; do
 done
 
 # delete files and directories present in the main SFS
-cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 5 -d \| | while read NAME; do
+cat ../status/findpkgs_FINAL_PKGS-${DISTRO_BINARY_COMPAT}-${DISTRO_COMPAT_VERSION} | cut -f 2,5 -d \| | while IFS=\| read TYPE NAME; do
+	[ "$TYPE" = "compat" ] || continue
+
 	LIST=bdrv/var/lib/dpkg/info/$NAME:$ARCH.list
 	[ -f "$LIST" ] || LIST=bdrv/var/lib/dpkg/info/$NAME.list
 	[ -f "$LIST" ] || continue

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -49,6 +49,9 @@ KBUILD_IN_ISO=yes
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 
+## build bdrv? yes/no
+BUILD_BDRV=yes
+
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 if [ "$DISTRO_VARIANT" = "dwl" -o "$DISTRO_VARIANT" = "xwayland" ]; then

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -46,6 +46,9 @@ KBUILD_IN_ISO=yes
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 
+## build bdrv? yes/no
+BUILD_BDRV=yes
+
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui gpicview rox-filer"

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -46,6 +46,9 @@ KBUILD_IN_ISO=yes
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 
+## build bdrv? yes/no
+BUILD_BDRV=yes
+
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 PETBUILDS="$PETBUILDS labwc swaylock wlopm xdg-puppy-labwc gpicview pcmanfm pupmoon-font pup-volume-monitor"

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -37,6 +37,9 @@ DEVX_IN_ISO=no
 ## symlink /bin, /sbin and /lib to their /usr counterparts, like Debian?
 USR_SYMLINKS=yes
 
+## build bdrv? yes/no
+BUILD_BDRV=yes
+
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec gpicview gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat"
 


### PR DESCRIPTION
See #3639.

@lakshayrohila What do you think?