### PR TITLE
Move "Puppy Setup" menu entry to top of its sub-menu.

### DIFF
--- a/woof-code/rootfs-skeleton/etc/xdg/menus/puppy-setup.menu
+++ b/woof-code/rootfs-skeleton/etc/xdg/menus/puppy-setup.menu
@@ -8,7 +8,7 @@
 
   <Layout>
     <Menuname inline="true" inline_limit="99">Setup-Sub</Menuname>
-<!--    <Separator/> -->
+    <Separator/>
     <Menuname inline="true" inline_limit="99">Setup-puppy</Menuname>
     <Separator/>
     <Menuname inline="true" inline_limit="99">Setup-wizard</Menuname>

--- a/woof-code/rootfs-skeleton/usr/share/applications/Wizard-Wizard.desktop
+++ b/woof-code/rootfs-skeleton/usr/share/applications/Wizard-Wizard.desktop
@@ -1,10 +1,10 @@
 [Desktop Entry]
 Encoding=UTF-8
-Name=Puppy setup
+Name=Puppy Setup
 Icon=/usr/share/pixmaps/puppy/puppy_config.svg
 Comment=Configure your Puppy OS
 Exec=wizardwizard
 Terminal=false
 Type=Application
-Categories=X-Setup-puppy
+Categories=X-Setup
 GenericName=Control panel


### PR DESCRIPTION
@dimkr, executing your [idea](https://github.com/puppylinux-woof-CE/woof-CE/pull/3839#issuecomment-1383121673):
![puppy-setup-screenshot](https://user-images.githubusercontent.com/103126231/213847355-0843eb57-8877-4328-a30e-c71f6ec62896.png)
