### PR TITLE
Revert mkfs.ext4 defaults change in 1.47.0 to allow use of old kernels

### DIFF
--- a/woof-code/packages-templates/e2fsprogs_FIXUPHACK
+++ b/woof-code/packages-templates/e2fsprogs_FIXUPHACK
@@ -1,0 +1,2 @@
+# retain file system compatibility with old kernels and boot loaders, when using e2fsprogs >=1.47.0
+sed -e s/,metadata_csum_seed,/,/ -e 's/,metadata_csum_seed$//g' -e s/,orphan_file,/,/g -e 's/,orphan_file$//g' -i etc/mke2fs.conf


### PR DESCRIPTION
Discussed in https://forum.puppylinux.com/viewtopic.php?t=9145.

(This change is not needed for bookworm, if e2fsprogs is >=1.47.0-2)