### PR TITLE
Put bdrv below ydrv and kbuild above fdrv

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1083,12 +1083,12 @@ fi
 [ "$KBUILD" ] && copy_onepupdrv "$KBUILD"
 
 #stack the SFSs on top of pdrv
+[ "$KBUILD" ] && { LOADMSG="kbuild"; stack_onepupdrv "$KBUILD" "k"; }
 [ "$FDRV" ] && { LOADMSG="fdrv"; stack_onepupdrv "$FDRV" "f"; }
 [ "$ZDRV" ] && { LOADMSG="zdrv"; stack_onepupdrv "$ZDRV" "z"; }
 [ "$BDRV" ] && { LOADMSG="bdrv"; stack_onepupdrv "$BDRV" "b" "p"; }
 [ "$YDRV" ] && { LOADMSG="ydrv"; stack_onepupdrv "$YDRV" "y" "p"; }
 [ "$ADRV" ] && { LOADMSG="adrv"; stack_onepupdrv "$ADRV" "a" "p"; }
-[ "$KBUILD" ] && { LOADMSG="kbuild"; stack_onepupdrv "$KBUILD" "k" "p"; }
 [ "$DEVX" ] && { LOADMSG="devx"; stack_onepupdrv "$DEVX" "dev" "p"; }
 [ "$DOCX" ] && { LOADMSG="docx"; stack_onepupdrv "$DOCX" "doc" "p"; }
 [ "$NLSX" ] && { LOADMSG="nlsx"; stack_onepupdrv "$NLSX" "nls" "p"; }

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1085,8 +1085,8 @@ fi
 #stack the SFSs on top of pdrv
 [ "$FDRV" ] && { LOADMSG="fdrv"; stack_onepupdrv "$FDRV" "f"; }
 [ "$ZDRV" ] && { LOADMSG="zdrv"; stack_onepupdrv "$ZDRV" "z"; }
-[ "$YDRV" ] && { LOADMSG="ydrv"; stack_onepupdrv "$YDRV" "y" "p"; }
 [ "$BDRV" ] && { LOADMSG="bdrv"; stack_onepupdrv "$BDRV" "b" "p"; }
+[ "$YDRV" ] && { LOADMSG="ydrv"; stack_onepupdrv "$YDRV" "y" "p"; }
 [ "$ADRV" ] && { LOADMSG="adrv"; stack_onepupdrv "$ADRV" "a" "p"; }
 [ "$KBUILD" ] && { LOADMSG="kbuild"; stack_onepupdrv "$KBUILD" "k" "p"; }
 [ "$DEVX" ] && { LOADMSG="devx"; stack_onepupdrv "$DEVX" "dev" "p"; }


### PR DESCRIPTION
Otherwise, ydrv can't override files from bdrv. kbuild doesn't replace any files from pdrv, only adds rarely used files, so performance will be better once it's below pdrv but above fdrv and zdrv (so it can override /lib/modules symlinks if needed).

~~(Not tested yet)~~