### PR TITLE
Fix X startup failure when nvidia_drv.so is a symlink

### DIFF
--- a/woof-code/rootfs-skeleton/usr/bin/xwin
+++ b/woof-code/rootfs-skeleton/usr/bin/xwin
@@ -249,7 +249,7 @@ elif [ -f /etc/X11/xorg.conf ];then
 	if [ "$USING_DRIVER" -a -d "$DRVRSPATH" ] ; then #find location of video chip drivers...
 		CURRENT_DRIVER="`grep '#card0driver' /etc/X11/xorg.conf | cut -f 2 -d '"'`"
 		if [ "$CURRENT_DRIVER" ];then
-			if ! [ "`find $DRVRSPATH -type f -name "*${CURRENT_DRIVER}*"`" ] ; then
+			if ! [ "`find -L $DRVRSPATH -type f -name "*${CURRENT_DRIVER}*"`" ] ; then
 				#driver file not found, comment out
 				sed -i "s|.*#card0driver|#	Driver      \"${CURRENT_DRIVER}\" #card0driver|" /etc/X11/xorg.conf
 			fi


### PR DESCRIPTION
xwin thinks the driver is missing and comments out the Driver line in xorg.conf, only because the driver is a symlink.