### PR TITLE
Update autologin: make it configurable

### DIFF
--- a/woof-code/rootfs-skeleton/bin/autologin
+++ b/woof-code/rootfs-skeleton/bin/autologin
@@ -1,12 +1,19 @@
 #!/bin/ash
 
 LOGINUSER=root
+
 [ "$AUTOLOGIN" ] && LOGINUSER=${AUTOLOGIN}
 
+LOGINEXEC="/bin/login"
+
+[ -e /etc/autologin.conf ] && . /etc/autologin.conf
+
+[ "$LOGIN_TYPE" == "busybox" ] && LOGINEXEC="busybox login"
+
 if [ "$LOGINUSER" ] ; then
-	exec login -f $LOGINUSER
+	exec $LOGINEXEC -f $LOGINUSER
 else
-	exec login
+	exec $LOGINEXEC
 fi
 
-### END ###
+#


### PR DESCRIPTION
util-linux overwrites login symlinks. Sometimes it triggers permission denied or authentication failed due to pam improper configuration. This will remain busybox as default login unless changed it to util-linux