### PR TITLE
Wait for 5s for a flash drive only if not recognized yet

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -942,7 +942,7 @@ elif [ "$PDRV" = "" ];then #not specified anywhere
 fi
 
 if [ "$LOOK_PUP" -o "$LOOK_SAVE" ];then #something to search for
- [ "${PMEDIA:0:3}" != "usb" ] && search_func
+ search_func
  NUM=0
  while [ "$LOOK_PUP" -a "$P_PART" = "" ] || [ "$LOOK_SAVE" -a "$SAVEPART" = "" ];do
   [ $NUM -ge $WAITDEV ] && break


### PR DESCRIPTION
I totally understand why this `sleep 5` is needed if the flash drive where the save is wasn't recognized yet. However, it's a waste of time on some computers, where it doesn't take so much time to recognize a flash drive. I have a 12 years old laptop that works fine (and boots much faster) without this delay.

Maybe, the logic should be changed so the init script waits for 5 seconds only if the partition wasn't found? (And/or, do this search thing every 1s and stop waiting if the partition was found?)

(This line was introduced in 22a6442962.)