### PR TITLE
Enhance runqemu_woof.sh

### DIFF
--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-PREV_ISO_or_IMG=0
+SOUND_CMD="-soundhw all"
+
+CONTINUE_WO_ERROR=0 # continue without spelling out error? Useful when the previous was such a flag which accepts its next cli option as well
 IMG_PATH_PROVIDED=0
 for cli_flag in $@; do
 	case $cli_flag in
@@ -12,6 +14,7 @@ Usage: runqemu_woof.sh [OPTIONS] -iso [ISO FILE]
 
 Option			Meaning
  -h, --help		 Show this help.
+ --no-sound		 Disable sound in opened VM.
  -img			 Use this as '-img [Disk Image '.img' File]'.
 
 Notes:
@@ -35,7 +38,7 @@ Notes:
 
 			shift
 
-			PREV_ISO_or_IMG=1 # previous was -iso or -img
+			CONTINUE_WO_ERROR=1
 			;;
 	        -img)
 			shift
@@ -47,12 +50,15 @@ Notes:
 
 			shift
 
-			PREV_ISO_or_IMG=1
+			CONTINUE_WO_ERROR=1
 			IMG_PATH_PROVIDED=1
 			;;
+		--no-sound)
+			SOUND_CMD=""
+			;;
 		*)
-			if [ $PREV_ISO_or_IMG -eq 1 ]; then
-				PREV_ISO_or_IMG=0
+			if [ $CONTINUE_WO_ERROR -eq 1 ]; then
+				CONTINUE_WO_ERROR=0
 				continue
 			fi
 
@@ -78,4 +84,4 @@ EXTRA_CLI_FLAGS="-cdrom $ISO_PATH"
 [ $IMG_PATH_PROVIDED -eq 1 ] && EXTRA_CLI_FLAGS="-boot d -cdrom $ISO_PATH -hda $IMG_PATH"
 
 [ "$REDIR" ] && REDIR="-redir tcp:$REDIR_PORT::22"
-$QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR $EXTRA_CLI_FLAGS
+$QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR $EXTRA_CLI_FLAGS $SOUND_CMD

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -2,10 +2,10 @@
 
 SOUND_CMD="-soundhw all"
 FLASH_CMD=""
+IMG_CMD=""
 
 CONTINUE_WO_ERROR=0 # continue without spelling out error? Useful when the previous was such a flag which accepts its next cli option as well
 ISO_PATH_PROVIDED=0
-IMG_PATH_PROVIDED=0
 for cli_flag in $@; do
 	case $cli_flag in
 		--help|-h)
@@ -57,12 +57,10 @@ Notes:
 			[ ! $1 ] && echo "Please specify the path to a 'IMG' disk image." && exit 1
 			[ ! -f $1 ] && echo "Disk image '$1' not found. Please refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial on creating one." && exit 1
 
-			IMG_PATH=$1
-
+			IMG_CMD="$IMG_CMD -drive file=$1"
 			shift
 
 			CONTINUE_WO_ERROR=1
-			IMG_PATH_PROVIDED=1
 			;;
 		-ext)
 			shift
@@ -106,9 +104,7 @@ QEMU=qemu-system-x86_64
 
 [ $ISO_PATH_PROVIDED -eq 0 ] && echo "Please specify the path to a valid bootable ISO image." && exit 1
 
-EXTRA_CLI_FLAGS="-boot d -cdrom $ISO_PATH"
-
-[ $IMG_PATH_PROVIDED -eq 1 ] && EXTRA_CLI_FLAGS="$EXTRA_CLI_FLAGS -hda $IMG_PATH"
+ISO_CMD="-boot d -cdrom $ISO_PATH"
 
 [ "$REDIR" ] && REDIR="-redir tcp:$REDIR_PORT::22"
-$QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR $EXTRA_CLI_FLAGS $SOUND_CMD $FLASH_CMD
+$QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR $ISO_CMD $SOUND_CMD $IMG_CMD $FLASH_CMD

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -1,11 +1,78 @@
 #!/bin/sh
+
+PREV_ISO_or_IMG=0
+for cli_flag in $@; do
+	case $cli_flag in
+		--help|-h)
+			echo \
+"Run your self built Puppy in qemu!
+
+Usage: runqemu_woof.sh [OPTIONS] -iso [ISO FILE]
+
+Option			Meaning
+ -h, --help		 Show this help.
+ -img			 Use this as '-img [Disk Image '.img' File]'.
+
+Notes:
+  1. QEMU is required to run this application.
+  2. [ISO FILE] is the path to the generated '.iso' file. This is necessary
+     field.
+  3. Disk Image file with '.img' file format is a file which can be used as a
+     'virtual storage drive (hard drive)'. Using this is optional, but can be
+     used if you want to save some of your work in the qemu session. Please
+     refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial
+     on creating one."
+			exit
+			;;
+		-iso)
+			shift
+
+			[ ! $1 ] && echo "Please specify the path to a valid bootable ISO image." && exit 1
+			[ ! -f $1 ] && echo "ISO image '$1' not found. Please specify the path to a valid bootable ISO image." && exit 1
+
+			ISO_PATH=$1
+
+			shift
+
+			PREV_ISO_or_IMG=1 # previous was -iso or -img
+			;;
+                -img)
+                        shift
+
+                        [ ! $1 ] && echo "Please specify the path to a 'IMG' disk image." && exit 1
+			[ ! -f $1 ] && echo "Disk image '$1' not found. Please refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial on creating one." && exit 1
+
+                        IMG_PATH=$1
+
+                        shift
+
+			PREV_ISO_or_IMG=1
+                        ;;
+		*)
+			if [ $PREV_ISO_or_IMG -eq 1 ]; then
+				continue
+			fi
+
+			echo "Unknown option $cli_flag. Please run 'runqemu_woof.sh --help' for help."
+			exit 1
+			;;
+	esac
+done
+
 VGA_TYPE=${VGA_TYPE:-std}
 REDIR_PORT=${REDIR_PORT:-3222}
 MEM=${MEM:-1024}
+
 QEMU=qemu-system-x86_64
-! type $QEMU > /dev/null && QEMU=qemu-system-x86
-! type $QEMU > /dev/null && QEMU=qemu-system-i386
-! type $QEMU > /dev/null && echo "Sorry I can't find qemu" && exit
-[ ! $1 ] && echo "Specify the path to a valid bootable iso image" && exit
+! type $QEMU >/dev/null 2>/dev/null && QEMU=qemu-system-x86
+! type $QEMU >/dev/null 2>/dev/null && QEMU=qemu-system-i386
+! type $QEMU >/dev/null 2>/dev/null && echo "Sorry I can't find QEMU. Please install one." && exit 1
+
+[ ! $ISO_PATH ] && echo "Please specify the path to a valid bootable ISO image." && exit 1
+
+EXTRA_CLI_FLAGS="-cdrom $ISO_PATH"
+
+[ -z {$IMG_PATH} ] && EXTRA_CLI_FLAGS="-boot d -cdrom $ISO_PATH -hda $IMG_PATH"
+
 [ "$REDIR" ] && REDIR="-redir tcp:$REDIR_PORT::22"
-$QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR -cdrom $1
+$QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR $EXTRA_CLI_FLAGS

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 PREV_ISO_or_IMG=0
+IMG_PATH_PROVIDED=0
 for cli_flag in $@; do
 	case $cli_flag in
 		--help|-h)
@@ -36,20 +37,22 @@ Notes:
 
 			PREV_ISO_or_IMG=1 # previous was -iso or -img
 			;;
-                -img)
-                        shift
-
-                        [ ! $1 ] && echo "Please specify the path to a 'IMG' disk image." && exit 1
+        -img)
+			shift
+			
+			[ ! $1 ] && echo "Please specify the path to a 'IMG' disk image." && exit 1
 			[ ! -f $1 ] && echo "Disk image '$1' not found. Please refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial on creating one." && exit 1
 
-                        IMG_PATH=$1
+			IMG_PATH=$1
 
-                        shift
+			shift
 
 			PREV_ISO_or_IMG=1
-                        ;;
+			IMG_PATH_PROVIDED=1
+			;;
 		*)
 			if [ $PREV_ISO_or_IMG -eq 1 ]; then
+				PREV_ISO_or_IMG=0
 				continue
 			fi
 
@@ -72,7 +75,7 @@ QEMU=qemu-system-x86_64
 
 EXTRA_CLI_FLAGS="-cdrom $ISO_PATH"
 
-[ -z {$IMG_PATH} ] && EXTRA_CLI_FLAGS="-boot d -cdrom $ISO_PATH -hda $IMG_PATH"
+[ $IMG_PATH_PROVIDED -eq 1 ] && EXTRA_CLI_FLAGS="-boot d -cdrom $ISO_PATH -hda $IMG_PATH"
 
 [ "$REDIR" ] && REDIR="-redir tcp:$REDIR_PORT::22"
 $QEMU -sdl -vga $VGA_TYPE -enable-kvm -m $MEM $REDIR $EXTRA_CLI_FLAGS

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -55,6 +55,7 @@ Notes:
 			;;
 		--no-sound)
 			SOUND_CMD=""
+			shift
 			;;
 		*)
 			if [ $CONTINUE_WO_ERROR -eq 1 ]; then

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -12,7 +12,7 @@ for cli_flag in $@; do
 			echo \
 "Run your self built Puppy in qemu!
 
-Usage: runqemu_woof.sh [OPTIONS] -iso [ISO FILE]
+Usage: $0 [OPTIONS] -iso [ISO FILE]
 
 Option			Meaning
  -h, --help		 Show this help.

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -18,20 +18,24 @@ Option			Meaning
  -h, --help		 Show this help.
  --no-sound		 Disable sound in opened VM.
  -img			 Use this as '-img [Disk Image '.img' File]'.
- -flash			 Use this as '-flash /dev/[BLOCK DEVICE NAME]'.
+ -ext			 Use this as '-ext /dev/[BLOCK DEVICE NAME]'.
 
 Notes:
   1. QEMU is required to run this application.
-  2. [ISO FILE] is the path to the generated '.iso' file. This is necessary
+  2. [ISO FILE] is the  path to the  generated '.iso' file. This is  necessary
      field.
-  3. Disk Image file with '.img' file format is a file which can be used as a
-     'virtual storage drive (hard drive)'. Using this is optional, but can be
-     used if you want to save some of your work in the qemu session. Please
+  3. Disk Image file with  '.img' file format is a file which can be used as a
+     'virtual storage drive (hard drive)'.  Using this is optional, but can be
+     used if you  want to save  some of your  work in the qemu session. Please
      refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial
      on creating one.
-  4. '-flash' can be used to allow QEMU to use external flash storage device.
-     You can use 'lsblk' to determine the [BLOCK DEVICE NAME] assigned by the
-     kernel to your flash device."
+  4. '-ext' can be used to allow QEMU to use external storage device which has
+     a  block name  assigned  to it. You  can use  'lsblk'  to  determine  the
+     [BLOCK DEVICE NAME]  assigned  by  the  kernel  to your  storage  device.
+     NOTE+ADVICE: This  option can be  used with  internal storage  devices as
+     well, but if the VM has been run from PuppyLinux itself, the Puppy ran in
+     VM may start using the same save file/folder which host is running on and
+     might corrupt it."
 			exit
 			;;
 		-iso)
@@ -60,10 +64,10 @@ Notes:
 			CONTINUE_WO_ERROR=1
 			IMG_PATH_PROVIDED=1
 			;;
-		-flash)
+		-ext)
 			shift
 
-			[ ! $1 ] && echo "Please specify block device name for flash drive to be used." && exit 1
+			[ ! $1 ] && echo "Please specify block device name to be used." && exit 1
                         if ! test -b $1; then
 				echo "'$1' is not a block device."
 				exit 1

--- a/woof-code/runqemu_woof.sh
+++ b/woof-code/runqemu_woof.sh
@@ -37,9 +37,9 @@ Notes:
 
 			PREV_ISO_or_IMG=1 # previous was -iso or -img
 			;;
-        -img)
+	        -img)
 			shift
-			
+
 			[ ! $1 ] && echo "Please specify the path to a 'IMG' disk image." && exit 1
 			[ ! -f $1 ] && echo "Disk image '$1' not found. Please refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial on creating one." && exit 1
 


### PR DESCRIPTION
This PR brings few changes in `woof-code/runqemu_woof.sh`. It now gives guidance about itself by `--help`, like any other program would do.

```
$ ./runqemu_woof.sh -h
Run your self built Puppy in qemu!

Usage: runqemu_woof.sh [OPTIONS] -iso [ISO FILE]

Option                  Meaning
 -h, --help              Show this help.
 -img                    Use this as '-img [Disk Image '.img' File]'.

Notes:
  1. QEMU is required to run this application.
  2. [ISO FILE] is the path to the generated '.iso' file. This is necessary
     field.
  3. Disk Image file with '.img' file format is a file which can be used as a
     'virtual storage drive (hard drive)'. Using this is optional, but can be
     used if you want to save some of your work in the qemu session. Please
     refer https://qemu-project.gitlab.io/qemu/system/images.html for tutorial
     on creating one.
```

As you might have read, it includes an optional `-img` command line flag, which can be used if a user wants to use a `.img` file as virtual hard-disk. I find it very useful to use such .img files when I have to test Puppies and save the things I want to know somewhere. A very useful guide for retrieving that data later on: https://askubuntu.com/a/1010660.

That's it for this PR.
Thanks!