### PR TITLE
Add PUPMODE 12 and quiet operation support in sfs_load.overlay

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1361,6 +1361,9 @@ case $PUPMODE in
 esac
 
 if [ "$SAVEPART" -a "$UNIONFS" = 'overlay' -a -f /pup_new/etc/rc.d/BOOTCONFIG ]; then
+ # under PUPMODE 12, a dynamically loaded SFS may leave behind symlinks in the save layer
+ chroot /pup_new /usr/sbin/sfs_load.overlay --cli stop
+
  EXTRASFSLIST=""
  . /pup_new/etc/rc.d/BOOTCONFIG
  for ONE_SFS in $EXTRASFSLIST; do

--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -1362,7 +1362,7 @@ esac
 
 if [ "$SAVEPART" -a "$UNIONFS" = 'overlay' -a -f /pup_new/etc/rc.d/BOOTCONFIG ]; then
  # under PUPMODE 12, a dynamically loaded SFS may leave behind symlinks in the save layer
- chroot /pup_new /usr/sbin/sfs_load.overlay --cli stop
+ PATH=/bin:/sbin:/usr/bin:/usr/sbin:/usr/local/bin:/usr/X11R7/bin chroot /pup_new /usr/sbin/sfs_load.overlay --cli stop
 
  EXTRASFSLIST=""
  . /pup_new/etc/rc.d/BOOTCONFIG

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.shutdown
@@ -86,7 +86,7 @@ do
 done
 #note, /etc/rc.d/rc.services does same, with 'start' parameter.
 
-[ "$PUNIONFS" = "aufs" ] && sfs_load --cli stop
+sfs_load --cli stop
 
 #remove file leftover by alsa script
 rm -f /tmp/snd-kmod.lst 2>/dev/null

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -304,7 +304,7 @@ else
 fi
 
 #------ load extra sfs's if any ------
-[ "$PUNIONFS" = "aufs"  ] && sfs_load --cli start
+sfs_load --cli start
 #-------------------------------------
 
 #######################VERSION UPDATE##########################

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -81,7 +81,7 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 			umount -l "$MNT" 2>/dev/null
 			rmdir "$MNT" 2>/dev/null
 		fi
-		
+
 		# delete the list only if all symlinks are deleted, to allow retry
 		[ $OK -eq 1 ] && DIRTY=1
 	done

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -51,6 +51,13 @@ do
 	shift
 done
 
+if [ -z "$PUP_HOME" ]; then
+	SFS_DIRS="/initrd/mnt/pdrv"
+else
+	SFS_DIRS="/initrd${PUP_HOME}"
+	[ -n "$PSUBDIR" ] && SFS_DIRS="/initrd${PUP_HOME}${PSUBDIR} $SFS_DIRS"
+fi
+
 if [ $# -ne 0 ]; then
 	for SFS in "$@"; do
 		ACTION=toggle
@@ -63,6 +70,16 @@ if [ $# -ne 0 ]; then
 			SFS=${SFS:1}
 			ACTION=unload
 			;;
+		esac
+
+		case "$SFS" in
+		*/*.sfs) ;;
+		*.sfs)
+			for SFS_DIR in $SFS_DIRS; do
+				[ -s "${SFS_DIR}/${SFS}" ] || continue
+				SFS="${SFS_DIR}/${SFS}"
+				break
+			done
 		esac
 
 		ASKMOUNT=1
@@ -106,16 +123,16 @@ if [ $# -ne 0 ]; then
 				[ $CLI -eq 0 ] && kill $PID
 			fi
 		elif [ $ACTION != load -a -n "$LOOPDEV" ]; then
-			if [ $QUIET -eq 1 ]; then
-				:
-			else
-				yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to unload") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
-			fi
-			if [ $? -eq 0 ]; then
-				MNT="`grep "^$LOOPDEV " /proc/mounts 2>/dev/null | head -n 1 | cut -f 2 -d ' '`"
-				case "$MNT" in
-				/initrd/pup_ro1|/initrd/pup_ro2) ;;
-				/initrd/pup_ro[1-9]*)
+			MNT="`grep "^$LOOPDEV " /proc/mounts 2>/dev/null | head -n 1 | cut -f 2 -d ' '`"
+			case "$MNT" in
+			/initrd/pup_ro1|/initrd/pup_ro2) ;;
+			/initrd/pup_ro[1-9]*)
+				if [ $QUIET -eq 1 ]; then
+					:
+				else
+					yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to unload") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+				fi
+				if [ $? -eq 0 ]; then
 					if [ $CLI -eq 0 ]; then
 						yaf-splash -bg orange -placement top -close never -text "$(gettext Unloading) ${SFS##*/}" &
 						PID=$!
@@ -128,11 +145,9 @@ if [ $# -ne 0 ]; then
 					/etc/rc.d/rc.update w
 					pidof -s jwm > /dev/null && jwm -reload
 					[ $CLI -eq 0 ] && kill $PID
-					;;
-				"")
-					losetup -d "$LOOPDEV" ;;
-				esac
-			fi
+				fi
+				;;
+			esac
 
 			ASKMOUNT=0
 		fi
@@ -189,13 +204,6 @@ fi
 [ $QUIET -eq 1 ] && exit 0
 
 export -f queue unqueue
-
-if [ -z "$PUP_HOME" ]; then
-	SFS_DIRS="/initrd/mnt/pdrv"
-else
-	SFS_DIRS="/initrd${PUP_HOME}"
-	[ -n "$PSUBDIR" ] && SFS_DIRS="$SFS_DIRS /initrd${PUP_HOME}${PSUBDIR}"
-fi
 
 BUTTONS=""
 KBUILDSFS="kbuild-`uname -r`.sfs"

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -260,7 +260,7 @@ if [ $# -ne 0 ]; then
 	exit 0
 fi
 
-[ $QUIET -eq 1 ] && exit 0
+[ $QUIET -eq 1 -o $CLI -eq 1 ] && exit 0
 
 export -f queue unqueue
 

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -68,13 +68,16 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 		# delete all symlinks to files under the SFS mount point
 		while read RELPATH; do
 			ABSPATH="/${RELPATH}"
-			[ -L "$ABSPATH" ] || continue
-			DST=`readlink "$ABSPATH"`
-			case "$DST" in
-			${MNT}/*)
-				rm -f "$ABSPATH" || OK=0
-				;;
-			esac
+			if [ -L "$ABSPATH" ]; then
+				DST=`readlink "$ABSPATH"`
+				case "$DST" in
+				${MNT}/*)
+					rm -f "$ABSPATH" || OK=0
+					;;
+				esac
+			elif [ -d "$ABSPATH" ]; then
+				rmdir "$ABSPATH" || OK=0
+			fi
 		done < "$LIST"
 
 		if [ $OK -eq 1 -a -d "$MNT" ]; then
@@ -193,11 +196,14 @@ if [ $# -ne 0 ]; then
 					if [ $PUPMODE -eq 12 -a -f "$LIST" ]; then
 						while read RELPATH; do
 							ABSPATH="/${RELPATH}"
-							[ -L "$ABSPATH" ] || continue
-							DST=`readlink "$ABSPATH"`
-							case "$DST" in
-							${MNT}/*) rm -f "$ABSPATH" ;;
-							esac
+							if [ -L "$ABSPATH" ]; then
+								DST=`readlink "$ABSPATH"`
+								case "$DST" in
+								${MNT}/*) rm -f "$ABSPATH" ;;
+								esac
+							elif [ -d "$ABSPATH" ]; then
+								rmdir "$ABSPATH" 2>/dev/null
+							fi
 						done < "$LIST"
 					else
 						while read ABSPATH; do

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -60,6 +60,7 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 	[ $PUPMODE -eq 5 ] && exit 0
 
 	DIRTY=0
+	CHANGED=0
 	# the directory may exist if a user moves away from PUMODE 12, so we still need to do this under 13
 	for LIST in `ls /var/lib/sfs_load.overlay/* 2>/dev/null`; do
 		MNT="/initrd/${LIST#/var/lib/sfs_load.overlay/}"
@@ -72,11 +73,11 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 				DST=`readlink "$ABSPATH"`
 				case "$DST" in
 				${MNT}/*)
-					rm -f "$ABSPATH" || OK=0
+					rm "$ABSPATH" && CHANGED=1 || OK=0
 					;;
 				esac
 			elif [ -d "$ABSPATH" ]; then
-				rmdir "$ABSPATH" || OK=0
+				rmdir "$ABSPATH" 2>/dev/null
 			fi
 		done < "$LIST"
 
@@ -89,10 +90,14 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 		[ $OK -eq 1 ] && DIRTY=1
 	done
 
+	# update cache and delete the list if all symlinks are deleted
 	if [ $DIRTY -eq 1 ]; then
 		/etc/rc.d/rc.update w
 		rm -f /var/lib/sfs_load.overlay/*
 		sync
+	# otherwise, if we made any change, update cache but keep the lists to allow retry
+	elif [ $CHANGED -eq 1 ]; then
+		/etc/rc.d/rc.update w
 	fi
 
 	exit 0
@@ -168,7 +173,7 @@ if [ $# -ne 0 ]; then
 				if [ $PUPMODE -eq 12 ]; then
 					mkdir -p /var/lib/sfs_load.overlay
 					LIST="/var/lib/sfs_load.overlay/${MNT#/initrd/}"
-					find "$MNT" -mindepth 1 | cut -f 4- -d / > "$LIST"
+					find "$MNT" -mindepth 1 | cut -f 4- -d / | sort -r > "$LIST"
 					sync "$LIST"
 				fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -77,13 +77,13 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 			esac
 		done < "$LIST"
 
-		# delete the list only if all symlinks and the mount point are deleted, to allow retry
 		if [ $OK -eq 1 -a -d "$MNT" ]; then
 			umount -l "$MNT" 2>/dev/null
-			rmdir "$MNT" && DIRTY=1
-		elif [ $OK -eq 1 ]; then
-			DIRTY=1
+			rmdir "$MNT" 2>/dev/null
 		fi
+		
+		# delete the list only if all symlinks are deleted, to allow retry
+		[ $OK -eq 1 ] && DIRTY=1
 	done
 
 	if [ $DIRTY -eq 1 ]; then
@@ -141,7 +141,7 @@ if [ $# -ne 0 ]; then
 				for i in `seq 3 99`
 				do
 					MNT="/initrd/pup_ro$i"
-					mountpoint -q "$MNT" && continue
+					[ -e "$MNT" ] && continue
 					FOUND=1
 					break
 				done

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -159,7 +159,7 @@ if [ $# -ne 0 ]; then
 				if [ $PUPMODE -eq 12 ]; then
 					mkdir -p /var/lib/sfs_load.overlay
 					LIST="/var/lib/sfs_load.overlay/${MNT#/initrd/}"
-					find "$MNT" | cut -f 4- -d / > "$LIST"
+					find "$MNT" -mindepth 1 | cut -f 4- -d / > "$LIST"
 					sync "$LIST"
 				fi
 

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -31,6 +31,8 @@ EOF
 
 QUIET=0
 CLI=0
+START=0
+STOP=0
 while [ -n "$1" ]
 do
 	case "$1" in
@@ -40,9 +42,11 @@ do
 			CLI=1
 			QUIET=1
 			;;
+		start) START=1 ;;
+		stop) STOP=1 ;;
 		-*.sfs) break ;;
 		-*)
-			echo "Usage: $0 [-q|--quiet] [-c|--cli] [+sfs|-sfs|sfs]..." 1>&2
+			echo "Usage: $0 [-q|--quiet] [-c|--cli] [start|stop] [+sfs|-sfs|sfs]..." 1>&2
 			exit 1
 			;;
 		*) break ;;
@@ -50,6 +54,40 @@ do
 
 	shift
 done
+
+# loading of SFSs in EXTRASFSLIST is handled by initrd, see initrd-progs/0initrd/init
+if [ $START -eq 1 -o $STOP -eq 1 ]; then
+	[ $PUPMODE -eq 5 ] && exit 0
+
+	SYNC=0
+	# the directory may exist if a user moves away from PUMODE 12, so we still need to do this under 13
+	for LIST in `ls /var/lib/sfs_load.overlay/* 2>/dev/null`; do
+		MNT="/initrd/${LIST#/var/lib/sfs_load.overlay/}"
+
+		OK=1
+		# delete all symlinks to files under the SFS mount point
+		while read RELPATH; do
+			ABSPATH="/${RELPATH}"
+			[ -L "$ABSPATH" ] || continue
+			DST=`readlink "$ABSPATH"`
+			case "$DST" in
+			${MNT}/*)
+				rm -f "$ABSPATH" || OK=0
+				;;
+			esac
+		done < "$LIST"
+
+		# delete the list only if all symlinks are deleted, to allow retry
+		if [ $OK -eq 1 ]; then
+			rm -f "$LIST"
+			SYNC=1
+		fi
+	done
+
+	[ $SYNC -eq 1 ] && sync
+
+	exit 0
+fi
 
 if [ -z "$PUP_HOME" ]; then
 	SFS_DIRS="/initrd/mnt/pdrv"
@@ -86,8 +124,7 @@ if [ $# -ne 0 ]; then
 		# assumption: if we have a loop device associated with this SFS, it's mounted or loaded
 		LOOPDEV="`losetup -n -j "$SFS" | head -n 1 | cut -f 1 -d :`"
 
-		# TODO: add PUPMODE 12 support, without leaving broken symlinks behind after reboot
-		if [ $ACTION != unload ] && [ $PUPMODE -eq 5 -o $PUPMODE -eq 13 ] && [ -z "$LOOPDEV" ]; then
+		if [ $ACTION != unload ] && [ -z "$LOOPDEV" ]; then
 			if [ $QUIET -eq 1 ]; then
 				:
 			else
@@ -117,6 +154,14 @@ if [ $# -ne 0 ]; then
 					PID=$!
 				fi
 
+				# create a list of files and flush it to disk before we create the symlinks, so we can delete them after power loss
+				if [ $PUPMODE -eq 12 ]; then
+					mkdir -p /var/lib/sfs_load.overlay
+					LIST="/var/lib/sfs_load.overlay/${MNT#/initrd/}"
+					find "$MNT" | cut -f 4- -d / > "$LIST"
+					sync "$LIST"
+				fi
+
 				cp -asn "$MNT"/* /
 				/etc/rc.d/rc.update w
 				pidof -s jwm > /dev/null && jwm -reload
@@ -137,13 +182,27 @@ if [ $# -ne 0 ]; then
 						yaf-splash -bg orange -placement top -close never -text "$(gettext Unloading) ${SFS##*/}" &
 						PID=$!
 					fi
-					while read ABSPATH; do
-						rm -f "${ABSPATH#/initrd/pup_rw}"
-					done < <(find /initrd/pup_rw/ -lname "$MNT/*")
+					LIST="/var/lib/sfs_load.overlay/${MNT#/initrd/}"
+					if [ $PUPMODE -eq 12 -a -f "$LIST" ]; then
+						while read RELPATH; do
+							ABSPATH="/${RELPATH}"
+							[ -L "$ABSPATH" ] || continue
+							DST=`readlink "$ABSPATH"`
+							case "$DST" in
+							${MNT}/*) rm -f "$ABSPATH" ;;
+							esac
+						done < "$LIST"
+					else
+						while read ABSPATH; do
+							rm -f "${ABSPATH#/initrd/pup_rw}"
+						done < <(find /initrd/pup_rw/ -lname "$MNT/*")
+					fi
 					umount -l "$LOOPDEV"
 					rmdir "$MNT"
+					rm -f "$LIST" # always remove the file list, to allow change from PUPMODE 12 to something else
 					/etc/rc.d/rc.update w
 					pidof -s jwm > /dev/null && jwm -reload
+					[ $PUPMODE -eq 12 ] && sync
 					[ $CLI -eq 0 ] && kill $PID
 				fi
 				;;

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -124,6 +124,7 @@ if [ $# -ne 0 ]; then
 				SFS="${SFS_DIR}/${SFS}"
 				break
 			done
+			;;
 		esac
 
 		ASKMOUNT=1

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -77,8 +77,13 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 			esac
 		done < "$LIST"
 
-		# delete the list only if all symlinks are deleted, to allow retry
-		[ $OK -eq 1 ] && DIRTY=1
+		# delete the list only if all symlinks and the mount point are deleted, to allow retry
+		if [ $OK -eq 1 -a -d "$MNT" ]; then
+			umount -l "$MNT" 2>/dev/null
+			rmdir "$MNT" && DIRTY=1
+		elif [ $OK -eq 1 ]; then
+			DIRTY=1
+		fi
 	done
 
 	if [ $DIRTY -eq 1 ]; then
@@ -198,7 +203,7 @@ if [ $# -ne 0 ]; then
 							rm -f "${ABSPATH#/initrd/pup_rw}"
 						done < <(find /initrd/pup_rw/ -lname "$MNT/*")
 					fi
-					umount -l "$LOOPDEV"
+					umount -l "$MNT"
 					rmdir "$MNT"
 					rm -f "$LIST" # always remove the file list, to allow change from PUPMODE 12 to something else
 					/etc/rc.d/rc.update w

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -29,15 +29,53 @@ EOF
 	mv -f /etc/rc.d/BOOTCONFIG.tmp /etc/rc.d/BOOTCONFIG
 }
 
+QUIET=0
+CLI=0
+while [ -n "$1" ]
+do
+	case "$1" in
+		-q|--quiet) QUIET=1 ;;
+		-c|--cli) CLI=1 ;;
+		-qc|-cq)
+			CLI=1
+			QUIET=1
+			;;
+		-*.sfs) break ;;
+		-*)
+			echo "Usage: $0 [-q|--quiet] [-c|--cli] [+sfs|-sfs|sfs]..." 1>&2
+			exit 1
+			;;
+		*) break ;;
+	esac
+
+	shift
+done
+
 if [ $# -ne 0 ]; then
 	for SFS in "$@"; do
+		ACTION=toggle
+		case "$SFS" in
+		+*)
+			SFS=${SFS:1}
+			ACTION=load
+			;;
+		-*)
+			SFS=${SFS:1}
+			ACTION=unload
+			;;
+		esac
+
 		ASKMOUNT=1
 		# assumption: if we have a loop device associated with this SFS, it's mounted or loaded
 		LOOPDEV="`losetup -n -j "$SFS" | head -n 1 | cut -f 1 -d :`"
 
 		# TODO: add PUPMODE 12 support, without leaving broken symlinks behind after reboot
-		if [ $PUPMODE -eq 5 -o $PUPMODE -eq 13 ] && [ -z "$LOOPDEV" ]; then
-			yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to load") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+		if [ $ACTION != unload ] && [ $PUPMODE -eq 5 -o $PUPMODE -eq 13 ] && [ -z "$LOOPDEV" ]; then
+			if [ $QUIET -eq 1 ]; then
+				:
+			else
+				yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to load") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+			fi
 			if [ $? -eq 0 ]; then
 				FOUND=0
 				for i in `seq 3 99`
@@ -57,21 +95,31 @@ if [ $# -ne 0 ]; then
 				fi
 				ASKMOUNT=0
 
-				yaf-splash -bg orange -placement top -close never -text "$(gettext Loading) ${SFS##*/}" &
-				PID=$!
+				if [ $CLI -eq 0 ]; then
+					yaf-splash -bg orange -placement top -close never -text "$(gettext Loading) ${SFS##*/}" &
+					PID=$!
+				fi
 
 				cp -asn "$MNT"/* /
 				/etc/rc.d/rc.update w
 				pidof -s jwm > /dev/null && jwm -reload
-				kill $PID
+				[ $CLI -eq 0 ] && kill $PID
 			fi
-		elif [ -n "$LOOPDEV" ]; then
-			yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to unload") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+		elif [ $ACTION != load -a -n "$LOOPDEV" ]; then
+			if [ $QUIET -eq 1 ]; then
+				:
+			else
+				yad --title sfs_load --window-icon=dialog-question --image=dialog-question --text "$(gettext "Do you want to unload") ${SFS}?" --form --button="gtk-yes:0" --button="gtk-no:1"
+			fi
 			if [ $? -eq 0 ]; then
 				MNT="`grep "^$LOOPDEV " /proc/mounts 2>/dev/null | head -n 1 | cut -f 2 -d ' '`"
-				if [ -n "$MNT" ]; then
-					yaf-splash -bg orange -placement top -close never -text "$(gettext Unloading) ${SFS##*/}" &
-					PID=$!
+				case "$MNT" in
+				/initrd/pup_ro1|/initrd/pup_ro2) ;;
+				/initrd/pup_ro[1-9]*)
+					if [ $CLI -eq 0 ]; then
+						yaf-splash -bg orange -placement top -close never -text "$(gettext Unloading) ${SFS##*/}" &
+						PID=$!
+					fi
 					while read ABSPATH; do
 						rm -f "${ABSPATH#/initrd/pup_rw}"
 					done < <(find /initrd/pup_rw/ -lname "$MNT/*")
@@ -79,14 +127,17 @@ if [ $# -ne 0 ]; then
 					rmdir "$MNT"
 					/etc/rc.d/rc.update w
 					pidof -s jwm > /dev/null && jwm -reload
-					kill $PID
-				else
-					losetup -d "$LOOPDEV"
-				fi
+					[ $CLI -eq 0 ] && kill $PID
+					;;
+				"")
+					losetup -d "$LOOPDEV" ;;
+				esac
 			fi
 
 			ASKMOUNT=0
 		fi
+
+		[ $QUIET -eq 1 ] && continue
 
 		BASE="${SFS##*/}"
 
@@ -134,6 +185,8 @@ if [ $# -ne 0 ]; then
 
 	exit 0
 fi
+
+[ $QUIET -eq 1 ] && exit 0
 
 export -f queue unqueue
 

--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -59,7 +59,7 @@ done
 if [ $START -eq 1 -o $STOP -eq 1 ]; then
 	[ $PUPMODE -eq 5 ] && exit 0
 
-	SYNC=0
+	DIRTY=0
 	# the directory may exist if a user moves away from PUMODE 12, so we still need to do this under 13
 	for LIST in `ls /var/lib/sfs_load.overlay/* 2>/dev/null`; do
 		MNT="/initrd/${LIST#/var/lib/sfs_load.overlay/}"
@@ -78,13 +78,14 @@ if [ $START -eq 1 -o $STOP -eq 1 ]; then
 		done < "$LIST"
 
 		# delete the list only if all symlinks are deleted, to allow retry
-		if [ $OK -eq 1 ]; then
-			rm -f "$LIST"
-			SYNC=1
-		fi
+		[ $OK -eq 1 ] && DIRTY=1
 	done
 
-	[ $SYNC -eq 1 ] && sync
+	if [ $DIRTY -eq 1 ]; then
+		/etc/rc.d/rc.update w
+		rm -f /var/lib/sfs_load.overlay/*
+		sync
+	fi
 
 	exit 0
 fi


### PR DESCRIPTION
This PR adds support for:
* -q: assume yes to all questions
* -c: hide the "Loading x" splash
* +/path/to/sfs to load a SFS if not loaded already
* -/path/to/sfs to unload a SFS if loaded
* /path/to/sfs to load or unload a SFS, depending on current state
* +name.sfs to load a SFS in PSUBDIR or root if not loaded already
* -name.sfs to unload a SFS in PSUBDIR or root if loaded
* name.sfs to load or unload a SFS, depending on current state

The idea is not to complicate sfs_load.overlay (230 lines) and make it impossible to maintain like sfs_load (2527 lines), but to allow the use case of `sfs_load -q` in a ~/Startup script.

EDIT: also added PUPMODE 12 support with protection against power failure and leftover symlinks.