### PR TITLE
improve shutdown reliability when using overlayfs

### DIFF
--- a/initrd-progs/0initrd/sbin/isoboot
+++ b/initrd-progs/0initrd/sbin/isoboot
@@ -115,7 +115,7 @@ if [ "$iso_path" ] ; then
   fi
 
   ISO_LOOP=$(losetup -f)
-  if losetup $ISO_LOOP "$FOUND_ISO" ; then
+  if losetup -r $ISO_LOOP "$FOUND_ISO" ; then
     echo "Using ${ISO_PSAVE}:${iso_path}"
     P_BP_ID=${ISO_LOOP#/dev/}
     SAVE_BP_ID=$ISO_PSAVE

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -409,6 +409,14 @@ if [ "`busybox mount | grep "/initrd${PUP_HOME}"`" != "" ];then
 fi
 
 # remount PUNIONFS read-only
+if [ "$PUNIONFS" = 'overlay' ]; then
+	busybox mount -no remount,ro / > /dev/console 2>&1
+	if [ "$SAVE_LAYER" ];then
+		SAVEMP="$(stat -Lc %m "/initrd${SAVE_LAYER}")"
+		SAVEDEV=`grep "$SAVEMP" /proc/mounts | cut -f 1 -d ' '`
+		[ "$SAVEDEV" ] && busybox mount -no remount,ro "$SAVEMP" > /dev/console 2>&1
+	fi
+fi
 if [ "$SAVE_LAYER" ];then
 	SAVEDEV=`grep "/initrd${SAVE_LAYER}" /proc/mounts | cut -f 1 -d ' '`
 	SAVEFS=`grep "/initrd${SAVE_LAYER}" /proc/mounts | cut -f 3 -d ' '`


### PR DESCRIPTION
Without commit:
With Puppy installed on ext4 partition, using savefolder, using overlayfs, and "pfix=nocopy,fsckp". On following boot fsck of the partition containing the savefolder, reports "recovering journal", and fixes a couple of things. With commit:
fsck of the same partition reports, only "clean"