### PR TITLE
Added rm wrapper script to prevent dangerous deletions

### DIFF
--- a/woof-code/rootfs-skeleton/usr/local/bin/rm
+++ b/woof-code/rootfs-skeleton/usr/local/bin/rm
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+for arg in "$@"
+do
+    if [ "$arg" == "/" ] || [ "$arg" == "/*" ]; then
+        echo "Blocked dangerous rm usage"
+        exit 1
+    fi
+done
+
+[ -f /usr/bin/rm ] && exec /usr/bin/rm "$@"
+[ -f /bin/rm ] && exec /bin/rm "$@"
+[ -f /bin/busybox ] && exec /bin/busybox rm "$@"


### PR DESCRIPTION
This script blocks rm -rf /* command to prevent accidental deletions since Puppy is running as root