### PR TITLE
Shrink docx and nlsx

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -60,15 +60,17 @@ pref("general.config.filename", "puppy.cfg");
 EOF
 
 (cd $FFDIR
-[ -f omni.ja ] && mkdir omnidir
-mv omni.ja omnidir/omni.zip
-cd omnidir
-unzip -qq omni.zip
-rm omni.zip
-zip -0 -q -y -R ../newomni '*'
+while read ZIP; do
+mkdir zipdir
+mv $ZIP zipdir/zip.zip
+cd zipdir
+unzip -qq zip.zip
+rm zip.zip
+zip -0 -q -y -R ../zipdir '*'
 cd ..
-mv newomni.zip omni.ja
-rm -r omnidir)
+mv zipdir.zip $ZIP
+rm -r zipdir
+done < <(find -name omni.ja -or -name '*.xpi'))
 
 NLSDIR=`pwd`_NLS/$FFDIR/browser/extensions
 mkdir -p $NLSDIR

--- a/woof-code/support/docx_nlsx.sh
+++ b/woof-code/support/docx_nlsx.sh
@@ -36,6 +36,7 @@ if [ "$BUILD_DOCX" = "yes" ] ; then
 	fi
 	echo
 	rm -f docx/pet.specs
+	find docx/usr/share/doc -iname 'changelog*.gz' -delete
 	[ "$USR_SYMLINKS" = "yes" ] && usrmerge docx 0
 	echo "Creating $DOCXSFS..."
 	[ -d docx/root ] && busybox chmod 700 docx/root


### PR DESCRIPTION
Changelogs and Firefox language packs are the biggest contributors to the compressed size of docx and nlsx 😨 