### PR TITLE
Explicitly add libmpg123 to enable the mp3 plugin of deadbeef

### DIFF
--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -56,7 +56,7 @@ yes|dash|dash|exe,dev,doc,nls||deps:yes
 yes|dbus|dbus,libdbus-1-dev|exe,dev,doc,nls||deps:yes
 yes|dbus-user-session|dbus-user-session|exe>null,dev>null,doc>null,nls>null
 yes|d-conf|dconf-gsettings-backend,dconf-service|exe,dev,doc,nls||deps:yes #needed by gsettings-desktop-settings
-yes|deadbeef-deps|libjansson-dev|exe,dev,doc,nls||deps:yes
+yes|deadbeef-deps|libjansson-dev,libmpg123-dev|exe,dev,doc,nls||deps:yes
 yes|debconf|debconf|exe,dev,doc,nls
 yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
 yes|dialog|dialog|exe,dev>null,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
+++ b/woof-distro/x86_64/debian/bullseye64/DISTRO_PKGS_SPECS-debian-bullseye
@@ -57,7 +57,7 @@ yes|curl|curl,libcurl4,libcurl4-openssl-dev|exe,dev,doc,nls||deps:yes
 yes|dash|dash|exe,dev,doc,nls||deps:yes
 yes|dbus|dbus,libdbus-1-dev|exe,dev,doc,nls||deps:yes
 yes|d-conf|dconf-gsettings-backend,dconf-service|exe,dev,doc,nls||deps:yes #needed by gsettings-desktop-settings
-yes|deadbeef-deps|libjansson-dev|exe,dev,doc,nls||deps:yes
+yes|deadbeef-deps|libjansson-dev,libmpg123-dev|exe,dev,doc,nls||deps:yes
 yes|debconf|debconf|exe,dev,doc,nls
 yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
 yes|dialog|dialog|exe,dev>null,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -58,7 +58,7 @@ yes|dash|dash|exe,dev,doc,nls||deps:yes
 yes|dbus|dbus,libdbus-1-dev|exe,dev,doc,nls||deps:yes
 yes|dbus-user-session|dbus-user-session|exe>null,dev>null,doc>null,nls>null
 yes|d-conf|dconf-gsettings-backend,dconf-service|exe,dev,doc,nls||deps:yes #needed by gsettings-desktop-settings
-yes|deadbeef-deps|libjansson-dev|exe,dev,doc,nls||deps:yes
+yes|deadbeef-deps|libjansson-dev,libmpg123-dev|exe,dev,doc,nls||deps:yes
 yes|debconf|debconf|exe,dev,doc,nls
 yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
 yes|dialog|dialog|exe,dev>null,doc,nls||deps:yes

--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -94,7 +94,7 @@ yes|dbus|dbus,dbus-x11,libdbus-1-3,libdbus-1-dev,libapparmor1|exe,dev,doc,nls||d
 no|dbus-glib|libdbus-glib-1-2|exe,dev,doc,nls||deps:yes
 yes|dbus-user-session|dbus-user-session|exe>null,dev>null,doc>null,nls>null
 yes|d-conf|dconf-gsettings-backend,dconf-service,libdconf1|exe,dev,doc,nls||deps:yes #needed by gsettings-desktop-settings
-yes|deadbeef-deps|libjansson-dev|exe,dev,doc,nls||deps:yes
+yes|deadbeef-deps|libjansson-dev,libmpg123-dev|exe,dev,doc,nls||deps:yes
 yes|debconf|debconf|exe,dev,doc,nls
 yes|debianutils|debianutils|exe,dev,doc,nls||deps:yes
 no|debootstrap|debootstrap|exe>dev,dev,doc,nls||deps:yes


### PR DESCRIPTION
libsndfile1 in bookworm pulls libmpg123 and that's one way to enable the MP3 plugin. The older libsndfile (<1.1.0) in bullseye and jammy doesn't depend on libmpg123 and nothing else pulls this dependency, so the MP3 plugin is disabled.