### PR TITLE
Fix breakage of trixie64 and sid64

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -460,7 +460,7 @@ fi
 mv -f sandbox3/rootfs-complete/{*.xpm,*.png} sandbox3/rootfs-complete/usr/share/pixmaps 2>/dev/null
 
 # busybox applets...
-if [ ! -f packages-${DISTRO_FILE_PREFIX}/busybox/bin/busybox.lst ] ; then
+if [ ! -f packages-${DISTRO_FILE_PREFIX}/busybox/bin/busybox.lst -a ! -f packages-${DISTRO_FILE_PREFIX}/busybox/usr/bin/busybox.lst ] ; then
 	echo "Please use the 'official' woofce busybox .pet package.."
 	exit 1
 fi

--- a/woof-code/_00func
+++ b/woof-code/_00func
@@ -292,6 +292,7 @@ mergedir() {
 
 	echo "Merging ${1} with ${2}"
 
+	local NAME
 	for NAME in `ls ${1} 2>/dev/null`; do
 		if [ -d ${1}/${NAME} ]; then
 			mergedir ${1}/${NAME} ${2}/${NAME}

--- a/woof-code/support/busybox_symlinks.sh
+++ b/woof-code/support/busybox_symlinks.sh
@@ -28,6 +28,8 @@ if [ "$lst" ] ; then
 	echo "$lst" > /tmp/busybox.lst
 elif [ -f ./bin/busybox.lst ] ; then
 	cp -f ./bin/busybox.lst /tmp/busybox.lst
+elif [ -f ./usr/bin/busybox.lst ] ; then
+	cp -f ./usr/bin/busybox.lst /tmp/busybox.lst
 else
 	echo "ERROR: could not get applet list"
 	exit 1

--- a/woof-code/support/petbuilds.sh
+++ b/woof-code/support/petbuilds.sh
@@ -75,6 +75,8 @@ for NAME in $PETBUILDS; do
             rm -rf petbuild-rootfs-complete
             cp -a rootfs-complete petbuild-rootfs-complete
 
+            [ "$USR_SYMLINKS" = "yes" ] && usrmerge petbuild-rootfs-complete 1
+
             rm -f petbuild-rootfs-complete/bin/sh
             ln -s bash petbuild-rootfs-complete/bin/sh
 
@@ -154,6 +156,8 @@ EOF
             if [ ! -f petbuild-rootfs-complete/bin/busybox ]; then
                 if [ -f ../petbuild-output/busybox-latest/bin/busybox ]; then # busybox petbuild
                     install -D -m 755 ../petbuild-output/busybox-latest/bin/busybox petbuild-rootfs-complete/bin/busybox
+                elif [ -f ../petbuild-output/busybox-latest/usr/bin/busybox ]; then # busybox petbuild
+                    install -D -m 755 ../petbuild-output/busybox-latest/usr/bin/busybox petbuild-rootfs-complete/bin/busybox
                 elif [ -f ../packages-${DISTRO_FILE_PREFIX}/busybox/bin/busybox ]; then # prebuilt busybox
                     install -D -m 755 ../packages-${DISTRO_FILE_PREFIX}/busybox/bin/busybox petbuild-rootfs-complete/bin/busybox
                 elif [ "$NAME" != "busybox" ]; then


### PR DESCRIPTION
usrmerge needs to be called in the temporary rootfs used for petbuilds, so /bin and /usr/bin have the same contents. Otherwise, scripts that look for /bin/grep or /bin/sed fail: both got moved recently in trixie and the deadbeef petbuild fails.