### PR TITLE
Loopback - generate an enhaned grub2 loopback.cfg file

### DIFF
--- a/woof-code/support/mk_iso.sh
+++ b/woof-code/support/mk_iso.sh
@@ -459,15 +459,15 @@ for e in "$NAME" \
 		"$NAME - RAM only - no pupsave" \
 		"$NAME - Ram Disk Shell" ; do
 		case "$e" in
-			"$NAME")opt='pfix=fsck' ;;
-			*"- Copy"*)opt='pfix=fsck,copy' ;;
-			*"- Don't copy"*)opt='pfix=fsck,nocopy' ;;
-			*"- Force xorgwizard"*)opt='pfix=xorgwizard,fsck'; gandl=no ;;
-			*"- No X"*)opt='pfix=nox,fsck' ;;
-			*"- No Kernel Mode"*)opt='nomodeset pfix=fsck'; gandl=no ;;
-			*"- Safe mode"*)opt='pfix=ram,nox,fsck' ;;
-			*"- RAM only"*)opt='pfix=ram,fsck' ;;
-			*"- Ram Disk"*)opt='pfix=rdsh' ;;
+			"$NAME")opt='pfix=fsck,fsckp' ;;
+			*"- Copy"*)opt='pfix=fsck,fsckp,copy' ;;
+			*"- Don't copy"*)opt='pfix=fsck,fsckp,nocopy' ;;
+			*"- Force xorgwizard"*)opt='pfix=fsck,fsckp,xorgwizard'; gandl=no ;;
+			*"- No X"*)opt='pfix=fsck,fsckp,nox' ;;
+			*"- No Kernel Mode"*)opt='nomodeset pfix=fsck,fsckp'; gandl=no ;;
+			*"- Safe mode"*)opt='pfix=fsck,fsckp,ram,nox' ;;
+			*"- RAM only"*)opt='pfix=fsck,fsckp,ram' ;;
+			*"- Ram Disk"*)opt='pfix=fsck,fsckp,rdsh' ;;
 		esac
 		[ "$gandl" = 'no' ] || build_grub2_cfg $BUILD/grub.cfg "$e" "$opt"
 		[ "$gandl" = 'no' ] || build_grub2_cfg $BUILD/boot/grub/loopback.cfg "$e" "$opt"


### PR DESCRIPTION
This modifies the script code that generetes grub.cfg and loopback.cfg files.

The loopback.cfg now boots Puppy with "img_dev=" and "img_loop=" boot parameters.
The 'isoboot' script in initrd.gz, is  already capable of handling these parameters.
The "img_dev=" parameter is the UUID of the partition that contains the ISO file.
So if it is provided, the 'isoboot' script does not have to search the partitions for the ISO file.

The code that generates the grub.cfg file has mainly been modified to fit with the approach taken for loopback.cfg.
It's functionality has not really changed, except it now displays a message indicating if ucode.cpio and initrd.gz or just initrd.gz, has been loaded.
