### PR TITLE
Turn off the screen without locking when the compositor is idle

### DIFF
--- a/woof-code/rootfs-skeleton/root/.config/swayidle/config
+++ b/woof-code/rootfs-skeleton/root/.config/swayidle/config
@@ -1,1 +1,1 @@
-timeout 600 'sh -c "(puplock &); wlopm --off \*"' resume 'sh -c "wlopm --on \*"'
+timeout 600 'sh -c "wlopm --off \*"' resume 'sh -c "wlopm --on \*"'


### PR DESCRIPTION
After #3189, power saving is turned on but the screen is not locked.

However, on Wayland, we activate power saving **and** lock the screen. This can be confusing for users, especially new ones, if they don't know what the default password is, or don't know they're supposed to type it.