### PR TITLE
Start Firefox "centered" to keep previous position

### DIFF
--- a/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
+++ b/woof-code/rootfs-packages/jwm_config/root/.jwm/jwmrc-personal
@@ -35,11 +35,11 @@
 <!-- <Option>aerosnap</Option> -->
 </Group>
 
-<!-- Start Firefox maximized, to save vertical space -->
+<!-- Start Firefox centered, to save last size,position settings -->
 <Group>
     <Name>Navigator</Name>
     <Name>Firefox</Name>
-    <Option>maximized</Option>
+    <Option>centered</Option>
 </Group>
 
 <!-- Key bindings -->


### PR DESCRIPTION
Start Firefox "centered" to help it remember previous position when "Open previous windows and tabs" is set in Firefox settings