### PR TITLE
Run fsck.f2fs without -y

### DIFF
--- a/initrd-progs/0initrd/init
+++ b/initrd-progs/0initrd/init
@@ -125,7 +125,7 @@ fsck_func() {
 # "$2" - fstype - ex: ext2
  case $2 in
   ext2|ext3|ext4) fsck_app='e2fsck -y' ;;
-  f2fs) fsck_app='fsck.f2fs -y' ;;
+  f2fs) fsck_app='fsck.f2fs' ;;
   #vfat)  fsck_app='fsck.fat -y'  ;;
   #exfat) fsck_app='exfatfsck'    ;;
   *) return ;;


### PR DESCRIPTION
`-y` slows down boot and doesn't mean the same thing as in fsck.ext4.