### PR TITLE
Fix trailing separator if last entry belongs to two directories

### DIFF
--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/double-separators.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/double-separators.patch
@@ -1,6 +1,6 @@
 diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
---- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2022-07-07 09:23:03.246665962 +0300
-+++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2022-07-07 09:51:08.043483904 +0300
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 09:37:40.513771855 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 09:37:29.457802304 +0200
 @@ -111,7 +111,7 @@ show_help()
  void
  process_directory(GMenuTreeDirectory *directory, char *menheight, GHashTable *history)
@@ -10,7 +10,7 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
  	char *mheight = menheight;
  	
    GMenuTreeItemType entryType;
-@@ -155,21 +155,24 @@ start:
+@@ -155,14 +155,16 @@ start:
  		case GMENU_TREE_ITEM_DIRECTORY:
  		  if (hasSeparator)
  		  {
@@ -27,8 +27,11 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 +			hadSeparator = 0;
  			break;
  		case GMENU_TREE_ITEM_ENTRY:
- 		  if (hasSeparator)
- 		  {
+ 			entry = GMENU_TREE_ENTRY(item);
+@@ -173,14 +175,16 @@ start:
+ 			}
+ 			if (hasSeparator)
+ 			{
 -				if (!first)
 +				if (!first && !hadSeparator)
  				{
@@ -36,12 +39,10 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 +					hadSeparator = 1;
  				}
  				hasSeparator = 0;
- 		  }
-@@ -179,6 +182,7 @@ start:
- 			{
- 				process_entry(entry);
- 				first = 0;
-+				hadSeparator = 0;
- 				g_hash_table_insert(history, g_strdup(path), (gpointer)1);
  			}
- 			break;
+ 			process_entry(entry);
+ 			first = 0;
++			hadSeparator = 0;
+ 			g_hash_table_insert(history, g_strdup(path), (gpointer)1);
+ 		case GMENU_TREE_ITEM_SEPARATOR:
+ 			hasSeparator = 1;

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
@@ -1,6 +1,6 @@
 diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
---- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2022-02-24 21:02:10.059689993 +0200
-+++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2022-02-25 03:35:24.503675651 +0200
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 09:34:28.614330714 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 09:35:50.174084257 +0200
 @@ -22,7 +22,7 @@
   * Declarations
   */
@@ -45,7 +45,7 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
    /* if the menu has no items, don't show an empty menu */
    for (l = entryList; l; l = l->next)
    {
-@@ -154,7 +161,7 @@ start:
+@@ -154,21 +161,27 @@ start:
  				}
  				hasSeparator = 0;
  		  }
@@ -54,20 +54,28 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
  			first = 0;
  			break;
  		case GMENU_TREE_ITEM_ENTRY:
-@@ -166,8 +173,14 @@ start:
- 				}
- 				hasSeparator = 0;
- 		  }
--			process_entry(GMENU_TREE_ENTRY(item));
--			first = 0;
+-		  if (hasSeparator)
+-		  {
 +			entry = GMENU_TREE_ENTRY(item);
 +			path = gmenu_tree_entry_get_desktop_file_path(entry);
-+			if (!g_hash_table_lookup(history, path))
++			if (g_hash_table_lookup(history, path))
 +			{
-+				process_entry(entry);
-+				first = 0;
-+				g_hash_table_insert(history, g_strdup(path), (gpointer)1);
++				continue;
 +			}
- 			break;
++			if (hasSeparator)
++			{
+ 				if (!first)
+ 				{
+ 					process_separator(GMENU_TREE_SEPARATOR(item));
+ 				}
+ 				hasSeparator = 0;
+-		  }
+-			process_entry(GMENU_TREE_ENTRY(item));
++			}
++			process_entry(entry);
+ 			first = 0;
+-			break;
++			g_hash_table_insert(history, g_strdup(path), (gpointer)1);
  		case GMENU_TREE_ITEM_SEPARATOR:
  			hasSeparator = 1;
+ 			break;

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
@@ -74,8 +74,8 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 +			}
 +			process_entry(entry);
  			first = 0;
--			break;
 +			g_hash_table_insert(history, g_strdup(path), (gpointer)1);
+-			break;
  		case GMENU_TREE_ITEM_SEPARATOR:
  			hasSeparator = 1;
  			break;

--- a/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-jwm/unique.patch
@@ -1,6 +1,6 @@
 diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c
---- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 09:34:28.614330714 +0200
-+++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 09:35:50.174084257 +0200
+--- xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 10:23:39.250395884 +0200
++++ xdg_puppy-0.7.6-9/jwm-xdgmenu/jwm-xdgmenu.c	2023-11-28 10:24:39.642263168 +0200
 @@ -22,7 +22,7 @@
   * Declarations
   */
@@ -45,7 +45,7 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
    /* if the menu has no items, don't show an empty menu */
    for (l = entryList; l; l = l->next)
    {
-@@ -154,21 +161,27 @@ start:
+@@ -154,20 +161,27 @@ start:
  				}
  				hasSeparator = 0;
  		  }
@@ -75,7 +75,6 @@ diff -rupN xdg_puppy-0.7.6-9-orig/jwm-xdgmenu/jwm-xdgmenu.c xdg_puppy-0.7.6-9/jw
 +			process_entry(entry);
  			first = 0;
 +			g_hash_table_insert(history, g_strdup(path), (gpointer)1);
--			break;
+ 			break;
  		case GMENU_TREE_ITEM_SEPARATOR:
  			hasSeparator = 1;
- 			break;

--- a/woof-code/rootfs-petbuilds/xdg-puppy-labwc/labwc-xdgmenu.c
+++ b/woof-code/rootfs-petbuilds/xdg-puppy-labwc/labwc-xdgmenu.c
@@ -142,22 +142,25 @@ start:
 				hadSeparator = 0;
                 break;
             case GMENU_TREE_ITEM_ENTRY:
+                entry = GMENU_TREE_ENTRY(item);
+                path = gmenu_tree_entry_get_desktop_file_path(entry);
+                if (g_hash_table_lookup(history, path))
+                {
+                    continue;
+                }
 				if (hasSeparator)
+				{
 					if (!first && !hadSeparator)
 	 				{
 	 					process_separator(GMENU_TREE_SEPARATOR(item));
 						hadSeparator = 1;
 	 				}
 					hasSeparator = 0;
-                entry = GMENU_TREE_ENTRY(item);
-                path = gmenu_tree_entry_get_desktop_file_path(entry);
-                if (!g_hash_table_lookup(history, path))
-                {
-                    process_entry(entry);
-                    g_hash_table_insert(history, g_strdup(path), (gpointer)1);
-					first = 0;
-					hadSeparator = 0;
-               }
+				}
+                process_entry(entry);
+                g_hash_table_insert(history, g_strdup(path), (gpointer)1);
+				first = 0;
+				hadSeparator = 0;
                 break;
 			case GMENU_TREE_ITEM_SEPARATOR:
 				hasSeparator = 1;


### PR DESCRIPTION
#2899 removes duplicate entries in the JWM menu but #3194 wasn't fixed correctly. The menu generator should add a separator only if it's not preceded by another separator **and** the following menu item is not a duplicate that's going to be dropped. Otherwise, if the last entry in a submenu is a duplicate, the submenu ends with a separator.

In other words, if the last application in a submenu belongs to more than one category and the last category in submenu is empty, the submenu ends with a separator.

It's not hard to reproduce this bug by installing applications that belong to submenus with many categories that may overlap, like the multimedia submenu.

To reproduce the bug artificially:

![sep](https://github.com/puppylinux-woof-CE/woof-CE/assets/1471149/22eb530d-9c01-49f8-b0f1-477dae7a9e5c)

(this PR doesn't fix other issues, clean up nonsense and reformat whitespace)