### PR TITLE
Poll block devices every 1s instead of waiting for 5s every time

### DIFF
--- a/initrd-progs/0initrd/README.txt
+++ b/initrd-progs/0initrd/README.txt
@@ -124,7 +124,7 @@ Boot parameters:
 
 pmedia=<atahd|ataflash|usbhd|usbflash|cd> 
    Indicates the type of boot device.
-   If it's "cd" then the partitions are searched for a save layer file, the only situation that triggers such a search.
+   If it's "cd" then all partitions are searched for Puppy files and a save layer file.
    If the first 3 characters are "usb", then any searching is restricted to only usb devices.
    If the last 5 characters are "flash" the top layer in the stack remains the tmpfs in memory, otherwise any found save layer becomes the top layer in the stack.
    This boot parameter should always be provided.

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -29,7 +29,7 @@ L_UPGRADE_NO="Backing off, not using personal storage, booting in RAM only, PUPM
 L_LOADING_FROM_CD="Loading folder %s from CD/DVD..." #printf
 L_RAM_DISK_FULL="RAM disk full, copy failed at %s" #printf
 L_ADDING_SAVE_LAYER_FAILED="adding %s to aufs stack failed." #printf
-L_WAITING_FOR_DEV='Waiting %s seconds for slow storage devices.' #printf
+L_WAITING_FOR_DEV='Waiting %s seconds for slow storage devices [%s/%s].' #printf
 L_WAITING_FOR_PART='Waiting for partition [%s]' #printf
 L_LOADING_KEYBOARD_LAYOUT="Loading '%s' keyboard layout..." #printf
 L_COPY_MESSAGE="Copying '%s' to ram..." #printf
@@ -747,16 +747,6 @@ get_part_info() {
  [ "$PDEBUG" ] && echo "$HAVE_PARTS" > /tmp/HAVE_PARTS
 }
 
-wait_for_dev() {
- echo -n "$(printf "$L_WAITING_FOR_DEV" "$WAITDEV")" > /dev/console
- for NUM in $(seq 1 $WAITDEV);do
-  sleep 1
-  echo -en "\\033[1;33m.\\033[0;39m" >/dev/console #yellow dot
- done
- get_part_info
- echo ""  > /dev/console
-}
-
 umount_unneeded() {
  [ "${ISO_LOOP}" ] && umount -d ${ISO_LOOP} # /sbin/isoboot &&&
  MTD_PARTS="$(mount | cut -f1 -d' ' | grep '^/dev' | grep -v loop | cut -f3 -d'/')"
@@ -969,8 +959,12 @@ fi
 
 if [ "$LOOK_PUP" -o "$LOOK_SAVE" ];then #something to search for
  [ "${PMEDIA:0:3}" != "usb" ] && search_func
- if [ "$P_PART" = "" ];then
-  wait_for_dev
+ NUM=0
+ while [ "$LOOK_PUP" -a "$P_PART" = "" ] || [ "$LOOK_SAVE" -a "$SAVEPART" = "" ];do
+  [ $NUM -ge $WAITDEV ] && break
+  printf "${L_WAITING_FOR_DEV}\n" "$WAITDEV" "$NUM" "$WAITDEV" > /dev/console
+  sleep 1
+  get_part_info
   USBDRVS="$(find /sys/block -maxdepth 1 -name 'sd*' -o -name 'sr*' | xargs -n 1 readlink 2>/dev/null | grep '/usb[0-9]' | rev | cut -f 1 -d '/' | rev | tr '\n' '|')"
   [ "$PDEBUG" ] && echo "2: USBDRVS=$USBDRVS -> ${USBDRVS%|}"
   if [ "$USBDRVS" ] ; then
@@ -978,7 +972,8 @@ if [ "$LOOK_PUP" -o "$LOOK_SAVE" ];then #something to search for
   else
     search_func
   fi
- fi
+  NUM=$(($NUM + 1))
+ done
 fi
 [ "$P_BP_ID" ] && { log_part_id "$P_BP_ID"; ONE_PART="$P_BP_ID"; }
 [ "$PDEBUG" ] && echo "6: ONE_PART=$ONE_PART ONE_TRY_FN=$ONE_TRY_FN PDRV=$PDRV"

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -190,19 +190,13 @@ decode_spec() {
 
 wait_for_blkid() {
  # $1 value to look for
- # $2 type of value 'id|fs'
  BLKID_PART=''
  [ "$1" ] || return
- [ "$2" ] || return
  local PART DIDMSG NUM
  DIDMSG=''
  # use loop to wait for device, if not found immediately
  for NUM in $(seq 1 15); do
-  case $2 in
-   id) PART="$(blkid | grep "$1" | grep -E "^/dev/$1| LABEL=.$1| UUID=.$1" | cut -f1 -d':' | cut -f3 -d'/')" ;;
-   fs) PART="$(blkid | grep -E " TYPE=.${1}" | cut -f1 -d':' | cut -f3 -d'/')" ;;
-   *) return ;;
-  esac
+  PART="$(blkid | grep "$1" | grep -E "^/dev/$1| LABEL=.$1| UUID=.$1" | cut -f1 -d':' | cut -f3 -d'/')"
   [ "$PART" ] && break
   [ $NUM -eq 1 ] && { echo -n "$(printf "$L_WAITING_FOR_PART" "${1}")" > /dev/console; DIDMSG='yes'; }
   sleep 1
@@ -226,7 +220,7 @@ decode_id() {
   ONE_PART="$1"
   return
  fi
- wait_for_blkid "$1" 'id'
+ wait_for_blkid "$1"
  ONE_PART="$BLKID_PART"
 }
 
@@ -931,16 +925,6 @@ FSCKDPARTS=""
 
 [ "$PDEBUG" ] && echo "1: PDRV=$PDRV P_BP_ID=$P_BP_ID P_BP_FN=$P_BP_FN"
 
-#"pdrv" is not specified on CD, so look for CD file system
-if [ "$PMEDIA" = "cd" ];then
- wait_for_blkid 'iso9660' 'fs'
- if [ "$BLKID_PART" ];then
-  if [ "$(echo $BLKID_PART | wc -w)" = "1" ];then
-   P_BP_ID="$BLKID_PART"
-  fi
- fi
-fi
-
 #establish PDRV
 P_PART=""; LOOK_PUP=""; LOOK_SAVE=""
 if [ "$P_BP_ID" ];then #specified as parameter
@@ -965,12 +949,16 @@ if [ "$LOOK_PUP" -o "$LOOK_SAVE" ];then #something to search for
   printf "${L_WAITING_FOR_DEV}\n" "$WAITDEV" "$NUM" "$WAITDEV" > /dev/console
   sleep 1
   get_part_info
-  USBDRVS="$(find /sys/block -maxdepth 1 -name 'sd*' -o -name 'sr*' | xargs -n 1 readlink 2>/dev/null | grep '/usb[0-9]' | rev | cut -f 1 -d '/' | rev | tr '\n' '|')"
-  [ "$PDEBUG" ] && echo "2: USBDRVS=$USBDRVS -> ${USBDRVS%|}"
-  if [ "$USBDRVS" ] ; then
+  if [ "${PMEDIA:0:3}" = "usb" ] ; then
+   USBDRVS="$(find /sys/block -maxdepth 1 -name 'sd*' -o -name 'sr*' | xargs -n 1 readlink 2>/dev/null | grep '/usb[0-9]' | rev | cut -f 1 -d '/' | rev | tr '\n' '|')"
+   [ "$PDEBUG" ] && echo "2: USBDRVS=$USBDRVS -> ${USBDRVS%|}"
+   if [ "$USBDRVS" ] ; then
     search_func "${USBDRVS%|}"
-  else
+   else
     search_func
+   fi
+  else
+   search_func
   fi
   NUM=$(($NUM + 1))
  done
@@ -1112,14 +1100,6 @@ if [ -f "/tmp/SAVESPEC" ];then
   SAVE_BP_FN="$SAVE_BP_DIR"
  fi
  [ "$SS_MEDIA" ] && PMEDIA="$SS_MEDIA"
-fi
-
-# might still need to search for save
-if [ "$PMEDIA" = "cd" ];then
- if [ "$SAVEPART" = "" ];then
-  LOOK_SAVE="yes"
-  search_func
- fi
 fi
 
 [ "$SAVEPART" ] || SAVEPART="$P_PART"
@@ -1265,7 +1245,7 @@ if [ "$PUPSAVE" ];then #refine pupmode
  # refine pupmode
  if [ $PUPMODE -eq 12 ];then
   SAVE_LAYER="/pup_rw"
-  if ! [ "$PMEDIA" ] ; then
+  if [ -z "$PMEDIA" -o "$PMEDIA" = "cd" ] ; then
    [ "`cat /sys/block/$(fx_get_drvname $SAVEPART)/removable`" = "1" ] && xPM=13
   fi
   if [ "${PMEDIA:3}" = "flash" -o "$xPM" = "13" ];then


### PR DESCRIPTION
If the flash drive is recognized after 1s but the timeout is 5s, boot is delayed by 1s and not by 5s.

~~In addition, this PR increases the default timeout from 5s to 20s: some users complain that 5s is not enough, and it doesn't matter if the timeout is 4x as long if users who needed 5s delay still wait for 5s, not more. 20s is just an upper limit now.~~ 

This is not the same as #3885: the two PRs complement each other. This PR makes Puppy boot faster if it takes time to recognize a flash drive: the init script waits until the flash drive is recognized instead of waiting for 5 seconds every time. The latter skips the entire waiting thing if the flash drive is recognized immediately and no delay is needed.

EDIT: 026bff1 also relaxes `pmedia=cd` and replaces the 15s delay with polling every 1s.

EDIT 2: 92c173b changes the meaning `pmedia=cd` and `pmedia=` (unspecified or empty) to _"search all partitions for Puppy files and a save file/folder in 1s intervals, up to 5 times by default"_. This should make Puppy boot more reliably when installed to a flash drive using a third-party tool that copies `pmedia=cd` from grub.cfg. This assumes most Puppy users don't use CDs. In addition, this makes it possible to boot Puppy from a CD but save to a flash drive that isn't recognized immediately.