### PR TITLE
More reliable save2flash

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy
@@ -254,7 +254,7 @@ Unable to save all files. You need to delete some.')"
 	ERRSTATUS=1
 fi
 
-sed -i '/No such file or directory/d' /tmp/snapmergepuppy-error	# discard errors caused by bad timing
+[ -s /tmp/snapmergepuppy-error ] && sed -i '/No such file or directory/d' /tmp/snapmergepuppy-error	# discard errors caused by bad timing
 
 if [ -s /tmp/snapmergepuppy-error ]; then	#140102 SFR
 	ERRMSG="$(gettext "WARNING!

--- a/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
+++ b/woof-code/rootfs-skeleton/usr/sbin/snapmergepuppy.overlay
@@ -239,7 +239,7 @@ Unable to save all files. You need to delete some.')"
 	ERRSTATUS=1
 fi
 
-sed -i '/No such file or directory/d' /tmp/snapmergepuppy-error	# discard errors caused by bad timing
+[ -s /tmp/snapmergepuppy-error ] && sed -i '/No such file or directory/d' /tmp/snapmergepuppy-error	# discard errors caused by bad timing
 
 if [ -s /tmp/snapmergepuppy-error ]; then	#140102 SFR
 	ERRMSG="$(gettext "WARNING!


### PR DESCRIPTION
from marv:
patch to /usr/sbin/snapmergepuppy and snapmergepuppy.overlay so save2flash works reliably