### PR TITLE
Reduce boot time by ~20%

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -870,6 +870,8 @@ if [ $CROSSBUILD -eq 0 -o -n "$QEMU" ];then
 	# 'chooselocale' is called from /etc/rc.d/rc.country at first boot and
 	# pre-creating this table speeds things up. 111123
 	chroot rootfs-complete /usr/sbin/chooselocale composeonly
+	chroot rootfs-complete localedef -f ISO-8859-1 -i en_US --no-archive en_US
+	chroot rootfs-complete localedef -f UTF-8 -i en_US --no-archive en_US.utf8
 else
 	#*** cross-build
 	touch rootfs-complete/etc/gtk-2.0/gtk.immodules

--- a/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
+++ b/woof-code/rootfs-skeleton/etc/rc.d/rc.sysinit
@@ -420,14 +420,8 @@ fi
 echo 5000 > /sys/module/block/parameters/events_dfl_poll_msecs
 
 #replay uevents from /sys...
-for ONEMODALIAS in $MODALIASES
-do
- ONEPATH="${ONEMODALIAS%/*}"
- if [ -e ${ONEPATH}/uevent ];then
-  echo add > ${ONEPATH}/uevent #generates an 'add' uevent.
-  [ "$DISTRO_TARGETARCH" = "x86" ] && sleep 0.02
- fi
-done
+udevadm trigger --type=subsystems --action=add
+udevadm trigger --type=devices --action=add
 
 if [ $PUPMODE -eq 2 ] ; then #full hd installation.
  modprobe nls_cp437 > /dev/null 2>&1 #these needed by vfat/ntfs/ext2 f.s.'s. 110712 maybe builtin.
@@ -583,7 +577,6 @@ if [ "$USBBUILTIN" = "no" ];then #110712
          #(delay before usb mouse info appears in /proc/bus/input/devices)
 fi
 
-udevadm trigger #--action=add --subsystem-match="input" --subsystem-match="sound" --subsystem-match="power_supply"
 udevadm settle -t 20
 
 # -- from slackware's /etc/rc.d/rc.udev -- modded. kmod 14+

--- a/woof-code/rootfs-skeleton/usr/sbin/set_hwclock_type
+++ b/woof-code/rootfs-skeleton/usr/sbin/set_hwclock_type
@@ -84,10 +84,10 @@ CMD="hwclock ${HWOPT} --${HWCLOCKTIME}"
 #echo $CMD
 if [ "${HWOPT}" = "--hctosys" ] ; then
 	#...--hctosys reads cmos clock to system, referencing /usr/share/zoneinfo/localtime
-	$CMD || $CMD --directisa #try --directisa if reading from /dev/rtc fails
+	busybox $CMD || $CMD || $CMD --directisa #try --directisa if reading from /dev/rtc fails
 else
 	# set hardware clock from system time/date
-	$CMD
+	busybox $CMD || $CMD
 fi
 
 exit $?


### PR DESCRIPTION
In a very non-scientific test, boot time drops from ~25s to ~20s in a VM on my old laptop. I did some basic profiling and these three things are the top 3 time wasters in rc.sysinit.

(With many more optimizations, a dpup built using my woof-CE fork achieves 15-17s, but it also doesn't have X.Org, xorgwizard and other sources of slowness, so I don't think I have more optimizations to upstream)