### PR TITLE
Drop get_libreoffice in jammy64.

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -169,7 +169,7 @@ yes|gdk-pixbuf|libgdk-pixbuf-2.0-0,libgdk-pixbuf2.0-common,libgdk-pixbuf-2.0-dev
 no|gdmap|gdmap|exe,dev>null,doc,nls
 no|geany|geany,geany-common|exe,dev,doc,nls #this is gtk3 version, use gtk2 pet instead
 no|getflash||exe
-yes|get_libreoffice||exe
+no|get_libreoffice||exe
 yes|gettext-full|gettext,gettext-base|exe,dev>exe,doc,nls||deps:yes
 no|gexec|gexec|exe,dev>null,doc,nls
 no|gftp|gftp-gtk,gftp-common|exe,dev>null,doc,nls


### PR DESCRIPTION
With the advent of `apt` in jammy64, it is now possible to install libreoffice through a package manager. This app was only needed when PPM was the default package manager and when PPM could not install libreoffice.