### PR TITLE
Make missingdefaultapp to point the user for using Synaptic instead of PPM if bdrv is present.

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
+++ b/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+# remember to add a .patch file at woof-code/support/bdrv_support/missingdefaultapp.patch when making any changes to this file
+# read https://www.thegeekstuff.com/2014/12/patch-command-examples/ for information on creating patches
+
 /usr/lib/gtkdialog/box_yesno \
 --info \
 --image-icon info.svg \

--- a/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
+++ b/woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp
@@ -4,7 +4,7 @@
 --info \
 --image-icon info.svg \
 --yes-label "Open PPM" \
---no-label "Open Puppy Apps" \
+--no-label "Open Default Apps" \
 --yes-icon package_pet.svg \
 --no-icon puppy_config.svg \
 "Configure default apps" \

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -208,3 +208,17 @@ if [ -d bdrv/usr/share/gnome/help ]; then
 	mv bdrv/usr/share/gnome/help bdrv_DOC/usr/share/gnome/
 	rmdir bdrv/usr/share/gnome 2>/dev/null
 fi
+
+#-----------------------------------------------------------------------
+# configure usr/local/bin/missingdefaultapp to point the user for using Synaptic instead of PPM
+if [ -f rootfs-complete/usr/local/bin/missingdefaultapp ]; then
+	cp rootfs-complete/usr/local/bin/missingdefaultapp ./
+	patch -N < bdrv_support/missingdefaultapp.patch
+	if [ $? -ne 0 ]; then
+		echo "ERROR: Unable to patch missingdefaultapp. Read above lines to get the error."
+		exit 1
+	fi
+	mkdir -p bdrv/usr/local/bin # ensure that the directory is present
+	mv missingdefaultapp bdrv/usr/local/bin/missingdefaultapp
+fi
+#-----------------------------------------------------------------------

--- a/woof-code/support/bdrv_support/missingdefaultapp.patch
+++ b/woof-code/support/bdrv_support/missingdefaultapp.patch
@@ -1,0 +1,23 @@
+--- missingdefaultapp.orig	2022-12-12 16:54:17.287701945 +0530
++++ missingdefaultapp	2022-12-12 16:54:44.541757676 +0530
+@@ -6,17 +6,17 @@
+ /usr/lib/gtkdialog/box_yesno \
+ --info \
+ --image-icon info.svg \
+---yes-label "Open PPM" \
++--yes-label "Open Synaptic" \
+ --no-label "Open Default Apps" \
+ --yes-icon package_pet.svg \
+ --no-icon puppy_config.svg \
+ "Configure default apps" \
+ "Configure your default $1 by either installing one from PPM or openning Puppy Apps
+ if an appropriate application is on your system." \
+-"Click Open PPM to start Puppy Package Manager or Open Puppy Apps to configure."
++"Click Open Synaptic to start synaptic or Open Puppy Apps to configure."
+ EXITCODE=$?
+ echo $EXITCODE
+ case $EXITCODE in
+-	0)exec ppm;;
++	0)exec synaptic;;
+ 	1)exec puppyapps;;
+ esac


### PR DESCRIPTION
Currently `woof-code/rootfs-skeleton/usr/local/bin/missingdefaultapp` points the user to use PPM even if bdrv is present. This PR solves the problem.