### PR TITLE
Fix /etc/rc.d/BOOTCONFIG not saved under PUPMODE 13 with overlay

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -153,8 +153,8 @@ find . -mount \
 	   -regextype posix-extended \
 	   -not \( -regex '^./initrd.*|^./mnt.*|^./media.*|^./proc.*|^./sys.*|^./tmp.*|^./pup_.*|^./zdrv_.*|^./root/tmp.*|.*_zdrv_.*|^./dev.*|^./var/run.*|^./root/ftpd.*|^./var/tmp.*|^./var/lock.*|.*\.XLOADED$' \) \
 	   -not \( -regex '.*\.thumbnails.*|.*\.part$|.*\.crdownload$' \) \
-	   -printf "%C@|%s|%P|%l\n" | sort -rn |
-while IFS='|' read -r NCTIME NSIZE N NDST
+	   -printf "%C@|%T@|%s|%P|%l\n" | sort -rn |
+while IFS='|' read -r NCTIME NDTIME NSIZE N NDST
 do
 	#v4.01 graceful exit if shutdown X (see /usr/X11R7/bin/restartwm,wmreboot,wmpoweroff)...
 	[ "$XRUNNING" = "yes" ] && [ -f /tmp/wmexitmode.txt ] && exit
@@ -189,19 +189,19 @@ do
 		if [ ! -e "$BASE/$N" ] ; then
 			cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 		else
-			read CTIME SIZE < <(stat -c "%Z %s" "$BASE/$N")
-			if [ ${NCTIME%%.*} -gt $CTIME ] ; then
-				if [ $SIZE -eq $NSIZE ] ; then
-					if cmp -s "$N" "$BASE/$N" ; then
+			read CTIME DTIME SIZE < <(stat -c "%Z %Y %s" "$BASE/$N")
+			if [ $SIZE -eq $NSIZE ] ; then
+				if [ ${NDTIME%%.*} -le $DTIME ] || cmp -s "$N" "$BASE/$N" ; then
+					if [ ${NCTIME%%.*} -gt $CTIME ] ; then
 						chmod "$BASE/$N" --reference="$N" 2>>/tmp/snapmergepuppy-error
 						chown-FULL "$BASE/$N" --reference="$N" 2>>/tmp/snapmergepuppy-error
 						touch "$BASE/$N" --reference="$N" 2>>/tmp/snapmergepuppy-error
-					else
-						cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 					fi
 				else
 					cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 				fi
+			else
+				cp -af "$N" "$BASE/$N" 2>>/tmp/snapmergepuppy-error
 			fi
 		fi
 	fi


### PR DESCRIPTION
If RTC doesn't work (this laptop thinks it's always 2015), files modified by initrd (like /etc/rc.d/BOOTCONFIG) have invalid modification timestamps in the past, because initrd uses hwclock to sync the software clock with the hardware clock.

Later, when the software clock is set over NTP, the modification times of these files are "in the past" and they never get saved.

/etc/rc.d/BOOTCONFIG is a special case because this file doesn't change in size when updating from 10.0.1 to 10.0.2.

Therefore, snapmergepuppy.overlay should compare files and check for changes even the modification timestamps suggest they're old. As an optimization, it should skip the comparison if the file contents modification timestamp indicates the file is already saved.