### PR TITLE
Unset XLIB_SKIP_ARGB_VISUALS=1 to make IME work under Chrome

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile
+++ b/woof-code/rootfs-skeleton/etc/profile
@@ -44,7 +44,7 @@ INPUTRC=/etc/inputrc
 export PS1 USER LOGNAME HISTSIZE INPUTRC EDITOR PAGER
 XFINANSDIR="/root/.xfinans"
 export XFINANSDIR
-export XLIB_SKIP_ARGB_VISUALS=1 #rox crashes with DRI modules. solution:
+#export XLIB_SKIP_ARGB_VISUALS=1 #rox crashes with DRI modules. solution:
 
 #this line gets edited by chooselocale script...
 LANG=en_US.UTF-8


### PR DESCRIPTION
Puppy has many fans in Japan, China and other places. These fans need IME to work in their browser.

When IME is installed (fcitx, fcitx5, scim), it seems to work for all applications except Chrome (and Chromium plus derivatives). The browser spits an error on every key stroke:

![errors](https://user-images.githubusercontent.com/1471149/214777836-d7538e14-4ae3-448a-b523-704f30cb6391.png)

However, IME works fine in GTK+ dialogs like the native GTK+ "open" and "save" dialogs used by Chrome. That lead me to the conclusion that the problem is somewhere inside Chrome's UI code and not in a lower layer (GTK+, X, etc'). UI elements inside the web page, like forms, are not rendered through GTK+.

If I understand correctly, this happens because Chrome reaches this code block:

![argb](https://user-images.githubusercontent.com/1471149/214778083-6cbe99ea-9831-4676-855e-5b82a7b2d41d.png)

- GetGdkWindow() returns `null`
- GetTargetWindow() returns `null`
- GdkEventFromImeKeyEvent() returns `null`
- DispatchKeyEvent() checks if GdkEventFromImeKeyEvent() returned `null` and spits the error

This only applies to GTK+ 3 under X: Chrome tries to load GTK+ 4 dynamically before it tries GTK+ 3. Chrome uses a different code path when GTK+ 4 is installed and that explains why bookworm is sometimes immune to this problem (bullseye doesn't have GTK+ 4). In addition, most major distros have switched to Wayland, and there's a separate code path for Wayland: Puppy is one of the few users of the legacy GTK+ 3 code path.

The only Puppy where IME works is Fossapup, and that's because this environment variable is unset (the line is commented out). Considering its popularity, I think it's safe to assume that upstreaming this change into woof-CE will be safe. woof-CE sets this environment variable since day 1, and maybe the comment about ROX-Filer crashes is no longer correct.