### PR TITLE
Update xorg-autoconf: add vmware and virtualbox distinction

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
+++ b/woof-code/rootfs-skeleton/usr/sbin/xorg-autoconf
@@ -1382,9 +1382,23 @@ else
 			10de) probe_nvidia "${vid}:${dvid}" "$cnum" ;;
 			1092) probe_diamond "${vid}:${dvid}" "$cnum" ;;
 			1023) probe_trident "${vid}:${dvid}" "$cnum" ;;
-					1002|1022) probe_amd "${vid}:${dvid}" "$cnum" ;;		
+			1002|1022) probe_amd "${vid}:${dvid}" "$cnum" ;;		
 			1412|1106) probe_via "${vid}:${dvid}" "$cnum" ;;
-			15ad|fffe) probe_vmware "${vid}:${dvid}" "$cnum" ;;
+			fffe) probe_vmware "${vid}:${dvid}" "$cnum" ;;			
+			15ad)
+			  #vmware and virtualbox uses the same vendor id for gpu 	
+			  
+			  dvmw=$(cat /sys/class/dmi/id/product_name | head | xargs | grep -E "[Vv][Mm]ware")
+			  dvbox=$(cat /sys/class/dmi/id/product_name | head | xargs | grep -E "[Vv]irtual[Bb]ox|vbox")	
+			
+			  if [ "$dvmw" != "" ]; then
+				probe_vmware "${vid}:${dvid}" "$cnum"
+			  elif [ "$dvbox" != "" ]; then
+			    write_generic "${vid}:${dvid}" "$cnum" vboxvideo
+			  else
+			    write_fallback "${vid}:${dvid}" "$cnum"
+			  fi
+			;;				
 			1013) write_generic "${vid}:${dvid}" "$cnum" cirrus ;;
 			1039) write_generic "${vid}:${dvid}" "$cnum" sis ;;
 			102b) write_generic "${vid}:${dvid}" "$cnum" mga ;;


### PR DESCRIPTION
VMware and VirtualBox (later versions) are both using the same vendor ID on video card. So it need to more identification to determine whether it was vmware or virtualbox in order to define the correct xorg driver.