### PR TITLE
Make pfix=fsckp work with f2fs

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -111,7 +111,7 @@ KFILESYSTEMS="$(cat /proc/filesystems | grep -v "nodev" | grep -v "fuseblk" | se
 LINUXFSLIST="ext2|ext3|ext4|btrfs|minix|f2fs|reiserfs"
 
 #Filesystem to be fsck
-FSCKLIST="ext2|ext3|ext4|vfat|msdos|exfat"
+FSCKLIST="ext2|ext3|ext4|f2fs|vfat|msdos|exfat"
 
 # Layered file system to use
 UNIONFS='aufs'
@@ -125,6 +125,7 @@ fsck_func() {
 # "$2" - fstype - ex: ext2
  case $2 in
   ext2|ext3|ext4) fsck_app='e2fsck -y' ;;
+  f2fs) fsck_app='fsck.f2fs -y' ;;
   #vfat)  fsck_app='fsck.fat -y'  ;;
   #exfat) fsck_app='exfatfsck'    ;;
   *) return ;;


### PR DESCRIPTION
Looks like initrd contains fsck.f2fs since puppylinux-woof-CE/initrd_progs@580e53a (2019) but doesn't do anything when  `pfix=fsckp` is specified.