### PR TITLE
Mount extra SFS below the main SFS when using overlay

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1088,15 +1088,15 @@ fi
 [ "$KBUILD" ] && copy_onepupdrv "$KBUILD"
 
 #stack the SFSs on top of pdrv
+[ "$DEVX" ] && { LOADMSG="devx"; stack_onepupdrv "$DEVX" "dev"; }
+[ "$NLSX" ] && { LOADMSG="nlsx"; stack_onepupdrv "$NLSX" "nls"; }
+[ "$DOCX" ] && { LOADMSG="docx"; stack_onepupdrv "$DOCX" "doc"; }
 [ "$KBUILD" ] && { LOADMSG="kbuild"; stack_onepupdrv "$KBUILD" "k"; }
 [ "$FDRV" ] && { LOADMSG="fdrv"; stack_onepupdrv "$FDRV" "f"; }
 [ "$ZDRV" ] && { LOADMSG="zdrv"; stack_onepupdrv "$ZDRV" "z"; }
 [ "$BDRV" ] && { LOADMSG="bdrv"; stack_onepupdrv "$BDRV" "b" "p"; }
 [ "$YDRV" ] && { LOADMSG="ydrv"; stack_onepupdrv "$YDRV" "y" "p"; }
 [ "$ADRV" ] && { LOADMSG="adrv"; stack_onepupdrv "$ADRV" "a" "p"; }
-[ "$DEVX" ] && { LOADMSG="devx"; stack_onepupdrv "$DEVX" "dev"; }
-[ "$DOCX" ] && { LOADMSG="docx"; stack_onepupdrv "$DOCX" "doc"; }
-[ "$NLSX" ] && { LOADMSG="nlsx"; stack_onepupdrv "$NLSX" "nls"; }
 
 #process SAVESPEC - takes precedence - written by shutdownconfig
 if [ -f "${P_MP}${PSUBDIR}/SAVESPEC" ];then

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1094,9 +1094,9 @@ fi
 [ "$BDRV" ] && { LOADMSG="bdrv"; stack_onepupdrv "$BDRV" "b" "p"; }
 [ "$YDRV" ] && { LOADMSG="ydrv"; stack_onepupdrv "$YDRV" "y" "p"; }
 [ "$ADRV" ] && { LOADMSG="adrv"; stack_onepupdrv "$ADRV" "a" "p"; }
-[ "$DEVX" ] && { LOADMSG="devx"; stack_onepupdrv "$DEVX" "dev" "p"; }
-[ "$DOCX" ] && { LOADMSG="docx"; stack_onepupdrv "$DOCX" "doc" "p"; }
-[ "$NLSX" ] && { LOADMSG="nlsx"; stack_onepupdrv "$NLSX" "nls" "p"; }
+[ "$DEVX" ] && { LOADMSG="devx"; stack_onepupdrv "$DEVX" "dev"; }
+[ "$DOCX" ] && { LOADMSG="docx"; stack_onepupdrv "$DOCX" "doc"; }
+[ "$NLSX" ] && { LOADMSG="nlsx"; stack_onepupdrv "$NLSX" "nls"; }
 
 #process SAVESPEC - takes precedence - written by shutdownconfig
 if [ -f "${P_MP}${PSUBDIR}/SAVESPEC" ];then

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1378,7 +1378,7 @@ if [ "$SAVEPART" -a "$UNIONFS" = 'overlay' -a -f /pup_new/etc/rc.d/BOOTCONFIG ];
  for ONE_SFS in $EXTRASFSLIST; do
   LOOP=`losetup -f`
   find_onepupdrv "$SAVEPART" "" "$ONE_SFS" "p" "1"
-  [ "$ONE_FN" ] && { LOADMSG="extra"; setup_onepupdrv "$ONE_PART,$ONE_FS,$ONE_FN" "ro${LOOP#/dev/loop}" "p"; }
+  [ "$ONE_FN" ] && { LOADMSG="extra"; setup_onepupdrv "$ONE_PART,$ONE_FS,$ONE_FN" "ro${LOOP#/dev/loop}" ""; }
  done
 fi
 


### PR DESCRIPTION
This is yet another inconsistency between aufs and overlay. 76b4f7e makes this possible.

With PUPMODE 13:

```
~$ grep union /proc/mounts
unionfs / overlay rw,relatime,lowerdir=/pup_ro1:/pup_b:/pup_ro2:/pup_nls:/pup_doc:/pup_k:/pup_f:/pup_z,upperdir=/mnt/tmpfs/pup_rw,workdir=/mnt/tmpfs/pup_work,xino=on 0 0
``