### PR TITLE
Sync x-www-browser with defaultbrowser when using Palemoon petbuild

### DIFF
--- a/woof-code/rootfs-petbuilds/palemoon/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/palemoon/pinstall.sh
@@ -1,3 +1,19 @@
-echo '#!/bin/sh
-exec palemoon "$@"' > usr/local/bin/defaultbrowser
-chmod 755 usr/local/bin/defaultbrowser
+# Set defaultbrowser to run x-www-browser - set the default browser the Debian way, not the Puppy way.
+case ${DISTRO_BINARY_COMPAT} in
+    ubuntu|trisquel|debian|devuan|raspbian)
+        /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/palemoon 200
+        echo '#!/bin/sh
+CMD=$(command -v x-www-browser)
+[ -z "$CMD" ] && CMD="/usr/bin/palemoon"
+exec "$CMD" "$@"
+' > /usr/local/bin/defaultbrowser
+        ;;
+    *)
+        echo '#!/bin/sh
+exec /usr/bin/palemoon "$@"
+' > /usr/local/bin/defaultbrowser
+        ;;
+esac
+
+chmod 755 /usr/local/bin/defaultbrowser
+cp /usr/local/bin/defaultbrowser /usr/local/bin/defaulthtmlviewer

--- a/woof-code/rootfs-petbuilds/palemoon/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/palemoon/pinstall.sh
@@ -16,4 +16,4 @@ exec /usr/bin/palemoon "$@"
 esac
 
 chmod 755 usr/local/bin/defaultbrowser
-cp usr/local/bin/defaultbrowser usr/local/bin/defaulthtmlviewer
+cp -p usr/local/bin/defaultbrowser usr/local/bin/defaulthtmlviewer

--- a/woof-code/rootfs-petbuilds/palemoon/pinstall.sh
+++ b/woof-code/rootfs-petbuilds/palemoon/pinstall.sh
@@ -1,19 +1,19 @@
 # Set defaultbrowser to run x-www-browser - set the default browser the Debian way, not the Puppy way.
 case ${DISTRO_BINARY_COMPAT} in
     ubuntu|trisquel|debian|devuan|raspbian)
-        /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/palemoon 200
+        chroot . /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/palemoon 200
         echo '#!/bin/sh
 CMD=$(command -v x-www-browser)
 [ -z "$CMD" ] && CMD="/usr/bin/palemoon"
 exec "$CMD" "$@"
-' > /usr/local/bin/defaultbrowser
+' > usr/local/bin/defaultbrowser
         ;;
     *)
         echo '#!/bin/sh
 exec /usr/bin/palemoon "$@"
-' > /usr/local/bin/defaultbrowser
+' > usr/local/bin/defaultbrowser
         ;;
 esac
 
-chmod 755 /usr/local/bin/defaultbrowser
-cp /usr/local/bin/defaultbrowser /usr/local/bin/defaulthtmlviewer
+chmod 755 usr/local/bin/defaultbrowser
+cp usr/local/bin/defaultbrowser usr/local/bin/defaulthtmlviewer

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -166,4 +166,5 @@ chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/66
 rm -f usr/bin/weechat-headless
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
+chroot . /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/local/bin/defaultbrowser 200
 "

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -166,9 +166,4 @@ chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/66
 rm -f usr/bin/weechat-headless
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
-# Set defaultbrowser to run x-www-browser - set the default browser the Debian way, not the Puppy way.
-chroot . /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/palemoon 200
-echo '#!/bin/ash
-exec /usr/bin/x-www-browser "$@"
-' > usr/local/bin/defaultbrowser
 "

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -166,5 +166,9 @@ chroot . run-as-spot weechat-headless -r \"/server add libera irc.libera.chat/66
 rm -f usr/bin/weechat-headless
 rm -f etc/localtime
 ln -s /usr/share/zoneinfo/Etc/GMT-0 etc/localtime
-chroot . /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/local/bin/defaultbrowser 200
+# Set defaultbrowser to run x-www-browser - set the default browser the Debian way, not the Puppy way.
+chroot . /usr/bin/update-alternatives --install /usr/bin/x-www-browser x-www-browser /usr/bin/palemoon 200
+echo '#!/bin/ash
+exec /usr/bin/x-www-browser "$@"
+' > usr/local/bin/defaultbrowser
 "


### PR DESCRIPTION
Use `update-alternatives` command to sync by default, `/usr/bin/x-www-browser` with `/usr/local/bin/defaultbrowser`.

Specifically, this is required in `epdfview` since it uses `x-www-browser` by default to open URL links.

@dimkr, @peabee please review.