### PR TITLE
Add Settings menu item to main menu.

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
+++ b/woof-code/rootfs-packages/jwm_config/etc/xdg/templates/_root_.jwmrc
@@ -40,6 +40,7 @@
 	PUPPYMENU jwm-xdgmenu /etc/xdg/menus/puppy-multimedia.menu
 	PUPPYMENU jwm-xdgmenu /etc/xdg/menus/puppy-fun.menu
 	<Separator/>
+	<Program label="Settings" icon="/usr/share/pixmaps/puppy/puppy_config.svg">wizardwizard</Program>
 	<Program label="Help" icon="help48.png">/usr/sbin/puppyhelp</Program>
 	<Program label="Leave" icon="shutdown48.png">/usr/sbin/logout_gui</Program>
 </RootMenu>


### PR DESCRIPTION
This PR adds a "Settings" menu item to main menu, as you will usually find in any desktop environment (including windows and KDE). Here is a screenshot:
![screenshot1](https://user-images.githubusercontent.com/103126231/212532260-23082ee6-629d-41b1-925b-a74a20babede.png)

Earlier, it would have been difficult to reach the "Puppy Setup" menu item (MENU > Setup > Puppy Setup) + many users will confuse between "Puppy Setup" and "Desktop settings" ("Puppy setup" is surrounded by many menu items, but "Desktop settings" is the topmost menu item in the top-most menu category).