### PR TITLE
{jammy64, noble64}: Fix bash's prompt (PS1)

### DIFF
--- a/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/jammy64/_00build.conf
@@ -135,7 +135,7 @@ defaultwordprocessor=
 "
 
 ## PROMPT - change the CLI prompt to whatever you like. Default is unset
-PROMPT='PS1="\e[1;32m\u@\H\e[0m:\e[1;34m\w\e[0m\$ "'
+PROMPT='PS1="\[\e[1;32m\]\u@\H\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ "'
 
 ## -- EXTRA FLAG --
 ## This allows some customisation for the iso name

--- a/woof-distro/x86_64/ubuntu/noble64/_00build.conf
+++ b/woof-distro/x86_64/ubuntu/noble64/_00build.conf
@@ -135,7 +135,7 @@ defaultwordprocessor=
 "
 
 ## PROMPT - change the CLI prompt to whatever you like. Default is unset
-PROMPT='PS1="\e[1;32m\u@\H\e[0m:\e[1;34m\w\e[0m\$ "'
+PROMPT='PS1="\[\e[1;32m\]\u@\H\[\e[0m\]:\[\e[1;34m\]\w\[\e[0m\]\$ "'
 
 ## -- EXTRA FLAG --
 ## This allows some customisation for the iso name


### PR DESCRIPTION
Older `PS1` did not enclose non-printable characters such as `\033[0m`, which stayed there for color, in `\[....\]`. This caused such issues when run in `lxterminal`:

https://github.com/puppylinux-woof-CE/woof-CE/assets/103126231/4df1c235-fbcd-4921-b971-e67626aa9279

This newer version fixes the issue:

https://github.com/puppylinux-woof-CE/woof-CE/assets/103126231/7cb8f824-c2ad-4526-893b-92b256dd5dd9

_(sorry for the video being slightly shifted)_
