### PR TITLE
Make upup look more like FossaPup

### DIFF
--- a/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
+++ b/woof-distro/x86_64/ubuntu/bionic64/DISTRO_PKGS_SPECS-ubuntu-bionic
@@ -243,6 +243,7 @@ yes|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
 yes|gstreamer1|gir1.2-gst-plugins-base-1.0,gir1.2-gstreamer-1.0,libgstreamer1.0-0,libgstreamer-gl1.0-0,libgstreamer-plugins-bad1.0-0,libgstreamer-plugins-base1.0-0,libgstreamer-plugins-good1.0-0,libwayland-server0,libwayland-client0,libgbm1,libegl1-mesa,libegl-mesa0|lexe,dev,doc,nls 
 yes|gstreamer1-dev|libgstreamer1.0-dev,libgstreamer-plugins-bad1.0-dev,libgstreamer-plugins-base1.0-dev,libgstreamer-plugins-good1.0-dev|exe>dev,dev,doc,nls| # GSTREAMER1.0
 yes|gtk+|gir1.2-gtk-2.0,libgtk2.0-0,libgtk2.0-dev|exe,dev,doc,nls
+yes|gtk2-engines-murrine|gtk2-engines-murrine|exe,dev,doc,nls
 yes|gtk2-engines-pixbuf|gtk2-engines-pixbuf|exe,dev,doc,nls
 yes|gtk+3|libgtk-3-0,libgtk-3-dev,libgtk-3-common|exe,dev,doc,nls| #have taken out all gtk3 apps. 140127 still have gnome-mplayer --no
 yes|gtk-chtheme|gtk-chtheme|exe,dev>null,doc,nls

--- a/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/bionic64/_00build.conf
@@ -54,10 +54,15 @@ SFSCOMP='-comp xz -Xbcj x86 -b 512K'
 ## This is usually not needed
 EXTRA_STRIPPING=yes
 
-
-## -- pTheme -- applies only if ptheme pkg is being used
-##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-PTHEME="Original Pup"
+## You can choose a theme here if you wish
+## otherwise 3builddistro will ask you to choose one
+THEME_WALLPAPER="431-dark.svg"
+THEME_GTK2="Numix"
+THEME_JWM="Numix"
+THEME_JWM_BUTTONS="Buntu"
+THEME_GTK_ICONS="PMaterial"
+THEME_DESK_ICONS="PMaterial"
+THEME_MOUSE="Breeze_Snow"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'

--- a/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
+++ b/woof-distro/x86_64/ubuntu/focal64/DISTRO_PKGS_SPECS-ubuntu-focal
@@ -264,6 +264,7 @@ yes|gsm|libgsm1,libgsm1-dev|exe,dev,doc,nls
 yes|gstreamer1|gir1.2-gst-plugins-base-1.0,gir1.2-gstreamer-1.0,libgstreamer1.0-0,libgstreamer-gl1.0-0,libgstreamer-plugins-bad1.0-0,libgstreamer-plugins-base1.0-0,libgstreamer-plugins-good1.0-0,libwayland-server0,libwayland-client0,libgbm1,libegl1-mesa,libegl-mesa0|lexe,dev,doc,nls
 yes|gstreamer1-dev|libgstreamer1.0-dev,libgstreamer-plugins-bad1.0-dev,libgstreamer-plugins-base1.0-dev,libgstreamer-plugins-good1.0-dev|exe>dev,dev,doc,nls| # GSTREAMER1.0
 yes|gtk+|gir1.2-gtk-2.0,libgtk2.0-0,libgtk2.0-common,libgtk2.0-dev|exe,dev,doc,nls
+yes|gtk2-engines-murrine|gtk2-engines-murrine|exe,dev,doc,nls
 yes|gtk2-engines-pixbuf|gtk2-engines-pixbuf|exe,dev,doc,nls
 yes|gtk+3|libgtk-3-0,libgtk-3-dev,libgtk-3-common,adwaita-icon-theme|exe,dev,doc,nls| #have taken out all gtk3 apps. 140127 still have gnome-mplayer --no
 yes|gtk3-nocsd|gtk3-nocsd,libgtk3-nocsd0|exe

--- a/woof-distro/x86_64/ubuntu/focal64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/focal64/_00build.conf
@@ -67,16 +67,15 @@ SFSCOMP='-comp xz -Xbcj x86 -b 256K -no-exports -no-xattrs'
 ## This is usually not needed
 EXTRA_STRIPPING=no
 
-## -- pTheme -- applies only if ptheme pkg is being used
-##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-## You can choose a ptheme here if you wish
+## You can choose a theme here if you wish
 ## otherwise 3builddistro will ask you to choose one
-#PTHEME="Dark Touch"
-#PTHEME="Dark Mouse"
-#PTHEME="Bright Touch"
-#PTHEME="Bright Mouse"
-#PTHEME="Dark_Blue"
-PTHEME="Tahrpup"
+THEME_WALLPAPER="431-dark.svg"
+THEME_GTK2="Numix"
+THEME_JWM="Numix"
+THEME_JWM_BUTTONS="Buntu"
+THEME_GTK_ICONS="PMaterial"
+THEME_DESK_ICONS="PMaterial"
+THEME_MOUSE="Breeze_Snow"
 
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=y

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -502,6 +502,7 @@ no|nspr|libnspr4|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built
 no|nss|libnss3|exe,dev,doc,nls||deps:yes #using seamonkey pkg with these built-in. 120913 enabled.
 yes|ntfs-3g|ntfs-3g|exe,dev,doc,nls||deps:yes
 yes|ntpdate|ntpdate|exe,dev>exe,doc,nls||deps:yes #used by psync to sync local time and date from the internet.
+yes|numix-gtk-theme|numix-gtk-theme|exe,dev,doc,nls||deps:yes
 no|numlockx||exe| #needed by shinobars firstrun.
 no|opencv|libopencv-core*,libopencv-imgproc*|exe,dev>null,doc,nls #ffmpeg needs this. dep: libtbb2. have left off the dev deb.
 no|openjdk-jre|openjdk-11-jre,openjdk-11-jre-headless,ca-certificates-java,java-common|exe,dev,doc,nls #needed if icedtea selected

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -61,17 +61,15 @@ SFSCOMP='-comp zstd -Xcompression-level 19 -b 256K -no-exports -no-xattrs'
 ## This is usually not needed
 EXTRA_STRIPPING=no
 
-## -- pTheme -- applies only if ptheme pkg is being used
-##    woof-code/rootfs-packages/ptheme/usr/share/ptheme/globals
-## You can choose a ptheme here if you wish
+## You can choose a theme here if you wish
 ## otherwise 3builddistro will ask you to choose one
-#PTHEME="Dark Touch"
-#PTHEME="Dark Mouse"
-#PTHEME="Bright Touch"
-#PTHEME="Bright Mouse"
-#PTHEME="Dark_Blue"
-#PTHEME="Tahrpup"
-PTHEME="Flat-grey"
+THEME_WALLPAPER="431-dark.svg"
+THEME_GTK2="Numix"
+THEME_JWM="Numix"
+THEME_JWM_BUTTONS="Buntu"
+THEME_GTK_ICONS="PMaterial"
+THEME_DESK_ICONS="PMaterial"
+THEME_MOUSE="Breeze_Snow"
 
 ## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
 ## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
@@ -161,8 +159,7 @@ mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
 rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop
-for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish) ;; *) rm -vrf \"\$i\" ;; esac; done
-for i in usr/share/ptheme/globals/*; do case \"\$i\" in usr/share/ptheme/globals/Flat-grey|usr/share/ptheme/globals/431|usr/share/ptheme/globals/412|usr/share/ptheme/globals/Buntoo|usr/share/ptheme/globals/Tahrpup) ;; *) rm -vf \"\$i\" ;; esac; done
+for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish|usr/share/themes/Numix) ;; *) rm -vrf \"\$i\" ;; esac; done
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf
 ln -s ../conf.avail/10-hinting-none.conf etc/fonts/conf.d/


### PR DESCRIPTION
Uses Numix (not the "dusk" variant, because only the former is available as an Ubuntu package), PMaterial, KDE cursors and @01micko's 431-dark.svg. I'd say this combination looks good, demonstrates how Puppy can be customized to be not-so-ugly, and it's pretty close to FossaPup.

![jammy64](https://user-images.githubusercontent.com/1471149/204453814-ffd9a99f-d036-442f-a0ee-7cdf62f56715.png)

@lakshayrohila What do you think?