### PR TITLE
Prevent fixmenus from breaking / if /etc/xdg/templates is deleted

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/fixmenus
+++ b/woof-code/rootfs-skeleton/usr/sbin/fixmenus
@@ -25,7 +25,7 @@ if [ "$LANG" = "C" ];then #fix in case this script gets called with LANG=C
 fi
 LANG1="${LANG%_*}" #120207 ex: de
 
-for ONESRC in /etc/xdg/templates/_* #ex: _root_.jwmrc
+for ONESRC in `ls /etc/xdg/templates/_* 2>/dev/null` #ex: _root_.jwmrc
 do
 	ONEDEST=${ONESRC##*/}    # basename: _root_.jwmrc
 	[ ! "$ONEDEST" = '_root_.jwmrc' ] && MENHEIGHT=''


### PR DESCRIPTION
```
root@home:~#  bash -x /usr/sbin/fixmenus 
+ for ONESRC in /etc/xdg/templates/_*
+ ONEDEST='_*'
+ '[' '!' '_*' = _root_.jwmrc ']'
+ MENHEIGHT=
+ '[' /root '!=' /root ']'
+ ONEDEST='/*'
+ echo 'Generating /*...'
Generating /*...
+ '[' -f /bin /boot /dev /etc /home /initrd /lib /lib32 /lib64 /libx32 /media /mnt /opt /proc /root /run /sbin /srv /sys /tmp /usr /var ']'
woof-code/rootfs-skeleton/usr/sbin/fixmenus: line 38: [: too many arguments
+ '[' '' ']'
+ MH=24
++ mktemp '/*.XXXXXXXXXX'
+ TMPDEST='/*.tdFvhIwBGi'
+ sed 's|MENHEIGHT|24|' '/etc/xdg/templates/_*'
+ read ONELINE
sed: can't read /etc/xdg/templates/_*: No such file or directory
+ '[' '' '!=' en ']'
+ '[' -f /usr/share/sss/menu_strings/menu_strings. ']'
+ mv -f '/*.tdFvhIwBGi' /bin /boot /dev /etc /home /initrd /lib /lib32 /lib64 /libx32 /media /mnt /opt /proc /root /run /sbin /srv /sys '/*.tdFvhIwBGi' /tmp /usr /var
```