### PR TITLE
include radeon_firmware

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
+++ b/woof-distro/x86_64/ubuntu/jammy64/DISTRO_PKGS_SPECS-ubuntu-jammy
@@ -583,7 +583,7 @@ no|python-dev|libpython3-dev,python3-dev|exe,dev,doc,nls||deps:yes
 no|qpdf|libqpdf21,libqpdf-dev|exe,dev,doc,nls #needed by cups.
 no|qemu||exe>dev
 no|qtweb||exe
-no|radeon_firmware||exe,dev
+yes|radeon_firmware||exe,dev
 no|raptor2|libraptor2-0,libraptor2-dev|exe,dev,doc,nls #needed by redland.
 yes|readline|libreadline8,libreadline-dev,readline-common|exe,dev,doc,nls||deps:yes
 no|redland|librdf0,librasqal3|exe,dev,doc,nls #needed by abiword. left out -dev libs.


### PR DESCRIPTION
include radeon_firmware, it take up very little space and enables amd gpus to work very well !