### PR TITLE
Change sh to bash for runner:ubuntu-24.04

### DIFF
--- a/woof-code/3builddistro
+++ b/woof-code/3builddistro
@@ -61,7 +61,7 @@ mkdir -p sandbox3
 echo
 echo "Now building sandbox3/rootfs-complete, with the complete filesystem..."
 if [ -n "$GITHUB_ACTIONS" ]; then
-	echo '#!/bin/sh -x' > sandbox3/pinstall.sh
+	echo '#!/bin/bash -x' > sandbox3/pinstall.sh
 else
 	echo '#!/bin/sh' > sandbox3/pinstall.sh
 fi

--- a/woof-code/support/bdrv.sh
+++ b/woof-code/support/bdrv.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -e
+#!/bin/bash -e
 
 . ../DISTRO_SPECS
 . ../_00build.conf

--- a/woof-code/support/download_file.sh
+++ b/woof-code/support/download_file.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # download and verify files
 #
 # $1: url

--- a/woof-code/support/huge_kernel.sh
+++ b/woof-code/support/huge_kernel.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 # install huge kernel to build
 # * called by 3builddistro
 # * can be run independently


### PR DESCRIPTION
Shellscripts with bashisms must use bash on Github Actions with runner:ubuntu-24.04. They fail with sh.