### PR TITLE
Create fix-duplicates script

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/fix-duplicates
+++ b/woof-code/rootfs-skeleton/usr/bin/fix-duplicates
@@ -1,0 +1,52 @@
+#!/bin/sh
+#Search for duplicate files in a directory and replace by symlinks
+#Written by mistfire based for Barry Kauler's mesa package fix
+
+   TARGET_PATH="$1"
+     
+   if [ "$TARGET_PATH" == "" ]; then
+      echo "Enter path first"
+      exit 1
+   elif [ -d "$TARGET_PATH" ];then
+	  PREFIX="$TARGET_PATH"
+	 else
+      echo "Invalid path"
+      exit 1	  
+	 fi
+     
+   echo "Searching \"$PREFIX\"..."
+     
+	 DRVS0="$(find "$PREFIX" -type f -maxdepth 1 -print0 | xargs -0 md5sum | sort | uniq -Dw 32 | sed -e s'#^.*\ \/#\/#g' | sed -e 's#\ #_whitespace_#g' | xargs -i basename {})"
+
+	 for aDRV in $DRVS0
+	 do
+	  xaDRV="$(echo "$aDRV" | sed -e 's#_whitespace_#\ #g')"
+	  aDRV="$xaDRV"
+	  [ -L "${PREFIX}/$aDRV" ] && continue
+	  if [ -f "${PREFIX}/$aDRV" ]; then
+	    
+		  for aaDRV in ${DRVS0}
+		  do
+		   
+       paaDRV="$aaDRV"
+       xaaDRV="$(echo "$aaDRV" | sed -e 's#_whitespace_#\ #g')"
+		   aaDRV="$xaaDRV"
+
+		   [ "$aaDRV" == "" ] && continue
+		   [ "$aaDRV" == "$aDRV" ] && continue
+		   [ -L "${PREFIX}/$aaDRV" ] && continue
+		   cmp -s "${PREFIX}/${aDRV}" "${PREFIX}/${aaDRV}"
+		   if [ $? -eq 0 ];then
+        if [ ! -L "${PREFIX}/${aDRV}" ] && [ -f "${PREFIX}/${aDRV}" ]; then
+         echo "Symlinking ${PREFIX}/${aaDRV}..."
+         echo "Source: ${PREFIX}/${aDRV}"
+         echo ""
+         rm -f "${PREFIX}/${aaDRV}"
+         ln -sr "${PREFIX}/${aDRV}" "${PREFIX}/${aaDRV}"
+        fi
+		   fi
+       
+		  done
+	  fi
+
+	 done


### PR DESCRIPTION
This script replaces duplicate files with symlinks relative to the original file. This will reduce disk space consumed.

Example of reducing disk space:
`find /usr -type d | xargs -i fix-duplicates '{}'`