### PR TITLE
Make encrypted save files work with non-ancient cryptsetup

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -157,6 +157,7 @@ killall dbus-launch >/dev/null 2>&1
 # udev
 udevadm control --exit
 killall udevd >/dev/null 2>&1
+export DM_DISABLE_UDEV=1 # prevent cryptsetup from waiting forever if built with udev support
 # pulse
 killall pulseaudio >/dev/null 2>&1
 # dhcpcd

--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -602,7 +602,11 @@ If anything looks wrong, choose \Zb\\\${T_notsave}\ZB...\"`"
   DEVLOOP="$(losetup -f)"
   if [ "$CRYPTO" = "luks" ] ; then
     losetup -v $DEVLOOP ${SMNTPT}$SAVEFILE >>/tmp/mk2fs.log
-    echo -n "$MYPASSWORD" | cryptsetup luksFormat -v $DEVLOOP - &>>/tmp/mk2fs.log
+    VER="$(cryptsetup --version)"
+    VER="${VER#cryptsetup }"
+    OPTS=""
+    vercmp "$VER" ge 2.1.0 && OPTS="--type luks1" # cryptsetup 1.7.5 in initrd doesn't support luks2
+    echo -n "$MYPASSWORD" | cryptsetup luksFormat -v $DEVLOOP $OPTS - &>>/tmp/mk2fs.log
     echo -n "$MYPASSWORD" | cryptsetup luksOpen -v $DEVLOOP savefile - &>>/tmp/mk2fs.log
     FSCK_DEV=/dev/mapper/savefile
   fi

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -51,6 +51,7 @@ yes|connman|connman|exe,dev,doc,nls||deps:yes
 yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
+yes|cryptsetup|cryptsetup-bin|exe,dev,doc,nls||deps:yes
 yes|curl|curl,libcurl4,libcurl4-openssl-dev|exe,dev,doc,nls||deps:yes
 yes|dash|dash|exe,dev,doc,nls||deps:yes
 yes|dbus|dbus,libdbus-1-dev|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -53,6 +53,7 @@ yes|connman|connman|exe,dev,doc,nls||deps:yes
 yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
 yes|crda|crda,wireless-regdb|exe,dev,doc,nls||deps:yes
+yes|cryptsetup|cryptsetup-bin|exe,dev,doc,nls||deps:yes
 yes|curl|curl,libcurl4,libcurl4-openssl-dev|exe,dev,doc,nls||deps:yes
 yes|dash|dash|exe,dev,doc,nls||deps:yes
 yes|dbus|dbus,libdbus-1-dev|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -53,6 +53,7 @@ yes|connman|connman|exe,dev,doc,nls||deps:yes
 yes|coreutils|coreutils|exe,dev,doc,nls||deps:yes
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
+yes|cryptsetup|cryptsetup-bin|exe,dev,doc,nls||deps:yes
 yes|curl|curl,libcurl4,libcurl4-openssl-dev|exe,dev,doc,nls||deps:yes
 yes|dash|dash|exe,dev,doc,nls||deps:yes
 yes|dbus|dbus,libdbus-1-dev|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -82,6 +82,7 @@ no|colord|libcolord2,libcolord-dev|exe,dev,doc,nls #needed by gtk+3.
 yes|cpio|cpio|exe,dev>null,doc,nls||deps:yes
 yes|cpp|cpp|exe,dev>exe,doc,nls||deps:yes # needed by x11-xserver-utils
 yes|crda|wireless-regdb|exe,dev,doc,nls||deps:yes
+yes|cryptsetup|cryptsetup-bin|exe,dev,doc,nls||deps:yes
 no|ctorrent|ctorrent|exe,dev>null,doc,nls
 no|cryptsetup||exe # must use wce static binary
 no|cups|cups-bsd,cups,cups-common,cups-core-drivers,cups-server-common,cups-client,cups-ppdc,libcups2,libcups2-dev,libcupsimage2,libcupsimage2-dev,cups-daemon|exe,dev,doc,nls


### PR DESCRIPTION
Until the old cryptsetup in initrd is updated to >= 2.0.0, it doesn't support LUKS2 and that's the default since 2.1.0.