### PR TITLE
Fix breakage of bash in noble

### DIFF
--- a/woof-code/packages-templates/bash_FIXUPHACK
+++ b/woof-code/packages-templates/bash_FIXUPHACK
@@ -1,6 +1,6 @@
 DISABLE_POST_INSTALL_SCRIPT=yes
 
-if [ "$DISTRO_BINARY_COMPAT" = "void" ]; then
+if [ -f usr/bin/bash -a ! -e bin/bash -a ! -L bin/bash ] ; then
 	mkdir -p bin
 	mv -f usr/bin/bash bin
 


### PR DESCRIPTION
jammy:

```
/bin/bash
/usr/bin/bashbug
```

noble:

```
/usr/bin/bash
/usr/bin/bashbug
```

The package template breaks bash because it replaces /usr/bin/bash with a symlink to /bin/bash, so it's a broken symlink or a recursive symlink (depending on whether or not /bin is a symlink to /usr/bin).