### PR TITLE
Add gtkhash petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/gtkhash/defaults.patch
+++ b/woof-code/rootfs-petbuilds/gtkhash/defaults.patch
@@ -1,0 +1,36 @@
+diff -rupN gtkhash-1.5-orig/data/nautilus/org.gtkhash.plugin.gschema.xml gtkhash-1.5/data/nautilus/org.gtkhash.plugin.gschema.xml
+--- gtkhash-1.5-orig/data/nautilus/org.gtkhash.plugin.gschema.xml	2023-01-13 23:05:54.464432321 +0200
++++ gtkhash-1.5/data/nautilus/org.gtkhash.plugin.gschema.xml	2023-01-13 23:05:58.064440094 +0200
+@@ -2,7 +2,7 @@
+ <schemalist>
+   <schema id="org.gtkhash.plugin" path="/org/gtkhash/plugin/">
+     <key name="hash-functions" type="as">
+-      <default>[ 'MD5', 'SHA1', 'SHA256', 'CRC32' ]</default>
++      <default>[ 'MD5', 'SHA1', 'SHA256', 'SHA512' ]</default>
+     </key>
+     <key name="show-disabled-hash-functions" type="b">
+       <default>true</default>
+diff -rupN gtkhash-1.5-orig/data/org.gtkhash.gschema.xml gtkhash-1.5/data/org.gtkhash.gschema.xml
+--- gtkhash-1.5-orig/data/org.gtkhash.gschema.xml	2023-01-13 23:05:54.464432321 +0200
++++ gtkhash-1.5/data/org.gtkhash.gschema.xml	2023-01-13 23:06:12.392470652 +0200
+@@ -10,7 +10,7 @@
+       <default>'hex-lower'</default>
+     </key>
+     <key name="hash-functions" type="as">
+-      <default>[ 'MD5', 'SHA1', 'SHA256', 'CRC32' ]</default>
++      <default>[ 'MD5', 'SHA1', 'SHA256', 'SHA512' ]</default>
+     </key>
+     <key name="show-hmac" type="b">
+       <default>false</default>
+diff -rupN gtkhash-1.5-orig/src/hash/hash-func.h gtkhash-1.5/src/hash/hash-func.h
+--- gtkhash-1.5-orig/src/hash/hash-func.h	2023-01-13 23:05:54.460432313 +0200
++++ gtkhash-1.5/src/hash/hash-func.h	2023-01-13 23:05:58.064440094 +0200
+@@ -32,7 +32,7 @@
+ 	(X) == HASH_FUNC_MD5 || \
+ 	(X) == HASH_FUNC_SHA1 || \
+ 	(X) == HASH_FUNC_SHA256 || \
+-	(X) == HASH_FUNC_CRC32)
++	(X) == HASH_FUNC_SHA512)
+ 
+ // All supported hash functions
+ // Note: Default ordering is defined here

--- a/woof-code/rootfs-petbuilds/gtkhash/pet.specs
+++ b/woof-code/rootfs-petbuilds/gtkhash/pet.specs
@@ -1,0 +1,1 @@
+gtkhash-1.5|gtkhash|1.5||Utility|6656K||gtkhash-1.5.pet||Checksum calculator|puppy|||

--- a/woof-code/rootfs-petbuilds/gtkhash/petbuild
+++ b/woof-code/rootfs-petbuilds/gtkhash/petbuild
@@ -1,0 +1,12 @@
+download() {
+    [ -f gtkhash-1.5.tar.xz ] || wget -t 3 -T 60 https://github.com/tristanheaven/gtkhash/releases/download/v1.5/gtkhash-1.5.tar.xz
+}
+
+build() {
+    tar -xJf gtkhash-1.5.tar.xz
+    cd gtkhash-1.5
+    patch -p1 < ../defaults.patch
+    ./configure --prefix=/usr --disable-blake2 --disable-internal-md6
+    make install
+    sed -i 's/^Categories=.*/Categories=Utility;/' /usr/share/applications/org.gtkhash.gtkhash.desktop
+}

--- a/woof-code/rootfs-petbuilds/gtkhash/sha256.sum
+++ b/woof-code/rootfs-petbuilds/gtkhash/sha256.sum
@@ -1,0 +1,1 @@
+7102a192eca3e82ed67a8252a6850440e50c1dbea7c6364bda154ec80f8ff005  gtkhash-1.5.tar.xz

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -55,7 +55,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad"
+[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash"
 if [ "$DISTRO_VARIANT" = "dwl" -o "$DISTRO_VARIANT" = "xwayland" ]; then
 	PETBUILDS="$PETBUILDS dwl-kiosk swaylock wlopm"
 fi

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -52,7 +52,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad"
+PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash"
 PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui viewnior rox-filer"
 PETBUILDS="$PETBUILDS xlockmore"
 

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -52,7 +52,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad"
+PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash"
 PETBUILDS="$PETBUILDS labwc swaylock wlopm xdg-puppy-labwc viewnior pcmanfm pupmoon-font pup-volume-monitor"
 
 ## GTK+ version to use when building packages that support GTK+ 2

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ USR_SYMLINKS=yes
 BUILD_BDRV=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
@lakshayrohila Like gmeasures and xpad, this application is tiny. I think I received more than one request to include it.

This is the (currently) latest version and it uses GTK+ 3, unlike the old version many Puppy releases have. It's patched so the default selection of algorithms is MD5, SHA1, SHA256 and SHA512, because CRC32 is not common in things like software releases and ISO images.

![gtkhash](https://user-images.githubusercontent.com/1471149/212420769-f8842d4a-c91a-4ff4-9c48-5a0e24580ee8.png)

