### PR TITLE
Create bluez-nologind.conf for pipewire

### DIFF
--- a/woof-code/rootfs-skeleton/etc/pipewire/wireplumber.conf.d/bluez-nologind.conf
+++ b/woof-code/rootfs-skeleton/etc/pipewire/wireplumber.conf.d/bluez-nologind.conf
@@ -1,0 +1,5 @@
+wireplumber.profiles = {
+  main = {
+    monitor.bluez.seat-monitoring = disabled
+  }
+}


### PR DESCRIPTION
This configuration is a workaround in order to make bluetooth devices work on pipewire without active login session like logind/elogind

See https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3828