### PR TITLE
Do nothing in setup-spot if nothing is changed (fixes #2847)

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/setup-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/setup-spot
@@ -129,6 +129,6 @@ do
 
 done
 
-[ $CHOWN -eq 1 ] && [ -n "`find ${PREFIXDIR}${SPOT_HOME} ! -user spot -or ! -group spot | head -n 1`" ] && chown -R spot:spot ${PREFIXDIR}${SPOT_HOME}
+[ $CHOWN -eq 1 ] && find ${PREFIXDIR}${SPOT_HOME} \( ! -user spot -or ! -group spot \) -exec chown -h spot:spot {} \;
 
 ###END###

--- a/woof-code/rootfs-skeleton/usr/sbin/setup-spot
+++ b/woof-code/rootfs-skeleton/usr/sbin/setup-spot
@@ -20,8 +20,14 @@ SPOT_HOME=$(awk -F: '$1=="spot" {print $6}' ${PREFIXDIR}/etc/passwd)
 touch ${PREFIXDIR}/root/.spot-status
 
 run_as_spot() { #$1:app  $2:filename
-	sed "s%CMD=''%CMD=${1}%" ${PREFIXDIR}/usr/sbin/run-as-spot > "$2"
-	chmod 755 "$2"
+	SCRIPT="/tmp/${2##*/}-as-spot"
+	sed "s%CMD=''%CMD=${1}%" ${PREFIXDIR}/usr/sbin/run-as-spot > "$SCRIPT"
+	chmod 755 "$SCRIPT"
+	if [ -e "$2" ] && cmp -s "$2" "$SCRIPT"; then
+		rm -f "$SCRIPT"
+		return
+	fi
+	mv -f "$SCRIPT" "$2"
 }
 
 run_as_spot_2() { #$1:app  $2:filename
@@ -39,7 +45,7 @@ generic_func() {
   case $ONEAPPvalue in
    true)
     TARGET=`readlink -f ${ONEAPPpath}/${ONEAPPname}`
-    if [ ! -e ${TARGET}.bin ]; then
+    if [ ! -e ${TARGET}.bin ] || ! grep -qE "^CMD=${TARGET}.bin$" ${TARGET}; then
      mv -f ${TARGET} ${TARGET}.bin
     fi
     case $RUNNINGPUP in
@@ -62,7 +68,7 @@ generic_func() {
  # if the executable is a file, replace the executable
  case $ONEAPPvalue in
   true)
-   if [ ! -e ${ONEAPPpath}/${ONEAPPname}.bin ]; then
+   if [ ! -e ${ONEAPPpath}/${ONEAPPname}.bin ] || ! grep -qE "^CMD=.+/${ONEAPPname}.bin$" ${ONEAPPpath}/${ONEAPPname}; then
     mv -f ${ONEAPPpath}/${ONEAPPname} ${ONEAPPpath}/${ONEAPPname}.bin
    fi
    case $RUNNINGPUP in
@@ -80,6 +86,8 @@ generic_func() {
  esac
  return 0
 }
+
+CHOWN=0
 
 for ONEAPP in $SPOTAPPS
 do
@@ -106,16 +114,21 @@ do
  fi
 
  #record choice, for future runs of Login&Security Manager...
- if [ "$(grep "^${ONEAPPname}=" ${PREFIXDIR}/root/.spot-status)" != "" ];then
-  sed -i -e "s%^${ONEAPPname}=.*%${ONEAPPname}=${ONEAPPvalue}%" ${PREFIXDIR}/root/.spot-status
- else
+ ONEAPPcurrent="$(grep "^${ONEAPPname}=" ${PREFIXDIR}/root/.spot-status)"
+ if [ "$ONEAPPcurrent" = "${ONEAPPname}=${ONEAPPvalue}" ];then
+  continue
+ elif [ "$ONEAPPcurrent" = "" ];then
   echo "${ONEAPPname}=${ONEAPPvalue}" >> ${PREFIXDIR}/root/.spot-status
+ elif [ "$ONEAPPcurrent" != "${ONEAPPname}=${ONEAPPvalue}" ];then
+  sed -i -e "s%^${ONEAPPname}=.*%${ONEAPPname}=${ONEAPPvalue}%" ${PREFIXDIR}/root/.spot-status
  fi
  
  case ${ONEAPPvalue} in true|TRUE|yes|YES|on|ON)
-   [ -n "`find ${PREFIXDIR}${SPOT_HOME} ! -user spot -or ! -group spot | head -n 1`" ] && chown -R spot:spot ${PREFIXDIR}${SPOT_HOME} ;;
+   CHOWN=1 ;;
  esac
 
 done
+
+[ $CHOWN -eq 1 ] && [ -n "`find ${PREFIXDIR}${SPOT_HOME} ! -user spot -or ! -group spot | head -n 1`" ] && chown -R spot:spot ${PREFIXDIR}${SPOT_HOME}
 
 ###END###


### PR DESCRIPTION
- Repeated `setup-spot x=true` re-creates the run-as-spot wrappers in the save file and this shouldn't happen if the wrapper is already in place; this becomes a problem when updating to a newer Puppy and run-as-spot is different
- `setup-spot` refuses to run if the executable already exists and it should ignore these leftovers next time
- The slow, recursive `chown /home/spot` should be avoided unless an application that used to run as root is now configured to run as spot; in addition, it should happen only once if multiple applications are configured to run as spot in one `setup-spot` call