### PR TITLE
Implement GetServerInformation in notification-daemon-stub

### DIFF
--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/main.c
@@ -9,6 +9,16 @@
 
 
 static gboolean
+on_get_server_information (OrgFreedesktopNotifications *object,
+                           GDBusMethodInvocation       *invocation,
+                           gpointer                    user_data)
+{
+  org_freedesktop_notifications_complete_get_server_information (object, invocation, "Notification Daemon Stub", "Nobody", "0.1", "1.2");
+  return G_DBUS_METHOD_INVOCATION_HANDLED;
+}
+
+
+static gboolean
 on_get_capabilities (OrgFreedesktopNotifications *object,
                      GDBusMethodInvocation       *invocation,
                      gpointer                    user_data)
@@ -47,6 +57,10 @@ on_bus_acquired (GDBusConnection *connection,
 
   object = org_freedesktop_notifications_skeleton_new();
 
+  g_signal_connect (object,
+                    "handle-get-server-information",
+                    G_CALLBACK (on_get_server_information),
+                    NULL);
   g_signal_connect (object,
                     "handle-get-capabilities",
                     G_CALLBACK (on_get_capabilities),

--- a/woof-code/rootfs-petbuilds/notification-daemon-stub/petbuild
+++ b/woof-code/rootfs-petbuilds/notification-daemon-stub/petbuild
@@ -6,6 +6,12 @@ build() {
     cat << EOF > org.freedesktop.Notifications.xml
 <node>
   <interface name="org.freedesktop.Notifications">
+    <method name="GetServerInformation">
+      <arg type="s" name="name" direction="out" />
+      <arg type="s" name="vendor" direction="out" />
+      <arg type="s" name="version" direction="out" />
+      <arg type="s" name="spec_version" direction="out" />
+    </method>
     <method name="GetCapabilities">
       <arg type="as" name="capabilities" direction="out" />
     </method>


### PR DESCRIPTION
This make `notify-send a` exit without an error. This should fool applications that rely on GetServerInformation to decide whether or not to use their internal implementation of notifications.