### PR TITLE
Fix https://github.com/puppylinux-woof-CE/woof-CE/issues/3646.

### DIFF
--- a/woof-code/rootfs-petbuilds/palemoon/petbuild
+++ b/woof-code/rootfs-petbuilds/palemoon/petbuild
@@ -1,5 +1,5 @@
 download() {
-    [ -f palemoon-31.4.0.linux-x86_64-gtk3.tar.xz ] || wget -t 3 -T 60 https://linux.palemoon.org/datastore/release/palemoon-31.4.0.linux-x86_64-gtk3.tar.xz
+    [ -f palemoon-31.4.0.linux-x86_64-gtk3.tar.xz ] || wget -t 3 -T 60 https://linux.palemoon.org/datastore/release/palemoon-31.4.0.linux-x86_64-gtk3.tar.xz || wget -t 3 -T 60 https://archive.palemoon.org/palemoon/31.x/31.4.0/palemoon-31.4.0.linux-x86_64-gtk3.tar.xz
 }
 
 build() {


### PR DESCRIPTION
Add `archive.palemoon.org` link as well, as a fallback, if `linux.palemoon.org` one is not found.