### PR TITLE
Update VoidPup64's kernel to 6.6 and VoidPup32's to 6.1

### DIFF
--- a/.github/workflows/void-voidpup.yml
+++ b/.github/workflows/void-voidpup.yml
@@ -11,10 +11,10 @@ jobs:
         include:
           - arch: x86_64
             compat-distro-version: voidpup64
-            kernel: 5.15.x
+            kernel: 6.6.x
           - arch: x86
             compat-distro-version: voidpup32
-            kernel: 5.10.x
+            kernel: 6.1.x
     if: github.repository == 'puppylinux-woof-CE/woof-CE'
     uses: ./.github/workflows/build.yml
     with:


### PR DESCRIPTION
Note that I've only tested VoidPup64, and not very much, but it seems to be working as usual, at least on my computer.