### PR TITLE
Change to flat connman-ui icons

### DIFF
--- a/woof-code/rootfs-petbuilds/connman-ui/usr/share/connman_ui_gtk/icons/network-idle-symbolic.svg
+++ b/woof-code/rootfs-petbuilds/connman-ui/usr/share/connman_ui_gtk/icons/network-idle-symbolic.svg
@@ -1,30 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" height="100" width="100">
-  <defs>
-    <linearGradient id="LG1">
-      <stop style="stop-color:#123141;stop-opacity:1;" offset="1"/>
-      <stop style="stop-color:#679BCB;stop-opacity:1;" offset="0"/>
-    </linearGradient>
-    <radialGradient id="RG1" cx="35%" cy="34%" fx="50%" fy="32%" r="28%">
-      <stop style="stop-color:rgb(103,155,203);stop-opacity:0.75;" offset="0%"/>
-      <stop style="stop-color:rgb(18,49,65);stop-opacity:1;" offset="100%"/>
-    </radialGradient>
-  </defs>
-
-  <ellipse cx="35" cy="34" rx="32" ry="30" style="fill:url(#RG1);fill-opacity:1;fill-rule:nonzero"/>
-  <g style="fill:none;stroke:#aaaaaa;stroke-width:1.5px;stroke-linecap:butt;" >
-    <path d="M 36,64 C 22,56 19,46 19,34 19,22 26,10 36,4 l 0,60 C 36,64 54,55 54,34 54,13 36,4 36,4" />
-    <path d="m 4,34 63,0 0,0"/>
-    <path d="m 13,15 c 0,0 12,7 23,7 13,0 23,-7 23,-7"/>
-    <path d="m 13,54 c 0,0 9,-7 23,-7 16,0 23,7 23,7"/>
-  </g>
-  <ellipse cx="35" cy="34" rx="32" ry="30" style="stroke-width:3;stroke:#123141;fill:none;"/>
-
-  <ellipse cx="35" cy="22" rx="5" ry="5" style="fill:#000000;stroke:#cccccc;stroke-width:2"/>
-  <path style="fill:none;stroke:#000000;stroke-width:4;" d="M 38,81 C 12,92 3.9,67 10,58 17,46 32,46 39,35 41,32 41,25 36,22"/>
-
-  <path style="fill:#222222;stroke:#222222" d="m 60,87 0,5 c 0,0 -3,0 -4,0 -2,0 -3,3 -3,3 1,0 26,0 27,0 0,0 -1,-3 -3,-3 -1,0 -4,0 -4,0 l 0,-5"/>
-  <path style="fill:none;stroke:#000000;stroke-width:4px;stroke-linecap:butt" d="m 39,83 c 0,-8 0,-25 0,-31 0,-2 0,-5 3,-5 6,0 45,0 48,0 3,0 3,3 3,7 0,6 0,26 0,29 0,1 0,3 -5,3 -3,0 -43,0 -46,0 -3,0 -3,-3 -3,-3 z"/>
-  <path style="fill:#444444;stroke:#cccccc" d="m 41,49 50,0 0,35 -50,0 z"/>
-
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="48px" width="48px" viewBox="0 0 100 100">
+  <path style="fill:#1E567D;" d="M 8,9 69,9 69,51 8,51 z"/>
+  <path style="fill:#3B739A;" d="m 31,41 61,0 0,42 -61,0 z"/>
 </svg>

--- a/woof-code/rootfs-petbuilds/connman-ui/usr/share/connman_ui_gtk/icons/network-offline-symbolic.svg
+++ b/woof-code/rootfs-petbuilds/connman-ui/usr/share/connman_ui_gtk/icons/network-offline-symbolic.svg
@@ -1,32 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" height="100" width="100">
-  <defs>
-    <linearGradient id="LG1">
-      <stop style="stop-color:#123141;stop-opacity:1;" offset="1"/>
-      <stop style="stop-color:#679BCB;stop-opacity:1;" offset="0"/>
-    </linearGradient>
-    <radialGradient id="RG1" cx="35%" cy="34%" fx="50%" fy="32%" r="28%">
-      <stop style="stop-color:rgb(103,155,203);stop-opacity:0.75;" offset="0%"/>
-      <stop style="stop-color:rgb(18,49,65);stop-opacity:1;" offset="100%"/>
-    </radialGradient>
-  </defs>
-
-  <ellipse cx="35" cy="34" rx="32" ry="30" style="fill:url(#RG1);fill-opacity:1;fill-rule:nonzero"/>
-  <g style="fill:none;stroke:#aaaaaa;stroke-width:1.5px;stroke-linecap:butt;" >
-    <path d="M 36,64 C 22,56 19,46 19,34 19,22 26,10 36,4 l 0,60 C 36,64 54,55 54,34 54,13 36,4 36,4" />
-    <path d="m 4,34 63,0 0,0"/>
-    <path d="m 13,15 c 0,0 12,7 23,7 13,0 23,-7 23,-7"/>
-    <path d="m 13,54 c 0,0 9,-7 23,-7 16,0 23,7 23,7"/>
-  </g>
-  <ellipse cx="35" cy="34" rx="32" ry="30" style="stroke-width:3;stroke:#123141;fill:none;"/>
-
-  <ellipse cx="35" cy="22" rx="5" ry="5" style="fill:#000000;stroke:#cccccc;stroke-width:2"/>
-  <path style="fill:none;stroke:#000000;stroke-width:4;" d="M 38,81 C 12,92 3.9,67 10,58 17,46 32,46 39,35 41,32 41,25 36,22"/>
-
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="48px" width="48px" viewBox="0 0 100 100">
+  <path style="fill:#1E567D;" d="M 8,9 69,9 69,51 8,51 z"/>
   <path style="fill:#FF3D3D;stroke:#730000;stroke-width:3;fill-opacity:0.85" d="M 15,4.6 5,15 25,35 5.5,55 15,65 35,45 55,65 65,55 45,35 65,14 55,4.6 35,25 z"/>
-
-  <path style="fill:#222222;stroke:#222222" d="m 60,87 0,5 c 0,0 -3,0 -4,0 -2,0 -3,3 -3,3 1,0 26,0 27,0 0,0 -1,-3 -3,-3 -1,0 -4,0 -4,0 l 0,-5"/>
-  <path style="fill:none;stroke:#000000;stroke-width:4px;stroke-linecap:butt" d="m 39,83 c 0,-8 0,-25 0,-31 0,-2 0,-5 3,-5 6,0 45,0 48,0 3,0 3,3 3,7 0,6 0,26 0,29 0,1 0,3 -5,3 -3,0 -43,0 -46,0 -3,0 -3,-3 -3,-3 z"/>
-  <path style="fill:#444444;stroke:#cccccc" d="m 41,49 50,0 0,35 -50,0 z"/>
-
+  <path style="fill:#3B739A;" d="m 31,41 61,0 0,42 -61,0 z"/>
 </svg>

--- a/woof-code/rootfs-petbuilds/connman-ui/usr/share/connman_ui_gtk/icons/network-transmit-receive-symbolic.svg
+++ b/woof-code/rootfs-petbuilds/connman-ui/usr/share/connman_ui_gtk/icons/network-transmit-receive-symbolic.svg
@@ -1,32 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" height="100" width="100">
-  <defs>
-    <linearGradient id="LG1">
-      <stop style="stop-color:#123141;stop-opacity:1;" offset="1"/>
-      <stop style="stop-color:#679BCB;stop-opacity:1;" offset="0"/>
-    </linearGradient>
-    <radialGradient id="RG1" cx="35%" cy="34%" fx="50%" fy="32%" r="28%">
-      <stop style="stop-color:rgb(103,155,203);stop-opacity:0.75;" offset="0%"/>
-      <stop style="stop-color:rgb(18,49,65);stop-opacity:1;" offset="100%"/>
-    </radialGradient>
-  </defs>
-
-  <ellipse cx="35" cy="34" rx="32" ry="30" style="fill:url(#RG1);fill-opacity:1;fill-rule:nonzero"/>
-  <g style="fill:none;stroke:#aaaaaa;stroke-width:1.5px;stroke-linecap:butt;" >
-    <path d="M 36,64 C 22,56 19,46 19,34 19,22 26,10 36,4 l 0,60 C 36,64 54,55 54,34 54,13 36,4 36,4" />
-    <path d="m 4,34 63,0 0,0"/>
-    <path d="m 13,15 c 0,0 12,7 23,7 13,0 23,-7 23,-7"/>
-    <path d="m 13,54 c 0,0 9,-7 23,-7 16,0 23,7 23,7"/>
-  </g>
-  <ellipse cx="35" cy="34" rx="32" ry="30" style="stroke-width:3;stroke:#123141;fill:none;"/>
-
-  <path style="fill:none;stroke:#cccccc;stroke-width:6;" d="M 11,56 C 19,45 32,46 39,35 41,32 41,25 36,22"/>
-  <ellipse cx="35" cy="22" rx="5" ry="5" style="fill:#007B00;stroke:#cccccc;stroke-width:2"/>
-  <path style="fill:#007B00;stroke:#cccccc;stroke-width:1" d="m 32,40 c -3,2 -10,1 -16,5 -6,4 -4,9 -7.8,14 -0.4,3 -2.6,7 1.3,3 5.5,-9 7.5,-4 14.5,-9 4,-3 5,-7 11,-11 3,-4 0,-4 -3,-2 z"/>
-  <path style="fill:none;stroke:#007B00;stroke-width:4;" d="M 38,81 C 12,92 3.9,67 10,58 17,46 32,46 39,35 41,32 41,25 36,22"/>
-
-  <path style="fill:#222222;stroke:#222222" d="m 60,87 0,5 c 0,0 -3,0 -4,0 -2,0 -3,3 -3,3 1,0 26,0 27,0 0,0 -1,-3 -3,-3 -1,0 -4,0 -4,0 l 0,-5"/>
-  <path style="fill:none;stroke:#000000;stroke-width:4px;stroke-linecap:butt" d="m 39,83 c 0,-8 0,-25 0,-31 0,-2 0,-5 3,-5 6,0 45,0 48,0 3,0 3,3 3,7 0,6 0,26 0,29 0,1 0,3 -5,3 -3,0 -43,0 -46,0 -3,0 -3,-3 -3,-3 z"/>
-  <path style="fill:#444444;stroke:#cccccc" d="m 41,49 50,0 0,35 -50,0 z"/>
-
+<svg xmlns="http://www.w3.org/2000/svg" version="1.1" height="48px" width="48px" viewBox="0 0 100 100">
+  <path style="fill:#007B00;" d="M 8,9 69,9 69,51 8,51 z"/>
+  <path style="fill:#7FFF00;" d="m 31,41 61,0 0,42 -61,0 z"/>
 </svg>


### PR DESCRIPTION
The current icons don't well work with some themes because they have too much detail and don't scale nicely, or the contrast is bad.

Before:

![before](https://user-images.githubusercontent.com/1471149/205503412-d2b94151-74fb-4c4b-889c-1c00e4fd0c51.png)

After:

![after](https://user-images.githubusercontent.com/1471149/205503443-1b710b85-3c7e-46e5-8a20-84d68075e9df.png)
