### PR TITLE
Prevent sysctl --system from increasing verbosity (fixes #3537)

### DIFF
--- a/woof-code/packages-templates/procps_FIXUPHACK
+++ b/woof-code/packages-templates/procps_FIXUPHACK
@@ -1,0 +1,2 @@
+# this increases console logging verbosity and reverts the initrd handling of loglevel=
+rm -f etc/sysctl.d/10-console-messages.conf


### PR DESCRIPTION
This problem affects only upup.