### PR TITLE
Change lp group to 7 from 102

### DIFF
--- a/woof-code/rootfs-skeleton/etc/group
+++ b/woof-code/rootfs-skeleton/etc/group
@@ -18,7 +18,7 @@ sshd::33:sshd
 webgroup:x:504:
 disk::100:root,spot
 audio::101:root,spot
-lp::102:root,daemon,spot
+lp::7:root,daemon,spot
 dialout::103:root,spot
 kmem::104:root,spot
 video::105:root,spot


### PR DESCRIPTION
To enable non debian/ubuntu builds to be configured correctly for cups when built on github using ubuntu dev facilities. Debian/ubuntu builds already have different group identities through the etc/group.xxx mechanism.