### PR TITLE
Allow process substitution in firefox_FIXUPHACK

### DIFF
--- a/woof-code/2createpackages
+++ b/woof-code/2createpackages
@@ -490,9 +490,9 @@ do
  if [ -f "$FIXUPHACK_FILE" ];then
 	echo " executing ${FIXUPHACK_FILE}"
 	if [ -d $PKG_DIR ] ; then
-		( cd $PKG_DIR ; sh ${MWD}/${FIXUPHACK_FILE} )
+		( cd $PKG_DIR ; bash ${MWD}/${FIXUPHACK_FILE} )
 	elif [ -d $DEV_DIR ] ; then #python-dev
-		( cd $DEV_DIR ; sh ${MWD}/${FIXUPHACK_FILE} )
+		( cd $DEV_DIR ; bash ${MWD}/${FIXUPHACK_FILE} )
 	fi
  fi
 


### PR DESCRIPTION
7a1a7c6 takes care of _PRE, not _FIXUPHACK.