### PR TITLE
In dpup, run X as spot

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -776,6 +776,12 @@ if [ "$XERRS_FLG" = 'yes' ];then
 	echo "Enabling X error log. User can change this later."
 fi
 
+# xwin_run_as_spot_flag
+if [ "$XSPOT_FLG" = 'yes' ];then
+	touch rootfs-complete/var/local/xwin_run_as_spot_flag && \
+	echo "Enabling X as spot."
+fi
+
 #shared library loading...
 mkdir -p rootfs-complete/etc/ld.so.conf.d/ # may not be there
 if [ "$USR_SYMLINKS" = "yes" ];then

--- a/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
+++ b/woof-code/rootfs-petbuilds/dwl-kiosk/root/.dwlinitrc
@@ -18,10 +18,10 @@ chown spot:spot /home/spot/.Xauthority
 if [ "$GDK_BACKEND" = "x11" ]; then
 	Xwayland-spot $DISPLAY &
 
-	MAX=20
+	MAX=100
 	CT=0
 	while ! xdpyinfo >/dev/null 2>&1; do
-		sleep 0.50s
+		sleep 0.1
 		CT=$(( CT + 1 ))
 		if [ "$CT" -ge "$MAX" ]; then
 			echo "FATAL: $0: Gave up waiting for X server $DISPLAY"

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -320,6 +320,7 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 	echo 'logging of X errors is disabled' > /tmp/xerrs.log
 	echo 'remove /var/local/xwin_disable_xerrs_log_flag to enable it, then restart X' >> /tmp/xerrs.log
 fi
+rm -f /var/log/Xorg.0.log
 if [ -f /var/local/xwin_run_as_spot ] ; then
 	(
 		export DISPLAY=":0"
@@ -336,6 +337,8 @@ if [ -f /var/local/xwin_run_as_spot ] ; then
 		run-as-spot X -br -nolisten tcp
 		kill $PID 2>/dev/null
 		unset DISPLAY
+
+		ln -s /home/spot/.local/share/xorg/Xorg.0.log /var/log/
 	) > $LOGFILE_X 2>&1
 else
 	/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -320,7 +320,26 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 	echo 'logging of X errors is disabled' > /tmp/xerrs.log
 	echo 'remove /var/local/xwin_disable_xerrs_log_flag to enable it, then restart X' >> /tmp/xerrs.log
 fi
-/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1
+if [ -f /var/local/xwin_run_as_spot ] ; then
+	(
+		export DISPLAY=":0"
+
+		(
+			while ! xdpyinfo > /dev/null 2>&1; do
+				sleep 0.5
+			done
+
+			exec ${XINITRC}
+		) &
+		PID=$!
+
+		run-as-spot X -br -nolisten tcp
+		kill $PID 2>/dev/null
+		unset DISPLAY
+	) > $LOGFILE_X 2>&1
+else
+	/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1
+fi
 #-----------------------------------------------------------------------
 echo -n "false" > /root/.XLOADED #see note above.
 rm -f /tmp/services/x_display

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -320,7 +320,6 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 	echo 'logging of X errors is disabled' > /tmp/xerrs.log
 	echo 'remove /var/local/xwin_disable_xerrs_log_flag to enable it, then restart X' >> /tmp/xerrs.log
 fi
-rm -f /var/log/Xorg.0.log
 if [ -f /var/local/xwin_run_as_spot_flag ] ; then
 	(
 		export DISPLAY=":0"
@@ -338,7 +337,10 @@ if [ -f /var/local/xwin_run_as_spot_flag ] ; then
 		kill $PID 2>/dev/null
 		unset DISPLAY
 
-		ln -s /home/spot/.local/share/xorg/Xorg.0.log /var/log/
+		if [ ! -L /var/log/Xorg.0.log ] ; then
+			rm -f /var/log/Xorg.0.log
+			ln -s /home/spot/.local/share/xorg/Xorg.0.log /var/log/
+		fi
 	) > $LOGFILE_X 2>&1
 else
 	/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -322,6 +322,11 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 fi
 if [ -f /var/local/xwin_run_as_spot_flag ] ; then
 	(
+		if [ ! -L /var/log/Xorg.0.log ] ; then
+			rm -f /var/log/Xorg.0.log
+			ln -s /home/spot/.local/share/xorg/Xorg.0.log /var/log/
+		fi
+
 		export DISPLAY=":0"
 
 		(
@@ -336,11 +341,6 @@ if [ -f /var/local/xwin_run_as_spot_flag ] ; then
 		run-as-spot X -br -nolisten tcp
 		kill $PID 2>/dev/null
 		unset DISPLAY
-
-		if [ ! -L /var/log/Xorg.0.log ] ; then
-			rm -f /var/log/Xorg.0.log
-			ln -s /home/spot/.local/share/xorg/Xorg.0.log /var/log/
-		fi
 	) > $LOGFILE_X 2>&1
 else
 	/usr/bin/xinit ${XINITRC} -- -br -nolisten tcp > $LOGFILE_X 2>&1

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -321,7 +321,7 @@ if [ "$LOGFILE_X" = "/dev/null" ] ; then
 	echo 'remove /var/local/xwin_disable_xerrs_log_flag to enable it, then restart X' >> /tmp/xerrs.log
 fi
 rm -f /var/log/Xorg.0.log
-if [ -f /var/local/xwin_run_as_spot ] ; then
+if [ -f /var/local/xwin_run_as_spot_flag ] ; then
 	(
 		export DISPLAY=":0"
 

--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -327,7 +327,7 @@ if [ -f /var/local/xwin_run_as_spot_flag ] ; then
 
 		(
 			while ! xdpyinfo > /dev/null 2>&1; do
-				sleep 0.5
+				sleep 0.1
 			done
 
 			exec ${XINITRC}

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -101,6 +101,10 @@ THEME_MOUSE="DMZ-Black"
 ## For testing builds XERRS_FLG=yes is recommended. If the target device is low RAM suggest to leave this unset, especially for release
 #XERRS_FLG=yes
 
+## XSPOT_FLG if set to 'yes' X runs as spot
+## if unset or or any value other than 'yes' X runs as root.
+XSPOT_FLG=yes
+
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n
 
@@ -168,7 +172,6 @@ rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 sed -i \"s/exec ppm/exec synaptic/\" usr/local/bin/missingdefaultapp
 echo \"kernel.yama.ptrace_scope = 1\" > etc/sysctl.d/10-ptrace.conf
-[ \"\$DISTRO_VARIANT\" = \"dwl\" -o \"\$DISTRO_VARIANT\" = \"xwayland\" ] || touch var/local/xwin_run_as_spot
 [ \"\$DISTRO_VARIANT\" = \"dwl\" ] && rm -f etc/xdg/autostart/blueman.desktop
 [ \"\$DISTRO_VARIANT\" = \"dwl\" -o \"\$DISTRO_VARIANT\" = \"xwayland\" ] && rm -f etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop
 "

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -168,6 +168,7 @@ rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
 sed -i \"s/exec ppm/exec synaptic/\" usr/local/bin/missingdefaultapp
 echo \"kernel.yama.ptrace_scope = 1\" > etc/sysctl.d/10-ptrace.conf
+[ \"\$DISTRO_VARIANT\" = \"dwl\" -o \"\$DISTRO_VARIANT\" = \"xwayland\" ] || touch var/local/xwin_run_as_spot
 [ \"\$DISTRO_VARIANT\" = \"dwl\" ] && rm -f etc/xdg/autostart/blueman.desktop
 [ \"\$DISTRO_VARIANT\" = \"dwl\" -o \"\$DISTRO_VARIANT\" = \"xwayland\" ] && rm -f etc/xdg/autostart/xinput-apply.desktop etc/xdg/autostart/xkb-apply.desktop etc/xdg/autostart/xorg-mousekeys.desktop
 "

--- a/woof-distro/x86_64/debian/bullseye64/_00build.conf
+++ b/woof-distro/x86_64/debian/bullseye64/_00build.conf
@@ -83,8 +83,14 @@ THEME_GTK_ICONS="Puppy Standard"
 THEME_DESK_ICONS="StandardSvg"
 THEME_MOUSE="DMZ-Black"
 
+## XERRS_FLG if set to 'yes' enables logging of X errors in /tmp/xerrs.log
+## if unset or or any value other than 'yes' X logging is disabled. User can change this in 'Startup Manager'
 ## For testing builds XERRS_FLG=yes is recommended. If the target device is low RAM suggest to leave this unset, especially for release
 #XERRS_FLG=yes
+
+## XSPOT_FLG if set to 'yes' X runs as spot
+## if unset or or any value other than 'yes' X runs as root.
+XSPOT_FLG=yes
 
 ## include Pkg in build (y/n). If commented then asked in 3builddistro
 INCLUDE_PKG=n


### PR DESCRIPTION
X.Org is an old codebase with many vulnerabilities. It should run as spot to reduce the impact of future vulnerability disclosures.

- [x] ~Check why X is slow to start~ X runs as spot and fails to send SIGUSR1 to the xinit parent that runs as root, causing xinit to wait until timeout
- [x] Apply to a development build of bookworm64 and get feedback
- [x] Fix segfault in gtkdialog during quicksetup
- [x] Backport to bullseye64

![xorg](https://user-images.githubusercontent.com/1471149/218298705-6a4852a5-0f5c-4943-a384-dad0b1db3365.png)
