### PR TITLE
Update palemoon to 33.0.1

### DIFF
--- a/woof-code/rootfs-petbuilds/palemoon/pet.specs
+++ b/woof-code/rootfs-petbuilds/palemoon/pet.specs
@@ -1,1 +1,1 @@
-palemoon-32.1.1|palemoon|32.1.1||Internet|2800K||palemoon-32.1.1||Palemoon web browser|puppy|||
+palemoon-33.0.1|palemoon|33.0.1||Internet|2800K||palemoon-33.0.1||Palemoon web browser|puppy|||

--- a/woof-code/rootfs-petbuilds/palemoon/petbuild
+++ b/woof-code/rootfs-petbuilds/palemoon/petbuild
@@ -1,9 +1,9 @@
 download() {
-    [ -f palemoon-32.1.1.linux-x86_64-gtk3.tar.xz ] || wget -t 3 -T 60 https://rm-us.palemoon.org/release/palemoon-32.1.1.linux-x86_64-gtk3.tar.xz || wget -t 3 -T 60 https://archive.palemoon.org/palemoon/32.x/32.1.1/Linux/palemoon-32.1.1.linux-x86_64-gtk3.tar.xz
+    [ -f palemoon-33.0.1.linux-x86_64-gtk3.tar.xz ] || wget -t 3 -T 60 https://rm-us.palemoon.org/release/palemoon-33.0.1.linux-x86_64-gtk3.tar.xz || wget -t 3 -T 60 https://archive.palemoon.org/palemoon/33.x/33.0.1/Linux/palemoon-33.0.1.linux-x86_64-gtk3.tar.xz
 }
 
 build() {
-    tar -xJf palemoon-32.1.1.linux-x86_64-gtk3.tar.xz palemoon/
+    tar -xJf palemoon-33.0.1.linux-x86_64-gtk3.tar.xz palemoon/
     mv palemoon/ /opt/
 
     ln -fs /opt/palemoon/palemoon /usr/bin/palemoon

--- a/woof-code/rootfs-petbuilds/palemoon/sha256.sum
+++ b/woof-code/rootfs-petbuilds/palemoon/sha256.sum
@@ -1,1 +1,1 @@
-56fc022b02f755db9efaa727d06af95d120b923f8b374857ff3bed8e9a51804e  palemoon-32.1.1.linux-x86_64-gtk3.tar.xz
+c09b562451fe7ee6190d179fabcf203afba1dcf617df64526466f2ca427d9ec4  palemoon-33.0.1.linux-x86_64-gtk3.tar.xz


### PR DESCRIPTION
This Palemoon version (basically `33.0.x`) brings support for many websites that could not load properly earlier with the Palemoon `32.x` series.

The biggest examples are `github.com` and `mega.nz`.