### PR TITLE
Update init: use binded mountpoint instead of direct path for save folder

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -503,12 +503,14 @@ setup_psave(){ # setup savefile or savefolder
   fi
  elif [ -d "$SAVE_FN" ];then #savefolder
   echo "--SAVEFOLDER-- $SAVE_FN" #debug
+  mkdir -p /pup_disk
+  mount -o bind $SAVE_FN /pup_disk
   if [ "$UNIONFS" = 'overlay' ]; then
-   mkdir -p "$SAVE_FN/upper" "$SAVE_FN/work"
-   ln -sv "$SAVE_FN/upper" "$SAVE_LAYER"
-   ln -sv "$SAVE_FN/work" "$WORKDIR"
+   mkdir -p "/pup_disk/upper" "/pup_disk/work"
+   ln -sv "/pup_disk/upper" "$SAVE_LAYER"
+   ln -sv "/pup_disk/work" "$WORKDIR"
   else
-   ln -sv "$SAVE_FN" "$SAVE_LAYER"
+   ln -sv "/pup_disk" "$SAVE_LAYER"
   fi
  else
   PUPSAVE=""


### PR DESCRIPTION
Reason: If savefolder was used and the actual path of savefolder was used. It would not release from layered root filesystem and unmount the drive when the save folder was located during shutdown. This may cause filesystem corruption. In order to detach the savefolder gracefully from layer root filesystem in aufs was to use bind mountpoint. In order to retain the attached path on aufs layered system.