### PR TITLE
Start, restart or stop the firewall on Apply (fixes #2883)

### DIFF
--- a/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
+++ b/woof-code/rootfs-packages/firewall_ng/usr/sbin/firewall_ng
@@ -1438,10 +1438,10 @@ echo "Load rules for mangle table ..."
 EOF_REST
 
 if [ -f "$TMPFW" ];then
-	[ $state = 1 -a "$1" != "enable" ] && /etc/init.d/rc.firewall stop && sleep 1
+	[ $state = 1 -a "$1" != "enable" ] && sh /etc/init.d/rc.firewall stop && sleep 1
 	echo "copying firewall"
 	cp -af "$TMPFW" /etc/init.d/rc.firewall
-	chmod 755 /etc/init.d/rc.firewall
+	[ "$MAIN" = "true" -o "$CONFIG_SSH" = "true" -o "$CONFIG_CUPS" = "true" -o "$CONFIG_SAMBA" = "true" -o "$CONFIG_SAMBA_CLIENT" = "true" -o "$CONFIG_DLNA" = "true" -o "$CONFIG_NTP" = "true" -o "$CONFIG_FTP" = "true" -o "$CONFIG_HTTP" = "true" -o "$CONFIG_DNS" = "true" -o "$CONFIG_DHCP" = "true" -o "$CONFIG_NFS" = "true" ] && chmod 755 /etc/init.d/rc.firewall || chmod 644 /etc/init.d/rc.firewall
 	rm -f "$TMPFW"
 else
 	echo "Something went wrong"
@@ -1449,6 +1449,7 @@ else
 fi
 
 [ "$1" = "enable" ] && exit
+[ "$MAIN" = "false" -a "$CONFIG_SSH" = "false" -a "$CONFIG_CUPS" = "false" -a "$CONFIG_SAMBA" = "false" -a "$CONFIG_SAMBA_CLIENT" = "false" -a "$CONFIG_DLNA" = "false" -a "$CONFIG_NTP" = "false" -a "$CONFIG_FTP" = "false" -a "$CONFIG_HTTP" = "false" -a "$CONFIG_DNS" = "false" -a "$CONFIG_DHCP" = "false" -a "$CONFIG_NFS" = "false" ] && exit
 
 # run it!
 gtkdialog-splash -bg yellow -timeout 2 -text "Starting firewall" &


### PR DESCRIPTION
Tests:
- [ ] Start the firewall
- [ ] Reboot - firewall should be started automatically
- [ ] Stop the firewall
- [ ] Reboot - the firewall should not be started automatically
- [ ] Start the firewall again
- [ ] Click Apply without any changes - firewall should be stopped and started again
- [ ] Stop the firewall and start it again, this time with exceptions for SSH and SMB