### PR TITLE
Really decrease the firewallstatus polling frequency after 30 tries

### DIFF
--- a/woof-code/rootfs-petbuilds/firewallstatus/firewallstatus-0.7/firewallstatus.c
+++ b/woof-code/rootfs-petbuilds/firewallstatus/firewallstatus-0.7/firewallstatus.c
@@ -53,6 +53,7 @@ gboolean Firestate(gpointer ptr) {    /* This is the constantly updated routine 
 	return TRUE;
 
 relax:
+	g_source_remove(id);
 	g_timeout_add(long_interval, Firestate, NULL);
 	id = 0;
 	return FALSE;


### PR DESCRIPTION
The polling frequency is decreased after SIGHUP from rc.firewall but not after 30 tries, because the old event source is not destroyed. In a Puppy that boots really fast, rc.firewall run early and sends the SIGHUP before firewallstatus is running, so the latter keeps running iptables in 2s intervals forever.