### PR TITLE
Restore removed menu entries in jammy64

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -159,7 +159,6 @@ mv -f root/.spot-status.orig root/.spot-status
 mv root/Downloads home/spot/
 chroot . chown -R spot:spot /home/spot/Downloads
 ln -s ../home/spot/Downloads root/
-rm -f usr/share/applications/pupX-X-settings.desktop usr/share/applications/Mouse-keyboard-Wizard.desktop usr/share/applications/Xorg-Video-Wizard.desktop usr/share/applications/BootManager-configure-bootup.desktop usr/share/applications/wallpaper.desktop usr/share/applications/FontManager.desktop usr/share/applications/Set-date-and-time.desktop usr/share/applications/Set-timezone.desktop usr/share/applications/ptheme.desktop usr/share/applications/Psync.desktop
 for i in usr/share/themes/*; do case \"\$i\" in usr/share/themes/Default|usr/share/themes/Emacs|usr/share/themes/Flat-grey-rounded|usr/share/themes/Polished-Blue|usr/share/themes/Gradient-grey|usr/share/themes/buntoo-ambience|usr/share/themes/stark-blueish|usr/share/themes/Numix) ;; *) rm -vrf \"\$i\" ;; esac; done
 rm -vf usr/share/backgrounds/*.jpg
 rm -f etc/fonts/conf.d/10-hinting-slight.conf etc/fonts/conf.d/10-autohint.conf


### PR DESCRIPTION
@lakshayrohila Originally, I removed them because pdesktop and wizardwizard lead to the various configuration tools.