### PR TITLE
Automatically run setup-spot only via apt

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -139,9 +139,11 @@ PROMPT='PS1="\w\$ "'
 ## Here add custom commands to be executed inside sandbox3/rootfs-complete
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
+chroot . /usr/sbin/setup-spot firefox=true
 chroot . /usr/sbin/setup-spot firefox-esr=true
 chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
+chroot . /usr/sbin/setup-spot transmission-daemon=true
 chroot . /usr/sbin/setup-spot weechat=true
 chroot . /usr/sbin/setup-spot putty=true
 [ \"\$DISTRO_VARIANT\" != \"dwl\" ] && mv -f root/.spot-status root/.spot-status.orig

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -124,9 +124,11 @@ PROMPT='PS1="\w\$ "'
 ## Here add custom commands to be executed inside sandbox3/rootfs-complete
 EXTRA_COMMANDS="
 chroot . /usr/sbin/firewall_ng enable
+chroot . /usr/sbin/setup-spot firefox=true
 chroot . /usr/sbin/setup-spot firefox-esr=true
 chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
+chroot . /usr/sbin/setup-spot transmission-daemon=true
 chroot . /usr/sbin/setup-spot weechat=true
 chroot . /usr/sbin/setup-spot putty=true
 mv -f root/.spot-status root/.spot-status.orig

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -128,6 +128,7 @@ chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot firefox=true
 chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
+chroot . /usr/sbin/setup-spot transmission-daemon=true
 chroot . /usr/sbin/setup-spot weechat=true
 chroot . /usr/sbin/setup-spot putty=true
 mv -f root/.spot-status root/.spot-status.orig

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -150,6 +150,7 @@ chroot . /usr/sbin/firewall_ng enable
 chroot . /usr/sbin/setup-spot netsurf-gtk=true
 chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
+chroot . /usr/sbin/setup-spot transmission-daemon=true
 chroot . /usr/sbin/setup-spot weechat=true
 mv -f root/.spot-status root/.spot-status.orig
 chroot . /usr/sbin/setup-spot powerapplet_tray=true


### PR DESCRIPTION
Users are complaining because they can't modify their /usr/bin/vlc or install a .pet package without triggering setup-spot.