### PR TITLE
Exclude apt package lists from the PUPMODE 66 archive

### DIFF
--- a/woof-code/rootfs-skeleton/root/.config/save-exclude.lst
+++ b/woof-code/rootfs-skeleton/root/.config/save-exclude.lst
@@ -10,3 +10,4 @@
 ./var/cache
 ./var/run
 ./var/tmp
+./var/lib/apt/lists


### PR DESCRIPTION
They're huge, >100 MB.