### PR TITLE
Default to COPY2RAM=yes based on free RAM, not total RAM

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -394,7 +394,8 @@ setup_onepupdrv() {
   MINRAM2CPY=$(($SIZESFSK * 2)) #100222 technosaurus: in case of very big puppies.
   #decide whether to copy .sfs's to ram
   if [ $RAMSIZE -gt 1048576 ] ; then
-   [ $RAMSIZE -gt $MINRAM2CPY ] && COPY2RAM="yes"
+   TFREEK=$(df | grep -m1 ' /mnt/tmpfs' | tr -s ' ' | cut -f 4 -d ' ')
+   [ $TFREEK -gt $MINRAM2CPY ] && COPY2RAM="yes"
   fi
  fi
  ONE_LOOP="$(losetup -f)"


### PR DESCRIPTION
Puppy used to be much smaller, and a modern Puppy no longer runs comfortably with 1 GB of RAM unless `pfix=nocopy`. It's just too big to fit in RAM and leave enough space for things like installing a browser in a live session, without constant swapping.

Right now, a SFS is copied to RAM if a computer has more than 1 GB of RAM **and** the amount of RAM is at least ~twice the SFS size. This condition is still true with 1 GB of RAM, although today's Puppy is so much bigger than it used to be around 2010, leaving the user with very little usable RAM by today's standards.

I'm proposing a change to the current logic: do the same check but with free ramdisk space instead. The amount of free RAM, not total RAM, is the way to predict bad user experience with the SFSs copied to RAM. Users who insist on copying to RAM despite the low amount of free RAM can always use `pfix=copy`, as today.