### PR TITLE
Update DISTRO_PKGS_SPECS-debian-sid: added zlib1g and libgcc-s1

### DIFF
--- a/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
+++ b/woof-distro/x86_64/debian/sid64/DISTRO_PKGS_SPECS-debian-sid
@@ -119,6 +119,7 @@ yes|less|less|exe,dev>null,doc,nls||deps:yes
 yes|libcanberra|libcanberra0,libcanberra-dev,libcanberra-gtk3-0,libcanberra-gtk3-dev|exe,dev,doc,nls||deps:yes #libbonobui needs this.
 yes|libfuse2|libfuse2|exe,dev,doc,nls||deps:yes # used by AppImages
 yes|libgcrypt|libgcrypt20,libgcrypt20-dev|exe,dev,doc,nls||deps:yes # needed by weechat
+yes|libgcc-s1|libgcc-s1|exe,dev>null,doc,nls||
 yes|libgtk-layer-shell|libgtk-layer-shell-dev|exe,dev,doc,nls||deps:yes
 yes|libjpeg62|libjpeg62-turbo,libjpeg62-turbo-dev,libjpeg-dev|exe,dev,doc,nls||deps:yes
 yes|libmpfr|libmpfr6|exe,dev,doc,nls||deps:yes
@@ -188,6 +189,7 @@ yes|xorg_dri|libgl1-mesa-dri,mesa-utils|exe,dev,doc,nls||deps:yes
 yes|xournalpp-deps|libsndfile1-dev,portaudio19-dev,libzip-dev|exe,dev,doc,nls||deps:yes
 yes|xz|xz-utils,liblzma5,liblzma-dev|exe,dev,doc,nls||deps:yes
 yes|zip|zip|exe,dev>null,doc,nls||deps:yes
+yes|zlib1g|zlib1g|exe,dev>null,doc,nls||
 yes|zstd|zstd|exe,dev,doc,nls||deps:yes
 '
 


### PR DESCRIPTION
Without zlib1g and libgcc-s1, some core-apps of debian-sid woof builds are broken