### PR TITLE
Revert "GID is the 4th field in /etc/passwd, not the 3rd"

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -905,7 +905,7 @@ busybox chmod 700 rootfs-complete/root rootfs-complete/home/spot
 
 if grep -q '^spot:' rootfs-complete/etc/passwd ; then
 	echo "Setting ownership of /home/spot"
-	busybox chown -h -R `grep ^spot rootfs-complete/etc/passwd | cut -f 3 -d :`:`grep ^spot rootfs-complete/etc/group | cut -f 4 -d :` rootfs-complete/home/spot
+	busybox chown -h -R `grep ^spot rootfs-complete/etc/passwd | cut -f 3 -d :`:`grep ^spot rootfs-complete/etc/group | cut -f 3 -d :` rootfs-complete/home/spot
 fi
 (
 	cd rootfs-complete


### PR DESCRIPTION
```
2022-12-05T19:22:27.8951126Z Setting ownership of /home/spot
2022-12-05T19:22:27.9119727Z chown: unknown user/group 502:spot
```