### PR TITLE
Make the default tray layout closer to the BionicPup and FossaPup one

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-tray1
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-tray1
@@ -4,10 +4,11 @@
 <Tray autohide="off" insert="right" border="0" layer="above" halign="left" valign="bottom" height="28" layout="horizontal" >
     <TrayButton label="Menu" icon="puppy.svg" border="true">root:9</TrayButton>
     <TrayButton popup="Show desktop" icon="desktop.svg">showdesktop</TrayButton>
+    <TrayButton popup="Browser" icon="internet.svg" border="true">exec:defaultbrowser</TrayButton>
+    <TrayButton popup="Terminal" icon="terminal.svg" border="true">exec:defaultterminal</TrayButton>
     <Pager/>
     <TaskList maxwidth="200"/>
     <Dock/>
-    <Swallow name="xload" width="32">xload -nolabel -fg "#225F7C" -hl white -bg "#222"</Swallow>
     <Clock format="%H:%M">root:7</Clock>
 </Tray>
 </JWM>


### PR DESCRIPTION
This shouldn't affect any Puppy built with pTheme enabled.