### PR TITLE
Allow PUPMODE 66 with exfat

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1159,7 +1159,7 @@ if [ "${SAVE_MP}" != "" -a "$PRAMONLY" != "yes" ];then #have mounted save? parti
  #check if save partition is linux
  set_fs_linux "$SAVE_FS"
  #check for pupmode=66
- if [ "$SAVE_FS" = "vfat" ];then
+ if [ "$SAVE_FS" = "vfat" -o "$SAVE_FS" = "exfat" ];then
   FN_66=${PSUBDIR}/${DISTRO_FILE_PREFIX}save66.tar.gz
   if [ -e "${SAVE_MP}${FN_66}" ];then
     PUPMODE=66

--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -731,7 +731,7 @@ autosavefunc() {
      [ "$SAVEPATH" = '/' ] && SAVEPATH=''
      PUPMODE=128
      return 0
-   elif [ "$SAVEFS" = "vfat" ];then
+   elif [ "$SAVEFS" = "vfat" -o "$SAVEFS" = "exfat" ];then
      PUPMODE=66
      umount ${SMNTPT} 2>/dev/null
      SMNTPT=''


### PR DESCRIPTION
FAT32 is very portable but also very limited. exFAT is relatively portable, doesn't suffer from the same limitations and has no journaling, making it a good choice for flash drives when compatibility is a concern.

However, exFAT is not perfect and shares some of the limitations of FAT32: for example, it doesn't support symlinks. If FAT32 supports both save files and PUPMODE 66 to work around these limitations, exFAT should support both options, too.