### PR TITLE
Revert "petbuild weechat fails so remove"

### DIFF
--- a/woof-distro/x86_64/debian/sid64/_00build.conf
+++ b/woof-distro/x86_64/debian/sid64/_00build.conf
@@ -50,7 +50,7 @@ USR_SYMLINKS=yes
 BUILD_BDRV=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub claws-mail"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
 PETBUILDS="$PETBUILDS abiword gnumeric mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap ExpenseTracker grsync hardinfo uget gfnrename fsearch mtr"
 PETBUILDS="$PETBUILDS labwc-puppy swaylock wlopm xdg-puppy-labwc viewnior spacefm sfwbar xdg-puppy-sfwbar lxterminal epdfview"

--- a/woof-distro/x86_64/debian/trixie64/_00build.conf
+++ b/woof-distro/x86_64/debian/trixie64/_00build.conf
@@ -50,7 +50,7 @@ USR_SYMLINKS=yes
 BUILD_BDRV=yes
 
 ## packages to build from source
-PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub claws-mail"
+PETBUILDS="busybox aaa_pup_c disktype dmz-cursor-theme geany gexec gtkdialog gtk_theme_flat_grey_rounded gtk_theme_polished_blue gtk_theme_gradient_grey gtk_theme_buntoo_ambience gtk_theme_stark_blueish gxmessage l3afpad lxtask mtpaint osmo transmission xarchiver xcur2png xdelta Xdialog yad pmaterial_icons puppy_standard_icons puppy_flat_icons ram-saver connman-puppy connman-gtk fixmenusd spot-pkexec notification-daemon-stub weechat claws-mail"
 [ "$DISTRO_TARGETARCH" = "x86_64" ] && PETBUILDS="$PETBUILDS efilinux"
 PETBUILDS="$PETBUILDS abiword gnumeric mpv gparted deadbeef gmeasures fpm2 xpad gtkhash gdmap ExpenseTracker grsync hardinfo uget gfnrename fsearch mtr"
 PETBUILDS="$PETBUILDS labwc-puppy swaylock wlopm xdg-puppy-labwc viewnior spacefm sfwbar xdg-puppy-sfwbar lxterminal epdfview"


### PR DESCRIPTION
Reverts puppylinux-woof-CE/woof-CE#4303
Does not fix petbuild problems - other fails