### PR TITLE
Add and use new color theme in lxterminal

### DIFF
--- a/woof-code/rootfs-petbuilds/lxterminal/colors.patch
+++ b/woof-code/rootfs-petbuilds/lxterminal/colors.patch
@@ -1,6 +1,15 @@
 diff -rup lxterminal-0.4.0-orig/src/setting.c lxterminal-0.4.0/src/setting.c
---- lxterminal-0.4.0-orig/src/setting.c	2021-03-12 20:20:26.156393104 +0200
-+++ lxterminal-0.4.0/src/setting.c	2021-03-13 20:43:20.653893675 +0200
+--- lxterminal-0.4.0-orig/src/setting.c	2024-01-26 11:00:15.817511151 +0530
++++ lxterminal-0.4.0/src/setting.c	2024-01-26 11:46:02.729178961 +0530
+@@ -42,7 +42,7 @@ ColorPreset color_presets[] = {
+         .foreground_color = "#aaaaaa",
+         .palette = {
+             "#000000", "#aa0000", "#00aa00", "#aa5500",
+-            "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
++            "#001fff", "#aa00aa", "#00aaaa", "#aaaaaa",
+             "#555555", "#ff5555", "#55ff55", "#ffff55",
+             "#5555ff", "#ff55ff", "#55ffff", "#ffffff"
+         }
 @@ -350,10 +350,12 @@ Setting * load_setting()
      /* Initialize nonzero integer values to defaults. */
  #if VTE_CHECK_VERSION (0, 38, 0)

--- a/woof-code/rootfs-petbuilds/lxterminal/colors.patch
+++ b/woof-code/rootfs-petbuilds/lxterminal/colors.patch
@@ -1,18 +1,39 @@
+diff -rup lxterminal-0.4.0-orig/data/lxterminal.conf lxterminal-0.4.0/data/lxterminal.conf
+--- lxterminal-0.4.0-orig/data/lxterminal.conf	2024-01-27 16:42:04.048250277 +0530
++++ lxterminal-0.4.0/data/lxterminal.conf	2024-01-28 03:03:44.136433337 +0530
+@@ -2,3 +2,6 @@
+ fontname=Monospace 10
+ selchars=-A-Za-z0-9,./?%&#:_
+ scrollback=1000
++bgcolor=rgb(36,31,49)
++fgcolor=rgb(222,221,218)
++boldbright=true
+diff -rup lxterminal-0.4.0-orig/data/lxterminal.conf.in lxterminal-0.4.0/data/lxterminal.conf.in
+--- lxterminal-0.4.0-orig/data/lxterminal.conf.in	2024-01-27 16:42:04.048250277 +0530
++++ lxterminal-0.4.0/data/lxterminal.conf.in	2024-01-28 03:05:37.924989756 +0530
+@@ -2,3 +2,6 @@
+ fontname=Monospace 10
+ selchars=-A-Za-z0-9,./?%&#:_
+ scrollback=1000
++bgcolor=rgb(36,31,49)
++fgcolor=rgb(222,221,218)
++boldbright=true
 diff -rup lxterminal-0.4.0-orig/src/setting.c lxterminal-0.4.0/src/setting.c
 --- lxterminal-0.4.0-orig/src/setting.c	2024-01-27 16:42:04.040251209 +0530
-+++ lxterminal-0.4.0/src/setting.c	2024-01-27 17:15:16.041523334 +0530
-@@ -37,6 +37,17 @@ Setting * setting;
++++ lxterminal-0.4.0/src/setting.c	2024-01-28 03:18:46.139740603 +0530
+@@ -37,6 +37,18 @@ Setting * setting;
  
  ColorPreset color_presets[] = {
      {
++        // add Puppy preset here; other modified settings in ../data/lxterminal.conf
 +        .name = "Puppy",
 +        .background_color = "#241f31",
-+        .foreground_color = "#f8f8f8",
++        .foreground_color = "#deddda",
 +        .palette = {
-+            "#000000", "#ff0000", "#26a269", "#986a44",
-+            "#1a5fb4", "#aa00aa", "#00aaaa", "#aaaaaa",
-+            "#3d3846", "#ff5454", "#33d17a", "#f6d32d",
-+            "#62a0ea", "#ff55ff", "#55ffff", "#ffffff"
++            "#000000", "#ff0000","#2ec27e", "#ff7600",
++            "#1c71d8", "#c061cb", "#00aaaa", "#deddda",
++            "#797979", "#ff5f5f", "#57e389", "#f6d32d",
++            "#62a0ea", "#ff55ff", "#55ffff", "#f6f5f4"
 +        }
 +    },
 +    {

--- a/woof-code/rootfs-petbuilds/lxterminal/colors.patch
+++ b/woof-code/rootfs-petbuilds/lxterminal/colors.patch
@@ -1,27 +1,21 @@
 diff -rup lxterminal-0.4.0-orig/src/setting.c lxterminal-0.4.0/src/setting.c
---- lxterminal-0.4.0-orig/src/setting.c	2024-01-26 11:00:15.817511151 +0530
-+++ lxterminal-0.4.0/src/setting.c	2024-01-26 11:46:02.729178961 +0530
-@@ -42,7 +42,7 @@ ColorPreset color_presets[] = {
-         .foreground_color = "#aaaaaa",
-         .palette = {
-             "#000000", "#aa0000", "#00aa00", "#aa5500",
--            "#0000aa", "#aa00aa", "#00aaaa", "#aaaaaa",
-+            "#001fff", "#aa00aa", "#00aaaa", "#aaaaaa",
-             "#555555", "#ff5555", "#55ff55", "#ffff55",
-             "#5555ff", "#ff55ff", "#55ffff", "#ffffff"
-         }
-@@ -350,10 +350,12 @@ Setting * load_setting()
-     /* Initialize nonzero integer values to defaults. */
- #if VTE_CHECK_VERSION (0, 38, 0)
-     setting->background_color.alpha = setting->foreground_color.alpha = 1;
--    setting->foreground_color.red = setting->foreground_color.green = setting->foreground_color.blue = (gdouble) 170/255;
-+    setting->background_color.red = setting->background_color.green = setting->background_color.blue = (gdouble) 0x1a/255;
-+    setting->foreground_color.red = setting->foreground_color.green = setting->foreground_color.blue = (gdouble) 0xf8/255;
- #else
-     setting->background_alpha = 65535;
--    setting->foreground_color.red = setting->foreground_color.green = setting->foreground_color.blue = 0xaaaa;
-+    setting->background_color.red = setting->background_color.green = setting->background_color.blue = 0x1a1a;
-+    setting->foreground_color.red = setting->foreground_color.green = setting->foreground_color.blue = 0xf8f8;
- #endif
+--- lxterminal-0.4.0-orig/src/setting.c	2024-01-27 16:42:04.040251209 +0530
++++ lxterminal-0.4.0/src/setting.c	2024-01-27 17:15:16.041523334 +0530
+@@ -37,6 +37,17 @@ Setting * setting;
  
-     /* Load configuration. */
+ ColorPreset color_presets[] = {
+     {
++        .name = "Puppy",
++        .background_color = "#241f31",
++        .foreground_color = "#f8f8f8",
++        .palette = {
++            "#000000", "#ff0000", "#26a269", "#986a44",
++            "#1a5fb4", "#aa00aa", "#00aaaa", "#aaaaaa",
++            "#3d3846", "#ff5454", "#33d17a", "#f6d32d",
++            "#62a0ea", "#ff55ff", "#55ffff", "#ffffff"
++        }
++    },
++    {
+         .name = "VGA",
+         .background_color = "#000000",
+         .foreground_color = "#aaaaaa",


### PR DESCRIPTION
VGA is the default lxterminal preset, but its dark blue color has very little contrast with the background (for lower brightness). This replaces the original dark blue color with the one that has better contrast (slightly brighter).

Old:
![old_lxterminal](https://github.com/puppylinux-woof-CE/woof-CE/assets/103126231/d0b12d63-d0bc-46e2-92f4-7f19104de392)
![lxterminal-htop-old](https://github.com/puppylinux-woof-CE/woof-CE/assets/103126231/757c2c4d-6db2-43a8-b5a9-326246306882)

New:
![lxterminal-htop new](https://github.com/puppylinux-woof-CE/woof-CE/assets/103126231/62da827f-352e-435d-8b90-c4e54b58db13)
![lxterminal-ls new](https://github.com/puppylinux-woof-CE/woof-CE/assets/103126231/e2539487-981c-46c0-a6d6-531ab5325ab1)


@dimkr, @peabee, please review.