### PR TITLE
Add missing AMD GPU firmware to fdrv

### DIFF
--- a/kernel-kit/firmware_picker.sh
+++ b/kernel-kit/firmware_picker.sh
@@ -174,6 +174,17 @@ do
 	done
 	rm -f /tmp/modstrings
 	;;
+	*/amdgpu.ko|*/radeon.ko) # some paths are formatted at runtime and don't appear in modinfo, i.e. radeon/%s_mec2.bin
+	for F in $SRC_FW_DIR/`basename "$m" .ko`/*_*.bin;do
+		fw_subdir=${F#$SRC_FW_DIR/}
+		fw_subdir=${fw_subdir%/*}
+		fw_basename=${F##*/}
+		[ -e ${FIRMWARE_RESULT_DIR}/${fw_subdir}/${fw_basename} ] && continue
+		[ -z "`ls ${FIRMWARE_RESULT_DIR}/${fw_subdir}/${fw_basename%%_*}_*.bin 2>/dev/null`" ] && continue
+		cp -L -n $F ${FIRMWARE_RESULT_DIR}/${fw_subdir}
+		fw_msg ${fw_subdir}/${fw_basename} $fw_tmp_list # log to zdrv
+	done
+	;;
 	esac
 done
 # extra firmware from other sources


### PR DESCRIPTION
The following files are present in Debian's firmware-amd-graphics but missing in fdrv:

```
/lib/firmware/amdgpu/arcturus_mec2.bin
/lib/firmware/amdgpu/fiji_mc.bin
/lib/firmware/amdgpu/navi10_gpu_info.bin
/lib/firmware/amdgpu/navi14_gpu_info.bin
/lib/firmware/amdgpu/psp_13_0_5_asd.bin
/lib/firmware/amdgpu/psp_13_0_8_asd.bin
/lib/firmware/amdgpu/renoir_gpu_info.bin
/lib/firmware/amdgpu/renoir_mec2.bin
/lib/firmware/amdgpu/tahiti_k_smc.bin
/lib/firmware/amdgpu/topaz_mec2.bin
/lib/firmware/amdgpu/yellow_carp_asd.bin
/lib/firmware/r128/r128_cce.bin
/lib/firmware/radeon/tahiti_k_smc.bin
```