### PR TITLE
If using an external monitor, turn off the internal display on lid close

### DIFF
--- a/woof-code/rootfs-packages/acpid_busybox/etc/acpi.map
+++ b/woof-code/rootfs-packages/acpid_busybox/etc/acpi.map
@@ -1,0 +1,4 @@
+"EV_KEY"	0x01	"KEY_POWER"	116	1	"button/power PWRF 00000080"
+"EV_KEY"	0x01	"KEY_POWER"	116	1	"button/power PWRB 00000080"
+"EV_SW"		0x05	"SW_LID"	0	1	"button/lid LID0 00000080"
+"EV_SW"		0x05	"SW_LID"	0	0	"button/lid LID0 00000080"

--- a/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
+++ b/woof-code/rootfs-packages/acpid_busybox/etc/acpi/actions/suspend.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # suspend.sh 28sep09 by shinobar
 # 12feb10 pass poweroff
 # 23apr12 fix was not suspend from acpi_poweroff.sh
@@ -6,6 +6,40 @@
 #20140629 shinobar: ACPI_CONFIG
 ACPI_CONFIG=/etc/acpi/acpi.conf
 [ -s "$ACPI_CONFIG" ] && . "$ACPI_CONFIG"
+
+case "$(awk '{print $2}' /proc/acpi/button/lid/LID*/state | head -n 1)" in
+# if the lid is closed:
+#  if an external monitor is connected and enabled:
+#   turn off the internal display
+#  otherwise
+#   suspend and let the screen locker take care of turning off the internal display while locked
+closed)
+  if [ -n "`comm -12 <(grep -l '^connected$' /sys/class/drm/*/status | cut -f 5 -d / | sort) <(grep -l '^enabled$' /sys/class/drm/*/enabled | cut -f 5 -d / | sort) | grep -Fv -e eDP -e LVDS`" ]; then
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+      wlr-randr --output "`wlr-randr | grep -e ^eDP -e ^LVDS | head -n 1 | awk '{print $1}'`" --off
+    elif [ -n "$DISPLAY" ]; then
+      xrandr --output "`xrandr | grep -e ^eDP -e ^LVDS | head -n 1 | awk '{print $1}'`" --off
+    fi
+    touch /tmp/.lid-closed
+    DISABLE_SUSPEND=y
+  fi
+  ;;
+# if the lid is opened:
+#  turn on the previously disabled internal display
+# (we must do this because we don't know if the laptop was supended while connected to an external monitor)
+open)
+  if [ -f /tmp/.lid-closed ]; then
+    if [ -n "$WAYLAND_DISPLAY" ]; then
+      wlr-randr --output "`wlr-randr | grep -e ^eDP -e ^LVDS | head -n 1 | awk '{print $1}'`" --on
+    elif [ -n "$DISPLAY" ]; then
+      xrandr --output "`xrandr | grep -e ^eDP -e ^LVDS | head -n 1 | awk '{print $1}'`" --auto
+    fi
+    rm -f /tmp/.lid-closed
+  fi
+  DISABLE_SUSPEND=y
+  ;;
+esac
+
 case "$DISABLE_SUSPEND" in
 y*|Y*|true|True|TRUE|1) exit;;
 esac


### PR DESCRIPTION
This PR makes Puppy:
1) Turn off the internal display and disable suspend on lid close, **if there's at least one external monitor**
2) Turn on the internal display on lid open, in case the laptop was suspended while connected to an external monitor, then disconnected and opened