### PR TITLE
/usr/share/doc: HOWTO build your own Puppy using Woof-CE

### DIFF
--- a/woof-code/rootfs-skeleton/usr/share/doc/HOWTO-woof-ce.htm
+++ b/woof-code/rootfs-skeleton/usr/share/doc/HOWTO-woof-ce.htm
@@ -1,0 +1,81 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN">
+<html>
+<head>
+	<title>Build your own Puppy using Woof-CE</title>
+	<meta charset="utf-8">
+	<link href="./manual.css" rel="stylesheet" type="text/css">
+	<base target="_blank">
+</head>
+<body>
+	<a href="#" class="scroll_back_button" target="_self">&uArr;</a>
+
+	<div id="container">
+		<header class="logo-header">
+				<img class="header-logo" alt="Logo" src="puppylogo96.png">
+				<h1>HOWTO: Build your own Puppy using Woof-CE</h1>
+		</header>
+		<p>
+			Woof-CE is the tool to build Puppies, including the one you're using right now! This page will walk you through how to build and customize a Puppy.
+		</p>
+		<p>
+			First, you need at least 10 gigabytes of free storage and your Puppy's devx SFS. How to get the latter is explained <a href="devx.htm">here</a>.
+		</p>
+		<p>
+			Open a terminal, and let's get going!
+		</p>
+		<section>
+			<h2>Building</h2>
+			<h3>Step 1: Clone Woof-CE</h3>
+			<p>
+				Run the command <code>git clone https://github.com/puppylinux-woof-CE/woof-CE.git</code> to clone (download) Woof-CE to your computer.
+			</p>
+
+			<h3>Step 2: Run merge2out</h3>
+			<p>
+				Run the command <code>./merge2out</code>, and follow the prompts.
+				Choose the target architecture of your Puppy, the Linux distro whose packages will be used, and which version of the distro to use.
+			</p>
+
+			<h3>Step 3: Build your Puppy!</h3>
+			<p>
+				Run the command <code>cd ../woof-out_*</code> to go to the newly created directory, and then just run the following commands in order!
+				<pre>
+					<code>./0setup</code>
+					<code>./1download</code>
+					<code>./2createpackages</code>
+					<code>./3builddistro</code>
+				</pre>
+				If everything went well, you should have a brand new Puppy .iso file in the directory! Congratulations!
+			</p>
+		</section>
+		<section>
+			<h2>Customizing</h2>
+			<p>
+				Now, this is great and all, but what if you want to customize your Puppy? Well, that's what this section is about.
+			</p>
+			<p>
+				The files we'll be talking about here are <code>DISTRO_SPECS</code>, <code>DISTRO_PKGS_SPECS</code>, and <code>_00build.conf</code>.
+			</p>
+			<h3>DISTRO_SPECS</h3>
+			<p>
+				<code>DISTRO_SPECS</code> is the file that specifies the name of the Puppy, its version number, the compatible distro, among other things.
+				If you've already used <code>merge2out</code>, the only relevant variables are <code>DISTRO_NAME</code>, <code>DISTRO_VERSION</code>, and <code>DISTRO_FILE_PREFIX</code>.
+			</p>
+			<h3>DISTRO_PKGS_SPECS</h3>
+			<p>
+				This is the file that specifies the packages that your Puppy includes, you can edit this to customize the packages in your Puppy!
+				How it's formatted is explained in comments in the file. Other files also have explanatory comments.
+			</p>
+			<h3>_00build.conf</h3>
+			<p>
+				This is the file that specifies other settings for the Puppy, including the default theme, the default apps, among other things.
+			</p>
+		</section>
+		<section>
+			<h2>There's so much more!</h2>
+			We're not even scratching the surface here! There is so much more to Woof-CE that we haven't even mentioned!
+			For more information about Woof-CE, including its structure, how to build a Puppy entirely within the browser, and how to contribute, see the <a href="https://github.com/puppylinux-woof-CE/woof-CE#readme">README</a>.
+		</section>
+	</div>
+</body>
+</html>

--- a/woof-code/rootfs-skeleton/usr/share/doc/HOWTO-woof-ce.htm
+++ b/woof-code/rootfs-skeleton/usr/share/doc/HOWTO-woof-ce.htm
@@ -32,19 +32,17 @@
 
 			<h3>Step 2: Run merge2out</h3>
 			<p>
-				Run the command <code>./merge2out</code>, and follow the prompts.
+				Run the command <code>./merge2out</code> and follow the prompts.
 				Choose the target architecture of your Puppy, the Linux distro whose packages will be used, and which version of the distro to use.
 			</p>
 
 			<h3>Step 3: Build your Puppy!</h3>
 			<p>
 				Run the command <code>cd ../woof-out_*</code> to go to the newly created directory, and then just run the following commands in order!
-				<pre>
-					<code>./0setup</code>
-					<code>./1download</code>
-					<code>./2createpackages</code>
-					<code>./3builddistro</code>
-				</pre>
+				<code>./0setup</code>
+				<code>./1download</code>
+				<code>./2createpackages</code>
+				<code>./3builddistro</code>
 				If everything went well, you should have a brand new Puppy .iso file in the directory! Congratulations!
 			</p>
 		</section>

--- a/woof-code/rootfs-skeleton/usr/share/doc/HOWTO-woof-ce.htm
+++ b/woof-code/rootfs-skeleton/usr/share/doc/HOWTO-woof-ce.htm
@@ -54,12 +54,12 @@
 				Now, this is great and all, but what if you want to customize your Puppy? Well, that's what this section is about.
 			</p>
 			<p>
-				The files we'll be talking about here are <code>DISTRO_SPECS</code>, <code>DISTRO_PKGS_SPECS</code>, and <code>_00build.conf</code>.
+				The files we'll be talking about here are DISTRO_SPECS, DISTRO_PKGS_SPECS, and _00build.conf.
 			</p>
 			<h3>DISTRO_SPECS</h3>
 			<p>
-				<code>DISTRO_SPECS</code> is the file that specifies the name of the Puppy, its version number, the compatible distro, among other things.
-				If you've already used <code>merge2out</code>, the only relevant variables are <code>DISTRO_NAME</code>, <code>DISTRO_VERSION</code>, and <code>DISTRO_FILE_PREFIX</code>.
+				DISTRO_SPECS is the file that specifies the name of the Puppy, its version number, the compatible distro, among other things.
+				If you've already used merge2out, the only relevant variables are DISTRO_NAME, DISTRO_VERSION, and DISTRO_FILE_PREFIX.
 			</p>
 			<h3>DISTRO_PKGS_SPECS</h3>
 			<p>

--- a/woof-code/rootfs-skeleton/usr/share/doc/index.html.top
+++ b/woof-code/rootfs-skeleton/usr/share/doc/index.html.top
@@ -55,6 +55,7 @@ window.location.href = url;
 				<li><a href="samba-printing.htm">HOWTO print with Samba and CUPS</a></li>
 				<li><a href="../../local/petget/help.htm">HOWTO use the Puppy Package Manager</a></li>
 				<li><a href="HOWTO-internationalization.htm">HOWTO Internationalization</a> (support non-English languages)</li>
+				<li><a href="HOWTO-woof-ce.htm">HOWTO: Build your own Puppy using Woof-CE</li>
 				<li><a href="devx.htm">About Devx</a> The Puppy development environment</li>
 				<li><a href="gtkdialog.htm">About Gtkdialog</a> The Puppy Linux GUI builder</li>
 				<li><a href="root.htm">About root (administrator) and spot</a></li>


### PR DESCRIPTION
This adds a page explaining the basics of using Woof-CE to the local documentation.