### PR TITLE
Request SCHED_RR for dwl and Xwayland to reduce input lag

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/dwl-kiosk.patch
@@ -1,10 +1,23 @@
-From 12eb25ef1e7fe9a5b201c09474447e4895e08f2a Mon Sep 17 00:00:00 2001
+From 2e7eaa9b251baca53536364989ca787e9a7a7698 Mon Sep 17 00:00:00 2001
 From: Dima Krasner <dima@dimakrasner.com>
-Date: Sat, 19 Nov 2022 11:55:32 +0200
+Date: Sun, 27 Nov 2022 09:23:23 +0200
 Subject: [PATCH] Squashed commit of the following:
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
 Content-Transfer-Encoding: 8bit
+
+commit e8a6cbffefe66ee68baeb2fde2211b15c779f320
+Merge: 54f9b86 ba35648
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Sun Nov 27 09:22:48 2022 +0200
+
+    Merge branch 'rr' of https://github.com/dimkr/dwl into dwl-kiosk-v4
+
+commit ba35648b60948f97ee4e786ec9f318c396b94012
+Author: Dima Krasner <dima@dimakrasner.com>
+Date:   Sun Nov 27 09:18:00 2022 +0200
+
+    request SCHED_RR like Sway does (see swaywm/sway@7f78467)
 
 commit 54f9b8635028ea5c04ca24a336d25ef1321f6a2c
 Merge: f2638da 569f554
@@ -284,10 +297,10 @@ Date:   Sun Jul 24 17:52:07 2022 +0300
 ---
  Makefile                                      |  13 +-
  config.def.h                                  |  42 +-
- dwl.c                                         | 629 ++++++++++++++++--
+ dwl.c                                         | 658 ++++++++++++++++--
  env.c                                         | 213 ++++++
  ...lr-output-power-management-unstable-v1.xml | 128 ++++
- 5 files changed, 958 insertions(+), 67 deletions(-)
+ 5 files changed, 987 insertions(+), 67 deletions(-)
  create mode 100644 env.c
  create mode 100644 protocols/wlr-output-power-management-unstable-v1.xml
 
@@ -414,10 +427,10 @@ index b3caab34..e70eb4c6 100644
  	CHVT(7), CHVT(8), CHVT(9), CHVT(10), CHVT(11), CHVT(12),
  };
 diff --git a/dwl.c b/dwl.c
-index b884d06a..d415e927 100644
+index b884d06a..ba7d08b9 100644
 --- a/dwl.c
 +++ b/dwl.c
-@@ -1,10 +1,12 @@
+@@ -1,10 +1,14 @@
  /*
   * See LICENSE file for copyright and license details.
   */
@@ -427,10 +440,12 @@ index b884d06a..d415e927 100644
  #include <limits.h>
  #include <linux/input-event-codes.h>
 +#include <pixman-1/pixman.h>
++#include <pthread.h>
++#include <sched.h>
  #include <signal.h>
  #include <stdio.h>
  #include <stdlib.h>
-@@ -29,12 +31,16 @@
+@@ -29,12 +33,16 @@
  #include <wlr/types/wlr_keyboard.h>
  #include <wlr/types/wlr_layer_shell_v1.h>
  #include <wlr/types/wlr_output.h>
@@ -447,7 +462,7 @@ index b884d06a..d415e927 100644
  #include <wlr/types/wlr_scene.h>
  #include <wlr/types/wlr_screencopy_v1.h>
  #include <wlr/types/wlr_seat.h>
-@@ -47,6 +53,7 @@
+@@ -47,6 +55,7 @@
  #include <wlr/types/wlr_xdg_output_v1.h>
  #include <wlr/types/wlr_xdg_shell.h>
  #include <wlr/util/log.h>
@@ -455,7 +470,7 @@ index b884d06a..d415e927 100644
  #include <xkbcommon/xkbcommon.h>
  #ifdef XWAYLAND
  #include <X11/Xlib.h>
-@@ -110,6 +117,10 @@ typedef struct {
+@@ -110,6 +119,10 @@ typedef struct {
  	struct wl_listener destroy;
  	struct wl_listener set_title;
  	struct wl_listener fullscreen;
@@ -466,7 +481,7 @@ index b884d06a..d415e927 100644
  	struct wlr_box prev;  /* layout-relative, includes border */
  #ifdef XWAYLAND
  	struct wl_listener activate;
-@@ -120,6 +131,8 @@ typedef struct {
+@@ -120,6 +133,8 @@ typedef struct {
  	unsigned int tags;
  	int isfloating, isurgent, isfullscreen;
  	uint32_t resize; /* configure serial of a pending resize */
@@ -475,7 +490,7 @@ index b884d06a..d415e927 100644
  } Client;
  
  typedef struct {
-@@ -195,6 +208,14 @@ typedef struct {
+@@ -195,6 +210,14 @@ typedef struct {
  	enum wl_output_transform rr;
  } MonitorRule;
  
@@ -490,7 +505,7 @@ index b884d06a..d415e927 100644
  typedef struct {
  	const char *id;
  	const char *title;
-@@ -215,6 +236,8 @@ static void arrangelayer(Monitor *m, struct wl_list *list,
+@@ -215,6 +238,8 @@ static void arrangelayer(Monitor *m, struct wl_list *list,
  static void arrangelayers(Monitor *m);
  static void axisnotify(struct wl_listener *listener, void *data);
  static void buttonpress(struct wl_listener *listener, void *data);
@@ -499,7 +514,7 @@ index b884d06a..d415e927 100644
  static void chvt(const Arg *arg);
  static void checkidleinhibitor(struct wlr_surface *exclude);
  static void cleanup(void);
-@@ -223,17 +246,22 @@ static void cleanupmon(struct wl_listener *listener, void *data);
+@@ -223,17 +248,22 @@ static void cleanupmon(struct wl_listener *listener, void *data);
  static void closemon(Monitor *m);
  static void commitlayersurfacenotify(struct wl_listener *listener, void *data);
  static void commitnotify(struct wl_listener *listener, void *data);
@@ -522,7 +537,7 @@ index b884d06a..d415e927 100644
  static Monitor *dirtomon(enum wlr_direction dir);
  static void focusclient(Client *c, int lift);
  static void focusmon(const Arg *arg);
-@@ -242,7 +270,7 @@ static Client *focustop(Monitor *m);
+@@ -242,7 +272,7 @@ static Client *focustop(Monitor *m);
  static void fullscreennotify(struct wl_listener *listener, void *data);
  static void incnmaster(const Arg *arg);
  static void inputdevice(struct wl_listener *listener, void *data);
@@ -531,7 +546,7 @@ index b884d06a..d415e927 100644
  static void keypress(struct wl_listener *listener, void *data);
  static void keypressmod(struct wl_listener *listener, void *data);
  static void killclient(const Arg *arg);
-@@ -250,15 +278,18 @@ static void maplayersurfacenotify(struct wl_listener *listener, void *data);
+@@ -250,15 +280,18 @@ static void maplayersurfacenotify(struct wl_listener *listener, void *data);
  static void mapnotify(struct wl_listener *listener, void *data);
  static void monocle(Monitor *m);
  static void motionabsolute(struct wl_listener *listener, void *data);
@@ -551,7 +566,7 @@ index b884d06a..d415e927 100644
  static void quit(const Arg *arg);
  static void quitsignal(int signo);
  static void rendermon(struct wl_listener *listener, void *data);
-@@ -270,19 +301,27 @@ static void setcursor(struct wl_listener *listener, void *data);
+@@ -270,19 +303,27 @@ static void setcursor(struct wl_listener *listener, void *data);
  static void setfloating(Client *c, int floating);
  static void setfullscreen(Client *c, int fullscreen);
  static void setlayout(const Arg *arg);
@@ -579,7 +594,7 @@ index b884d06a..d415e927 100644
  static void toggletag(const Arg *arg);
  static void toggleview(const Arg *arg);
  static void unmaplayersurfacenotify(struct wl_listener *listener, void *data);
-@@ -309,6 +348,7 @@ static struct wlr_scene_node *layers[NUM_LAYERS];
+@@ -309,6 +350,7 @@ static struct wlr_scene_node *layers[NUM_LAYERS];
  static struct wlr_renderer *drw;
  static struct wlr_allocator *alloc;
  static struct wlr_compositor *compositor;
@@ -587,7 +602,7 @@ index b884d06a..d415e927 100644
  
  static struct wlr_xdg_shell *xdg_shell;
  static struct wlr_xdg_activation_v1 *activation;
-@@ -321,20 +361,36 @@ static struct wlr_layer_shell_v1 *layer_shell;
+@@ -321,20 +363,36 @@ static struct wlr_layer_shell_v1 *layer_shell;
  static struct wlr_output_manager_v1 *output_mgr;
  static struct wlr_virtual_keyboard_manager_v1 *virtual_keyboard_mgr;
  
@@ -624,7 +639,7 @@ index b884d06a..d415e927 100644
  /* global event handlers */
  static struct wl_listener cursor_axis = {.notify = axisnotify};
  static struct wl_listener cursor_button = {.notify = buttonpress};
-@@ -348,6 +404,7 @@ static struct wl_listener layout_change = {.notify = updatemons};
+@@ -348,6 +406,7 @@ static struct wl_listener layout_change = {.notify = updatemons};
  static struct wl_listener new_input = {.notify = inputdevice};
  static struct wl_listener new_virtual_keyboard = {.notify = virtualkeyboard};
  static struct wl_listener new_output = {.notify = createmon};
@@ -632,7 +647,7 @@ index b884d06a..d415e927 100644
  static struct wl_listener new_xdg_surface = {.notify = createnotify};
  static struct wl_listener new_layer_shell_surface = {.notify = createlayersurface};
  static struct wl_listener output_mgr_apply = {.notify = outputmgrapply};
-@@ -378,6 +435,8 @@ static Atom netatom[NetLast];
+@@ -378,6 +437,8 @@ static Atom netatom[NetLast];
  /* attempt to encapsulate suck into one file */
  #include "client.h"
  
@@ -641,7 +656,7 @@ index b884d06a..d415e927 100644
  /* compile-time check if all tags fit into an unsigned int bit array. */
  struct NumTags { char limitexceeded[LENGTH(tags) > 31 ? -1 : 1]; };
  
-@@ -491,6 +550,17 @@ applyrules(Client *c)
+@@ -491,6 +552,17 @@ applyrules(Client *c)
  					mon = m;
  		}
  	}
@@ -659,7 +674,7 @@ index b884d06a..d415e927 100644
  	wlr_scene_node_reparent(c->scene, layers[c->isfloating ? LyrFloat : LyrTile]);
  	setmon(c, mon, newtags);
  }
-@@ -505,7 +575,7 @@ arrange(Monitor *m)
+@@ -505,7 +577,7 @@ arrange(Monitor *m)
  
  	if (m && m->lt[m->sellt]->arrange)
  		m->lt[m->sellt]->arrange(m);
@@ -668,7 +683,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -663,12 +733,11 @@ buttonpress(struct wl_listener *listener, void *data)
+@@ -663,12 +735,11 @@ buttonpress(struct wl_listener *listener, void *data)
  		xytonode(cursor->x, cursor->y, NULL, &c, NULL, NULL, NULL);
  		if (c && (!client_is_unmanaged(c) || client_wants_focus(c)))
  			focusclient(c, 1);
@@ -682,7 +697,7 @@ index b884d06a..d415e927 100644
  				b->func(&b->arg);
  				return;
  			}
-@@ -683,7 +752,7 @@ buttonpress(struct wl_listener *listener, void *data)
+@@ -683,7 +754,7 @@ buttonpress(struct wl_listener *listener, void *data)
  			 * we will send an enter event after which the client will provide us
  			 * a cursor surface */
  			wlr_seat_pointer_clear_focus(seat);
@@ -691,7 +706,7 @@ index b884d06a..d415e927 100644
  			/* Drop the window off on its new monitor */
  			selmon = xytomon(cursor->x, cursor->y);
  			setmon(grabc, selmon, 0);
-@@ -699,6 +768,59 @@ buttonpress(struct wl_listener *listener, void *data)
+@@ -699,6 +770,59 @@ buttonpress(struct wl_listener *listener, void *data)
  			event->time_msec, event->button, event->state);
  }
  
@@ -751,7 +766,7 @@ index b884d06a..d415e927 100644
  void
  chvt(const Arg *arg)
  {
-@@ -745,6 +867,9 @@ cleanup(void)
+@@ -745,6 +869,9 @@ cleanup(void)
  	wlr_output_layout_destroy(output_layout);
  	wlr_seat_destroy(seat);
  	wl_display_destroy(dpy);
@@ -761,7 +776,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -860,6 +985,14 @@ commitnotify(struct wl_listener *listener, void *data)
+@@ -860,6 +987,14 @@ commitnotify(struct wl_listener *listener, void *data)
  		c->resize = 0;
  }
  
@@ -776,7 +791,7 @@ index b884d06a..d415e927 100644
  void
  createidleinhibitor(struct wl_listener *listener, void *data)
  {
-@@ -951,9 +1084,11 @@ createmon(struct wl_listener *listener, void *data)
+@@ -951,9 +1086,11 @@ createmon(struct wl_listener *listener, void *data)
  	/* This event is raised by the backend when a new output (aka a display or
  	 * monitor) becomes available. */
  	struct wlr_output *wlr_output = data;
@@ -789,7 +804,7 @@ index b884d06a..d415e927 100644
  	m->wlr_output = wlr_output;
  
  	wlr_output_init_render(wlr_output, alloc, drw);
-@@ -966,8 +1101,21 @@ createmon(struct wl_listener *listener, void *data)
+@@ -966,8 +1103,21 @@ createmon(struct wl_listener *listener, void *data)
  		if (!r->name || strstr(wlr_output->name, r->name)) {
  			m->mfact = r->mfact;
  			m->nmaster = r->nmaster;
@@ -813,7 +828,7 @@ index b884d06a..d415e927 100644
  			m->lt[0] = m->lt[1] = r->lt;
  			wlr_output_set_transform(wlr_output, r->rr);
  			break;
-@@ -978,7 +1126,17 @@ createmon(struct wl_listener *listener, void *data)
+@@ -978,7 +1128,17 @@ createmon(struct wl_listener *listener, void *data)
  	 * monitor supports only a specific set of modes. We just pick the
  	 * monitor's preferred mode; a more sophisticated compositor would let
  	 * the user configure it. */
@@ -832,7 +847,7 @@ index b884d06a..d415e927 100644
  	wlr_output_enable_adaptive_sync(wlr_output, 1);
  
  	/* Set up event listeners */
-@@ -989,6 +1147,14 @@ createmon(struct wl_listener *listener, void *data)
+@@ -989,6 +1149,14 @@ createmon(struct wl_listener *listener, void *data)
  	if (!wlr_output_commit(wlr_output))
  		return;
  
@@ -847,7 +862,7 @@ index b884d06a..d415e927 100644
  	wl_list_insert(&mons, &m->link);
  	printstatus();
  
-@@ -999,7 +1165,7 @@ createmon(struct wl_listener *listener, void *data)
+@@ -999,7 +1167,7 @@ createmon(struct wl_listener *listener, void *data)
  	 * output (such as DPI, scale factor, manufacturer, etc).
  	 */
  	m->scene_output = wlr_scene_output_create(scene, wlr_output);
@@ -856,7 +871,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -1043,6 +1209,14 @@ createnotify(struct wl_listener *listener, void *data)
+@@ -1043,6 +1211,14 @@ createnotify(struct wl_listener *listener, void *data)
  	LISTEN(&xdg_surface->toplevel->events.set_title, &c->set_title, updatetitle);
  	LISTEN(&xdg_surface->toplevel->events.request_fullscreen, &c->fullscreen,
  			fullscreennotify);
@@ -871,7 +886,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -1083,11 +1257,80 @@ createpointer(struct wlr_input_device *device)
+@@ -1083,11 +1259,80 @@ createpointer(struct wlr_input_device *device)
  			libinput_device_config_accel_set_profile(libinput_device, accel_profile);
  			libinput_device_config_accel_set_speed(libinput_device, accel_speed);
  		}
@@ -952,7 +967,7 @@ index b884d06a..d415e927 100644
  void
  cursorframe(struct wl_listener *listener, void *data)
  {
-@@ -1099,6 +1342,31 @@ cursorframe(struct wl_listener *listener, void *data)
+@@ -1099,6 +1344,31 @@ cursorframe(struct wl_listener *listener, void *data)
  	wlr_seat_pointer_notify_frame(seat);
  }
  
@@ -984,7 +999,7 @@ index b884d06a..d415e927 100644
  void
  destroydragicon(struct wl_listener *listener, void *data)
  {
-@@ -1106,7 +1374,7 @@ destroydragicon(struct wl_listener *listener, void *data)
+@@ -1106,7 +1376,7 @@ destroydragicon(struct wl_listener *listener, void *data)
  	wlr_scene_node_destroy(icon->data);
  	/* Focus enter isn't sent during drag, so refocus the focused node. */
  	focusclient(selclient(), 1);
@@ -993,7 +1008,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -1141,6 +1409,10 @@ destroynotify(struct wl_listener *listener, void *data)
+@@ -1141,6 +1411,10 @@ destroynotify(struct wl_listener *listener, void *data)
  	wl_list_remove(&c->destroy.link);
  	wl_list_remove(&c->set_title.link);
  	wl_list_remove(&c->fullscreen.link);
@@ -1004,7 +1019,7 @@ index b884d06a..d415e927 100644
  #ifdef XWAYLAND
  	if (c->type != XDGShell) {
  		wl_list_remove(&c->configure.link);
-@@ -1151,6 +1423,26 @@ destroynotify(struct wl_listener *listener, void *data)
+@@ -1151,6 +1425,26 @@ destroynotify(struct wl_listener *listener, void *data)
  	free(c);
  }
  
@@ -1031,7 +1046,7 @@ index b884d06a..d415e927 100644
  Monitor *
  dirtomon(enum wlr_direction dir)
  {
-@@ -1174,7 +1466,7 @@ focusclient(Client *c, int lift)
+@@ -1174,7 +1468,7 @@ focusclient(Client *c, int lift)
  	int i;
  
  	/* Raise client in stacking order if requested */
@@ -1040,7 +1055,7 @@ index b884d06a..d415e927 100644
  		wlr_scene_node_raise_to_top(c->scene);
  
  	if (c && client_surface(c) == old)
-@@ -1231,7 +1523,7 @@ focusclient(Client *c, int lift)
+@@ -1231,7 +1525,7 @@ focusclient(Client *c, int lift)
  	}
  
  	/* Change cursor surface */
@@ -1049,7 +1064,7 @@ index b884d06a..d415e927 100644
  
  	/* Have a client, so focus its top-level wlr_surface */
  	client_notify_enter(client_surface(c), wlr_seat_get_keyboard(seat));
-@@ -1337,7 +1629,7 @@ inputdevice(struct wl_listener *listener, void *data)
+@@ -1337,7 +1631,7 @@ inputdevice(struct wl_listener *listener, void *data)
  }
  
  int
@@ -1058,7 +1073,7 @@ index b884d06a..d415e927 100644
  {
  	/*
  	 * Here we handle compositor keybindings. This is when the compositor is
-@@ -1348,7 +1640,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
+@@ -1348,7 +1642,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
  	const Key *k;
  	for (k = keys; k < END(keys); k++) {
  		if (CLEANMASK(mods) == CLEANMASK(k->mod) &&
@@ -1067,7 +1082,7 @@ index b884d06a..d415e927 100644
  			k->func(&k->arg);
  			handled = 1;
  		}
-@@ -1359,6 +1651,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
+@@ -1359,6 +1653,7 @@ keybinding(uint32_t mods, xkb_keysym_t sym)
  void
  keypress(struct wl_listener *listener, void *data)
  {
@@ -1075,7 +1090,7 @@ index b884d06a..d415e927 100644
  	int i;
  	/* This event is raised when a key is pressed or released. */
  	Keyboard *kb = wl_container_of(listener, kb, key);
-@@ -1369,7 +1662,7 @@ keypress(struct wl_listener *listener, void *data)
+@@ -1369,7 +1664,7 @@ keypress(struct wl_listener *listener, void *data)
  	/* Get a list of keysyms based on the keymap for this keyboard */
  	const xkb_keysym_t *syms;
  	int nsyms = xkb_state_key_get_syms(
@@ -1084,7 +1099,7 @@ index b884d06a..d415e927 100644
  
  	int handled = 0;
  	uint32_t mods = wlr_keyboard_get_modifiers(kb->device->keyboard);
-@@ -1381,7 +1674,7 @@ keypress(struct wl_listener *listener, void *data)
+@@ -1381,7 +1676,7 @@ keypress(struct wl_listener *listener, void *data)
  	if (!input_inhibit_mgr->active_inhibitor
  			&& event->state == WL_KEYBOARD_KEY_STATE_PRESSED)
  		for (i = 0; i < nsyms; i++)
@@ -1093,7 +1108,7 @@ index b884d06a..d415e927 100644
  
  	if (!handled) {
  		/* Pass unhandled keycodes along to the client. */
-@@ -1422,7 +1715,7 @@ maplayersurfacenotify(struct wl_listener *listener, void *data)
+@@ -1422,7 +1717,7 @@ maplayersurfacenotify(struct wl_listener *listener, void *data)
  {
  	LayerSurface *l = wl_container_of(listener, l, map);
  	wlr_surface_send_enter(l->layer_surface->surface, l->mon->wlr_output);
@@ -1102,7 +1117,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -1487,6 +1780,7 @@ mapnotify(struct wl_listener *listener, void *data)
+@@ -1487,6 +1782,7 @@ mapnotify(struct wl_listener *listener, void *data)
  		c->isfloating = 1;
  		wlr_scene_node_reparent(c->scene, layers[LyrFloat]);
  		setmon(c, p->mon, p->tags);
@@ -1110,7 +1125,7 @@ index b884d06a..d415e927 100644
  	} else {
  		applyrules(c);
  	}
-@@ -1519,21 +1813,61 @@ motionabsolute(struct wl_listener *listener, void *data)
+@@ -1519,21 +1815,61 @@ motionabsolute(struct wl_listener *listener, void *data)
  	 * so we have to warp the mouse there. There is also some hardware which
  	 * emits these events. */
  	struct wlr_event_pointer_motion_absolute *event = data;
@@ -1175,7 +1190,7 @@ index b884d06a..d415e927 100644
  		wlr_idle_notify_activity(idle, seat);
  
  		/* Update selmon (even while dragging a window) */
-@@ -1557,18 +1891,6 @@ motionnotify(uint32_t time)
+@@ -1557,18 +1893,6 @@ motionnotify(uint32_t time)
  		return;
  	}
  
@@ -1194,7 +1209,7 @@ index b884d06a..d415e927 100644
  	/* If there's no client surface under the cursor, set the cursor image to a
  	 * default. This is what makes the cursor image appear when you move it
  	 * off of a client or over its border. */
-@@ -1589,8 +1911,8 @@ motionrelative(struct wl_listener *listener, void *data)
+@@ -1589,8 +1913,8 @@ motionrelative(struct wl_listener *listener, void *data)
  	 * special configuration applied for the specific input device which
  	 * generated the event. You can pass NULL for the device if you want to move
  	 * the cursor around without any input. */
@@ -1205,7 +1220,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -1604,6 +1926,8 @@ moveresize(const Arg *arg)
+@@ -1604,6 +1928,8 @@ moveresize(const Arg *arg)
  
  	/* Float the window and tell motionnotify to grab it */
  	setfloating(grabc, 1);
@@ -1214,7 +1229,7 @@ index b884d06a..d415e927 100644
  	switch (cursor_mode = arg->ui) {
  	case CurMove:
  		grabcx = cursor->x - grabc->geom.x;
-@@ -1706,6 +2030,14 @@ outputmgrtest(struct wl_listener *listener, void *data)
+@@ -1706,6 +2032,14 @@ outputmgrtest(struct wl_listener *listener, void *data)
  	outputmgrapplyortest(config, 1);
  }
  
@@ -1229,7 +1244,7 @@ index b884d06a..d415e927 100644
  void
  pointerfocus(Client *c, struct wlr_surface *surface, double sx, double sy,
  		uint32_t time)
-@@ -1769,6 +2101,16 @@ printstatus(void)
+@@ -1769,6 +2103,16 @@ printstatus(void)
  	}
  }
  
@@ -1246,7 +1261,7 @@ index b884d06a..d415e927 100644
  void
  quit(const Arg *arg)
  {
-@@ -1895,7 +2237,10 @@ run(char *startup_cmd)
+@@ -1895,7 +2239,10 @@ run(char *startup_cmd)
  	 * instead of (0, 0) and then jumping.  still may not be fully
  	 * initialized, as the image/coordinates are not transformed for the
  	 * monitor when displayed here */
@@ -1258,7 +1273,7 @@ index b884d06a..d415e927 100644
  	wlr_xcursor_manager_set_cursor_image(cursor_mgr, cursor_image, cursor);
  
  	/* Run the Wayland event loop. This does not return until you exit the
-@@ -1940,6 +2285,8 @@ setfloating(Client *c, int floating)
+@@ -1940,6 +2287,8 @@ setfloating(Client *c, int floating)
  {
  	c->isfloating = floating;
  	wlr_scene_node_reparent(c->scene, layers[c->isfloating ? LyrFloat : LyrTile]);
@@ -1267,7 +1282,7 @@ index b884d06a..d415e927 100644
  	arrange(c->mon);
  	printstatus();
  }
-@@ -1947,6 +2294,7 @@ setfloating(Client *c, int floating)
+@@ -1947,6 +2296,7 @@ setfloating(Client *c, int floating)
  void
  setfullscreen(Client *c, int fullscreen)
  {
@@ -1275,7 +1290,7 @@ index b884d06a..d415e927 100644
  	c->isfullscreen = fullscreen;
  	if (!c->mon)
  		return;
-@@ -1955,7 +2303,10 @@ setfullscreen(Client *c, int fullscreen)
+@@ -1955,7 +2305,10 @@ setfullscreen(Client *c, int fullscreen)
  
  	if (fullscreen) {
  		c->prev = c->geom;
@@ -1287,7 +1302,7 @@ index b884d06a..d415e927 100644
  		/* The xdg-protocol specifies:
  		 *
  		 * If the fullscreened surface is not opaque, the compositor must make
-@@ -1997,6 +2348,25 @@ setlayout(const Arg *arg)
+@@ -1997,6 +2350,25 @@ setlayout(const Arg *arg)
  	printstatus();
  }
  
@@ -1313,7 +1328,47 @@ index b884d06a..d415e927 100644
  /* arg > 1.0 will set mfact absolutely */
  void
  setmfact(const Arg *arg)
-@@ -2087,6 +2457,7 @@ setup(void)
+@@ -2059,12 +2431,39 @@ setsel(struct wl_listener *listener, void *data)
+ 	wlr_seat_set_selection(seat, event->source, event->serial);
+ }
+ 
++static int child_policy;
++static struct sched_param child_prio;
++
++void
++rr_reset(void)
++{
++	pthread_setschedparam(pthread_self(), child_policy, &child_prio);
++}
++
++void
++rr(void)
++{
++	pthread_t self;
++	struct sched_param param;
++
++	self = pthread_self();
++
++	if (pthread_getschedparam(self, &child_policy, &child_prio) != 0)
++		return;
++
++	param.sched_priority = sched_get_priority_min(SCHED_RR);
++	if (pthread_setschedparam(self, SCHED_RR, &param) == 0)
++		pthread_atfork(NULL, NULL, rr_reset);
++}
++
+ void
+ setup(void)
+ {
+ 	/* Force line-buffered stdout */
+ 	setvbuf(stdout, NULL, _IOLBF, 0);
+ 
++	rr();
++
+ 	/* The Wayland display is managed by libwayland. It handles accepting
+ 	 * clients from the Unix socket, manging Wayland globals, and so on. */
+ 	dpy = wl_display_create();
+@@ -2087,6 +2486,7 @@ setup(void)
  
  	/* Initialize the scene graph used to lay out windows */
  	scene = wlr_scene_create();
@@ -1321,7 +1376,7 @@ index b884d06a..d415e927 100644
  	layers[LyrBg] = &wlr_scene_tree_create(&scene->node)->node;
  	layers[LyrBottom] = &wlr_scene_tree_create(&scene->node)->node;
  	layers[LyrTile] = &wlr_scene_tree_create(&scene->node)->node;
-@@ -2123,6 +2494,9 @@ setup(void)
+@@ -2123,6 +2523,9 @@ setup(void)
  	activation = wlr_xdg_activation_v1_create(dpy);
  	wl_signal_add(&activation->events.request_activate, &request_activate);
  
@@ -1331,7 +1386,7 @@ index b884d06a..d415e927 100644
  	/* Creates an output layout, which a wlroots utility for working with an
  	 * arrangement of screens in a physical layout. */
  	output_layout = wlr_output_layout_create();
-@@ -2159,7 +2533,7 @@ setup(void)
+@@ -2159,7 +2562,7 @@ setup(void)
  	/* Use decoration protocols to negotiate server-side decorations */
  	wlr_server_decoration_manager_set_default_mode(
  			wlr_server_decoration_manager_create(dpy),
@@ -1340,7 +1395,7 @@ index b884d06a..d415e927 100644
  	wlr_xdg_decoration_manager_v1_create(dpy);
  
  	/*
-@@ -2200,6 +2574,10 @@ setup(void)
+@@ -2200,6 +2603,10 @@ setup(void)
  	 * let us know when new input devices are available on the backend.
  	 */
  	wl_list_init(&keyboards);
@@ -1351,7 +1406,7 @@ index b884d06a..d415e927 100644
  	wl_signal_add(&backend->events.new_input, &new_input);
  	virtual_keyboard_mgr = wlr_virtual_keyboard_manager_v1_create(dpy);
  	wl_signal_add(&virtual_keyboard_mgr->events.new_virtual_keyboard,
-@@ -2215,9 +2593,17 @@ setup(void)
+@@ -2215,9 +2622,17 @@ setup(void)
  	wl_signal_add(&output_mgr->events.apply, &output_mgr_apply);
  	wl_signal_add(&output_mgr->events.test, &output_mgr_test);
  
@@ -1369,7 +1424,7 @@ index b884d06a..d415e927 100644
  	/*
  	 * Initialise the XWayland X server.
  	 * It will be started when the first X client is started.
-@@ -2250,6 +2636,99 @@ sigchld(int unused)
+@@ -2250,6 +2665,99 @@ sigchld(int unused)
  			child_pid = -1;
  }
  
@@ -1469,7 +1524,7 @@ index b884d06a..d415e927 100644
  void
  spawn(const Arg *arg)
  {
-@@ -2270,10 +2749,26 @@ startdrag(struct wl_listener *listener, void *data)
+@@ -2270,10 +2778,26 @@ startdrag(struct wl_listener *listener, void *data)
  		return;
  
  	drag->icon->data = wlr_scene_subsurface_tree_create(layers[LyrDragIcon], drag->icon->surface);
@@ -1497,7 +1552,7 @@ index b884d06a..d415e927 100644
  void
  tag(const Arg *arg)
  {
-@@ -2344,6 +2839,40 @@ togglefullscreen(const Arg *arg)
+@@ -2344,6 +2868,40 @@ togglefullscreen(const Arg *arg)
  		setfullscreen(sel, !sel->isfullscreen);
  }
  
@@ -1538,7 +1593,7 @@ index b884d06a..d415e927 100644
  void
  toggletag(const Arg *arg)
  {
-@@ -2388,7 +2917,7 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
+@@ -2388,7 +2946,7 @@ unmaplayersurfacenotify(struct wl_listener *listener, void *data)
  	if (layersurface->layer_surface->surface ==
  			seat->keyboard_state.focused_surface)
  		focusclient(selclient(), 1);
@@ -1547,7 +1602,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -2418,7 +2947,7 @@ unmapnotify(struct wl_listener *listener, void *data)
+@@ -2418,7 +2976,7 @@ unmapnotify(struct wl_listener *listener, void *data)
  	wl_list_remove(&c->commit.link);
  	wlr_scene_node_destroy(c->scene);
  	printstatus();
@@ -1556,7 +1611,7 @@ index b884d06a..d415e927 100644
  }
  
  void
-@@ -2456,6 +2985,7 @@ updatemons(struct wl_listener *listener, void *data)
+@@ -2456,6 +3014,7 @@ updatemons(struct wl_listener *listener, void *data)
  			wlr_output_layout_add_auto(output_layout, m->wlr_output);
  	/* Now that we update the output layout we can get its box */
  	sgeom = *wlr_output_layout_get_box(output_layout, NULL);
@@ -1564,7 +1619,7 @@ index b884d06a..d415e927 100644
  	wl_list_for_each(m, &mons, link) {
  		if (!m->wlr_output->enabled)
  			continue;
-@@ -2641,6 +3171,14 @@ createnotifyx11(struct wl_listener *listener, void *data)
+@@ -2641,6 +3200,14 @@ createnotifyx11(struct wl_listener *listener, void *data)
  	LISTEN(&xwayland_surface->events.destroy, &c->destroy, destroynotify);
  	LISTEN(&xwayland_surface->events.request_fullscreen, &c->fullscreen,
  			fullscreennotify);
@@ -1579,7 +1634,7 @@ index b884d06a..d415e927 100644
  }
  
  Atom
-@@ -2704,11 +3242,13 @@ main(int argc, char *argv[])
+@@ -2704,11 +3271,13 @@ main(int argc, char *argv[])
  	char *startup_cmd = NULL;
  	int c;
  
@@ -1594,7 +1649,7 @@ index b884d06a..d415e927 100644
  		else
  			goto usage;
  	}
-@@ -2718,11 +3258,12 @@ main(int argc, char *argv[])
+@@ -2718,11 +3287,12 @@ main(int argc, char *argv[])
  	/* Wayland requires XDG_RUNTIME_DIR for creating its communications socket */
  	if (!getenv("XDG_RUNTIME_DIR"))
  		die("XDG_RUNTIME_DIR must be set");

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -11,13 +11,12 @@ done
 
 [ "$GDK_BACKEND" = "x11" ] && export DISPLAY=:0
 
-XAUTHORITY=~/.Xauthority
-echo "add $DISPLAY . `mcookie`" | xauth -q -f "$XAUTHORITY"
-cp -f $XAUTHORITY /home/spot/.Xauthority
+echo "add $DISPLAY . `mcookie`" | xauth -q -f ~/.Xauthority
+cp -f ~/.Xauthority /home/spot/.Xauthority
 chown spot:spot /home/spot/.Xauthority
 
 if [ "$GDK_BACKEND" = "x11" ]; then
-	Xwayland $DISPLAY -auth $XAUTHORITY &
+	Xwayland-spot $DISPLAY &
 
 	MAX=20
 	CT=0

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/Xwayland-spot
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/Xwayland-spot
@@ -1,3 +1,4 @@
 #!/bin/ash
 
+chrt -r -p 1 $$
 exec Xwayland "$@" -auth ~/.Xauthority


### PR DESCRIPTION
This can help with issues like mouse lag in games that run under Xwayland (see https://github.com/puppylinux-woof-CE/woof-CE/issues/2593#issuecomment-950169060) and improve responsiveness under CPU load.