### PR TITLE
Update .profile: detect display managers

### DIFF
--- a/woof-code/rootfs-skeleton/root/.profile
+++ b/woof-code/rootfs-skeleton/root/.profile
@@ -11,8 +11,11 @@ mkdir -p /tmp/services
 	echo "PATH='${PATH}'"
 ) > /tmp/services/user_info
 
+#Check for display managers
+DM_RUNNING=$(pidof lightdm gdm kdm sddm xdm lxdm slim ly wdm)
+
 if command -v startlabwc >/dev/null 2>&1 ; then
-	if [ ! -f /tmp/bootcnt.txt ] ; then
+	if [ ! -f /tmp/bootcnt.txt ] && [ "$DM_RUNNING" == "" ]; then
 		touch /tmp/bootcnt.txt
 		startlabwc
 	else
@@ -20,7 +23,7 @@ if command -v startlabwc >/dev/null 2>&1 ; then
 	fi
 elif command -v Xorg >/dev/null 2>&1 ; then
 	#want to go straight into X on bootup only...
-	if [ ! -f /tmp/bootcnt.txt ] ; then
+	if [ ! -f /tmp/bootcnt.txt ] && [ "$DM_RUNNING" == "" ]; then
 		touch /tmp/bootcnt.txt
 		dmesg > /tmp/bootkernel.log
 		xwin

--- a/woof-code/rootfs-skeleton/root/.profile
+++ b/woof-code/rootfs-skeleton/root/.profile
@@ -12,7 +12,14 @@ mkdir -p /tmp/services
 ) > /tmp/services/user_info
 
 #Check for display managers
-DM_RUNNING=$(pidof lightdm gdm kdm sddm xdm lxdm slim ly wdm)
+
+DM_LIST=$(cat /etc/display-managers.list 2>/dev/null | tr '\n' ' ')
+
+if [ "$DM_LIST" != "" ]; then
+   DM_RUNNING=$(pidof $DMLIST)
+else
+   DM_RUNNING=""
+fi
 
 if command -v startlabwc >/dev/null 2>&1 ; then
 	if [ ! -f /tmp/bootcnt.txt ] && [ "$DM_RUNNING" == "" ]; then

--- a/woof-code/rootfs-skeleton/root/.profile
+++ b/woof-code/rootfs-skeleton/root/.profile
@@ -16,7 +16,7 @@ mkdir -p /tmp/services
 DM_LIST=$(cat /etc/display-managers.list 2>/dev/null | tr '\n' ' ')
 
 if [ "$DM_LIST" != "" ]; then
-   DM_RUNNING=$(pidof $DMLIST)
+   DM_RUNNING=$(pidof $DM_LIST)
 else
    DM_RUNNING=""
 fi


### PR DESCRIPTION
Initiate xorg or wayland compositor only if there is no display manager running
Reason: Display Managers already initiated Xorg or Wayland compositors so skip some routines