### PR TITLE
Automate the construction of the BookwormPup64 adrv

### DIFF
--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/.DirIcon
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/.DirIcon
@@ -1,0 +1,1 @@
+firefox64/browser/chrome/icons/default/default64.png

--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/DATA/firefox_esr-portable.desktop
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/DATA/firefox_esr-portable.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Firefox ESR
+Comment=Firefox web browser
+Exec=/usr/bin/firefox_esr
+Icon=/usr/share/pixmaps/firefox_esr.png
+Type=Application
+Terminal=false
+Categories=X-Internet-browser;

--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/DATA/firefox_esr.png
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/DATA/firefox_esr.png
@@ -1,0 +1,1 @@
+../firefox64/browser/chrome/icons/default/default64.png

--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/LAUNCH
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/LAUNCH
@@ -1,0 +1,8 @@
+#!/bin/sh
+#
+# Launcher for 'portable' Firefox ESR browser
+#
+HERE="$(dirname "$(readlink -f "$0")")"
+mkdir "$HERE/profile" 2> /dev/null
+#
+"$HERE/firefox64/firefox" "$@" -profile "$HERE/profile"

--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/Menu-Add
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/Menu-Add
@@ -1,0 +1,15 @@
+#!/bin/sh
+#
+# Add Menu Entry...
+#
+HERE="$(dirname "$(readlink -f "$0")")"
+APP=firefox_esr
+#
+ln -s $HERE/LAUNCH /usr/bin/$APP
+cp $HERE/DATA/$APP-portable.desktop /usr/share/applications/$APP-portable.desktop
+cp $HERE/DATA/$APP.png /usr/share/pixmaps/$APP.png
+#
+fixmenus
+sleep 1
+#
+jwm -restart

--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/Menu-Remove
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/Menu-Remove
@@ -1,0 +1,14 @@
+#!/bin/sh
+#
+# Remove Menu Entry...
+#
+APP=firefox_esr
+#
+rm /usr/bin/$APP
+rm /usr/share/applications/$APP-portable.desktop
+rm /usr/share/pixmaps/$APP.png
+#
+fixmenus
+sleep 1
+#
+jwm -restart

--- a/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/MenuReadMe
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/opt/FirefoxESR-portable64/MenuReadMe
@@ -1,0 +1,17 @@
+PLEASE NOTE:-
+--------------------
+
+The *recommended* location for this portable application is in /mnt/home. If you place your portable in /mnt/home, when adding the MenuEntry it will sym-link the 'LAUNCH' script into /usr/bin, place a .desktop entry in /usr/share/applications, and an icon in /usr/share/pixmaps. It will then restart "X", in order that the MenuEntry will show up in the Menu.
+
+Specific advice for Chromium-based browsers:-
+------------------------------------------------------------
+
+CAUTION: make sure to use the appropriate 'MenuAdd' script for your Puppy. 'MenuAdd-Old' is for Bionicpup64 and older; 'MenuAdd-New' is for Fossapup64 and newer. This ensures the correct 'LAUNCH' script is sym-linked into /usr/bin. 
+
+It should launch without issue.
+
+However; IF you wish to place the portable application in a different location, that's not a problem. First, use the 'MenuRemove' script to remove the existing MenuEntry. Let the desktop settle after "X" has restarted, then move the portable to the desired location. Finally, re-add the MenuEntry with the appropriate 'Menu-Add' script.
+
+The MenuEntry removal/re-adding steps are necessary because Linux does not, under normal circumstances, permit the migrating of links from one location/file-system to another. 'Soft' links will lose their 'target', and hard links can no longer locate the specified inode. Therefore, the MenuEntry needs to be re-created from its new location.
+
+None of these steps take long to perform, and add another layer of convenience, since with a .desktop file you can also add the application to the QuickLaunch area of the tray, etc.

--- a/woof-code/rootfs-petbuilds/firefox-portable64/pet.specs
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/pet.specs
@@ -1,0 +1,1 @@
+firefox-portable64-115.9.1esr|firefox-portable64|115.9.1esr||Internet|2800K||firefox-portable64-115.9.1esr||Firefox web browser|puppy|||

--- a/woof-code/rootfs-petbuilds/firefox-portable64/petbuild
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/petbuild
@@ -1,0 +1,9 @@
+download() {
+    [ -f firefox-115.9.1esr.tar.bz2 ] || wget -t 3 -T 60 https://ftp.mozilla.org/pub/firefox/releases/115.9.1esr/linux-x86_64/en-US/firefox-115.9.1esr.tar.bz2
+}
+
+build() {
+    mkdir -p /opt/FirefoxESR-portable64
+    tar -xjf firefox-115.9.1esr.tar.bz2 -C /opt/FirefoxESR-portable64
+    mv /opt/FirefoxESR-portable64/firefox{,64}
+}

--- a/woof-code/rootfs-petbuilds/firefox-portable64/sha256.sum
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/sha256.sum
@@ -1,0 +1,1 @@
+ecaa0d9a965973a1c29c21ae01f46fb3503e8c7acab934fde8f40afa5a28c03d  firefox-115.9.1esr.tar.bz2

--- a/woof-code/rootfs-petbuilds/firefox-portable64/usr/bin/firefox_esr
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/usr/bin/firefox_esr
@@ -1,0 +1,1 @@
+../../opt/FirefoxESR-portable64/LAUNCH

--- a/woof-code/rootfs-petbuilds/firefox-portable64/usr/local/bin/defaultbrowser
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/usr/local/bin/defaultbrowser
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec firefox_esr "$@"

--- a/woof-code/rootfs-petbuilds/firefox-portable64/usr/local/bin/defaulthtmlviewer
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/usr/local/bin/defaulthtmlviewer
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec firefox_esr "$@"

--- a/woof-code/rootfs-petbuilds/firefox-portable64/usr/share/applications/firefox_esr-portable.desktop
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/usr/share/applications/firefox_esr-portable.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Encoding=UTF-8
+Name=Firefox ESR
+Comment=Firefox web browser
+Exec=/usr/bin/firefox_esr
+Icon=/usr/share/pixmaps/firefox_esr.png
+Type=Application
+Terminal=false
+Categories=X-Internet-browser;

--- a/woof-code/rootfs-petbuilds/firefox-portable64/usr/share/pixmaps/firefox_esr.png
+++ b/woof-code/rootfs-petbuilds/firefox-portable64/usr/share/pixmaps/firefox_esr.png
@@ -1,0 +1,1 @@
+../../../opt/FirefoxESR-portable64/firefox64/browser/chrome/icons/default/default64.png

--- a/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86_64/debian/bookworm64/DISTRO_PKGS_SPECS-debian-bookworm
@@ -192,7 +192,6 @@ yes|debconf|debconf|exe,dev,doc,nls
 yes|deadbeef-deps|libjansson-dev,libmpg123-dev,libcddb2-dev,libcdio-paranoia-dev,libfaad-dev|exe,dev,doc,nls||deps:yes
 yes|dkms|dkms|exe,dev>exe,doc,nls||deps:yes
 yes|ExpenseTracker-deps|libsqlite3-dev|exe,dev,doc,nls||deps:yes
-yes|firefox-esr|firefox-esr,firefox-esr-l10n-all|exe,dev,doc,nls||deps:yes
 yes|flatpak|flatpak|exe,dev,doc,nls||deps:yes
 yes|fonts-dejavu-core|fonts-dejavu-core|exe>null,dev>null,doc>null,nls>null
 yes|fonts-liberation2|fonts-liberation2|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86_64/debian/bookworm64/_00build.conf
+++ b/woof-distro/x86_64/debian/bookworm64/_00build.conf
@@ -19,6 +19,7 @@ KIT_KERNEL_REPO_URL=http://distro.ibiblio.org/puppylinux/huge_kernels
 ## an array of generically named programs to send to the ADRIVE, FDRIVE, YDRIVE
 ## ADRV_INC="abiword gnumeric goffice"
 ADRV_INC=""
+[ "$DISTRO_VARIANT" != "retro" ] && ADRV_INC="firefox-portable64"
 ## YDRV_INC=""
 YDRV_INC=""
 ## FDRV_INC="" #this one is very experimental and it's recommended to be left unset
@@ -56,8 +57,7 @@ BUILD_BDRV=yes
 ## packages to build from source
 PETBUILDS="busybox aaa_pup_c disktype geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask xarchiver xcur2png xdelta Xdialog yad puppy_standard_icons viewnior"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
-[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS dmz-cursor-theme mtpaint osmo transmission pmaterial_icons puppy_flat_icons ram-saver connman-puppy connman-gtk
- fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail abiword gnumeric xournalpp gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap ExpenseTracker grsync hardinfo uget gfnrename fsearch mtr"
+[ "$DISTRO_VARIANT" != "retro" ] && PETBUILDS="$PETBUILDS dmz-cursor-theme mtpaint osmo transmission pmaterial_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail abiword gnumeric xournalpp gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap ExpenseTracker grsync hardinfo uget gfnrename fsearch mtr firefox-portable64"
 PETBUILDS="$PETBUILDS firewallstatus freememapplet jwm lxterminal pa-applet powerapplet_tray xdg-puppy-jwm rox-filer xlockmore"
 if [ "$DISTRO_VARIANT" = "retro" ]; then
 	PETBUILDS="$PETBUILDS netmon_wce"
@@ -125,7 +125,7 @@ defaultarchiver=xarchiver
 defaultaudioeditor=mhwaveedit
 defaultaudiomixer=pavucontrol
 defaultaudioplayer=deadbeef
-defaultbrowser=firefox-esr
+defaultbrowser=firefox_esr
 defaultcalendar=osmo --calendar
 defaultcdplayer=deadbeef /dev/sr0/all.cda
 defaultcdrecorder=pburn
@@ -138,7 +138,7 @@ defaultemail=claws-mail
 defaultfilemanager=roxfiler
 defaulthandler=
 defaulthtmleditor=geany
-defaulthtmlviewer=firefox-esr
+defaulthtmlviewer=firefox_esr
 defaultimageeditor=mtpaint
 defaultimageviewer=viewnior
 defaultmediaplayer=mpv --player-operation-mode=pseudo-gui
@@ -168,8 +168,6 @@ PROMPT='PS1="\w\$ "'
 ## Here add custom commands to be executed inside sandbox3/rootfs-complete
 EXTRA_COMMANDS="
 [ \"\$DISTRO_VARIANT\" != \"retro\" ] && chroot . /usr/sbin/firewall_ng enable
-chroot . /usr/sbin/setup-spot firefox=true
-chroot . /usr/sbin/setup-spot firefox-esr=true
 chroot . /usr/sbin/setup-spot claws-mail=true
 chroot . /usr/sbin/setup-spot transmission-gtk=true
 chroot . /usr/sbin/setup-spot weechat=true


### PR DESCRIPTION
I -
1. Unpacked adrv from BookwormPup64 10.0.6
2. Unpacked the Firefox tarball of the same version
3. Deduplicated the two directories, so the unpacked adrv has only the "secret sauce" and not files that came from the tarball
4. Replaced the .png icons with symlinks to browser/chrome/icons/default/default64.png from the tarball (the Firefox logo itself, not a custom icon taken from a particular theme)
5. Converted all remaining symlinks from absolute to relative
6. Automated the process of downloading the tarball and unpacking it to the right location
7. Bumped to the latest 115 ESR version

(I don't know who wrote the remaining files, but I can add a `Co-authored-by:` line if you tell me who it is.)

![1](https://github.com/puppylinux-woof-CE/woof-CE/assets/1471149/fcc75a97-a2e0-4cda-8ae6-5705ed8e6074)

