### PR TITLE
set_hwclock_type: sync /etc/adjtime file

### DIFF
--- a/woof-code/rootfs-skeleton/usr/sbin/set_hwclock_type
+++ b/woof-code/rootfs-skeleton/usr/sbin/set_hwclock_type
@@ -62,6 +62,16 @@ fi
 
 echo "HWCLOCKTIME='$HWCLOCKTIME'" > /etc/clock
 
+if [ "$HWCLOCKTIME" = "utc" ]; then
+	ADJTIME_L3="UTC"
+else
+	ADJTIME_L3="LOCAL"
+fi
+
+echo "0.000000 0 0.000000
+0
+$ADJTIME_L3" > /etc/adjtime
+
 [ "$QUIET" ] && [ ! "$HWOPT" ] && HWOPT=--hctosys
 
 if [ -z $HWOPT ] ; then
@@ -72,6 +82,7 @@ if [ -z $HWOPT ] ; then
 	[ "$RET" = "to match software" ] && HWOPT=--hctosys #cmos clock to system.
 	[ "$RET" = "to match hardware" ] && HWOPT=--systohc #system to hardware clock.
 fi
+
 rm -f $REP
 
 #===================================================


### PR DESCRIPTION
make sure that /etc/adjtime was set either UTC or localtime hardware clock