### PR TITLE
Provide support for "root=UUID=" boot parameter - init and isoboot

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -60,8 +60,12 @@ for i in $(cat /proc/cmdline) ; do
     fullinstall) exec ash /sbin/init_full_install ;;
     bootmenu)    ZBOOTMENU=1 ;;
     loglevel=*)  LOGLEVEL=${i##*=}  ;;
+    root=*)      GRUB_ROOT=${i#root=} ;;
   esac
 done
+if [ "$GRUB_ROOT" ]; then
+	[ "${GRUB_ROOT%=*}" = 'UUID' ] && GRUB_ROOT=${GRUB_ROOT#*=}
+fi
 # always call init-bootmenu on ARM devices
 case $(uname -m) in arm*) ZBOOTMENU=1 ;; esac
 
@@ -898,8 +902,14 @@ export PFSCK # read by /sbin/load_ext_file
 [ "$TZ" ] && export TZ
 hwclock -l -s
 
+ISO_LOOP=''
 if [ -f /sbin/isoboot ] ; then
   . /sbin/isoboot # optional, can remove all occurrences of "isoboot" from this script
+fi
+if [ "$PDRV" = '' ]; then
+  if [ "$ISO_LOOP" = '' ]; then
+    [ "$GRUB_ROOT" ] && PDRV=$GRUB_ROOT
+  fi
 fi
 
 [ "$PDEBUG" ] && echo "0: PMEDIA=$PMEDIA PDRV=$PDRV PSUBDIR=$PSUBDIR pfix=$pfix"

--- a/initrd-progs/0initrd/sbin/isoboot
+++ b/initrd-progs/0initrd/sbin/isoboot
@@ -91,6 +91,9 @@ if [ "$iso_path" ] ; then
   FOUND_ISO=
 
   [ "$iso_dev" ] && img_dev="$iso_dev"
+  if [ "$img_dev" = '' ]; then
+    [ "$GRUB_ROOT" ] && img_dev=$GRUB_ROOT
+  fi
   if [ "$img_dev" ] ; then
     img_dev="${img_dev##*/}"
     decode_id "$img_dev"


### PR DESCRIPTION
This provides support for "root=UUID=" boot paarameter in both init and isoboot.
Such parameters may be generated by grub2 utilitiy scripts.