### PR TITLE
Fix breakage of busybox in noble

### DIFF
--- a/woof-code/rootfs-petbuilds/busybox/no-cbq.patch
+++ b/woof-code/rootfs-petbuilds/busybox/no-cbq.patch
@@ -1,0 +1,40 @@
+diff -rupN busybox-1.36.1-orig/networking/tc.c busybox-1.36.1/networking/tc.c
+--- busybox-1.36.1-orig/networking/tc.c	2024-03-03 20:43:59.423846018 +0200
++++ busybox-1.36.1/networking/tc.c	2024-03-03 20:44:50.036173484 +0200
+@@ -231,6 +231,7 @@ static int cbq_parse_opt(int argc, char
+ 	return 0;
+ }
+ #endif
++#if 0
+ static int cbq_print_opt(struct rtattr *opt)
+ {
+ 	struct rtattr *tb[TCA_CBQ_MAX+1];
+@@ -322,6 +323,7 @@ static int cbq_print_opt(struct rtattr *
+  done:
+ 	return 0;
+ }
++#endif
+ 
+ static FAST_FUNC int print_qdisc(
+ 		const struct sockaddr_nl *who UNUSED_PARAM,
+@@ -372,8 +374,6 @@ static FAST_FUNC int print_qdisc(
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			prio_print_opt(tb[TCA_OPTIONS]);
+-		} else if (qqq == 1) { /* class based queuing */
+-			cbq_print_opt(tb[TCA_OPTIONS]);
+ 		} else {
+ 			/* don't know how to print options for this qdisc */
+ 			printf("(options for %s)", name);
+@@ -442,9 +442,11 @@ static FAST_FUNC int print_class(
+ 		int qqq = index_in_strings(_q_, name);
+ 		if (qqq == 0) { /* pfifo_fast aka prio */
+ 			/* nothing. */ /*prio_print_opt(tb[TCA_OPTIONS]);*/
++#if 0
+ 		} else if (qqq == 1) { /* class based queuing */
+ 			/* cbq_print_copt() is identical to cbq_print_opt(). */
+ 			cbq_print_opt(tb[TCA_OPTIONS]);
++#endif
+ 		} else {
+ 			/* don't know how to print options for this class */
+ 			printf("(options for %s)", name);

--- a/woof-code/rootfs-petbuilds/busybox/petbuild
+++ b/woof-code/rootfs-petbuilds/busybox/petbuild
@@ -8,6 +8,8 @@ build() {
     cd busybox-1.36.1
 
     patch -p1  < ../busybox-guess_fstype.patch
+    # hack for Linux 6.8
+    grep -q TCA_CBQ_MAX /usr/include/linux/pkt_sched.h || patch -p1  < ../no-cbq.patch
 
     # we need sleep and echo to build busybox, so we have to improvise
     echo -e '#include <stdlib.h>\n#include <unistd.h>\nint main(int argc, char *argv[]) {sleep(atoi(argv[1])); return 0;}' | $CC -x c -o /bin/sleep -


### PR DESCRIPTION
Linux 6.8 drops TCA_CBQ_MAX and friends, and it's unlikely that anyone uses busybox `tc` on Puppy. The easy fix is to remove this support.