### PR TITLE
Strip debugging symbols from dpup kernel modules

### DIFF
--- a/.github/workflows/dpup-kernel.yml
+++ b/.github/workflows/dpup-kernel.yml
@@ -66,6 +66,7 @@ jobs:
           echo "kernel_ver=$ver" >> build.conf
           echo "package_name_suffix=kernel-kit" >> build.conf
           echo "COMP=\"-comp zstd -Xcompression-level 19 -b 256K -no-exports -no-xattrs\"" >> build.conf
+          echo "STRIP_KMODULES=debug" >> build.conf
           echo "AUTO=yes" >> build.conf
           echo "AUFS=no" >> build.conf
           CREATE_KBUILD_SFS=yes ./build.sh

--- a/kernel-kit/build.sh
+++ b/kernel-kit/build.sh
@@ -867,7 +867,11 @@ else
 	export MAKE_TARGETS="bzImage modules"
 fi
 echo "$MAKE ${JOBS} ${MAKE_TARGETS}
-$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} INSTALL_MOD_STRIP=1 modules_install" > compile ## debug
+if [ "$STRIP_KMODULES" = "debug" ] ; then
+	$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} INSTALL_MOD_STRIP=1 modules_install" > compile ## debug
+else
+	$MAKE INSTALL_MOD_PATH=${linux_kernel_dir} modules_install" > compile ## debug
+fi
 
 log_msg "Compiling the kernel"
 $MAKE ${JOBS} ${MAKE_TARGETS} >> ${BUILD_LOG} 2>&1


### PR DESCRIPTION
This is by far the largest contributor to the huge increase in ISO size between Vanilla Dpup 9.3.x and 10.0.x.