### PR TITLE
Add `tldr_c_client` petbuild and add it to Jammy64

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1073,10 +1073,6 @@ else
 fi
 echo
 
-## TESTS
-echo "TLDR_C_CLIENT TESTS"
-find ./ -name *tldr*
-
 #-------------------------
 #before building puppy.sfs from rootfs-complete, check for any invalid symlinks
 #and move them to the devx...

--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -1073,6 +1073,10 @@ else
 fi
 echo
 
+## TESTS
+echo "TLDR_C_CLIENT TESTS"
+find ./ -name *tldr*
+
 #-------------------------
 #before building puppy.sfs from rootfs-complete, check for any invalid symlinks
 #and move them to the devx...

--- a/woof-code/rootfs-petbuilds/tldr_c_client/pet.specs
+++ b/woof-code/rootfs-petbuilds/tldr_c_client/pet.specs
@@ -1,0 +1,1 @@
+tldr-1.6.1|tldr|1.6.1|||84K||tldr-1.6.1.pet||C command-line client for tldr pages|puppy|||

--- a/woof-code/rootfs-petbuilds/tldr_c_client/petbuild
+++ b/woof-code/rootfs-petbuilds/tldr_c_client/petbuild
@@ -1,0 +1,21 @@
+# see deps.sh in the downloaded archive's tldr-c-client-*/ folder for dependencies depending on your target system
+
+download() {
+    [ -f tldr_c_client-1.6.1.tar.gz ] || wget -t 3 -T 60 -O tldr_c_client-1.6.1.tar.gz https://github.com/tldr-pages/tldr-c-client/archive/refs/tags/v1.6.1.tar.gz
+}
+
+build() {
+    tar -xzf tldr_c_client-1.6.1.tar.gz
+    cd tldr-c-client-1.6.1/
+
+    make
+    make install
+
+    # enable autocompletion for bash
+
+    # uncomment the following lines when https://github.com/tldr-pages/tldr-c-client/pull/113 is merged and new release is made
+    # the fix is currently directly included in woof-CE
+
+    # mkdir -p /usr/share/bash-completion/completions/
+    # mv autocomplete/complete.bash /usr/share/bash-completion/completions/tldr
+}

--- a/woof-code/rootfs-petbuilds/tldr_c_client/sha256.sum
+++ b/woof-code/rootfs-petbuilds/tldr_c_client/sha256.sum
@@ -1,0 +1,1 @@
+1a2aa8e764846fad1f41a0304e28416f5c38b6d3a3131ad1e85116749aec34ba  tldr_c_client-1.6.1.tar.gz

--- a/woof-code/rootfs-petbuilds/tldr_c_client/usr/share/bash-completion/completions/tldr
+++ b/woof-code/rootfs-petbuilds/tldr_c_client/usr/share/bash-completion/completions/tldr
@@ -14,10 +14,10 @@ _tldr_complete() {
     local word="${COMP_WORDS[COMP_CWORD]}"
     local cmpl=""
     if [[ "$word" == "--"* ]] || [ -z "$word" ]; then
-        cmpl=$'--version\n--help\n--update\n--clear-cache\n--platform\n--render'
+        cmpl=$'--help\n--color\n--platform\n--render\n--update\n--version\n--clear-cache\n--verbose\n--list'
     elif [[ "$word" == "-"* ]]; then
-        cmpl=$'\n-v\n-h\n-u\n-c\n-p\n-r'
-    elif [[ "$word" == *"/"* ]]; then # the file command will give error if passed directly since this will actually be a directory
+        cmpl=$'-h\n-C\n-p\n-r\n-u\n-v\n-c\n-V\n-l'
+    elif [[ "$word" == *"/"* ]]; then # the file command will give an error if passed directly since this will be a directory name - an invalid command
         cmpl=""
     else
         if [ -d "$HOME/.tldrc/tldr/pages" ]; then
@@ -25,11 +25,14 @@ _tldr_complete() {
             platform="$(uname)"
             cmpl="$(_tldr_get_files common "$word")"
             if [ "$platform" = "Darwin" ]; then
-                cmpl="${cmpl}$(_tldr_get_files osx "$word")"
+                cmpl="${cmpl}
+$(_tldr_get_files osx "$word")"
             elif [ "$platform" = "Linux" ]; then
-                cmpl="${cmpl}$(_tldr_get_files linux "$word")"
+                cmpl="${cmpl}
+$(_tldr_get_files linux "$word")"
             elif [ "$platform" = "SunOS" ]; then
-                cmpl="${cmpl}$(_tldr_get_files sunos "$word")"
+                cmpl="${cmpl}
+$(_tldr_get_files sunos "$word")"
             fi
         fi
     fi
@@ -37,5 +40,4 @@ _tldr_complete() {
     cmpl_sorted_n_uniq=$(printf "%s" "$cmpl" | sort | uniq)
     COMPREPLY=( $(compgen -W "$cmpl_sorted_n_uniq" -- "$word") )
 }
-
 complete -F _tldr_complete tldr

--- a/woof-code/rootfs-petbuilds/tldr_c_client/usr/share/bash-completion/completions/tldr
+++ b/woof-code/rootfs-petbuilds/tldr_c_client/usr/share/bash-completion/completions/tldr
@@ -6,14 +6,14 @@
 
 # usage: _tldr_get_files [architecture] [semi-completed word to search]
 _tldr_get_files() {
-    find "$HOME"/.tldrc/tldr/pages/"$1" -name "$2"'*.md' -exec basename {} .md \;
+    find "$HOME"/.tldrc/tldr/pages/"$1" -name "$2"'*.md' -exec basename -s .md {} +
 }
 
 _tldr_complete() {
     COMPREPLY=()
     local word="${COMP_WORDS[COMP_CWORD]}"
     local cmpl=""
-    if [[ "$word" == "--"* ]] || [ -z "$word" ]; then
+    if [[ "$word" == "--"* ]]; then
         cmpl=$'--help\n--color\n--platform\n--render\n--update\n--version\n--clear-cache\n--verbose\n--list'
     elif [[ "$word" == "-"* ]]; then
         cmpl=$'-h\n-C\n-p\n-r\n-u\n-v\n-c\n-V\n-l'

--- a/woof-code/rootfs-petbuilds/tldr_c_client/usr/share/bash-completion/completions/tldr
+++ b/woof-code/rootfs-petbuilds/tldr_c_client/usr/share/bash-completion/completions/tldr
@@ -1,0 +1,41 @@
+# I don't use bash, but I remember this works.
+# If anyone has an improved, and better version, go ahead, open a pull-request.
+#
+# Copyright (C) 2016 Arvid Gerstmann
+#
+
+# usage: _tldr_get_files [architecture] [semi-completed word to search]
+_tldr_get_files() {
+    find "$HOME"/.tldrc/tldr/pages/"$1" -name "$2"'*.md' -exec basename {} .md \;
+}
+
+_tldr_complete() {
+    COMPREPLY=()
+    local word="${COMP_WORDS[COMP_CWORD]}"
+    local cmpl=""
+    if [[ "$word" == "--"* ]] || [ -z "$word" ]; then
+        cmpl=$'--version\n--help\n--update\n--clear-cache\n--platform\n--render'
+    elif [[ "$word" == "-"* ]]; then
+        cmpl=$'\n-v\n-h\n-u\n-c\n-p\n-r'
+    elif [[ "$word" == *"/"* ]]; then # the file command will give error if passed directly since this will actually be a directory
+        cmpl=""
+    else
+        if [ -d "$HOME/.tldrc/tldr/pages" ]; then
+            local platform
+            platform="$(uname)"
+            cmpl="$(_tldr_get_files common "$word")"
+            if [ "$platform" = "Darwin" ]; then
+                cmpl="${cmpl}$(_tldr_get_files osx "$word")"
+            elif [ "$platform" = "Linux" ]; then
+                cmpl="${cmpl}$(_tldr_get_files linux "$word")"
+            elif [ "$platform" = "SunOS" ]; then
+                cmpl="${cmpl}$(_tldr_get_files sunos "$word")"
+            fi
+        fi
+    fi
+    local cmpl_sorted_n_uniq
+    cmpl_sorted_n_uniq=$(printf "%s" "$cmpl" | sort | uniq)
+    COMPREPLY=( $(compgen -W "$cmpl_sorted_n_uniq" -- "$word") )
+}
+
+complete -F _tldr_complete tldr

--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -41,7 +41,7 @@ USR_SYMLINKS=yes
 BUILD_BDRV=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap homebank grsync hardinfo uget gfnrename fsearch mtr epdfview"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme firewallstatus freememapplet geany gexec viewnior gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage jwm l3afpad lxtask lxterminal mtpaint pa-applet powerapplet_tray rox-filer claws-mail transmission tldr_c_client xarchiver xcur2png xdelta xdg-puppy-jwm Xdialog xlockmore yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-ui connman-gtk fixmenusd spot-pkexec notification-daemon-stub palemoon weechat osmo abiword gnumeric xournalpp mpv efilinux gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap homebank grsync hardinfo uget gfnrename fsearch mtr epdfview"
 
 ## GTK+ version to use when building packages that support GTK+ 2
 PETBUILD_GTK=3


### PR DESCRIPTION
Tested and working in Jammy64. I'll keep this as a draft for few days, in case `tldr-c-client` makes a new release with the fix I proposed for bash auto-completion (for now, it is an open PR there; the same file is also copied in woof-CE directly, which would be removed as soon as the former repo is updated).