### PR TITLE
Add error message about cups not being installed to cups_shell.

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/cups_shell
+++ b/woof-code/rootfs-skeleton/usr/sbin/cups_shell
@@ -16,6 +16,12 @@
 #130802 changed default browser.
 #140107 zigbert: gui (gtkdialog) improvements.
 
+if [ ! -e /etc/init.d/cups ]; then
+        /usr/lib/gtkdialog/box_splash -bg red -fg white -timeout 5 -text "ERROR: cups is not installed. Install cups first."
+        echo "ERROR: cups is not installed. Install cups first."
+        exit 1
+fi
+
 export TEXTDOMAIN=cups_shell
 export TEXTDOMAINDIR=/usr/share/locale
 export OUTPUT_CHARSET=UTF-8


### PR DESCRIPTION
If `cups_shell` is started through shell, it will try running `/etc/init.d/cups` even if it is not there.