### PR TITLE
Add homebank petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/homebank/pet.specs
+++ b/woof-code/rootfs-petbuilds/homebank/pet.specs
@@ -1,0 +1,1 @@
+homebank-5.0.9|homebank|5.0.9||Business|6656K||homebank-5.0.9.pet||Personal finance|puppy|||

--- a/woof-code/rootfs-petbuilds/homebank/petbuild
+++ b/woof-code/rootfs-petbuilds/homebank/petbuild
@@ -1,0 +1,10 @@
+download() {
+    [ -f homebank-5.0.9.tar.gz ] || wget -t 3 -T 60 -O homebank-5.0.9.tar.gz http://deb.debian.org/debian/pool/main/h/homebank/homebank_5.0.9.orig.tar.gz
+}
+
+build() {
+    tar -xzf homebank-5.0.9.tar.gz
+    cd homebank-5.0.9
+    ./configure --prefix=/usr
+    make install
+}

--- a/woof-code/rootfs-petbuilds/homebank/sha256.sum
+++ b/woof-code/rootfs-petbuilds/homebank/sha256.sum
@@ -1,0 +1,1 @@
+1eece7c11b3286a53385386fb6d4a39902bffaba027cdd5a284aee58f4aa20d8  homebank-5.0.9.tar.gz

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -55,7 +55,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
+[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap homebank"
 if [ "$DISTRO_VARIANT" = "dwl" -o "$DISTRO_VARIANT" = "xwayland" ]; then
 	PETBUILDS="$PETBUILDS dwl-kiosk swaylock wlopm"
 fi

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -52,7 +52,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
+PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap homebank"
 PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm connman-ui viewnior rox-filer"
 PETBUILDS="$PETBUILDS xlockmore"
 

--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -52,7 +52,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
+PETBUILDS="$PETBUILDS abiword gnumeric xournalpp mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap homebank"
 PETBUILDS="$PETBUILDS labwc swaylock wlopm xdg-puppy-labwc viewnior pcmanfm pupmoon-font pup-volume-monitor"
 
 ## GTK+ version to use when building packages that support GTK+ 2

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ USR_SYMLINKS=yes
 BUILD_BDRV=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap homebank"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
This is a really old version, which uses GTK+ 3 and doesn't depend on libsoup. Users who want a more full-featured application can install a newer version or even `apt install homebank`.

@lakshayrohila What do you think? It's another traditional Puppy application.

![homebank](https://user-images.githubusercontent.com/1471149/212434723-0141977b-8fa5-44f7-8459-c83dd7ddcebc.png)
