### PR TITLE
Update firewall_ng to allow correct Cancel and Apply button function. 

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1450,6 +1450,7 @@ fi
 
 [ "$1" = "enable" -a "$MAIN" = "false" ] && exit
 
+
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &
 urxvt -bg yellow -fg black -geometry 60X10+1+1 --hold -e /etc/init.d/rc.firewall start &

--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1448,7 +1448,7 @@ else
 	exit
 fi
 
-[ "$MAIN" = "false" ] && exit
+[ "$1" = "enable" -a "$MAIN" = "false" ] && exit
 
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &

--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1448,7 +1448,7 @@ else
 	exit
 fi
 
-[ "$1" = "enable" ] && exit
+["$MAIN" = "false" ] && exit
 
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &

--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1448,7 +1448,7 @@ else
 	exit
 fi
 
-["$MAIN" = "false" ] && exit
+[ "$MAIN" = "false" ] && exit
 
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &


### PR DESCRIPTION
This change will not turn on firewall when user cancels out of the dialog box. My testing shows when "Cancel" is pressed, the original firewall state is preserved and when "Apply" is pressed the new settings are applied and the firewall is restarted.