### PR TITLE
Drop /var/local/bdrv_loaded

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -45,7 +45,7 @@ else
   . /root/.packages/DISTRO_PET_REPOS
   cd /root/.packages
   RUNNINGPUP='yes'
-  if [ -e /var/local/bdrv_loaded ]; then
+  if command -v apt > /dev/null; then
     PKG_DOCS_DISTRO_COMPAT=""
     REPOS_DISTRO_COMPAT=""
   fi

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -208,6 +208,3 @@ if [ -d bdrv/usr/share/gnome/help ]; then
 	mv bdrv/usr/share/gnome/help bdrv_DOC/usr/share/gnome/
 	rmdir bdrv/usr/share/gnome 2>/dev/null
 fi
-
-mkdir -p bdrv/var/local
-touch bdrv/var/local/bdrv_loaded


### PR DESCRIPTION
The "nlsx is loaded" flag is gone, so let's get rid of this one too in the sake of consistency.