### PR TITLE
Set XDG_STATE_HOME to fix application state loss

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile
+++ b/woof-code/rootfs-skeleton/etc/profile
@@ -77,6 +77,7 @@ export XDG_DATA_DIRS=/usr/share:/usr/local/share
 export XDG_CONFIG_DIRS=/etc/xdg #v2.14 changed from /usr/etc
 export XDG_CACHE_HOME=$HOME/.cache
 export XDG_RUNTIME_DIR=/tmp/runtime-${USER}
+export XDG_STATE_HOME=$HOME/.local/state
 [ ! -d $XDG_RUNTIME_DIR ] && mkdir -p $XDG_RUNTIME_DIR && chmod 0700 $XDG_RUNTIME_DIR
 
 export HISTFILESIZE=2000

--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -60,8 +60,9 @@ EOF
 	export XDG_CONFIG_HOME=${USER_HOME}/.config
 	export XDG_CACHE_HOME=${USER_HOME}/.cache
 	export XDG_DATA_HOME=${USER_HOME}/.local/share
+	export XDG_STATE_HOME=${USER_HOME}/.local/state
 
-	for i in ${XDG_CONFIG_HOME} ${XDG_CACHE_HOME} ${XDG_DATA_HOME}
+	for i in ${XDG_CONFIG_HOME} ${XDG_CACHE_HOME} ${XDG_DATA_HOME} ${XDG_STATE_HOME}
 	do
 		if ! [ -d $i ] ; then
 			mkdir -p $i


### PR DESCRIPTION
For example, tofi doesn't remember command history because it fails to save to the default path of `$XDG_STATE_HOME/tofi-history`.