### PR TITLE
Revert "force Firefox CSD to save space and fix theming issues"

### DIFF
--- a/woof-code/packages-templates/firefox_FIXUPHACK
+++ b/woof-code/packages-templates/firefox_FIXUPHACK
@@ -77,13 +77,6 @@ NLSDIR=`pwd`_NLS/$FFDIR/browser/extensions
 mkdir -p $NLSDIR
 mv -vf $FFDIR/browser/extensions/langpack-* $NLSDIR/
 
-# force Firefox to combine the tab bar with the tile bar, to save vertical space
-# and fix inconsistency with some GTK 3 themes
-mkdir -p etc/profile.d
-cat << EOF > etc/profile.d/firefox
-export MOZ_GTK_TITLEBAR_DECORATION=client
-EOF
-
 (
 echo "echo '"'#!/bin/sh'"' > usr/local/bin/defaultbrowser"
 echo "echo '"'#!/bin/sh'"' > usr/local/bin/defaulthtmlviewer"


### PR DESCRIPTION
Unneeded since 029155e.