### PR TITLE
Remove symlink emblems from the default ROX-Filer pinboard

### DIFF
--- a/woof-code/rootfs-petbuilds/rox-filer/root/Choices/ROX-Filer/PuppyPin
+++ b/woof-code/rootfs-petbuilds/rox-filer/root/Choices/ROX-Filer/PuppyPin
@@ -9,12 +9,12 @@
   <icon x="288" y="32" label="setup">/usr/sbin/wizardwizard</icon>
   <icon x="224" y="128" label="draw">/usr/local/bin/defaultdraw</icon>
   <icon x="352" y="32" label="edit">/usr/local/bin/defaulttexteditor</icon>
-  <icon x="416" y="32" label="console">/usr/bin/urxvt</icon>
+  <icon x="416" y="32" label="console">/usr/local/bin/defaultterminal</icon>
   <icon x="32" y="128" label="write">/usr/local/bin/defaultwordprocessor</icon>
   <icon x="32" y="224" label="browse">/usr/local/bin/defaultbrowser</icon>
   <icon x="160" y="36" label="mount">/usr/sbin/pmount</icon>
   <icon x="96" y="36" label="help">/usr/sbin/puppyhelp</icon>
-  <icon x="32" y="32" label="file">/usr/local/bin/rox</icon>
+  <icon x="32" y="32" label="file">/usr/local/bin/defaultfilemanager</icon>
   <icon x="32" y="320" label="plan">/usr/local/bin/defaultcalendar</icon>
   <icon x="32" y="416" label="connect">/usr/local/apps/Connect</icon>
   <icon x="96" y="128" label="calc">/usr/local/bin/defaultspreadsheet</icon>


### PR DESCRIPTION
This shouldn't affect  any Puppy built with pTheme enabled.