### PR TITLE
this will fix the puppyinstaller to work with bdrv

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/puppyinstaller
+++ b/woof-code/rootfs-skeleton/usr/sbin/puppyinstaller
@@ -8,12 +8,11 @@
 #   export ENABLE_FULLINSTALL=1 
 
 [ "`whoami`" != "root" ] && exec sudo -A ${0} ${@} #110505
-
-if [ -d /sys/firmware/efi ] ; then
-	/usr/lib/gtkdialog/box_yesno --ok-cancel --no-first --yes-label Continue --no-label Close --warning "Puppy Installer" "This installer does not support UEFI. It's only useful if you want to install to a drive that will not be booted on this machine.."
-	[ $? -ne 0 ] && exit
-fi
-
+## this is false "puppyinstaller" workes with efi... in FRUGAL MODE only. full install is already behind a lock read above. (full install does NOT work with efi) ... this is all really old code from pupies legacy days... 
+#if [ -d /sys/firmware/efi ] ; then
+#	/usr/lib/gtkdialog/box_yesno --ok-cancel --no-first --yes-label Continue --no-label Close --warning "Puppy Installer" "This installer is ment to be used for Hard drive installs."
+#	[ $? -ne 0 ] && exit
+#fi
 export TEXTDOMAIN=puppyinstaller
 export OUTPUT_CHARSET=UTF-8
 . gettext.sh
@@ -34,6 +33,7 @@ if [ "$PUPSFS" ] ; then #PUPSTATE
 	DISTRO_FDRVSFS=${FDRV##*/}
 	DISTRO_ADRVSFS=${ADRV##*/}
 	DISTRO_YDRVSFS=${YDRV##*/}
+	DISTRO_BDRVSFS=${BDRV##*/}
 fi
 
 #===================================================================
@@ -864,7 +864,7 @@ case $PMEDIA in usb*)
 		yaf-splash -bg orange -text "`eval_gettext \"Please wait, copying files to \\\$DESTPART ...\"`" &
 		XPID=$!
 		mkdir -p /mnt/data
-		for i in vmlinuz initrd.gz ${DISTRO_PUPPYSFS} ${DISTRO_ZDRVSFS} ${DISTRO_FDRVSFS} ${DISTRO_ADRVSFS} ${DISTRO_YDRVSFS}; do
+		for i in vmlinuz initrd.gz ${DISTRO_PUPPYSFS} ${DISTRO_ZDRVSFS} ${DISTRO_FDRVSFS} ${DISTRO_ADRVSFS} ${DISTRO_YDRVSFS} ${DISTRO_BDRVSFS}; do
 			[ -f "${SRCPATH}/${i}" ] && cp -f "${SRCPATH}/${i}" /mnt/data/
 			sync
 		done
@@ -943,7 +943,7 @@ $(gettext 'Enter a unique name for the folder. No spaces.')
 		yaf-splash -bg orange -text "`eval_gettext \"Please wait, copying files to \\\$DESTPART, in folder \\\$NEWPSUBDIR...\"`" &
 		XPID=$!
 		mkdir -p "$DESTMNTPT"/"$NEWPSUBDIR"
-		for pupfiles in vmlinuz initrd.gz ${DISTRO_PUPPYSFS} ${DISTRO_ZDRVSFS} ${DISTRO_FDRVSFS} ${DISTRO_ADRVSFS} ${DISTRO_YDRVSFS}; do
+		for pupfiles in vmlinuz initrd.gz ${DISTRO_PUPPYSFS} ${DISTRO_ZDRVSFS} ${DISTRO_FDRVSFS} ${DISTRO_ADRVSFS} ${DISTRO_YDRVSFS} ${DISTRO_BDRVSFS}; do
 			[ -f "$SRCPATH"/"$pupfiles" ] && cp -f "$SRCPATH"/"$pupfiles" "$DESTMNTPT"/"$NEWPSUBDIR"/ || continue
 			sync
 		done #140630 made loop
@@ -1071,26 +1071,26 @@ $(gettext 'your PC for all installations of Puppy and other operating systems)')
 		rm -fv ${DESTMNTPT}/etc/rc.d/funct*
 		echo "installing"
 		#loop-device mount ${DISTRO_PUPPYSFS} in DESTPART, copy contents of ${DISTRO_PUPPYSFS} to DESTPART...
-		for SFS in ${DISTRO_PUPPYSFS} ${DISTRO_ZDRVSFS} ${DISTRO_FDRVSFS} ${DISTRO_ADRVSFS} ${DISTRO_YDRVSFS}
-		do
-			[ -f ${SRCPATH}/${SFS} ] || continue
-			echo "$SFS" #debug
-			msg="$(printf "$(gettext 'Copying files from %s to %s...')" "$SFS" "$DESTPART")"
-			yaf-splash -close never -bg orange -text "$msg" &
-			XPID=$!
-			FREEDEV=$(losetup -f)
-			losetup ${FREEDEV} "${SRCPATH}/${SFS}" #100913
-			mkdir -p ${DESTMNTPT}/srcmntpt
-			mount -r -t squashfs ${FREEDEV} ${DESTMNTPT}/srcmntpt
-			cp -a --remove-destination ${DESTMNTPT}/srcmntpt/* ${DESTMNTPT}/ || {
+		for SFS in ${DISTRO_PUPPYSFS} ${DISTRO_ZDRVSFS} ${DISTRO_FDRVSFS} ${DISTRO_ADRVSFS} ${DISTRO_YDRVSFS} ${DISTRO_BDRVSFS}
+			do
+				[ -f ${SRCPATH}/${SFS} ] || continue
+				echo "$SFS" #debug
+				msg="$(printf "$(gettext 'Copying files from %s to %s...')" "$SFS" "$DESTPART")"
+				yaf-splash -close never -bg orange -text "$msg" &
+				XPID=$!
+				FREEDEV=$(losetup -f)
+				losetup ${FREEDEV} "${SRCPATH}/${SFS}" #100913
+				mkdir -p ${DESTMNTPT}/srcmntpt
+				mount -r -t squashfs ${FREEDEV} ${DESTMNTPT}/srcmntpt
+				cp -a --remove-destination ${DESTMNTPT}/srcmntpt/* ${DESTMNTPT}/ || {
 				[ "$SFS" = "$DISTRO_PUPPYSFS" ] && fatal
-			}
-			sync
-			umount ${DESTMNTPT}/srcmntpt
-			rm -rf ${DESTMNTPT}/srcmntpt
-			kill $XPID
-			sleep 0.5
-		done
+				}
+				sync
+				umount ${DESTMNTPT}/srcmntpt
+				rm -rf ${DESTMNTPT}/srcmntpt
+				kill $XPID
+				sleep 0.5
+			done
 		sync
 
 		( 


### PR DESCRIPTION
hey, I fixed the puppy installer, please read the commits I made in the above file.. I am also submitting another pull request for the dotpup file, I can see how you are confused, but the puppyinstaller does work with efi in " frugal mode" so puppy Linux use to have multiple hard drive install methods, the one you are referring to that dose not work with efi is the "full install" with this install method the file system was un-compressed , so it was never really recommended .. and the dot pup variable names adds to this confusion..  I hope I don't come off as rude, but I have tested this on 3 machines all of which have efi ..