### PR TITLE
Fix ptheme_gtk not showing up after one theme change

### DIFF
--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -200,6 +200,7 @@ done
 
 if [ "$THEME" ]; then
 	set_theme_gtk
+	unset THEME # if inherited by ROX-Filer and ptheme_gtk is invoked through the pinboard, we always enter this if
 	if pidof ROX-Filer >/dev/null 2>&1; then
 		HOMEDIR=`echo $HOME`
 		ROX_OPEN="$(xwininfo -root -tree | grep -i 'ROX' | awk '{print $2}' | grep -Evi 'ROX|has' | sed -e 's/[\(";:\)]//g' -e "s%\~%$HOMEDIR%g")" # store open rox windows 


### PR DESCRIPTION
Very fun bug that left me puzzled because it seemed so random. Now I realize it worked _sometimes_ because sometimes I started ptheme_gtk via the JWM menu.

To reproduce the bug:

1. Run ptheme_gtk **through the pinboard icon** (setup -> Desktop -> Desktop Settings -> Theming)
2. Change the GTK+ theme
3. Repeat (1)

Nothing will happen, because ptheme_gtk re-runs ROX-Filer while the THEME environment variable is set. Then, when ROX-Filer runs ptheme_gtk (via pdesktop, etc'), this environment variable is inherited multiple times until it reaches ptheme_gtk, and ptheme_gtk sets the theme instead of showing a dialog when THEME is set.

If I understand correctly, this bug is present since 6f3e8b7 (2015) 🎂 