### PR TITLE
Update probepart: block device revision

### DIFF
--- a/woof-code/rootfs-skeleton/sbin/probepart
+++ b/woof-code/rootfs-skeleton/sbin/probepart
@@ -170,18 +170,22 @@ probepart_func() {
 
 # $1: device
 do_probepart() {
+
 	#ALLDEVS="`grep " ${device}$" /proc/partitions | tr -s ' ' | cut -f 4-5 -d ' '`"
+
 	ONEDEV_ARG=1
 	unset ok
 	device="${1##*/}" #basename
 	device="${device//./}" #remove dots / convert grep wilcards to unix shell wildcards..
+
+	grep -vE 'loop|zram|ram' /proc/partitions |
 	while read major minor blocks name #< /proc/partitions
 	do
 		case $name in $device)
 			ok=1
 			probepart_func $name $blocks ;;
 		esac
-	done < /proc/partitions
+	done
 	if [ ! "$ok" ] ; then
 		# optical = problems
 		for dev in /sys/block/${device} ; do
@@ -204,7 +208,7 @@ do_probepart_all() {
 		esac
 		echo $name $blocks
 		#-
-	done < /proc/partitions | sort | \
+	done < /proc/partitions | grep -vE 'loop|zram|ram' | sort | \
 		while read l ; do
 			probepart_func $l
 		done
@@ -213,6 +217,10 @@ do_probepart_all() {
 		for dev in /sys/block/sr* ; do
 			probepart_func ${dev##*/} #basename
 		done
+		for dev in /sys/block/scd* ; do
+			probepart_func ${dev##*/} #basename
+		done
+
 	fi
 }
 


### PR DESCRIPTION
* filtered out /dev/loop*, /dev/zram*, and /dev/ram* block devices
* added /dev/scd[0-9] block devices for probing optical drives