### PR TITLE
mtpaint - remove no* build options

### DIFF
--- a/woof-code/rootfs-petbuilds/mtpaint/petbuild
+++ b/woof-code/rootfs-petbuilds/mtpaint/petbuild
@@ -7,9 +7,9 @@ build() {
     cd mtPaint-199472ad6a4ecee6c8583fb5a504a2e99712b4fc
     patch -p1 < ../wayland.patch
     if [ $PETBUILD_GTK -eq 3 ]; then
-        ./configure gtk3 gtkfilesel gtkcolsel cflags nojp2 notiff nowebp nolcms intl --prefix=/usr
+        ./configure gtk3 gtkfilesel gtkcolsel cflags intl --prefix=/usr
     else
-        ./configure gtk2 gtkfilesel gtkcolsel cflags nojp2 notiff nowebp nolcms intl --prefix=/usr
+        ./configure gtk2 gtkfilesel gtkcolsel cflags intl --prefix=/usr
     fi
     make
     make install


### PR DESCRIPTION
OscarTalks says:
Looking at the mtpaint recipe I see that the configure options do have webp and tiff (and also lcms and jpeg2000) actively disabled. So I would remove the nowebp, notiff, nolcms and nojp2 configure options from both of the 2 lines (one for gtk3 and the other for gtk2) The configure script will look for the DEV packages and autodetect everything, so if those libraries are in the build environment then support will be compiled in. No reason to actively disable anything unless we are encountering some kind of a problem. I don't think I have ever encountered tiff image files in common usage, but webp is increasing in popularity, including animated ones.