### PR TITLE
profile: Added debian library path

### DIFF
--- a/woof-code/rootfs-skeleton/etc/profile
+++ b/woof-code/rootfs-skeleton/etc/profile
@@ -3,11 +3,13 @@
 #110804 fix double-login when exit from X, allow /etc/profile to complete. see also "echo -n '# '" in /usr/bin/xwin at exit.
 
 PATH="/bin:/usr/bin:/sbin:/usr/sbin:/usr/local/bin:/root/my-applications/bin:/usr/games"
+
 if [ -f /lib64/libc.so.6 ] ; then #slackware64
-	LD_LIBRARY_PATH="/lib64:/usr/lib64:/root/my-applications/lib:/usr/local/lib"
+	LD_LIBRARY_PATH="/lib64:/usr/lib64:/usr/lib/x86_64-linux-gnu:/root/my-applications/lib:/usr/local/lib"
 else
-	LD_LIBRARY_PATH="/lib:/usr/lib:/root/my-applications/lib:/usr/local/lib"
+	LD_LIBRARY_PATH="/lib:/usr/lib:/usr/lib/i386-linux-gnu:/root/my-applications/lib:/usr/local/lib"
 fi
+
 export PATH LD_LIBRARY_PATH
 
 export GDK_USE_XFT=1 #for gtk...


### PR DESCRIPTION
Newly built debian-based puppy unable to detect library installed at /usr/lib/<arch>-linux-gnu. This will fix the problem