### PR TITLE
Update wireplumber_FIXUPHACK: Disable active login session monitoring

### DIFF
--- a/woof-code/packages-templates/wireplumber_FIXUPHACK
+++ b/woof-code/packages-templates/wireplumber_FIXUPHACK
@@ -1,1 +1,9 @@
 rm -f `find . -name libwireplumber-module-logind.so` 2>/dev/null
+
+cat << EOF > /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf
+wireplumber.profiles = {
+  main = {
+    monitor.bluez.seat-monitoring = disabled
+  }
+}
+EOF

--- a/woof-code/packages-templates/wireplumber_FIXUPHACK
+++ b/woof-code/packages-templates/wireplumber_FIXUPHACK
@@ -1,6 +1,6 @@
 rm -f `find . -name libwireplumber-module-logind.so` 2>/dev/null
 
-if [ -f /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf ]; then
+if [ ! -f /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf ]; then
 
 #Enable bluez without session from display manager. Puppy has no display manager
 cat << EOF > /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf

--- a/woof-code/packages-templates/wireplumber_FIXUPHACK
+++ b/woof-code/packages-templates/wireplumber_FIXUPHACK
@@ -1,5 +1,8 @@
 rm -f `find . -name libwireplumber-module-logind.so` 2>/dev/null
 
+if [ -f /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf ]; then
+
+#Enable bluez without session from display manager. Puppy has no display manager
 cat << EOF > /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf
 wireplumber.profiles = {
   main = {
@@ -7,3 +10,5 @@ wireplumber.profiles = {
   }
 }
 EOF
+
+fi

--- a/woof-code/packages-templates/wireplumber_FIXUPHACK
+++ b/woof-code/packages-templates/wireplumber_FIXUPHACK
@@ -1,9 +1,11 @@
 rm -f `find . -name libwireplumber-module-logind.so` 2>/dev/null
 
-if [ ! -f /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf ]; then
+if [ ! -f ./etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf ]; then
+
+[ ! -d ./etc/wireplumber/wireplumber.conf.d ] && mkdir -p ./etc/wireplumber/wireplumber.conf.d
 
 #Enable bluez without session from display manager. Puppy has no display manager
-cat << EOF > /etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf
+cat << EOF > ./etc/wireplumber/wireplumber.conf.d/bluez-nologind.conf
 wireplumber.profiles = {
   main = {
     monitor.bluez.seat-monitoring = disabled


### PR DESCRIPTION
wireplumber-0.5 onwards now looks for active login session in order to make bluez work on pipewire otherwise bluetooth devices will not work on pipewire since Puppy has no display manager

See [https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3828](https://gitlab.freedesktop.org/pipewire/pipewire/-/issues/3828)