### PR TITLE
Run Xwayland as spot

### DIFF
--- a/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/Xwayland-spot
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/usr/bin/Xwayland-spot
@@ -1,3 +1,3 @@
 #!/bin/ash
 
-exec Xwayland "$@" -auth ~/.Xauthority
+exec run-as-spot /usr/bin/Xwayland "$@" -auth /home/spot/.Xauthority

--- a/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/run-as-spot
@@ -17,9 +17,11 @@ case $0 in *run-as|*run-as-user)
 	shift
 esac
 
+PROG="$1"
+
 # if spot-sandbox is present, run the shell inside a sandbox
 SANDBOX=
-case "$1" in
+case "$PROG" in
 *.AppImage|flatpak|*/flatpak) ;;
 dbus-daemon) ;; # Landlock breaks xdg-desktop-portal, which fails to open /proc/%u/root
 *) SANDBOX=`command -v spot-sandbox` ;;
@@ -85,10 +87,12 @@ EOF
 
 	# close all file descriptors except std{in,out,err}, in case one of
 	# them points to a file under /root
-	for FD in /proc/self/fd/*; do
-		FD="${FD##*/}"
-		[ $FD -gt 2 ] && eval "exec ${FD}<&-"
-	done
+	if [ "$PROG" != "/usr/bin/Xwayland" ]; then
+		for FD in /proc/self/fd/*; do
+			FD="${FD##*/}"
+			[ $FD -gt 2 ] && eval "exec ${FD}<&-"
+		done
+	fi
 
 	exec su ${XUSER} -s /bin/ash -c '
 # try to switch to original directory, unless it is under /root


### PR DESCRIPTION
[X.Org and Xwayland and have yet another series of vulnerabilities.](https://www.phoronix.com/news/X.Org-Server-Holiday-2022) X.Org is beyond repair, but the attack surface of Xwayland can be reduced.

The compositor has to run as root to make key bindings run applications as root, but Xwayland doesn't have to run as root: it only needs to inherit few file descriptors from the compositor, and doesn't start child processes.

In addition, this saves some memory and CPU in a "pure Wayland" dwl setup, because root and spot now use a single Xwayland instance instead of having two of them.

![spotx](https://user-images.githubusercontent.com/1471149/208052234-b4e67559-a603-49b1-8c16-f0115b2fbcbd.png)


