### PR TITLE
Add "Default Apps" (puppyapps) to wizardwizard.

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
+++ b/woof-code/rootfs-skeleton/usr/sbin/wizardwizard
@@ -81,6 +81,14 @@ export WizardWizard='
         <action>/usr/sbin/timewizard &</action>
       </button>
     </hbox>
+
+    <hbox spacing="10" homogeneous="true" space-expand="true" space-fill="true">
+      <button image-position="2" tooltip-text="'$(gettext 'Set default apps')'">
+        <label>'$(gettext 'Default Apps')'</label>
+        '"`/usr/lib/gtkdialog/xml_button-icon execute_inspect.svg huge`"'
+        <action>/usr/sbin/puppyapps &</action>
+      </button>
+    </hbox>
   </frame>
   </vbox>
 


### PR DESCRIPTION
"Default Apps" (or `puppyapps`) is not in either of `pdesktop` or `wizardwizard`. This PR adds it to `wizardwizard`.

![screenshot2](https://user-images.githubusercontent.com/103126231/212536039-5546dd36-8e5b-4f9a-b1a8-8339cb955cfc.png)