### PR TITLE
Strip %{f,F,u,U} from the Exec= line when adding tray buttons

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/usr/local/jwm_config/tray
+++ b/woof-code/rootfs-packages/jwm_config/usr/local/jwm_config/tray
@@ -386,7 +386,7 @@ add (){
 		esac
 		;;
 	Program\ button)
-		EXEC="$(grep -iFm 1 'Exec=' "/usr/share/applications/${PROGRAM}.desktop" | cut -d'=' -f2)"
+		EXEC="$(grep -iFm 1 'Exec=' "/usr/share/applications/${PROGRAM}.desktop" | cut -d'=' -f2 | sed 's/ %[a-zA-Z]$//')"
 		POPUP="$(grep -iFm 1 'Name=' "/usr/share/applications/${PROGRAM}.desktop" | cut -d'=' -f2)" #find description
 		[ ! "$POPUP" ] && POPUP="$EXEC"
 		NAME="$(grep -iFm 1 'GenericName=' "/usr/share/applications/${PROGRAM}.desktop" | cut -d'=' -f2)"


### PR DESCRIPTION
Before:

![a1](https://user-images.githubusercontent.com/1471149/209427011-7e9f3184-2d58-47e0-9638-6590c433c5c1.png)
![a2](https://user-images.githubusercontent.com/1471149/209427012-705641c7-e947-4637-ba1a-e968accba7c1.png)

After:

![a3](https://user-images.githubusercontent.com/1471149/209427013-e165c533-6e36-4b87-8ac1-3b29ceebfc2a.png)
![a4](https://user-images.githubusercontent.com/1471149/209427014-67988c5c-5faf-4b3d-9708-04727f42c457.png)
