### PR TITLE
Update sfs_load.overlay: Workarounds for /etc, /run, and /var

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/sfs_load.overlay
@@ -182,7 +182,28 @@ if [ $# -ne 0 ]; then
 				done < <(find "$MNT" -mindepth 1 | cut -f 4- -d / | sort -r)
 				[ $PUPMODE -eq 12 ] && sync "$LIST"
 
-				cp -asn "$MNT"/* /
+				#link anything except /etc, /run, and /var
+				for fld1 in $(ls $MNT 2>/dev/null | grep -vE '\/etc|\/run|\/var')
+				do
+ 				  if [ "$fld1" != "" ]; then
+					  if [ ! -d "/$fld1" ] && [ ! -L "/$fld1" ]; then 
+					    mkdir -p "/$fld1"
+					  fi
+					  cp -rasn "$MNT/$fld1"/* "/$fld1"/
+				  fi
+				done
+
+				#copy files in /etc, /run, and /var
+				for fld1 in etc run var
+				do
+ 				  if [ "$fld1" != "" ]; then
+					  if [ ! -d "/$fld1" ] && [ ! -L "/$fld1" ]; then 
+					    mkdir -p "/$fld1"
+					  fi
+					  cp -ran "$MNT/$fld1"/* "/$fld1"/
+				  fi
+				done
+
 				/etc/rc.d/rc.update w
 				pidof -s jwm > /dev/null && jwm -reload
 				[ $CLI -eq 0 ] && kill $PID


### PR DESCRIPTION
The problem with symlink method for loading sfs modules on the fly on overlay is that files under /etc, /run, and /var where got read-only. To fix this issue simply exclude those folder when creating symlinks. Then perform copy of files of /etc, /run, and /var from sfs module to rootfs