### PR TITLE
Put fdrv and zdrv below pdrv when using overlay

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -402,8 +402,13 @@ stack_onepupdrv() {
   grep -qm1 aufs /proc/filesystems || UNIONFS="overlay"
  fi
  if [ "$UNIONFS" = 'overlay' ]; then
-  remount_overlay -e "s~lowerdir=([^,]+)~lowerdir=${SFS_MP}:\1~" -e "s~lowerdir=,~lowerdir=${SFS_MP},~"
-  [ $? -eq 0 ] || return 5
+  if [ "$ONE_PREP" ];then
+   remount_overlay -e "s~lowerdir=([^,]+)~lowerdir=${SFS_MP}:\1~" -e "s~lowerdir=,~lowerdir=${SFS_MP},~"
+   [ $? -eq 0 ] || return 5
+  else
+   remount_overlay -e "s~lowerdir=([^,]+)~lowerdir=\1:${SFS_MP}~" -e "s~lowerdir=,~lowerdir=${SFS_MP},~"
+   [ $? -eq 0 ] || return 5
+  fi
  else
   mountpoint -q /pup_new
   if [ $? -ne 0 ];then


### PR DESCRIPTION
This inconsistency with aufs can cause issues for users who assume the same stacking order.

~~(Not tested yet)~~

![image](https://user-images.githubusercontent.com/1471149/210546947-b2bf9441-6e28-4154-a488-1b44aaefa7a0.png)
