### PR TITLE
Add gdmap petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/gdmap/pet.specs
+++ b/woof-code/rootfs-petbuilds/gdmap/pet.specs
@@ -1,0 +1,1 @@
+gdmap-1.2.0|gdmap|1.2.0||Filesystem|6656K||gdmap-1.2.0.pet||Display disk space using tree maps|puppy|||

--- a/woof-code/rootfs-petbuilds/gdmap/petbuild
+++ b/woof-code/rootfs-petbuilds/gdmap/petbuild
@@ -1,0 +1,10 @@
+download() {
+    [ -f gdmap-v1.2.0.tar.gz ] || wget -t 3 -T 60 https://gitlab.com/sjohannes/gdmap/-/archive/v1.2.0/gdmap-v1.2.0.tar.gz
+}
+
+build() {
+    tar -xzf gdmap-v1.2.0.tar.gz
+    cd gdmap-v1.2.0
+    meson --buildtype=release --prefix=/usr build
+    ninja -C build install
+}

--- a/woof-code/rootfs-petbuilds/gdmap/sha256.sum
+++ b/woof-code/rootfs-petbuilds/gdmap/sha256.sum
@@ -1,0 +1,1 @@
+48f9e2c6ffa1ae8801da019bb31817499732ff73c34bb64f54ca9e8db655beb6  gdmap-v1.2.0.tar.gz

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -55,7 +55,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash"
+[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
 if [ "$DISTRO_VARIANT" = "dwl" -o "$DISTRO_VARIANT" = "xwayland" ]; then
 	PETBUILDS="$PETBUILDS dwl-kiosk swaylock wlopm"
 fi

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -52,7 +52,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash"
+PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
 PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui viewnior rox-filer"
 PETBUILDS="$PETBUILDS xlockmore"
 

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -52,7 +52,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash"
+PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
 PETBUILDS="$PETBUILDS labwc swaylock wlopm xdg-puppy-labwc viewnior pcmanfm pupmoon-font pup-volume-monitor"
 
 ## GTK+ version to use when building packages that support GTK+ 2

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ USR_SYMLINKS=yes
 BUILD_BDRV=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
Classic Puppy application, tiny compared to [baobab](https://gitlab.gnome.org/GNOME/baobab) and this is a GTK+ 3 port.

@lakshayrohila Very useful to analyze free save space!

![gdmap](https://user-images.githubusercontent.com/1471149/212430165-819cc88a-a1d4-4e36-9e73-9706f442a7e3.png)
