### PR TITLE
Avoid unneeded cache update if PREVUNIONRECORD is empty

### DIFF
--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.update
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.update
@@ -336,7 +336,7 @@ if [ "$PUNIONFS" = "aufs" -o "$PUNIONFS" = "overlay" ];then
 	xLASTUNIONRECORD="`echo -n "$LASTUNIONRECORD" | sed -e 's/^20[0-9][0-9][-0123456789]* //'`"
 	xPREVUNIONRECORD="`echo -n "$PREVUNIONRECORD" | sed -e 's/^20[0-9][0-9][-0123456789]* //'`"
 	#-
-	if [ "$xLASTUNIONRECORD" != "$xPREVUNIONRECORD" ];then
+	if [ -n "$xPREVUNIONRECORD" -a "$xLASTUNIONRECORD" != "$xPREVUNIONRECORD" ];then
 		echo -en " layered-filesystem \\033[1;35mnext boot will be faster!\\033[0;39m" > /dev/console
 		echo "$PUNIONFS layers have changed since previous boot, updating menus..."
 		update_cache_files


### PR DESCRIPTION
#3547 was supposed to fix this but this fix is more minimal and won't upset anyone.