### PR TITLE
Correct BWP32 distro_specs oddities

### DIFF
--- a/woof-distro/x86/debian/dpupbw32/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86/debian/dpupbw32/DISTRO_PKGS_SPECS-debian-bookworm
@@ -92,7 +92,7 @@ yes|fonts-liberation2|fonts-liberation2|exe,dev,doc,nls||deps:yes
 yes|freetype|libfreetype6,libfreetype-dev,libfreetype6-dev|exe,dev,doc,nls||deps:yes
 yes|galculator|galculator|exe,dev>null,doc,nls||deps:yes
 yes|gawk|gawk|exe,dev>null,doc,nls||deps:yes
-yes|gdk-pixbuf|libgdk-pixbuf-2.0-0,libgdk-pixbuf2.0-common,libgdk-pixbuf-2.0-dev,libgdk-pixbuf2.0-0,libgdk-pixbuf2.0-dev,libgdk-pixbuf-xlib-2.0-0,libgdk-pixbuf-xlib-2.0-dev.webp-pixbuf-loader|exe,dev,doc,nls||deps:yes
+yes|gdk-pixbuf|libgdk-pixbuf-2.0-0,libgdk-pixbuf2.0-common,libgdk-pixbuf-2.0-dev,libgdk-pixbuf2.0-0,libgdk-pixbuf2.0-dev,libgdk-pixbuf-xlib-2.0-0,libgdk-pixbuf-xlib-2.0-dev,webp-pixbuf-loader|exe,dev,doc,nls||deps:yes
 yes|gettext-full|gettext,gettext-base|exe,dev>exe,doc,nls||deps:yes
 yes|glib|libglib2.0-bin,libglib2.0-0,libglib2.0-data,libglib2.0-dev,libglib2.0-dev-bin|exe,dev,doc,nls||deps:yes
 yes|glibc|libc-bin,libc6,libc6-dev,tzdata|exe,dev,doc,nls||deps:yes

--- a/woof-distro/x86/debian/dpupbw32/DISTRO_PKGS_SPECS-debian-bookworm
+++ b/woof-distro/x86/debian/dpupbw32/DISTRO_PKGS_SPECS-debian-bookworm
@@ -418,7 +418,7 @@ yes|xournalpp|xournalpp|exe,dev,doc,nls
 yes|BW_rightclick||exe,dev,doc,nls
 yes|cdrtools||exe,dev,doc,nls
 yes|conky-gtk||exe,dev,doc,nls
-yes|dict_1.13.0_i386||exe,dev,doc,nls
+yes|dict||exe,dev,doc,nls
 yes|gatotray||exe,dev,doc,nls
 yes|gcolor2||exe,dev,doc,nls
 yes|grub2config||exe,dev,doc,nls
@@ -426,7 +426,7 @@ yes|gtk-themes-bookworm64||exe,dev,doc,nls
 yes|JQ8raised||exe,dev,doc,nls
 yes|jwm-themes-bookworm64||exe,dev,doc,nls
 yes|magdock-gtk3||exe,dev,doc,nls
-yes|mm_view-0.3.1||exe,dev,doc,nls
+yes|mm_view||exe,dev,doc,nls
 yes|multirename||exe,dev,doc,nls
 yes|netmon_wce||exe,dev,doc,nls
 yes|nicOS-Utility-Suite||exe,dev,doc,nls


### PR DESCRIPTION
A . that should be a ,
dict & mmview wrongly specified with spurious version numbers
Both oddities in that they haven't caused problems previously