### PR TITLE
Fix broken sorting by version in 0setup

### DIFF
--- a/woof-code/0setup
+++ b/woof-code/0setup
@@ -314,9 +314,24 @@ if [ "$DBUPDATEFLAG" = "yes" ];then
   echo -n "$PKGLISTS_COMPAT_UPDATES" | tr ' ' '\n' | grep "\-${REPOFIELD}$" | while read PKGUPDATES
   do
    [ ! -f "$PKGUPDATES" ] && continue
-   cat $PKGUPDATES $ONE_PKGLISTS_COMPAT > /tmp/0setup_xxx1
+   cat $PKGUPDATES $ONE_PKGLISTS_COMPAT | sort --stable --field-separator='|' --key=2,2 > /tmp/0setup_xxx1
    #want to discard the older package...
-   sort --reverse --version-sort --field-separator='|' --key=3,3 /tmp/0setup_xxx1 | sort --stable --unique --field-separator='|' --key=2,2 > $ONE_PKGLISTS_COMPAT
+   LASTPKG=
+   MAXVER=
+   MAXVERLINE=
+   while read ONELINE; do
+    IFS="|" read F1 F2 F3 ETC <<< "$ONELINE"
+    if [ "$F2" = "$LASTPKG" ]; then
+     vercmp "$F3" gt "$MAXVER" || continue
+     echo "Selecting $F2 $F3 over $MAXVER" 1>&2
+    else
+     [ -n "$MAXVERLINE" ] && echo "$MAXVERLINE"
+     LASTPKG="$F2"
+    fi
+    MAXVER="$F3"
+    MAXVERLINE="$ONELINE"
+   done < /tmp/0setup_xxx1 > $ONE_PKGLISTS_COMPAT
+   echo "$MAXVERLINE" >> $ONE_PKGLISTS_COMPAT
    #...assumes pkg names remain the same, ex "firefox" (2nd field in db).
    mv -f $PKGUPDATES /tmp/$PKGUPDATES #dump -updates db file.
   done


### PR DESCRIPTION
`sort --version-sort` doesn't respsect Debian and Ubuntu package revisions, resulting in security updates that don't get applied:

```
~$ (echo 1.2.3-ubuntu4; echo 1.2.3-ubuntu4.1) | sort --version-sort
1.2.3-ubuntu4
1.2.3-ubuntu4.1
```