### PR TITLE
Update sfs_load.overlay: Dealing with config files

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -182,7 +182,12 @@ if [ $# -ne 0 ]; then
 				done < <(find "$MNT" -mindepth 1 | cut -f 4- -d / | sort -r)
 				[ $PUPMODE -eq 12 ] && sync "$LIST"
 
-				cp -asn "$MNT"/* /
+				#link except files at /etc
+				find "$MNT" | grep -v "/etc/" | xargs -i cp -asn '{}' $PREPATH/
+				
+				#copy config files to /etc
+				find "$MNT" | grep "/etc/" | xargs -i cp -an '{}' $PREPATH/
+
 				/etc/rc.d/rc.update w
 				pidof -s jwm > /dev/null && jwm -reload
 				[ $CLI -eq 0 ] && kill $PID


### PR DESCRIPTION
The problem with linking method that the config files at /etc was read-only. This fix will allow to modify config files of an sfs module located at /etc