### PR TITLE
Create display-managers.list

### DIFF
--- a/woof-code/rootfs-skeleton/etc/display-managers.list
+++ b/woof-code/rootfs-skeleton/etc/display-managers.list
@@ -1,0 +1,15 @@
+lightdm
+gdm
+sddm
+lxdm
+xdm
+entrance
+slim
+ly
+nodm
+emptty
+cdm
+console-tdm
+lemurs
+lidm
+tbsm


### PR DESCRIPTION
A list of display managers which can be used for detecting running display manager using pidof command