### PR TITLE
Reapply the wmonitors.sh configuration when a monitor is connected

### DIFF
--- a/woof-code/rootfs-skeleton/etc/udev/rules.d/93-wmonitors.rules
+++ b/woof-code/rootfs-skeleton/etc/udev/rules.d/93-wmonitors.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="drm", ACTION=="change", ENV{HOME}="/root", ENV{XDG_RUNTIME_DIR}="/tmp/runtime-root", ENV{WAYLAND_DISPLAY}="wayland-0", RUN+="/bin/sh -c '[ -e ~/.config/wmonitors/wmon_cmd ] && ! pidof -s ROX-Filer && sh ~/.config/wmonitors/wmon_cmd'"


### PR DESCRIPTION
Xwayland needs to be restarted to fix the messed up ROX-Filer pinboard, so this happens only if ROX-Filer is not running.