### PR TITLE
Make ptheme_gtk window to appear even after -t is used (add option -T)

### DIFF
--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -181,11 +181,11 @@ while [ $# != 0 ]; do
 			-t) export THEME="$2"
 				[ ! "$THEME" ] && export THEME="$ACTIVE_THEME"
 				shift
-				export EXIT_WITHOUT_GUI=1;;
+				EXIT_WITHOUT_GUI=1;;
 			-T) export THEME="$2"
 				[ ! "$THEME" ] && export THEME="$ACTIVE_THEME"
 				shift
-				export EXIT_WITHOUT_GUI=0;;
+				EXIT_WITHOUT_GUI=0;;
 			-f) export FONT="$2"; shift;;
 			-i) export ICON_THEME="$2"
 				shift;;
@@ -219,11 +219,8 @@ if [ "$THEME" ]; then
 	fi
 
 	if [ $EXIT_WITHOUT_GUI -eq 1 ]; then
-		unset EXIT_WITHOUT_GUI
 		exit
 	fi
-
-	unset EXIT_WITHOUT_GUI
 fi
 
 #build list

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -173,6 +173,7 @@ set_font (){
 
 export -f set_theme_gtk set_font set_gtk3_theme set_gtk4_theme
 
+EXIT_WITHOUT_GUI=0
 #parameters
 while [ $# != 0 ]; do
 	I=1
@@ -184,8 +185,7 @@ while [ $# != 0 ]; do
 				EXIT_WITHOUT_GUI=1;;
 			-T) export THEME="$2"
 				[ ! "$THEME" ] && export THEME="$ACTIVE_THEME"
-				shift
-				EXIT_WITHOUT_GUI=0;;
+				shift;;
 			-f) export FONT="$2"; shift;;
 			-i) export ICON_THEME="$2"
 				shift;;

--- a/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
+++ b/woof-code/rootfs-packages/ptheme/usr/sbin/ptheme_gtk
@@ -180,7 +180,12 @@ while [ $# != 0 ]; do
 		case $1 in
 			-t) export THEME="$2"
 				[ ! "$THEME" ] && export THEME="$ACTIVE_THEME"
-				shift;;
+				shift
+				export EXIT_WITHOUT_GUI=1;;
+			-T) export THEME="$2"
+				[ ! "$THEME" ] && export THEME="$ACTIVE_THEME"
+				shift
+				export EXIT_WITHOUT_GUI=0;;
 			-f) export FONT="$2"; shift;;
 			-i) export ICON_THEME="$2"
 				shift;;
@@ -190,7 +195,8 @@ echo 'Usage: ptheme_gtk [OPTIONS]
 Options
   -f FONT       Set font for theme
   -i ICON_THEME Set icon-theme for theme
-  -t THEME      Set theme without open gui 
+  -T THEME      Set theme and open gui 
+  -t THEME      Set theme without opening gui 
   -h            Show this help message'; exit;;
 		esac
 		shift
@@ -211,7 +217,13 @@ if [ "$THEME" ]; then
 			roxfiler $d
 		done # re-open killed windows
 	fi
-	exit
+
+	if [ $EXIT_WITHOUT_GUI -eq 1 ]; then
+		unset EXIT_WITHOUT_GUI
+		exit
+	fi
+
+	unset EXIT_WITHOUT_GUI
 fi
 
 #build list
@@ -325,8 +337,8 @@ export pThemeGTK='
     </button>
     <button>
       '"`/usr/lib/gtkdialog/xml_button-icon ok`"'
-      <label>'$(gettext 'Ok')'</label>
-      <action>ptheme_gtk -t '$THEME' &</action>
+      <label>'$(gettext 'Apply')'</label>
+      <action>ptheme_gtk -T '$THEME' &</action>
       <action>EXIT:exit</action>
     </button>
     '"`/usr/lib/gtkdialog/xml_scalegrip`"'


### PR DESCRIPTION
This completes https://github.com/puppylinux-woof-CE/woof-CE/issues/3736.

When using this application the user might find it frustrating to re-enter the command again and again even if they just want to test the themes. This PR allows the window to appear, as if window getting reloading (but a bit of lag in between :grin:; of course the window has to close and then reopen). This might remove their source of frustration (at least mine).