### PR TITLE
Update shutdownconfig: bugfix for booting from iso file

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -122,9 +122,12 @@ get_DRV() {
 
 choosepartfunc() {
  #dialog to choose what partition to create ${DISTRO_FILE_PREFIX}save.2fs on...
+ 
  case "$PMEDIA" in ""|cd|scsicd|satacd|idecd|atacd|usbcd) PCHOOSE="yes" ;; esac
- case "$DEV1FS" in ntfs|xxx) PCHOOSE="yes" ;; esac
- [ "$DEV1FS" = "msdos" ] && DEV1FS="vfat"
+
+ case "$DEV1FS" in iso9960|udf|ntfs3|ntfs|xxx) PCHOOSE="yes" ;; esac
+ 
+[ "$DEV1FS" = "msdos" ] && DEV1FS="vfat"
 
  expBOOTDRV=''
  if [ "$PMEDIA" = "usbflash" ];then #may have a small boot partition and a big 2nd.

--- a/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
+++ b/woof-code/rootfs-skeleton/usr/sbin/shutdownconfig
@@ -125,7 +125,7 @@ choosepartfunc() {
  
  case "$PMEDIA" in ""|cd|scsicd|satacd|idecd|atacd|usbcd) PCHOOSE="yes" ;; esac
 
- case "$DEV1FS" in iso9960|udf|ntfs3|ntfs|xxx) PCHOOSE="yes" ;; esac
+ case "$DEV1FS" in iso9660|udf|ntfs3|ntfs|xxx) PCHOOSE="yes" ;; esac
  
 [ "$DEV1FS" = "msdos" ] && DEV1FS="vfat"
 


### PR DESCRIPTION
When a puppy was booted using find_iso parameter. It triggered a bug that automatically to select /dev/loop[0-9] where the iso file is mounted as the default partition instead of selecting partition when the puppy was booted from iso file.