### PR TITLE
Make 83a4bf5 work

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1507,7 +1507,7 @@ cp -a /init* /sbin /README.txt /pup_new/initrd/
 chmod -x /pup_new/initrd/init
 dmesg > /tmp/dmesg.txt
 
-[ -f /bin/cryptsetup ] && cp -af /bin/cryptsetup /pup_new/initrd/bin/ 
+[ -f /bin/cryptsetup ] && cp -af /bin/cryptsetup /pup_new/initrd/sbin/ 
 [ -f /sbin/cryptsetup ] && cp -af /sbin/cryptsetup /pup_new/initrd/sbin/ 
 
 [ -d "/pup_new/initrd/tmp" ] && rm -rf /pup_new/initrd/tmp


### PR DESCRIPTION
@rizalmart This commit never worked? /bin is not copied so it doesn't exist.

```
cp -a /init* /sbin /README.txt /pup_new/initrd/
```