### PR TITLE
Update snapmergepuppy.overlay: use busybox pidof

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -62,9 +62,9 @@ fi
 SAVEPART="`echo -n "$PUPSAVE" | cut -f 1 -d ','`"
 
 SHUTDOWN="no"
-pidof rc.shutdown >/dev/null && SHUTDOWN="yes"
+busybox pidof rc.shutdown >/dev/null && SHUTDOWN="yes"
 XRUNNING="no"
-pidof -s X Xorg `cat /etc/windowmanager 2>/dev/null` >/dev/null 2>&1 && XRUNNING="yes"
+busybox pidof -s X Xorg `cat /etc/windowmanager 2>/dev/null` >/dev/null 2>&1 && XRUNNING="yes"
 
 PATH="/bin:/sbin:/usr/bin:/usr/sbin:/usr/X11R7/bin"
 WD="`pwd`"


### PR DESCRIPTION
util-linux pidof does not recognize scripts, busybox pidof does